### PR TITLE
Fixed several grammar and spelling errors in the Javadocs

### DIFF
--- a/descriptor/qsar/src/main/java/org/openscience/cdk/qsar/DescriptorException.java
+++ b/descriptor/qsar/src/main/java/org/openscience/cdk/qsar/DescriptorException.java
@@ -26,7 +26,7 @@ package org.openscience.cdk.qsar;
 import org.openscience.cdk.exception.CDKException;
 
 /**
- * Exception that is thrown by descriptor routines when a problem has occured.
+ * Exception that is thrown by descriptor routines when a problem has occurred.
  *
  * @cdk.module qsar
  * @cdk.githash

--- a/descriptor/qsar/src/main/java/org/openscience/cdk/qsar/IDescriptor.java
+++ b/descriptor/qsar/src/main/java/org/openscience/cdk/qsar/IDescriptor.java
@@ -163,7 +163,7 @@ public interface IDescriptor {
      * <p/>
      * In many cases, these names can be as simple as X1, X2, ..., XN where X is a prefix
      * and 1, 2, ..., N are the indices. On the other hand it is also possible to return
-     * other arbitrary names, which should be documented in the Javadocs for the decsriptor
+     * other arbitrary names, which should be documented in the Javadocs for the descriptor
      * (e.g., the CPSA descriptor).
      * <p/>
      * Note that by default if a descriptor returns a single value

--- a/descriptor/qsar/src/main/java/org/openscience/cdk/tools/AtomicProperties.java
+++ b/descriptor/qsar/src/main/java/org/openscience/cdk/tools/AtomicProperties.java
@@ -29,7 +29,7 @@ import java.util.Map;
 /**
  * Provides atomic property values for descriptor calculations.
  *
- * This class currently provides values for mass, Vanderwaals volume, electronegativity and
+ * This class currently provides values for mass, van der Waals volume, electronegativity and
  * polarizability.
  *
  * @author     Todd Martin

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/CovalentRadiusDescriptor.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/CovalentRadiusDescriptor.java
@@ -34,7 +34,7 @@ import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
 /**
- *  This class return the covalent radius of a given atom.
+ *  This class returns the covalent radius of a given atom.
  *
  * <p>This descriptor uses these parameters:
  * <table border="1">
@@ -65,7 +65,7 @@ public class CovalentRadiusDescriptor extends AbstractAtomicDescriptor implement
     /**
      *  Constructor for the CovalentRadiusDescriptor object.
      *
-     *  @throws IOException if an error ocurrs when reading atom type information
+     *  @throws IOException if an error occurs when reading atom type information
      *  @throws ClassNotFoundException if an error occurs during tom typing
      */
     public CovalentRadiusDescriptor() throws IOException, ClassNotFoundException {}
@@ -115,7 +115,7 @@ public class CovalentRadiusDescriptor extends AbstractAtomicDescriptor implement
     }
 
     /**
-     *  This method calculate the Covalent radius of an atom.
+     *  This method calculates the Covalent radius of an atom.
      *
      *@param  atom              The IAtom for which the DescriptorValue is requested
      *@param  container         The {@link IAtomContainer} for which the descriptor is to be calculated

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/DistanceToAtomDescriptor.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/DistanceToAtomDescriptor.java
@@ -137,7 +137,7 @@ public class DistanceToAtomDescriptor extends AbstractAtomicDescriptor implement
     }
 
     /**
-     * generic method for calculation of distance btw 2 atoms
+     * generic method for calculation of distance between 2 atoms
      *
      * @param atom1 The IAtom 1
      * @param atom2 The IAtom 2

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/EffectiveAtomPolarizabilityDescriptor.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/EffectiveAtomPolarizabilityDescriptor.java
@@ -32,7 +32,7 @@ import org.openscience.cdk.qsar.IAtomicDescriptor;
 import org.openscience.cdk.qsar.result.DoubleResult;
 
 /**
- * Effective polarizability of an heavy atom
+ * Effective polarizability of a heavy atom
  *
  * <p>This descriptor uses these parameters:
  * <table border="1">
@@ -109,7 +109,7 @@ public class EffectiveAtomPolarizabilityDescriptor extends AbstractAtomicDescrip
      *
      *@param  atom              The IAtom for which the DescriptorValue is requested
      *@param  ac                AtomContainer
-     *@return                   return the efective polarizability
+     *@return                   return the effective polarizability
      */
     @Override
     public DescriptorValue calculate(IAtom atom, IAtomContainer ac) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/IPAtomicHOSEDescriptor.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/IPAtomicHOSEDescriptor.java
@@ -41,7 +41,7 @@ import org.openscience.cdk.tools.LonePairElectronChecker;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 /**
- *  This class returns the ionization potential of an atom containg lone
+ *  This class returns the ionization potential of an atom containing lone
  *  pair electrons. It is
  *  based on a decision tree which is extracted from Weka(J48) from
  *  experimental values. Up to now is only possible predict for

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/geometry/surface/NumericalSurface.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/geometry/surface/NumericalSurface.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 /**
- * A class representing the solvent acessible surface area surface of a molecule.
+ * A class representing the solvent accessible surface area surface of a molecule.
  *
  * <p>This class is based on the Python implementation of the DCLM method
  * ({@cdk.cite EIS95}) by Peter McCluskey, which is a non-analytical method to generate a set of points
@@ -86,7 +86,7 @@ public class NumericalSurface {
      * @param atomContainer The {@link IAtomContainer} for which the surface is to be calculated
      * @param solventRadius The radius of a solvent molecule that is used to extend
      * the radius of each atom. Setting to 0 gives the Van der Waals surface
-     * @param tesslevel The number of levels that the subdivision algorithm for tessllation
+     * @param tesslevel The number of levels that the subdivision algorithm for tessellation
      * should use
      */
     public NumericalSurface(IAtomContainer atomContainer, double solventRadius, int tesslevel) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/geometry/surface/Tessellate.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/geometry/surface/Tessellate.java
@@ -28,9 +28,9 @@ import javax.vecmath.Point3d;
  * This class generates the coordinates of the triangles that will
  * tessellate the unit sphere. The algorithm is recursive subdivision
  * of an initial representation which can be tetrahedral, octahedral or
- * icoshedral. The default is icosahedral. The number of points generated
+ * icosahedral. The default is icosahedral. The number of points generated
  * depends on the level of subdivision. The default is 4 levels and with the
- * initial icoshedral representation this gives 1536 points.
+ * initial icosahedral representation this gives 1536 points.
  * <p>
  * The constants for the tetrahedral and icosahedral representations were
  * taken from http://eeg.sourceforge.net/eegdoc/eeg_toolbox/sphere_tri.html

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/atompair/PiContactDetectionDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/atompair/PiContactDetectionDescriptor.java
@@ -37,7 +37,7 @@ import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 /**
  * This class checks if two atoms have pi-contact (this is true when there is
  * one and the same conjugated pi-system which contains both atoms, or directly
- * linked neighboors of the atoms).
+ * linked neighbours of the atoms).
  *
  * <p>This descriptor uses these parameters:
  * <table border="1">
@@ -195,7 +195,7 @@ public class PiContactDetectionDescriptor extends AbstractAtomPairDescriptor imp
     }
 
     /**
-     * Gets if neighboors of an atom are in an atom container.
+     * Gets if neighbours of an atom are in an atom container.
      *
      * @param  neighs  array of atoms
      * @param  ac      AtomContainer


### PR DESCRIPTION
I fixed a number of grammar and spelling errors in the Javadocs for QSAR.