### PR TITLE
Partition extended tetrahedral elements

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
@@ -22,6 +22,7 @@ package org.openscience.cdk.graph;
 import org.openscience.cdk.annotations.TestClass;
 import org.openscience.cdk.annotations.TestMethod;
 import org.openscience.cdk.interfaces.*;
+import org.openscience.cdk.stereo.ExtendedTetrahedral;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -113,8 +114,12 @@ public class ConnectivityChecker
                 IBond bond = ((IDoubleBondStereochemistry) stereo).getStereoBond();
                 if (componentsMap.containsKey(bond.getAtom(0)) && componentsMap.containsKey(bond.getAtom(1)))
                     componentsMap.get(bond.getAtom(0)).addStereoElement(stereo);
+            } else if (stereo instanceof ExtendedTetrahedral) {
+                IAtom atom = ((ExtendedTetrahedral) stereo).focus();
+                if (componentsMap.containsKey(atom))
+                    componentsMap.get(atom).addStereoElement(stereo);
             } else {
-                System.err.println("New stereoelement is not currently paritioned with ConnectivityChecker:" + stereo.getClass());
+                System.err.println("New stereochemistry element is not currently partitioned with ConnectivityChecker:" + stereo.getClass());
             }
         }
         

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/ConnectivityCheckerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/ConnectivityCheckerTest.java
@@ -39,9 +39,14 @@ import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.io.HINReader;
 import org.openscience.cdk.io.ISimpleChemObjectReader;
 import org.openscience.cdk.io.MDLV2000Reader;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.templates.MoleculeFactory;
 import org.openscience.cdk.tools.manipulator.ChemFileManipulator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  *  Checks the functionality of the ConnectivityChecker
@@ -196,6 +201,14 @@ public class ConnectivityCheckerTest extends CDKTestCase {
         IAtomContainer ac = cList.get(0);
 
         Assert.assertTrue("Molecule appears not to be connected", ConnectivityChecker.isConnected(ac));
+    }
+    
+    @Test public void testPartitionExtendedTetrahedral() throws Exception {
+        SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer container = smipar.parseSmiles("CC=[C@]=CC.C");
+        IAtomContainerSet containerSet = ConnectivityChecker.partitionIntoMolecules(container);
+        assertThat(containerSet.getAtomContainerCount(), is(2));
+        assertTrue(containerSet.getAtomContainer(0).stereoElements().iterator().hasNext());
     }
 
     /**


### PR DESCRIPTION
Ensures extended tetrahedral elements are partitioned by the connectivity checker.
