### PR TITLE
Small fix for adjusting double bonds to be flush with extreme angles …

### DIFF
--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -804,6 +804,7 @@ final class StandardBondGenerator {
         final Vector2d perpendicular1 = newPerpendicularVector(unit);
         final Vector2d perpendicular2 = negate(perpendicular1);
 
+        final double halfBondLength = atom1BackOffPoint.distance(atom2BackOffPoint) / 2;
         final double halfSeparation = separation / 2;
 
         ElementGroup group = new ElementGroup();
@@ -821,6 +822,10 @@ final class StandardBondGenerator {
             double line1Adjust = adjacentLength(nearest1, perpendicular1, halfSeparation);
             double line2Adjust = adjacentLength(nearest2, perpendicular2, halfSeparation);
 
+            // don't adjust beyond half the bond length
+            if (line1Adjust > halfBondLength) line1Adjust = 0;
+            if (line2Adjust > halfBondLength) line2Adjust = 0;
+
             // corner case when the adjacent bonds are acute to the double bond,
             if (nearest1.dot(unit) > 0) line1Adjust = -line1Adjust;
             if (nearest2.dot(unit) > 0) line2Adjust = -line2Adjust;
@@ -836,6 +841,10 @@ final class StandardBondGenerator {
 
             double line1Adjust = adjacentLength(nearest1, perpendicular1, halfSeparation);
             double line2Adjust = adjacentLength(nearest2, perpendicular2, halfSeparation);
+
+            // don't adjust beyond half the bond length
+            if (line1Adjust > halfBondLength) line1Adjust = 0;
+            if (line2Adjust > halfBondLength) line2Adjust = 0;
 
             // corner case when the adjacent bonds are acute to the double bond
             if (nearest1.dot(unit) < 0) line1Adjust = -line1Adjust;


### PR DESCRIPTION
…- we don't adust more than half the bond length.

Small problem I noticed when testing the Sgroup rendering.