### PR TITLE
Feature/update template handler

### DIFF
--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
@@ -433,6 +433,40 @@ public final class Mappings implements Iterable<int[]> {
     }
 
     /**
+     * Obtain the mapped substructures (atoms/bonds) of the target compound. The atoms
+     * and bonds are the same as in the target molecule but there may be less of them.
+     *
+     * <blockquote><pre>
+     * IAtomContainer query, target
+     * Mappings mappings = ...;
+     * for (IAtomContainer mol : mol.toSubstructures()) {
+     *    for (IAtom atom : mol.atoms())
+     *      target.contains(atom); // always true
+     *    for (IAtom atom : target.atoms())
+     *      mol.contains(atom): // not always true
+     * }
+     * </pre></blockquote>
+     *
+     * @return lazy iterable of molecules
+     */
+    public Iterable<IAtomContainer> toSubstructures() {
+        return FluentIterable.from(map(new ToAtomBondMap(query, target)))
+                             .transform(new Function<Map<IChemObject, IChemObject>, IAtomContainer>() {
+                                 @Override
+                                 public IAtomContainer apply(Map<IChemObject, IChemObject> map) {
+                                     final IAtomContainer submol = target.getBuilder()
+                                                                         .newInstance(IAtomContainer.class,
+                                                                                      query.getAtomCount(), target.getBondCount(), 0, 0);
+                                     for (IAtom atom : query.atoms())
+                                         submol.addAtom((IAtom)map.get(atom));
+                                     for (IBond bond : query.bonds())
+                                         submol.addBond((IBond)map.get(bond));
+                                     return submol;
+                                 }
+                             });
+    }
+
+    /**
      * Efficiently determine if there are at least 'n' matches
      *
      * <blockquote><pre>

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -775,6 +775,10 @@ final class StandardBondGenerator {
             if (closest.dot(perpendicular) < 0) atom2Offset = -atom2Offset;
         }
 
+        final double halfBondLength = atom1Point.distance(atom2BackOffPoint) / 2;
+        if (Math.abs(atom1Offset) > halfBondLength) atom1Offset = 0;
+        if (Math.abs(atom2Offset) > halfBondLength) atom2Offset = 0;
+
         final ElementGroup group = new ElementGroup();
 
         group.add(newLineElement(atom1Point, atom2BackOffPoint));

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -99,7 +99,7 @@ public class StructureDiagramGenerator {
     private List<IRingSet>          ringSystems              = null;
     private final String            disconnectedMessage      = "Molecule not connected. Use ConnectivityChecker.partitionIntoMolecules() and do the layout for every single component.";
     private TemplateHandler         templateHandler          = null;
-    private boolean                 useTemplates             = true;
+    private boolean                 useTemplates             = false;
     private boolean                 useIdentTemplates        = true;
     
     /** Atoms of the molecule that mapped a template */

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -88,10 +88,11 @@ import org.openscience.cdk.tools.manipulator.RingSetManipulator;
 public class StructureDiagramGenerator {
 
     private static ILoggingTool logger = LoggingToolFactory.createLoggingTool(StructureDiagramGenerator.class);
+    public static final double DEFAULT_BOND_LENGTH = 1.5;
     
     private IAtomContainer          molecule;
     private IRingSet                sssr;
-    private double                  bondLength               = 1.5;
+    private double                  bondLength               = DEFAULT_BOND_LENGTH;
     private Vector2d                firstBondVector;
     private RingPlacer              ringPlacer               = new RingPlacer();
     private AtomPlacer              atomPlacer               = new AtomPlacer();

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/TemplateHandler.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/TemplateHandler.java
@@ -155,6 +155,13 @@ public final class TemplateHandler {
      * @param molecule The molecule to be added to the TemplateHandler
      */
     public void addMolecule(IAtomContainer molecule) {
+        if (!GeometryUtil.has2DCoordinates(molecule))
+            throw new IllegalArgumentException("Template did not have 2D coordinates");
+
+        // we want a consistent scale!
+        GeometryUtil.scaleMolecule(molecule, GeometryUtil.getScaleFactor(molecule,
+                                                                         StructureDiagramGenerator.DEFAULT_BOND_LENGTH));
+
         templates.add(molecule);
         anonPatterns.add(VentoFoggia.findSubstructure(molecule,
                                                       anonAtomMatcher,
@@ -308,8 +315,6 @@ public final class TemplateHandler {
         try {
             TemplateHandler handler = new TemplateHandler();
             IAtomContainer copy = template.clone();
-            if (!GeometryUtil.has2DCoordinates(copy))
-                throw new IllegalArgumentException("Template did not have 2D coordinates");
             handler.addMolecule(copy);
             return handler;
         } catch (CloneNotSupportedException e) {

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/TemplateHandler.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/TemplateHandler.java
@@ -92,10 +92,16 @@ public final class TemplateHandler {
     };
 
     /**
-     * Creates a new TemplateHandler.
+     * Creates a new TemplateHandler with default templates loaded.
      */
     public TemplateHandler(IChemObjectBuilder builder) {
         loadTemplates(builder);
+    }
+
+    /**
+     * Creates a new TemplateHandler without any default templates.
+     */
+    public TemplateHandler() {
     }
 
     /**

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingsTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingsTest.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -227,6 +228,30 @@ public class MappingsTest {
         assertThat(m2.get(query.getAtom(2)), is((IChemObject)target.getAtom(0)));
         assertThat(m2.get(query.getBond(0)), is((IChemObject)target.getBond(1)));
         assertThat(m2.get(query.getBond(1)), is((IChemObject)target.getBond(0)));
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void toSubstructures() throws Exception {
+        IAtomContainer query  = smi("O1CC1");
+        IAtomContainer target = smi("C1OC1CCC");
+
+        Iterable<IAtomContainer> iterable = Pattern.findSubstructure(query)
+                                                   .matchAll(target)
+                                                   .uniqueAtoms()
+                                                   .toSubstructures();
+        Iterator<IAtomContainer> iterator = iterable.iterator();
+
+        assertTrue(iterator.hasNext());
+        IAtomContainer submol = iterator.next();
+        assertThat(submol, is(not(query)));
+        // note that indices are mapped from query to target
+        assertThat(submol.getAtom(0), is(target.getAtom(1))); // oxygen
+        assertThat(submol.getAtom(1), is(target.getAtom(0))); // C
+        assertThat(submol.getAtom(2), is(target.getAtom(2))); // C
+        assertThat(submol.getBond(0), is(target.getBond(0))); // C-O bond
+        assertThat(submol.getBond(1), is(target.getBond(2))); // O-C bond
+        assertThat(submol.getBond(2), is(target.getBond(1))); // C-C bond
         assertFalse(iterator.hasNext());
     }
 


### PR DESCRIPTION
I suspected this the other month when trying to handle Rich A's example of the fullerene with a custom template. The TemplateHandler used for 2d substructure templates has been out of action for a while. This patch updates it to newer graph (sub)isomorphism APIs and adds some utils for aligning to a reference.

The primary use case I wanted was to align depictions to a common (sub)structure:

![image](https://cloud.githubusercontent.com/assets/983232/10349139/e58a5b88-6d34-11e5-9f8c-f30926e83399.png)

It turns out you get some odd layouts now it's fixed, the default library has 5 templates, the forth one (a macrocycle) hit one of my tests and threw up something unexpected:

![image](https://cloud.githubusercontent.com/assets/983232/10349148/ef032816-6d34-11e5-95bc-05be8f71b308.png)

For now I've disabled the templates by default due to this. One way to have the best of both would be to have two sets of substructure templates, ring systems / general. We only match the ring templates if there are no bridges. Open to other suggestions.