### PR TITLE
Java 1.6 does not appear to be supported anymore: update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ CDK library.
 
 ## Compiling
 
-Compiling the library is performed with Apache Maven and requires Java 1.6.0 or later:
+Compiling the library is performed with Apache Maven and requires Java 1.7 or later:
 
 ```bash
 cdk/$ ls pom.xml


### PR DESCRIPTION
Is this true? I edited the pom.xml to compile for 1.6, but got errors like "multi-catch statement is not supported in -source 1.6".