### PR TITLE
A updated version of the SINGLE_OR_DOUBLE-flag

### DIFF
--- a/src/main/org/openscience/cdk/CDKConstants.java
+++ b/src/main/org/openscience/cdk/CDKConstants.java
@@ -169,9 +169,20 @@ public class CDKConstants {
      */
     public static final int IS_TYPEABLE = 11;
     /**
+     * Flag used for marking uncertainty of the bond order.
+     * If used on an 
+     * - IMolecule it means that one or several of the bonds have 
+     * 		this flag raised (which may indicate aromaticity). 
+     * - IBond it means that it's unclear whether the bond is a single or
+     * 		double bond.
+     * - IAtom is a way for the Smiles parser to indicate that this atom was 
+     * 		written with a lowercase letter, e.g. 'c' rather than 'C'
+     */
+    public final static int SINGLE_OR_DOUBLE = 12;
+    /**
      * Maximum flags array index.
      */
-    public final static int MAX_FLAG_INDEX = 12;
+    public final static int MAX_FLAG_INDEX = 13;
     /**
      * Flag used for JUnit testing the pointer functionality.
      */

--- a/src/test/org/openscience/cdk/CDKConstantsTest.java
+++ b/src/test/org/openscience/cdk/CDKConstantsTest.java
@@ -28,6 +28,13 @@ package org.openscience.cdk;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.config.Elements;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IMolecule;
+import org.openscience.cdk.ringsearch.AllRingsFinder;
+import org.openscience.cdk.smiles.DeduceBondSystemTool;
+import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 /**
  * Included so that CoreCoverageTest won't complain. The class does not have
@@ -42,6 +49,50 @@ public class CDKConstantsTest extends CDKTestCase {
     @Test
     public void testCDKConstants() {
         Assert.assertFalse(CDKConstants.ISAROMATIC == -1);
+    }
+    
+    @Test
+    public void testSingleOrDoubleFlag() throws Exception {
+    	AtomContainer mol = new AtomContainer();
+    	
+    	IAtom atom1 = new Atom(Elements.CARBON);
+    	atom1.setFlag(CDKConstants.SINGLE_OR_DOUBLE, true);
+    	IAtom atom2 = new Atom(Elements.CARBON);
+    	IAtom atom3 = new Atom(Elements.CARBON);
+    	IAtom atom4 = new Atom(Elements.CARBON);
+    	IAtom atom5 = new Atom(Elements.CARBON);
+    	
+    	IBond bond1 = new Bond(atom1, atom2);
+    	bond1.setFlag(CDKConstants.SINGLE_OR_DOUBLE, true);
+    	IBond bond2 = new Bond(atom2, atom3);
+    	IBond bond3 = new Bond(atom3, atom4);
+    	IBond bond4 = new Bond(atom4, atom5);
+    	IBond bond5 = new Bond(atom5, atom1);
+    	
+    	mol.addAtom(atom1);
+    	mol.addAtom(atom2);
+    	mol.addAtom(atom3);
+    	mol.addAtom(atom4);
+    	mol.addAtom(atom5);
+    	
+    	mol.addBond(bond1);
+    	mol.addBond(bond2);
+    	mol.addBond(bond3);
+    	mol.addBond(bond4);
+    	mol.addBond(bond5);
+    	  	
+    	for (int i=0; i<5; i++){
+    		if (mol.getAtom(i).getFlag(CDKConstants.SINGLE_OR_DOUBLE))
+    			mol.setFlag(CDKConstants.SINGLE_OR_DOUBLE, true);
+    	}
+    	
+    	// Now we have created a molecule, so let's test it...
+    	Assert.assertTrue(atom1.getFlag(CDKConstants.SINGLE_OR_DOUBLE));
+    	Assert.assertTrue(bond1.getFlag(CDKConstants.SINGLE_OR_DOUBLE));
+    	Assert.assertTrue(mol.getAtom(0).getFlag(CDKConstants.SINGLE_OR_DOUBLE));
+    	Assert.assertTrue(mol.getBond(0).getFlag(CDKConstants.SINGLE_OR_DOUBLE));
+    	Assert.assertTrue(mol.getFlag(CDKConstants.SINGLE_OR_DOUBLE));
+    	
     }
     
     // FIXME: should add a test here that used introspection and test whether there


### PR DESCRIPTION
Due to the change to using the AtomContainer instead of IMolecule (to make it fit in the master branch as well) I had to remove the part of the test that do something with the molecule and then test it again. Because in cdk-1.4.x. the methods of DeduceBondSystemTool.java demands that it's a IMolecule that is sent in, while in the master branch the same methods demands an AtomContainer.
