### PR TITLE
Make sure array index is now called out of range. We only sort by low at...

### DIFF
--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -1234,7 +1234,8 @@ final class StandardBondGenerator {
             // count elements up to Argon (number=18)
             int[] freq = new int[19];
             for (IAtom atom : container.atoms()) {
-                freq[atom.getAtomicNumber()]++;
+                if (atom.getAtomicNumber() >= 0 && atom.getAtomicNumber() < 19)
+                    freq[atom.getAtomicNumber()]++;
             }
             return freq;
         }

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/StandardBondGeneratorTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/StandardBondGeneratorTest.java
@@ -91,6 +91,16 @@ public class StandardBondGeneratorTest {
         assertThat(freq[6], is(6));
     }
 
+
+    @Test
+    public void highAtomicNoElementCount() {
+        IAtomContainer container = TestMoleculeFactory.makeBenzene();
+        container.getAtom(0).setAtomicNumber(34);
+        container.getAtom(0).setSymbol("Se");
+        int[] freq = RingBondOffsetComparator.countLightElements(container);
+        assertThat(freq[6], is(5));
+    }
+
     @Test
     public void adenineElementCount() {
         int[] freq = RingBondOffsetComparator.countLightElements(TestMoleculeFactory.makeAdenine());


### PR DESCRIPTION
...omic number elements to minimise ring double bonds flipping between.
