### PR TITLE
Patch/2d atom colors

### DIFF
--- a/display/render/src/main/java/org/openscience/cdk/renderer/color/CDK2DAtomColors.java
+++ b/display/render/src/main/java/org/openscience/cdk/renderer/color/CDK2DAtomColors.java
@@ -27,15 +27,44 @@ import org.openscience.cdk.annotations.TestMethod;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
 
+import static org.openscience.cdk.config.Elements.Aluminium;
+import static org.openscience.cdk.config.Elements.Argon;
+import static org.openscience.cdk.config.Elements.Barium;
+import static org.openscience.cdk.config.Elements.Beryllium;
+import static org.openscience.cdk.config.Elements.Boron;
+import static org.openscience.cdk.config.Elements.Bromine;
+import static org.openscience.cdk.config.Elements.Cadmium;
+import static org.openscience.cdk.config.Elements.Caesium;
+import static org.openscience.cdk.config.Elements.Calcium;
 import static org.openscience.cdk.config.Elements.Carbon;
+import static org.openscience.cdk.config.Elements.Chlorine;
+import static org.openscience.cdk.config.Elements.Fluorine;
+import static org.openscience.cdk.config.Elements.Francium;
+import static org.openscience.cdk.config.Elements.Helium;
 import static org.openscience.cdk.config.Elements.Hydrogen;
+import static org.openscience.cdk.config.Elements.Iodine;
+import static org.openscience.cdk.config.Elements.Iron;
+import static org.openscience.cdk.config.Elements.Krypton;
+import static org.openscience.cdk.config.Elements.Lithium;
+import static org.openscience.cdk.config.Elements.Magnesium;
+import static org.openscience.cdk.config.Elements.Neon;
 import static org.openscience.cdk.config.Elements.Nitrogen;
 import static org.openscience.cdk.config.Elements.Oxygen;
 import static org.openscience.cdk.config.Elements.Phosphorus;
+import static org.openscience.cdk.config.Elements.Potassium;
+import static org.openscience.cdk.config.Elements.Radium;
+import static org.openscience.cdk.config.Elements.Rubidium;
+import static org.openscience.cdk.config.Elements.Silver;
+import static org.openscience.cdk.config.Elements.Sodium;
+import static org.openscience.cdk.config.Elements.Strontium;
 import static org.openscience.cdk.config.Elements.Sulfur;
