### PR TITLE
MolecularFormulaManipulator.getHTML()

### DIFF
--- a/src/main/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/src/main/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -304,9 +304,9 @@ public class MolecularFormulaManipulator {
 	}
 
 	/**
-	 * Returns the string representation of the molecule formula with
-	 * numbers wrapped in &lt;sub&gt;&lt;/sub&gt; tags.
-	 * Useful for displaying formulae in Swing components or on the web.
+	 * Returns the string representation of the molecule formula based on Hill
+	 * System with numbers wrapped in &lt;sub&gt;&lt;/sub&gt; tags. Useful for
+	 * displaying formulae in Swing components or on the web.
 	 * 
 	 *
 	 * @param   formula  The IMolecularFormula object
@@ -320,11 +320,11 @@ public class MolecularFormulaManipulator {
 	}
 
 	/**
-	 * Returns the string representation of the molecule formula with
-	 * numbers wrapped in &lt;sub&gt;&lt;/sub&gt; tags and the isotope
-	 * of each Element in &lt;sup&gt;&lt;/sup&gt; tags and the total
-	 * charge of IMolecularFormula in &lt;sup&gt;&lt;/sup&gt; tags.
-	 * Useful for displaying formulae in Swing components or on the web.
+	 * Returns the string representation of the molecule formula based on Hill
+	 * System with numbers wrapped in &lt;sub&gt;&lt;/sub&gt; tags and the
+	 * isotope of each Element in &lt;sup&gt;&lt;/sup&gt; tags and the total
+	 * charge of IMolecularFormula in &lt;sup&gt;&lt;/sup&gt; tags. Useful for
+	 * displaying formulae in Swing components or on the web.
 	 * 
 	 *
 	 * @param   formula  The IMolecularFormula object
@@ -337,7 +337,11 @@ public class MolecularFormulaManipulator {
 	@TestMethod("testGetHTML_IMolecularFormula_boolean_boolean")
 	public static String getHTML(IMolecularFormula formula, boolean chargeB, boolean isotopeB) {
 		String htmlString = "";
-		String[] orderElements = generateOrderEle();
+		String[] orderElements;
+		if (containsElement(formula, formula.getBuilder().newInstance(IElement.class,"C")))
+			orderElements = generateOrderEle_Hill_WithCarbons();
+		else
+			orderElements = generateOrderEle_Hill_NoCarbons();
 		for (String orderElement : orderElements) {
 			IElement element = formula.getBuilder().newInstance(IElement.class,orderElement);
 			if (containsElement(formula, element)) {

--- a/src/test/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/src/test/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -534,7 +534,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
     	formula.addIsotope(builder.newInstance(IIsotope.class,"Cl"),2);
     	formula.addIsotope(builder.newInstance(IIsotope.class,"O"),2);
     	
-        Assert.assertEquals("C<sub>8</sub>H<sub>10</sub>O<sub>2</sub>Cl<sub>2</sub>", MolecularFormulaManipulator.getHTML(formula));
+        Assert.assertEquals("C<sub>8</sub>H<sub>10</sub>Cl<sub>2</sub>O<sub>2</sub>", MolecularFormulaManipulator.getHTML(formula));
     }
     @Test 
     public void testGetHTML_IMolecularFormula_boolean_boolean() {


### PR DESCRIPTION
Changed the getHTML method to return the elements in the Hill System order (CDK bug #3432131).
