### PR TITLE
SMARTS stereo matching requires additional checks to ensure we don't acc...

### DIFF
--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
@@ -132,6 +132,9 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
     private boolean checkTetrahedral(int u, int[] mapping) {
 
         int v = mapping[u];
+        
+        if (targetTypes[v] != null && targetTypes[v] != Type.Tetrahedral)
+            return false;
 
         ITetrahedralChirality queryElement = (ITetrahedralChirality) queryElements[u];
         ITetrahedralChirality targetElement = (ITetrahedralChirality) targetElements[v];
@@ -187,6 +190,11 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
 
         int v1 = mapping[u1];
         int v2 = mapping[u2];
+
+        if (targetTypes[v1] != null && targetTypes[v1] != Type.Geometric)
+            return false;
+        if (targetTypes[v2] != null && targetTypes[v2] != Type.Geometric)
+            return false;
 
         IDoubleBondStereochemistry queryElement = (IDoubleBondStereochemistry) queryElements[u1];
         IBond[] queryBonds = queryElement.getBonds();

--- a/tool/smarts/src/test/java/org/openscience/cdk/smiles/smarts/parser/SMARTSSearchTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smiles/smarts/parser/SMARTSSearchTest.java
@@ -1994,4 +1994,14 @@ public class SMARTSSearchTest extends CDKTestCase {
         assertThat(match("([#8]).([#8])", "OCCO"), is(new int[]{0, 0}));
         assertThat(match("([#8]).([#8])", "O.CCO"), is(new int[]{2, 1}));
     }
+
+    /**
+     * Ensure a class cast exception is not thrown when matching stereochemistry. 
+     * @cdk.bug 1358
+     */
+    @Test
+    public void bug1358() throws Exception {
+        assertThat(match("[$([*@](~*)(~*)(*)*),$([*@H](*)(*)*),$([*@](~*)(*)*)]",
+                         "N#CN/C(=N/CCSCC=1N=CNC1C)NC"), is(new int[]{0, 0}));        
+    }
 }


### PR DESCRIPTION
...identally attempt to compare a tetrahedral centre to a double-bond (was causing a class cast). The typical case is when this occurs is when bond orders are not matched.