### PR TITLE
Detect correct molfile format in IteratingSDFReader.

### DIFF
--- a/storage/io/src/main/java/org/openscience/cdk/io/iterator/IteratingSDFReader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/iterator/IteratingSDFReader.java
@@ -232,7 +232,7 @@ public class IteratingSDFReader extends DefaultIteratingChemObjectReader<IAtomCo
                 // do MDL molfile version checking
                 Matcher versionMatcher = MDL_VERSION.matcher(currentLine);
                 if (versionMatcher.find()) {
-                    currentFormat = versionMatcher.group(1) != null ? (IChemFormat) MDLV2000Format.getInstance()
+                    currentFormat = "2000".equals(versionMatcher.group(1)) ? (IChemFormat) MDLV2000Format.getInstance()
                             : (IChemFormat) MDLV3000Format.getInstance();
                 }
 

--- a/storage/io/src/test/java/org/openscience/cdk/io/iterator/IteratingSDFReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/iterator/IteratingSDFReaderTest.java
@@ -315,4 +315,27 @@ public class IteratingSDFReaderTest extends CDKTestCase {
 
     }
 
+    @Test
+    public void testV3000MolfileFormat() throws IOException, CDKException {
+
+        String path = "data/mdl/molV3000.mol";
+        InputStream in = getClass().getClassLoader().getResourceAsStream(path);
+        IChemObjectBuilder builder = DefaultChemObjectBuilder.getInstance();
+        IteratingSDFReader reader = new IteratingSDFReader(in, builder);
+
+        reader.setSkip(true); // skip over null entries and keep reading until EOF
+
+        int count = 0;
+
+        while (reader.hasNext()) {
+            IAtomContainer molecule = reader.next();
+            count++;
+        }
+
+        reader.close();
+
+        Assert.assertEquals(1, count);
+
+    }
+
 }


### PR DESCRIPTION
The documentation for IteratingSDFReader says it will read both V2000 and V3000 Molfiles, but it appeared broken. 