### PR TITLE
Use the hasItems matcher instead of is to match a list, avoiding orderin...

### DIFF
--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/ExhaustiveFragmenterTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/ExhaustiveFragmenterTest.java
@@ -88,7 +88,7 @@ public class ExhaustiveFragmenterTest extends CDKTestCase {
         fragmenter.generateFragments(mol);
         String[] frags = fragmenter.getFragments();
         Assert.assertNotNull(frags);
-        Assert.assertThat(frags, is(new String[]{"c1ccc(cc1)C", "c1ccccc1"}));
+        Assert.assertThat(Arrays.asList(frags), hasItems("c1ccc(cc1)C", "c1ccccc1"));
         Assert.assertNotNull(fragmenter.getFragmentsAsContainers());
         Assert.assertEquals(2, fragmenter.getFragmentsAsContainers().length);
 


### PR DESCRIPTION
...g problems
