### PR TITLE
Updated the default value in the unit test

### DIFF
--- a/display/render/src/test/java/org/openscience/cdk/renderer/color/CDK2DAtomColorsTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/color/CDK2DAtomColorsTest.java
@@ -52,6 +52,6 @@ public class CDK2DAtomColorsTest extends CDKTestCase {
 
         Assert.assertNotNull(colors);
         IAtom imaginary = new Atom("Ix");
-        Assert.assertEquals(Color.BLACK, colors.getAtomColor(imaginary, Color.BLACK));
+        Assert.assertEquals(new Color(51, 51, 51), colors.getAtomColor(imaginary, Color.BLACK));
     }
 }


### PR DESCRIPTION
Fixes this regression reported by Jenkins:

Error Message

expected: but was:
Stacktrace

java.lang.AssertionError: expected: but was:
at org.junit.Assert.fail(Assert.java:88)
at org.junit.Assert.failNotEquals(Assert.java:743)
at org.junit.Assert.assertEquals(Assert.java:118)
at org.junit.Assert.assertEquals(Assert.java:144)
at org.openscience.cdk.renderer.color.CDK2DAtomColorsTest.testGetDefaultAtomColor(CDK2DAtomColorsTest.java:55)
