### PR TITLE
Patch/faster sdg tests

### DIFF
--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
@@ -758,8 +758,10 @@ public class StructureDiagramGeneratorTest extends CDKTestCase {
         IAtomContainer mol = sp.parseSmiles(smiles);
 
         StructureDiagramGenerator sdg = new StructureDiagramGenerator();
-        sdg.setMolecule(mol);
-        sdg.generateCoordinates(new Vector2d(0, 1));
+        sdg.setUseIdentityTemplates(true);
+        sdg.setUseTemplates(false);
+        sdg.setMolecule(mol, false);
+        sdg.generateCoordinates();
         mol = sdg.getMolecule();
 
         int invalidCoordCount = 0;


### PR DESCRIPTION
One of the fails on jenkins is a timeout - we can fix this by using better options for the SDG and reusing the same instance when possible.