### PR TITLE
SMARTS matching for smallest ring size atom defaults to any ring atom.

### DIFF
--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/SmallestRingAtom.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/SmallestRingAtom.java
@@ -57,6 +57,7 @@ public final class SmallestRingAtom extends SMARTSAtom {
     /** @inheritDoc */
     @Override
     public boolean matches(IAtom atom) {
-        return invariants(atom).ringSize().contains(ringSize);
+        return ringSize < 0 ? invariants(atom).ringConnectivity() > 0
+                            : invariants(atom).ringSize().contains(ringSize);
     }
 }

--- a/tool/smarts/src/main/jjtree/org/openscience/cdk/smiles/smarts/parser/SMARTSParser.jjt
+++ b/tool/smarts/src/main/jjtree/org/openscience/cdk/smiles/smarts/parser/SMARTSParser.jjt
@@ -728,7 +728,7 @@ void RingMembership() #RingMembership :
 void SmallestRingSize() #SmallestRingSize : 
 { StringBuffer digits = new StringBuffer(); }
 {
-    <r> { jjtThis.setSize(1); } 
+    <r> { jjtThis.setSize(-1); }
     [ ( <DIGIT> { digits.append(token.image); } )+ 
     { jjtThis.setSize( Integer.parseInt(digits.toString()) ); } ]
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smiles/smarts/parser/SMARTSSearchTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smiles/smarts/parser/SMARTSSearchTest.java
@@ -2004,4 +2004,18 @@ public class SMARTSSearchTest extends CDKTestCase {
         assertThat(match("[$([*@](~*)(~*)(*)*),$([*@H](*)(*)*),$([*@](~*)(*)*)]",
                          "N#CN/C(=N/CCSCC=1N=CNC1C)NC"), is(new int[]{0, 0}));        
     }
+
+    /**
+     * Ensure 'r' without a size is equivalent to !R0 and R.
+     * @cdk.bug 1364
+     */
+    @Test
+    public void bug1364() throws Exception {
+        assertThat(match("[!R0!R1]", "C[C@]12CC3CC([NH2+]CC(=O)NCC4CC4)(C1)C[C@@](C)(C3)C2"),
+                   is(new int[]{7, 7}));
+        assertThat(match("[R!R1]", "C[C@]12CC3CC([NH2+]CC(=O)NCC4CC4)(C1)C[C@@](C)(C3)C2"),
+                   is(new int[]{7, 7}));
+        assertThat(match("[r!R1]", "C[C@]12CC3CC([NH2+]CC(=O)NCC4CC4)(C1)C[C@@](C)(C3)C2"),
+                   is(new int[]{7, 7}));
+    }
 }


### PR DESCRIPTION
Fixes [#1364](http://sourceforge.net/p/cdk/bugs/1364/)