### PR TITLE
Ignore PMD warnings/errors in the SMSD section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,9 @@
                     <rulesets>
                         <ruleset>/pmd/custom.xml</ruleset>
                     </rulesets>
+                    <excludes>
+                        <exclude>**/smsd/*.java</exclude>
+                    </excludes>
                     <excludeRoots>
                         <excludeRoot>${basedir}/target/generated-sources/javacc</excludeRoot>
                     </excludeRoots>


### PR DESCRIPTION
John, I was working my way through PMD warnings (see another branch, PR pending), but got tired of reading issues in the SMSD code which is outdated.

Why not ignore the cdk.smsd package in the PMD tests?