+import static org.openscience.cdk.config.Elements.Titanium;
+import static org.openscience.cdk.config.Elements.Unknown;
+import static org.openscience.cdk.config.Elements.Xenon;
 
 /**
- * Gives a short table of atom colors for 2D display.
+ * Gives a short table of atom colors for 2D display. The coloring is loosely
+ * based on CPK.
  *
  * The internal color map can be modified by invoking the set method. For convenience the set method
  * returns the colorer instance for chaining.
@@ -47,24 +76,72 @@ import static org.openscience.cdk.config.Elements.Sulfur;
  *
  * @cdk.module render
  * @cdk.githash
+ * @see <a href="http://en.wikipedia.org/wiki/CPK_coloring">CPK coloring</a>
  */
 @TestClass("org.openscience.cdk.renderer.color.CDK2DAtomColorsTest")
 public class CDK2DAtomColors implements IAtomColorer, java.io.Serializable {
 
     private static final long         serialVersionUID = 6712994043820219426L;
 
-    private final static Color        DEFAULT          = Color.black;
+    private final static Color        OFF_BLACK        = new Color(0x333333);
+    private final static Color        SKY_BLUE         = new Color(0x455FFF);
+    private final static Color        PASTEL_RED       = new Color(0xFF4B54);
+    private final static Color        LUMINOUS_GREEN   = new Color(0x44FF54);
+    private final static Color        MAROON           = new Color(0x983534);
+    private final static Color        VIOLET           = new Color(0x983E91);
+    private final static Color        CYAN             = new Color(0x67C2FF);
+    private final static Color        ORANGE           = new Color(0xFFB24A);
+    private final static Color        MUSTARD          = new Color(0xFFDD0B);
+    private final static Color        PEACH            = new Color(0xFFB8A0);
+    private final static Color        FOREST_GREEN     = new Color(0x2A9E3B);
+    private final static Color        SILVER           = new Color(0xC0C0C0);
+    private final static Color        DARK_ORANGE      = new Color(0xFF9A12);
+    private final static Color        PINK             = new Color(0xFF59AE);
 
     // Mapping of atomic numbers colors to their color
     private final Map<Integer, Color> colorMap         = new HashMap<Integer, Color>(100);
 
     public CDK2DAtomColors() {
-        set(Hydrogen, Color.black);
-        set(Carbon, Color.black);
-        set(Nitrogen, Color.blue);
-        set(Oxygen, Color.red);
-        set(Phosphorus, Color.green.darker());
-        set(Sulfur, Color.yellow.darker());
+        // Superatoms/aliases 
+        set(Unknown, OFF_BLACK);
+        // organic
+        set(Hydrogen, OFF_BLACK);
+        set(Carbon, OFF_BLACK);
+        set(Nitrogen, SKY_BLUE);
+        set(Oxygen, PASTEL_RED);
+        set(Phosphorus, ORANGE);
+        set(Sulfur, MUSTARD);
+        set(Boron, PEACH);
+        // halogens
+        set(Fluorine, LUMINOUS_GREEN);
+        set(Chlorine, LUMINOUS_GREEN);
+        set(Bromine, MAROON);
+        set(Iodine, VIOLET);
+        // nobel gases
+        set(Helium, CYAN);
+        set(Neon, CYAN);
+        set(Argon, CYAN);
+        set(Xenon, CYAN);
+        set(Krypton, CYAN);
+        // alkali metals
+        set(Lithium, VIOLET);
+        set(Sodium, VIOLET);
+        set(Potassium, VIOLET);
+        set(Rubidium, VIOLET);
+        set(Caesium, VIOLET);
+        set(Francium, VIOLET);
+        // alkali earth metals
+        set(Beryllium, FOREST_GREEN);
+        set(Magnesium, FOREST_GREEN);
+        set(Calcium, FOREST_GREEN);
+        set(Strontium, FOREST_GREEN);
+        set(Barium, FOREST_GREEN);
+        set(Radium, FOREST_GREEN);
+        // others
+        set(Titanium, SILVER);
+        set(Aluminium, SILVER);
+        set(Silver, SILVER);
+        set(Iron, DARK_ORANGE);
     }
 
     /**
@@ -110,7 +187,7 @@ public class CDK2DAtomColors implements IAtomColorer, java.io.Serializable {
     @TestMethod("testGetAtomColor")
     @Override
     public Color getAtomColor(IAtom atom) {
-        return getAtomColor(atom, DEFAULT);
+        return getAtomColor(atom, PINK);
     }
 
     /**

--- a/display/render/src/test/java/org/openscience/cdk/renderer/color/CDK2DAtomColorsTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/color/CDK2DAtomColorsTest.java
@@ -40,10 +40,10 @@ public class CDK2DAtomColorsTest extends CDKTestCase {
         Assert.assertNotNull(colors);
         IAtom hydrogen = new Atom("H");
         hydrogen.setAtomicNumber(1);
-        Assert.assertEquals(Color.black, colors.getAtomColor(hydrogen));
+        Assert.assertEquals(new Color(51, 51, 51), colors.getAtomColor(hydrogen));
         IAtom helium = new Atom("He");
         helium.setAtomicNumber(2);
-        Assert.assertEquals(Color.black, colors.getAtomColor(helium));
+        Assert.assertEquals(new Color(103, 194, 255), colors.getAtomColor(helium));
     }
 
     @Test
@@ -52,6 +52,6 @@ public class CDK2DAtomColorsTest extends CDKTestCase {
 
         Assert.assertNotNull(colors);
         IAtom imaginary = new Atom("Ix");
-        Assert.assertEquals(Color.ORANGE, colors.getAtomColor(imaginary, Color.ORANGE));
+        Assert.assertEquals(Color.BLACK, colors.getAtomColor(imaginary, Color.BLACK));
     }
 }


### PR DESCRIPTION
ChEBI is starting to use the CDK for depictions. This patch makes it easier to modify the color mapping and extended the default set to more defacto colors (i.e. orange of phosphorus instead of green).
