### PR TITLE
Allow SMARTS expressions of the form [h0] and [!h0] analogous to [H0] an...

### DIFF
--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/ImplicitHCountAtom.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/ImplicitHCountAtom.java
@@ -32,28 +32,17 @@ import org.openscience.cdk.interfaces.IChemObjectBuilder;
 public class ImplicitHCountAtom extends SMARTSAtom {
 
     private static final long serialVersionUID = 6752937431492584928L;
+    private final int hcount;
 
     /**
      * Creates a new instance
      *
-     * @param hCount
+     * @param hcount
      */
-    public ImplicitHCountAtom(int hCount, IChemObjectBuilder builder) {
+    public ImplicitHCountAtom(int hcount, IChemObjectBuilder builder) {
         super(builder);
-        this.setImplicitHydrogenCount(hCount);
-    }
-
-    /**
-     * Returns the implicit hydrogen count of an atom
-     *
-     * @param atom an atom
-     * @return obtain the implicit hydrogen count, 0 if null
-     */
-    private int getIMPH(IAtom atom) {
-        if (atom.getImplicitHydrogenCount() == CDKConstants.UNSET)
-            return 0;
-        else
-            return atom.getImplicitHydrogenCount();
+        this.hcount = hcount;
+        this.setImplicitHydrogenCount(hcount);
     }
 
     /*
@@ -64,7 +53,10 @@ public class ImplicitHCountAtom extends SMARTSAtom {
      */
     @Override
     public boolean matches(IAtom atom) {
-        return (getIMPH(atom) != 0 && getIMPH(atom) == getIMPH(this));
+        // h counts should be set before match throw runtime exception?
+        if (atom.getImplicitHydrogenCount() == null)
+            return false;
+        return atom.getImplicitHydrogenCount() == hcount;
     }
 
     /*
@@ -76,7 +68,7 @@ public class ImplicitHCountAtom extends SMARTSAtom {
         StringBuilder s = new StringBuilder();
         s.append("ImplicitHCountAtom(");
         s.append(this.hashCode()).append(", ");
-        s.append("IH:" + getIMPH(this));
+        s.append("IH:" + hcount);
         s.append(')');
         return s.toString();
     }


### PR DESCRIPTION
...d [!H0]. Previously this was not possible to null handling semantics.
