### PR TITLE
Deprecate MoleculeFactory and replace all test usage with TestMolecul…

### DIFF
--- a/base/reaction/pom.xml
+++ b/base/reaction/pom.xml
@@ -83,6 +83,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-testdata</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>

--- a/base/reaction/src/test/java/org/openscience/cdk/tools/StructureResonanceGeneratorTest.java
+++ b/base/reaction/src/test/java/org/openscience/cdk/tools/StructureResonanceGeneratorTest.java
@@ -46,7 +46,7 @@ import org.openscience.cdk.reaction.type.SharingLonePairReaction;
 import org.openscience.cdk.reaction.type.parameters.IParameterReact;
 import org.openscience.cdk.reaction.type.parameters.SetReactionCenter;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 import java.util.ArrayList;
@@ -1116,7 +1116,7 @@ public class StructureResonanceGeneratorTest extends CDKTestCase {
     @Test
     public void testCyclobutadiene() throws Exception {
         // anti-aromatic
-        IAtomContainer molecule = MoleculeFactory.makeCyclobutadiene();
+        IAtomContainer molecule = TestMoleculeFactory.makeCyclobutadiene();
         addExplicitHydrogens(molecule);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         lpcheck.saturate(molecule);
@@ -1135,7 +1135,7 @@ public class StructureResonanceGeneratorTest extends CDKTestCase {
      */
     @Test
     public void testBenzene() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeBenzene();
+        IAtomContainer molecule = TestMoleculeFactory.makeBenzene();
         addExplicitHydrogens(molecule);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         lpcheck.saturate(molecule);

--- a/base/test-atomtype/pom.xml
+++ b/base/test-atomtype/pom.xml
@@ -88,6 +88,13 @@
             <type>test-jar</type>
             <scope>test</scope>            
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/base/test-atomtype/src/test/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcherTest.java
+++ b/base/test-atomtype/src/test/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcherTest.java
@@ -40,7 +40,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.io.Mol2Reader;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomTypeManipulator;
 
 /**
@@ -82,7 +82,7 @@ public class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
     public void testFindMatchingAtomType_IAtomContainer_IAtom() throws Exception {
         IAtomTypeMatcher matcher = SybylAtomTypeMatcher.getInstance(SilentChemObjectBuilder.getInstance());
         Assert.assertNotNull(matcher);
-        IAtomContainer ethane = MoleculeFactory.makeAlkane(2);
+        IAtomContainer ethane = TestMoleculeFactory.makeAlkane(2);
         String[] expectedTypes = {"C.3", "C.3"};
         assertAtomTypes(testedAtomTypes, expectedTypes, ethane);
     }
@@ -128,7 +128,7 @@ public class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
      */
     @Test
     public void testBenzene() throws Exception {
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         // test if the perceived atom types match that
         SybylAtomTypeMatcher matcher = SybylAtomTypeMatcher.getInstance(benzene.getBuilder());
@@ -140,7 +140,7 @@ public class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     public void testAdenine() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeAdenine();
+        IAtomContainer mol = TestMoleculeFactory.makeAdenine();
         String[] expectedTypes = {"C.ar", "C.ar", "C.ar", "N.ar", "N.ar", "N.ar", "N.ar", "N.3", "C.ar", "C.ar"};
         SybylAtomTypeMatcher matcher = SybylAtomTypeMatcher.getInstance(mol.getBuilder());
         IAtomType[] types = matcher.findMatchingAtomTypes(mol);
@@ -154,7 +154,7 @@ public class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
      */
     @Test
     public void testBenzene_AtomContainer() throws Exception {
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         // test if the perceived atom types match that
         SybylAtomTypeMatcher matcher = SybylAtomTypeMatcher.getInstance(benzene.getBuilder());
@@ -752,7 +752,7 @@ public class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     public void testAniline() throws Exception {
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
         IAtom nitrogen = benzene.getBuilder().newInstance(IAtom.class, "N");
         benzene.addAtom(nitrogen);
         benzene.addBond(benzene.getBuilder().newInstance(IBond.class, benzene.getAtom(0), nitrogen, IBond.Order.SINGLE));

--- a/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
@@ -47,7 +47,7 @@ import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.silent.AtomType;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.AtomTypeManipulator;
 import org.openscience.cdk.tools.periodictable.PeriodicTable;
@@ -491,14 +491,14 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     public void testPiperidine() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makePiperidine();
+        IAtomContainer molecule = TestMoleculeFactory.makePiperidine();
         String[] expectedTypes = {"N.sp3", "C.sp3", "C.sp3", "C.sp3", "C.sp3", "C.sp3", "H"};
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testTetrahydropyran() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeTetrahydropyran();
+        IAtomContainer molecule = TestMoleculeFactory.makeTetrahydropyran();
         String[] expectedTypes = {"O.sp3", "C.sp3", "C.sp3", "C.sp3", "C.sp3", "C.sp3"};
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
@@ -779,7 +779,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     public void testAdenine() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeAdenine();
+        IAtomContainer mol = TestMoleculeFactory.makeAdenine();
         String[] expectedTypes = {"C.sp2", "C.sp2", "C.sp2", "N.sp2", "N.sp2", "N.planar3", "N.sp2", "N.sp3", "C.sp2",
                 "C.sp2"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
@@ -2141,7 +2141,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     public void testAzulene() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeAzulene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAzulene();
         String[] expectedTypes = new String[]{"C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2",
                 "C.sp2", "C.sp2"};
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
@@ -2150,7 +2150,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testIndole() throws Exception {
         String[] expectedTypes = {"C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "N.planar3"};
-        IAtomContainer molecule = MoleculeFactory.makeIndole();
+        IAtomContainer molecule = TestMoleculeFactory.makeIndole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
@@ -2160,7 +2160,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testno937() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.planar3", "C.sp2", "N.sp2", "C.sp2", "C.sp3"};
-        IAtomContainer molecule = MoleculeFactory.makePyrrole();
+        IAtomContainer molecule = TestMoleculeFactory.makePyrrole();
         molecule.getAtom(3).setSymbol("N");
         molecule.addAtom(molecule.getBuilder().newInstance(IAtom.class, "C"));
         molecule.addBond(1, 5, IBond.Order.SINGLE);
@@ -2199,14 +2199,14 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testPyrrole() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.planar3", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyrrole();
+        IAtomContainer molecule = TestMoleculeFactory.makePyrrole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testPyrrole_SingleOrDouble() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.planar3", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyrrole();
+        IAtomContainer molecule = TestMoleculeFactory.makePyrrole();
         for (IBond bond : molecule.bonds()) {
             bond.setOrder(IBond.Order.UNSET);
             bond.setFlag(CDKConstants.SINGLE_OR_DOUBLE, true);
@@ -2220,56 +2220,56 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testPyrroleAnion() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.minus.planar3", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyrroleAnion();
+        IAtomContainer molecule = TestMoleculeFactory.makePyrroleAnion();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testImidazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.planar3", "C.sp2", "N.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeImidazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeImidazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testPyrazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.planar3", "N.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyrazole();
+        IAtomContainer molecule = TestMoleculeFactory.makePyrazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void test124Triazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.planar3", "N.sp2", "C.sp2", "N.sp2"};
-        IAtomContainer molecule = MoleculeFactory.make124Triazole();
+        IAtomContainer molecule = TestMoleculeFactory.make124Triazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void test123Triazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.planar3", "N.sp2", "N.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.make123Triazole();
+        IAtomContainer molecule = TestMoleculeFactory.make123Triazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testTetrazole() throws Exception {
         String[] expectedTypes = {"N.sp2", "N.planar3", "N.sp2", "N.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeTetrazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeTetrazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testOxazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "O.planar3", "C.sp2", "N.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeOxazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeOxazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testIsoxazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "O.planar3", "N.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeIsoxazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeIsoxazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
@@ -2278,35 +2278,35 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testIsothiazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "S.planar3", "N.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeIsothiazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeIsothiazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testThiadiazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "S.planar3", "C.sp2", "N.sp2", "N.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeThiadiazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeThiadiazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testOxadiazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "O.planar3", "C.sp2", "N.sp2", "N.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeOxadiazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeOxadiazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testPyridine() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyridine();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridine();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testPyridine_SingleOrDouble() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyridine();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridine();
         for (IBond bond : molecule.bonds()) {
             bond.setOrder(IBond.Order.UNSET);
             bond.setFlag(CDKConstants.SINGLE_OR_DOUBLE, true);
@@ -2376,7 +2376,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testChargedSulphurSpecies() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.sp2", "C.sp2", "C.sp2", "S.plus", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyridine();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridine();
         molecule.getAtom(4).setSymbol("S");
         molecule.getAtom(4).setFormalCharge(+1);
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
@@ -2385,7 +2385,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testPyridineOxide_Charged() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.plus.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "O.minus"};
-        IAtomContainer molecule = MoleculeFactory.makePyridineOxide();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridineOxide();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
@@ -2445,7 +2445,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testPyridineOxideCharged_SP2() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.plus.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "O.minus"};
-        IAtomContainer molecule = MoleculeFactory.makePyridineOxide();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridineOxide();
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext())
             bonds.next().setOrder(Order.SINGLE);
@@ -2458,28 +2458,28 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testPyrimidine() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.sp2", "C.sp2", "N.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyrimidine();
+        IAtomContainer molecule = TestMoleculeFactory.makePyrimidine();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testPyridazine() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.sp2", "N.sp2", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makePyridazine();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridazine();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testTriazine() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.sp2", "C.sp2", "N.sp2", "C.sp2", "N.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeTriazine();
+        IAtomContainer molecule = TestMoleculeFactory.makeTriazine();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
     @Test
     public void testThiazole() throws Exception {
         String[] expectedTypes = {"C.sp2", "N.sp2", "C.sp2", "S.planar3", "C.sp2"};
-        IAtomContainer molecule = MoleculeFactory.makeThiazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeThiazole();
         assertAtomTypes(testedAtomTypes, expectedTypes, molecule);
     }
 
@@ -3414,7 +3414,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     public void testIodosobenzene() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeBenzene();
+        IAtomContainer mol = TestMoleculeFactory.makeBenzene();
         IAtom iodine = mol.getBuilder().newInstance(IAtom.class, "I");
         IAtom oxygen = mol.getBuilder().newInstance(IAtom.class, "O");
         mol.addAtom(iodine);
@@ -3431,7 +3431,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     public void testIodoxybenzene() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeBenzene();
+        IAtomContainer mol = TestMoleculeFactory.makeBenzene();
         IAtom iodine = mol.getBuilder().newInstance(IAtom.class, "I");
         IAtom oxygen1 = mol.getBuilder().newInstance(IAtom.class, "O");
         IAtom oxygen2 = mol.getBuilder().newInstance(IAtom.class, "O");
@@ -3451,7 +3451,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     public void testThiobenzamideSOxide() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeBenzene();
+        IAtomContainer mol = TestMoleculeFactory.makeBenzene();
         IAtom carbon = mol.getBuilder().newInstance(IAtom.class, "C");
         IAtom sulphur = mol.getBuilder().newInstance(IAtom.class, "S");
         IAtom oxygen = mol.getBuilder().newInstance(IAtom.class, "O");

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/AllPairsShortestPathsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/AllPairsShortestPathsTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.AtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -69,7 +69,7 @@ public class AllPairsShortestPathsTest {
     @Test
     public void testFrom_Atom_Benzene() throws Exception {
 
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
         AllPairsShortestPaths asp = new AllPairsShortestPaths(benzene);
 
         IAtom c1 = benzene.getAtom(0);
@@ -121,7 +121,7 @@ public class AllPairsShortestPathsTest {
     @Test
     public void testFrom_Int_Benzene() throws Exception {
 
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
         AllPairsShortestPaths asp = new AllPairsShortestPaths(benzene);
 
         //    1 - 2

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/PathToolsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/PathToolsTest.java
@@ -40,7 +40,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * @cdk.module test-core
@@ -52,7 +52,7 @@ public class PathToolsTest extends CDKTestCase {
 
     @BeforeClass
     public static void setUp() {
-        molecule = MoleculeFactory.makeAlphaPinene();
+        molecule = TestMoleculeFactory.makeAlphaPinene();
         sp = new SmilesParser(DefaultChemObjectBuilder.getInstance());
     }
 

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/ShortestPathsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/ShortestPathsTest.java
@@ -32,7 +32,7 @@ import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -68,7 +68,7 @@ public class ShortestPathsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_Container_MissingAtom() {
-        new ShortestPaths(MoleculeFactory.makeBenzene(), new Atom());
+        new ShortestPaths(TestMoleculeFactory.makeBenzene(), new Atom());
     }
 
     @Test
@@ -106,7 +106,7 @@ public class ShortestPathsTest {
     @Test
     public void testPathTo_Atom_Benzene() {
 
-        IAtomContainer simple = MoleculeFactory.makeBenzene();
+        IAtomContainer simple = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(simple, simple.getAtom(0));
 
@@ -121,7 +121,7 @@ public class ShortestPathsTest {
     @Test
     public void testPathTo_Int_Benzene() {
 
-        IAtomContainer simple = MoleculeFactory.makeBenzene();
+        IAtomContainer simple = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(simple, simple.getAtom(0));
 
@@ -131,7 +131,7 @@ public class ShortestPathsTest {
 
     @Test
     public void testIsPrecedingPathTo() {
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
         int[][] graph = GraphUtil.toAdjList(benzene);
         int[] order = new int[]{0, 1, 2, 3, 4, 5};
         ShortestPaths paths = new ShortestPaths(graph, benzene, 0, order);
@@ -165,7 +165,7 @@ public class ShortestPathsTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testIsPrecedingPathTo_OutOfBounds() {
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
         ShortestPaths paths = new ShortestPaths(benzene, benzene.getAtom(0));
         assertFalse(paths.isPrecedingPathTo(-1));
     }
@@ -369,7 +369,7 @@ public class ShortestPathsTest {
     @Test
     public void testPathsTo_Atom_Benzene() {
 
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(benzene, benzene.getAtom(0));
 
@@ -425,7 +425,7 @@ public class ShortestPathsTest {
     @Test
     public void testPathsTo_Int_Benzene() {
 
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(benzene, benzene.getAtom(0));
 
@@ -613,7 +613,7 @@ public class ShortestPathsTest {
     @Test
     public void testAtomsTo_Atom_Benzene() {
 
-        IAtomContainer simple = MoleculeFactory.makeBenzene();
+        IAtomContainer simple = TestMoleculeFactory.makeBenzene();
 
         IAtom c1 = simple.getAtom(0);
         IAtom c2 = simple.getAtom(1);
@@ -633,7 +633,7 @@ public class ShortestPathsTest {
     @Test
     public void testAtomsTo_Int_Benzene() {
 
-        IAtomContainer simple = MoleculeFactory.makeBenzene();
+        IAtomContainer simple = TestMoleculeFactory.makeBenzene();
 
         IAtom c1 = simple.getAtom(0);
         IAtom c2 = simple.getAtom(1);
@@ -835,7 +835,7 @@ public class ShortestPathsTest {
     @Test
     public void testNPathsTo_Atom_Benzene() {
 
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(benzene, benzene.getAtom(0));
 
@@ -851,7 +851,7 @@ public class ShortestPathsTest {
     @Test
     public void testNPathsTo_Int_Benzene() {
 
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(benzene, benzene.getAtom(0));
 
@@ -1074,7 +1074,7 @@ public class ShortestPathsTest {
     @Test
     public void testDistanceTo_Atom_Benzene() {
 
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(benzene, benzene.getAtom(0));
 
@@ -1090,7 +1090,7 @@ public class ShortestPathsTest {
     @Test
     public void testDistanceTo_Int_Benzene() {
 
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(benzene, benzene.getAtom(0));
 
@@ -1105,7 +1105,7 @@ public class ShortestPathsTest {
 
     @Test
     public void testDistanceTo_Int_Benzene_limited() {
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
         ShortestPaths paths = new ShortestPaths(GraphUtil.toAdjList(benzene), benzene, 0, 2, null);
 

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/SpanningTreeTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/SpanningTreeTest.java
@@ -38,7 +38,7 @@ import org.openscience.cdk.interfaces.IChemSequence;
 import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * @cdk.module test-core
@@ -170,7 +170,7 @@ public class SpanningTreeTest extends CDKTestCase {
 
     @Test
     public void testGetSpanningTreeForPyridine() throws NoSuchAtomException {
-        IAtomContainer mol = MoleculeFactory.makePyridine();
+        IAtomContainer mol = TestMoleculeFactory.makePyridine();
         SpanningTree spanningTree = new SpanningTree(mol);
         Assert.assertEquals(6, spanningTree.getBondsCyclicCount());
         Assert.assertEquals(6, spanningTree.getCyclicFragmentsContainer().getAtomCount());

--- a/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterTest.java
@@ -44,7 +44,7 @@ import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.io.MDLRXNV2000Reader;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.ChemFileManipulator;
@@ -64,8 +64,8 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
 
     @Test
     public void testRegression() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makePyrrole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makePyrrole();
         Fingerprinter fingerprinter = new Fingerprinter();
         IBitFingerprint bs1 = fingerprinter.getBitFingerprint(mol1);
         Assert.assertEquals(
@@ -95,7 +95,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
     public void testgetBitFingerprint_IAtomContainer() throws java.lang.Exception {
         Fingerprinter fingerprinter = new Fingerprinter();
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         IBitFingerprint bs = fingerprinter.getBitFingerprint(mol);
         Assert.assertNotNull(bs);
         Assert.assertEquals(fingerprinter.getSize(), bs.size());
@@ -106,9 +106,9 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         Fingerprinter fingerprinter = new Fingerprinter();
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
     }
@@ -118,9 +118,9 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         Fingerprinter fingerprinter = new Fingerprinter(512);
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
     }
@@ -130,9 +130,9 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         Fingerprinter fingerprinter = new Fingerprinter(1024, 7);
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
     }
@@ -141,7 +141,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
     public void testFingerprinterBitSetSize() throws Exception {
         Fingerprinter fingerprinter = new Fingerprinter(1024, 7);
         Assert.assertNotNull(fingerprinter);
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
         Assert.assertEquals(994, bs.length()); // highest set bit
         Assert.assertEquals(1024, bs.size()); // actual bit set size
@@ -228,7 +228,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
 
     @Test
     public void testBondPermutation2() throws CDKException {
-        IAtomContainer pamine = MoleculeFactory.makeCyclopentane();
+        IAtomContainer pamine = TestMoleculeFactory.makeCyclopentane();
         Fingerprinter fp = new Fingerprinter();
         IBitFingerprint bs1 = fp.getBitFingerprint(pamine);
 
@@ -242,7 +242,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
 
     @Test
     public void testAtomPermutation2() throws CDKException {
-        IAtomContainer pamine = MoleculeFactory.makeCyclopentane();
+        IAtomContainer pamine = TestMoleculeFactory.makeCyclopentane();
         Fingerprinter fp = new Fingerprinter();
         IBitFingerprint bs1 = fp.getBitFingerprint(pamine);
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterToolTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterToolTest.java
@@ -31,7 +31,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -50,9 +50,9 @@ public class FingerprinterToolTest extends CDKTestCase {
     public void testIsSubset_BitSet_BitSet() throws java.lang.Exception {
         Fingerprinter fingerprinter = new Fingerprinter();
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         assertTrue(FingerprinterTool.isSubset(bs, bs1));
     }

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/ConnectivityCheckerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/ConnectivityCheckerTest.java
@@ -40,7 +40,7 @@ import org.openscience.cdk.io.ISimpleChemObjectReader;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.ChemFileManipulator;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -68,9 +68,9 @@ public class ConnectivityCheckerTest extends CDKTestCase {
     public void testPartitionIntoMolecules_IAtomContainer() {
         //logger.debug(atomCon);
         AtomContainer atomCon = new org.openscience.cdk.AtomContainer();
-        atomCon.add(MoleculeFactory.make4x3CondensedRings());
-        atomCon.add(MoleculeFactory.makeAlphaPinene());
-        atomCon.add(MoleculeFactory.makeSpiroRings());
+        atomCon.add(TestMoleculeFactory.make4x3CondensedRings());
+        atomCon.add(TestMoleculeFactory.makeAlphaPinene());
+        atomCon.add(TestMoleculeFactory.makeSpiroRings());
         IAtomContainerSet moleculeSet = ConnectivityChecker.partitionIntoMolecules(atomCon);
         Assert.assertNotNull(moleculeSet);
         Assert.assertEquals(3, moleculeSet.getAtomContainerCount());
@@ -106,9 +106,9 @@ public class ConnectivityCheckerTest extends CDKTestCase {
     public void testPartitionIntoMolecules_IsConnected_Consistency() {
         //logger.debug(atomCon);
         AtomContainer atomCon = new org.openscience.cdk.AtomContainer();
-        atomCon.add(MoleculeFactory.make4x3CondensedRings());
-        atomCon.add(MoleculeFactory.makeAlphaPinene());
-        atomCon.add(MoleculeFactory.makeSpiroRings());
+        atomCon.add(TestMoleculeFactory.make4x3CondensedRings());
+        atomCon.add(TestMoleculeFactory.makeAlphaPinene());
+        atomCon.add(TestMoleculeFactory.makeSpiroRings());
         IAtomContainerSet moleculeSet = ConnectivityChecker.partitionIntoMolecules(atomCon);
         Assert.assertNotNull(moleculeSet);
         Assert.assertEquals(3, moleculeSet.getAtomContainerCount());
@@ -170,7 +170,7 @@ public class ConnectivityCheckerTest extends CDKTestCase {
      */
     @Test
     public void testIsConnected_IAtomContainer() {
-        IAtomContainer spiro = MoleculeFactory.makeSpiroRings();
+        IAtomContainer spiro = TestMoleculeFactory.makeSpiroRings();
         Assert.assertTrue(ConnectivityChecker.isConnected(spiro));
     }
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/MorganNumbersToolsTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/MorganNumbersToolsTest.java
@@ -31,7 +31,7 @@ import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.ChemFileManipulator;
 
 /**
@@ -50,7 +50,7 @@ public class MorganNumbersToolsTest extends CDKTestCase {
         // This is an array with the expected Morgan Numbers for a-pinene
         long[] reference = {28776, 17899, 23549, 34598, 31846, 36393, 9847, 45904, 15669, 15669};
 
-        IAtomContainer mol = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer mol = TestMoleculeFactory.makeAlphaPinene();
         long[] morganNumbers = MorganNumbersTools.getMorganNumbers((AtomContainer) mol);
         Assert.assertEquals(reference.length, morganNumbers.length);
         for (int f = 0; f < morganNumbers.length; f++) {
@@ -64,7 +64,7 @@ public class MorganNumbersToolsTest extends CDKTestCase {
         // This is an array with the expected Morgan Numbers for a-pinene
         String[] reference = {"C-457", "C-428", "C-325", "C-354", "C-325", "C-428", "N-251"};
 
-        IAtomContainer mol = MoleculeFactory.makePhenylAmine();
+        IAtomContainer mol = TestMoleculeFactory.makePhenylAmine();
         String[] morganNumbers = MorganNumbersTools.getMorganNumbersWithElementSymbol((AtomContainer) mol);
         Assert.assertEquals(reference.length, morganNumbers.length);
         for (int f = 0; f < morganNumbers.length; f++) {

--- a/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTesterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTesterTest.java
@@ -58,7 +58,7 @@ import org.openscience.cdk.isomorphism.matchers.smarts.AliphaticSymbolAtom;
 import org.openscience.cdk.isomorphism.matchers.smarts.AnyAtom;
 import org.openscience.cdk.isomorphism.mcss.RMap;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.AtomTypeManipulator;
@@ -80,8 +80,8 @@ public class UniversalIsomorphismTesterTest extends CDKTestCase {
 
     @Test
     public void testIsSubgraph_IAtomContainer_IAtomContainer() throws java.lang.Exception {
-        IAtomContainer mol = MoleculeFactory.makeAlphaPinene();
-        IAtomContainer frag1 = MoleculeFactory.makeCyclohexene(); //one double bond in ring
+        IAtomContainer mol = TestMoleculeFactory.makeAlphaPinene();
+        IAtomContainer frag1 = TestMoleculeFactory.makeCyclohexene(); //one double bond in ring
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         Aromaticity.cdkLegacy().apply(mol);
@@ -133,8 +133,8 @@ public class UniversalIsomorphismTesterTest extends CDKTestCase {
 
     @Test
     public void test2() throws java.lang.Exception {
-        IAtomContainer mol = MoleculeFactory.makeAlphaPinene();
-        IAtomContainer frag1 = MoleculeFactory.makeCyclohexane(); // no double bond in ring
+        IAtomContainer mol = TestMoleculeFactory.makeAlphaPinene();
+        IAtomContainer frag1 = TestMoleculeFactory.makeCyclohexane(); // no double bond in ring
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         Aromaticity.cdkLegacy().apply(mol);
@@ -149,8 +149,8 @@ public class UniversalIsomorphismTesterTest extends CDKTestCase {
 
     @Test
     public void test3() throws java.lang.Exception {
-        IAtomContainer mol = MoleculeFactory.makeIndole();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         Aromaticity.cdkLegacy().apply(mol);
@@ -178,8 +178,8 @@ public class UniversalIsomorphismTesterTest extends CDKTestCase {
         int[] result1 = {6, 5, 7, 8, 0};
         int[] result2 = {3, 4, 2, 1, 0};
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         Aromaticity.cdkLegacy().apply(mol);
@@ -357,8 +357,8 @@ public class UniversalIsomorphismTesterTest extends CDKTestCase {
 
     @Test
     public void testGetSubgraphAtomsMap_Butane() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeAlkane(4);
-        IAtomContainer mol2 = MoleculeFactory.makeAlkane(4);
+        IAtomContainer mol1 = TestMoleculeFactory.makeAlkane(4);
+        IAtomContainer mol2 = TestMoleculeFactory.makeAlkane(4);
 
         // Test for atom mapping between the mols
         List<RMap> maplist = uiTester.getSubgraphAtomsMap(mol2, mol1);
@@ -372,8 +372,8 @@ public class UniversalIsomorphismTesterTest extends CDKTestCase {
 
     @Test
     public void testGetSubgraphAtomsMaps_Butane() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeAlkane(4);
-        IAtomContainer mol2 = MoleculeFactory.makeAlkane(4);
+        IAtomContainer mol1 = TestMoleculeFactory.makeAlkane(4);
+        IAtomContainer mol2 = TestMoleculeFactory.makeAlkane(4);
 
         List<List<RMap>> list = uiTester.getSubgraphAtomsMaps(mol1, mol2);
         Assert.assertNotNull(list);

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/AllRingsFinderTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/AllRingsFinderTest.java
@@ -40,7 +40,7 @@ import org.openscience.cdk.io.CMLReader;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.silent.ChemFile;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -71,7 +71,7 @@ public class AllRingsFinderTest extends CDKTestCase {
     public void testFindAllRings_IAtomContainer() throws Exception {
         IRingSet ringSet = null;
         AllRingsFinder arf = new AllRingsFinder();
-        IAtomContainer molecule = MoleculeFactory.makeEthylPropylPhenantren();
+        IAtomContainer molecule = TestMoleculeFactory.makeEthylPropylPhenantren();
         //display(molecule);
 
         ringSet = arf.findAllRings(molecule);
@@ -86,7 +86,7 @@ public class AllRingsFinderTest extends CDKTestCase {
     public void testBondsWithinRing() throws Exception {
         IRingSet ringSet = null;
         AllRingsFinder arf = new AllRingsFinder();
-        IAtomContainer molecule = MoleculeFactory.makeEthylPropylPhenantren();
+        IAtomContainer molecule = TestMoleculeFactory.makeEthylPropylPhenantren();
         //display(molecule);
 
         ringSet = arf.findAllRings(molecule);
@@ -106,7 +106,7 @@ public class AllRingsFinderTest extends CDKTestCase {
     @Test
     public void testFindAllRings_IAtomContainer_boolean() throws Exception {
         AllRingsFinder arf = new AllRingsFinder();
-        IAtomContainer molecule = MoleculeFactory.makeEthylPropylPhenantren();
+        IAtomContainer molecule = TestMoleculeFactory.makeEthylPropylPhenantren();
         arf.findAllRings(molecule);
     }
 
@@ -114,7 +114,7 @@ public class AllRingsFinderTest extends CDKTestCase {
     public void testSetTimeout_long() throws Exception {
         AllRingsFinder arf = new AllRingsFinder();
         arf.setTimeout(1);
-        IAtomContainer molecule = MoleculeFactory.makeEthylPropylPhenantren();
+        IAtomContainer molecule = TestMoleculeFactory.makeEthylPropylPhenantren();
         arf.findAllRings(molecule);
     }
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingPartitionerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingPartitionerTest.java
@@ -26,7 +26,7 @@ import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IRingSet;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * This class tests the RingPartitioner class.
@@ -48,7 +48,7 @@ public class RingPartitionerTest extends CDKTestCase {
 
     @Test
     public void testConvertToAtomContainer_IRingSet() {
-        IAtomContainer molecule = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAlphaPinene();
 
         IRingSet ringSet = Cycles.sssr(molecule).toRingSet();
         IAtomContainer ac = RingPartitioner.convertToAtomContainer(ringSet);
@@ -58,17 +58,17 @@ public class RingPartitionerTest extends CDKTestCase {
 
     @Test
     public void testPartitionIntoRings() {
-        IAtomContainer azulene = MoleculeFactory.makeAzulene();
+        IAtomContainer azulene = TestMoleculeFactory.makeAzulene();
         IRingSet ringSet = Cycles.sssr(azulene).toRingSet();
         List<IRingSet> list = RingPartitioner.partitionRings(ringSet);
         Assert.assertEquals(1, list.size());
 
-        IAtomContainer biphenyl = MoleculeFactory.makeBiphenyl();
+        IAtomContainer biphenyl = TestMoleculeFactory.makeBiphenyl();
         ringSet = Cycles.sssr(biphenyl).toRingSet();
         list = RingPartitioner.partitionRings(ringSet);
         Assert.assertEquals(2, list.size());
 
-        IAtomContainer spiro = MoleculeFactory.makeSpiroRings();
+        IAtomContainer spiro = TestMoleculeFactory.makeSpiroRings();
         ringSet = Cycles.sssr(spiro).toRingSet();
         list = RingPartitioner.partitionRings(ringSet);
         Assert.assertEquals(1, list.size());

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Benzene.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Benzene.java
@@ -24,7 +24,7 @@ package org.openscience.cdk.ringsearch;
 
 import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
  */
 public final class RingSearchTest_Benzene {
 
-    private final IAtomContainer benzene = MoleculeFactory.makeBenzene();
+    private final IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
 
     @Test
     public void testCyclic() {

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Bicyclo.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Bicyclo.java
@@ -24,7 +24,7 @@ package org.openscience.cdk.ringsearch;
 
 import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.List;
 
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertTrue;
  */
 public final class RingSearchTest_Bicyclo {
 
-    private static final IAtomContainer bicyclo = MoleculeFactory.makeBicycloRings();
+    private static final IAtomContainer bicyclo = TestMoleculeFactory.makeBicycloRings();
 
     @Test
     public void testCyclic() {

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Biphenyl.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Biphenyl.java
@@ -24,7 +24,7 @@ package org.openscience.cdk.ringsearch;
 
 import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
  */
 public final class RingSearchTest_Biphenyl {
 
-    private final IAtomContainer biphenyl = MoleculeFactory.makeBiphenyl();
+    private final IAtomContainer biphenyl = TestMoleculeFactory.makeBiphenyl();
 
     @Test
     public void testCyclic() {

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Fused.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Fused.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.List;
 
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class RingSearchTest_Fused {
 
-    private final IAtomContainer fusedRings = MoleculeFactory.makeFusedRings();
+    private final IAtomContainer fusedRings = TestMoleculeFactory.makeFusedRings();
 
     @Test
     public void testCyclic_Int() {

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_NonCyclic.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_NonCyclic.java
@@ -24,7 +24,7 @@ package org.openscience.cdk.ringsearch;
 
 import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
  */
 public final class RingSearchTest_NonCyclic {
 
-    private final IAtomContainer nonCyclic = MoleculeFactory.makeBranchedAliphatic();
+    private final IAtomContainer nonCyclic = TestMoleculeFactory.makeBranchedAliphatic();
 
     @Test
     public void testCyclic() {

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_SpiroRings.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_SpiroRings.java
@@ -24,7 +24,7 @@ package org.openscience.cdk.ringsearch;
 
 import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.List;
 
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertTrue;
  */
 public final class RingSearchTest_SpiroRings {
 
-    private final IAtomContainer spiro = MoleculeFactory.makeSpiroRings();
+    private final IAtomContainer spiro = TestMoleculeFactory.makeSpiroRings();
 
     @Test
     public void testCyclic() {

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -59,7 +59,6 @@ import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.stereo.TetrahedralChirality;
-import org.openscience.cdk.templates.MoleculeFactory;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 
@@ -72,12 +71,12 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Before
     public void setUp() {
-        ac = MoleculeFactory.makeAlphaPinene();
+        ac = TestMoleculeFactory.makeAlphaPinene();
     }
 
     @Test
     public void testExtractSubstructure() throws CloneNotSupportedException {
-        IAtomContainer source = MoleculeFactory.makeEthylCyclohexane();
+        IAtomContainer source = TestMoleculeFactory.makeEthylCyclohexane();
         IAtomContainer ringSubstructure = AtomContainerManipulator.extractSubstructure(source, 0, 1, 2, 3, 4, 5);
         Assert.assertEquals(6, ringSubstructure.getAtomCount());
         Assert.assertEquals(6, ringSubstructure.getBondCount());
@@ -834,7 +833,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
      */
     @Test
     public void testGetImplicitHydrogenCount_unperceived() throws Exception {
-        IAtomContainer container = MoleculeFactory.makeAdenine();
+        IAtomContainer container = TestMoleculeFactory.makeAdenine();
         Assert.assertEquals("Container has not been atom-typed - should have 0 implicit hydrogens", 0,
                 AtomContainerManipulator.getImplicitHydrogenCount(container));
     }
@@ -852,7 +851,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
      */
     @Test
     public void testGetImplicitHydrogenCount_adenine() throws Exception {
-        IAtomContainer container = MoleculeFactory.makeAdenine();
+        IAtomContainer container = TestMoleculeFactory.makeAdenine();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(container);
         CDKHydrogenAdder.getInstance(DefaultChemObjectBuilder.getInstance()).addImplicitHydrogens(container);
         Assert.assertEquals("Adenine should have 5 implicit hydrogens", 5,
@@ -990,7 +989,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
     @Test
     public void testAnonymise() throws Exception {
 
-        IAtomContainer cyclohexane = MoleculeFactory.makeCyclohexane();
+        IAtomContainer cyclohexane = TestMoleculeFactory.makeCyclohexane();
 
         cyclohexane.getAtom(0).setSymbol("O");
         cyclohexane.getAtom(2).setSymbol("O");
@@ -1002,7 +1001,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
 
         IAtomContainer anonymous = AtomContainerManipulator.anonymise(cyclohexane);
 
-        Assert.assertTrue(new UniversalIsomorphismTester().isIsomorph(anonymous, MoleculeFactory.makeCyclohexane()));
+        Assert.assertTrue(new UniversalIsomorphismTester().isIsomorph(anonymous, TestMoleculeFactory.makeCyclohexane()));
 
         assertThat(anonymous.getAtom(0).getSymbol(), is("C"));
         assertThat(anonymous.getAtom(2).getSymbol(), is("C"));
@@ -1017,7 +1016,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
     @Test
     public void skeleton() throws Exception {
 
-        IAtomContainer adenine = MoleculeFactory.makeAdenine();
+        IAtomContainer adenine = TestMoleculeFactory.makeAdenine();
         IAtomContainer skeleton = AtomContainerManipulator.skeleton(adenine);
 
         assertThat(skeleton, is(not(sameInstance(adenine))));

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/RingSetManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/RingSetManipulatorTest.java
@@ -39,7 +39,7 @@ import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IRing;
 import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.ringsearch.AllRingsFinder;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * @cdk.module test-standard
@@ -200,13 +200,13 @@ public class RingSetManipulatorTest extends CDKTestCase {
 
     @Test
     public void testGetBondCount() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeAdenine();
+        IAtomContainer mol = TestMoleculeFactory.makeAdenine();
         AllRingsFinder arf = new AllRingsFinder();
         IRingSet ringSet = arf.findAllRings(mol);
         Assert.assertEquals(3, ringSet.getAtomContainerCount());
         Assert.assertEquals(20, RingSetManipulator.getBondCount(ringSet));
 
-        mol = MoleculeFactory.makeBiphenyl();
+        mol = TestMoleculeFactory.makeBiphenyl();
         ringSet = arf.findAllRings(mol);
         Assert.assertEquals(2, ringSet.getAtomContainerCount());
         Assert.assertEquals(12, RingSetManipulator.getBondCount(ringSet));
@@ -214,7 +214,7 @@ public class RingSetManipulatorTest extends CDKTestCase {
 
     @Test
     public void markAromatic() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeBiphenyl();
+        IAtomContainer mol = TestMoleculeFactory.makeBiphenyl();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         Aromaticity.cdkLegacy().apply(mol);
 
@@ -239,7 +239,7 @@ public class RingSetManipulatorTest extends CDKTestCase {
     public void testGetLargestRingSet_List_IRingSet() throws Exception {
         List<IRingSet> list = new Vector<IRingSet>();
         list.add(ringset);
-        IAtomContainer mol = MoleculeFactory.makeBiphenyl();
+        IAtomContainer mol = TestMoleculeFactory.makeBiphenyl();
 
         AllRingsFinder arf = new AllRingsFinder();
         IRingSet ringSet = arf.findAllRings(mol);

--- a/descriptor/fingerprint/pom.xml
+++ b/descriptor/fingerprint/pom.xml
@@ -106,6 +106,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-smiles</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ExtendedFingerprinterTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ExtendedFingerprinterTest.java
@@ -42,7 +42,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.ringsearch.RingPartitioner;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.diff.AtomContainerDiff;
 
 /**
@@ -66,9 +66,9 @@ public class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterT
         IFingerprinter fingerprinter = new ExtendedFingerprinter();
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
         Assert.assertFalse(FingerprinterTool.isSubset(bs1, bs));
@@ -79,11 +79,11 @@ public class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterT
         ExtendedFingerprinter fingerprinter = new ExtendedFingerprinter();
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         IRingSet rs = Cycles.sssr(mol).toRingSet();
         List<IRingSet> rslist = RingPartitioner.partitionRings(rs);
         BitSet bs = fingerprinter.getBitFingerprint(mol, rs, rslist).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
         Assert.assertFalse(FingerprinterTool.isSubset(bs1, bs));
@@ -101,9 +101,9 @@ public class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterT
         IFingerprinter fingerprinter = new ExtendedFingerprinter(512);
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
         Assert.assertFalse(FingerprinterTool.isSubset(bs1, bs));
@@ -114,9 +114,9 @@ public class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterT
         IFingerprinter fingerprinter = new ExtendedFingerprinter(512, 7);
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
         Assert.assertFalse(FingerprinterTool.isSubset(bs1, bs));
@@ -418,7 +418,7 @@ public class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterT
      */
     @Test
     public void testMoleculeInvariance() throws Exception, CloneNotSupportedException {
-        IAtomContainer mol = MoleculeFactory.makePyrrole();
+        IAtomContainer mol = TestMoleculeFactory.makePyrrole();
         IAtomContainer clone = (IAtomContainer) mol.clone();
 
         // should pass since we have not explicitly detected aromaticity

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ShortestPathFingerprinterTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ShortestPathFingerprinterTest.java
@@ -40,7 +40,7 @@ import org.openscience.cdk.graph.AtomContainerBondPermutor;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
@@ -61,8 +61,8 @@ public class ShortestPathFingerprinterTest extends AbstractFixedLengthFingerprin
 
     @Test
     public void testRegression() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makePyrrole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makePyrrole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol1);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol2);
         ShortestPathFingerprinter fingerprinter = new ShortestPathFingerprinter();
@@ -208,7 +208,7 @@ public class ShortestPathFingerprinterTest extends AbstractFixedLengthFingerprin
     public void testgetBitFingerprint_IAtomContainer() throws java.lang.Exception {
         ShortestPathFingerprinter fingerprinter = new ShortestPathFingerprinter();
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         IBitFingerprint bs = fingerprinter.getBitFingerprint(mol);
         Assert.assertNotNull(bs);
@@ -220,10 +220,10 @@ public class ShortestPathFingerprinterTest extends AbstractFixedLengthFingerprin
         ShortestPathFingerprinter fingerprinter = new ShortestPathFingerprinter();
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
@@ -234,10 +234,10 @@ public class ShortestPathFingerprinterTest extends AbstractFixedLengthFingerprin
         ShortestPathFingerprinter fingerprinter = new ShortestPathFingerprinter(512);
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
@@ -248,10 +248,10 @@ public class ShortestPathFingerprinterTest extends AbstractFixedLengthFingerprin
         ShortestPathFingerprinter fingerprinter = new ShortestPathFingerprinter(1024);
         Assert.assertNotNull(fingerprinter);
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
         Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
@@ -261,7 +261,7 @@ public class ShortestPathFingerprinterTest extends AbstractFixedLengthFingerprin
     public void testFingerprinterBitSetSize() throws Exception {
         ShortestPathFingerprinter fingerprinter = new ShortestPathFingerprinter(1024);
         Assert.assertNotNull(fingerprinter);
-        IAtomContainer mol = MoleculeFactory.makeIndole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
         Assert.assertEquals(1024, bs.length()); // highest set bit
@@ -316,7 +316,7 @@ public class ShortestPathFingerprinterTest extends AbstractFixedLengthFingerprin
 
     @Test
     public void testBondPermutation2() throws CDKException {
-        IAtomContainer pamine = MoleculeFactory.makeCyclopentane();
+        IAtomContainer pamine = TestMoleculeFactory.makeCyclopentane();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(pamine);
         ShortestPathFingerprinter fp = new ShortestPathFingerprinter();
         IBitFingerprint bs1 = fp.getBitFingerprint(pamine);
@@ -331,7 +331,7 @@ public class ShortestPathFingerprinterTest extends AbstractFixedLengthFingerprin
 
     @Test
     public void testAtomPermutation2() throws CDKException {
-        IAtomContainer pamine = MoleculeFactory.makeCyclopentane();
+        IAtomContainer pamine = TestMoleculeFactory.makeCyclopentane();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(pamine);
         ShortestPathFingerprinter fp = new ShortestPathFingerprinter();
         IBitFingerprint bs1 = fp.getBitFingerprint(pamine);

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ShortestPathWalkerTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ShortestPathWalkerTest.java
@@ -2,7 +2,7 @@ package org.openscience.cdk.fingerprint;
 
 import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -19,7 +19,7 @@ public class ShortestPathWalkerTest {
 
     @Test
     public void testPaths() throws Exception {
-        IAtomContainer triazole = MoleculeFactory.make123Triazole();
+        IAtomContainer triazole = TestMoleculeFactory.make123Triazole();
         ShortestPathWalker walker = new ShortestPathWalker(triazole);
         Set<String> expected = new TreeSet<String>(Arrays.asList("C", "N2N1N", "N", "N1N1C", "N1C2C", "C1N", "N2N1C",
                 "C1N2N", "C1N1N", "N1C", "C2C1N", "C2C", "N2N", "N1N2N", "N1N"));
@@ -29,7 +29,7 @@ public class ShortestPathWalkerTest {
 
     @Test
     public void testToString() throws Exception {
-        IAtomContainer triazole = MoleculeFactory.make123Triazole();
+        IAtomContainer triazole = TestMoleculeFactory.make123Triazole();
         ShortestPathWalker walker = new ShortestPathWalker(triazole);
         assertThat(walker.toString(),
                 is("C->C1N->C1N1N->C1N2N->C2C->C2C1N->N->N1C->N1C2C->N1N->N1N1C->N1N2N->N2N->N2N1C->N2N1N"));

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/SimpleAtomCanonicalizerTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/SimpleAtomCanonicalizerTest.java
@@ -6,7 +6,7 @@ import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomType;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 import java.util.ArrayList;
@@ -22,7 +22,7 @@ public class SimpleAtomCanonicalizerTest {
     @Test
     public void testCanonicalizeAtoms() throws CDKException {
 
-        IAtomContainer container = MoleculeFactory.makeAdenine();
+        IAtomContainer container = TestMoleculeFactory.makeAdenine();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(container);
 
         Collection<IAtom> atoms = new SimpleAtomCanonicalizer().canonicalizeAtoms(container);

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/similarity/LingoSimilarityTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/similarity/LingoSimilarityTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.fingerprint.LingoFingerprinter;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 /**
@@ -42,8 +42,8 @@ public class LingoSimilarityTest extends CDKTestCase {
 
     @Test
     public void testLingoSim() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makeIndole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makeIndole();
         addImplicitHydrogens(mol1);
         addImplicitHydrogens(mol2);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol1);

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/similarity/TanimotoTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/similarity/TanimotoTest.java
@@ -37,7 +37,7 @@ import org.openscience.cdk.fingerprint.IntArrayFingerprint;
 import org.openscience.cdk.fingerprint.LingoFingerprinter;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 import java.util.BitSet;
@@ -57,8 +57,8 @@ public class TanimotoTest extends CDKTestCase {
 
     @Test
     public void testTanimoto1() throws java.lang.Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makePyrrole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makePyrrole();
         Fingerprinter fingerprinter = new Fingerprinter();
         BitSet bs1 = fingerprinter.getBitFingerprint(mol1).asBitSet();
         BitSet bs2 = fingerprinter.getBitFingerprint(mol2).asBitSet();
@@ -69,8 +69,8 @@ public class TanimotoTest extends CDKTestCase {
 
     @Test
     public void testTanimoto2() throws java.lang.Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makeIndole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makeIndole();
         Fingerprinter fingerprinter = new Fingerprinter();
         BitSet bs1 = fingerprinter.getBitFingerprint(mol1).asBitSet();
         BitSet bs2 = fingerprinter.getBitFingerprint(mol2).asBitSet();
@@ -81,8 +81,8 @@ public class TanimotoTest extends CDKTestCase {
 
     @Test
     public void testCalculate_BitFingerprint() throws java.lang.Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makePyrrole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makePyrrole();
         Fingerprinter fp = new Fingerprinter();
         double similarity = Tanimoto.calculate(fp.getBitFingerprint(mol1), fp.getBitFingerprint(mol2));
         Assert.assertEquals(0.3939, similarity, 0.01);
@@ -90,8 +90,8 @@ public class TanimotoTest extends CDKTestCase {
 
     @Test
     public void testExactMatch() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makeIndole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makeIndole();
         addImplicitHydrogens(mol1);
         addImplicitHydrogens(mol2);
         LingoFingerprinter fingerprinter = new LingoFingerprinter();
@@ -174,8 +174,8 @@ public class TanimotoTest extends CDKTestCase {
 
     @Test
     public void testCompareBitSetandBitFingerprintTanimoto() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.make123Triazole();
-        IAtomContainer mol2 = MoleculeFactory.makeImidazole();
+        IAtomContainer mol1 = TestMoleculeFactory.make123Triazole();
+        IAtomContainer mol2 = TestMoleculeFactory.makeImidazole();
         Fingerprinter fingerprinter = new Fingerprinter();
         BitSet bs1 = fingerprinter.getBitFingerprint(mol1).asBitSet();
         BitSet bs2 = fingerprinter.getBitFingerprint(mol2).asBitSet();

--- a/descriptor/qsarmolecular/pom.xml
+++ b/descriptor/qsarmolecular/pom.xml
@@ -176,6 +176,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-qsar</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AromaticAtomsCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AromaticAtomsCountDescriptorTest.java
@@ -29,7 +29,7 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.qsar.result.IntegerResult;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * TestSuite that runs all QSAR tests.
@@ -57,7 +57,7 @@ public class AromaticAtomsCountDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     public void testViaFlags() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeBenzene();
+        IAtomContainer molecule = TestMoleculeFactory.makeBenzene();
         for (Iterator atoms = molecule.atoms().iterator(); atoms.hasNext();) {
             ((IAtom) atoms.next()).setFlag(CDKConstants.ISAROMATIC, true);
         }

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AromaticBondsCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AromaticBondsCountDescriptorTest.java
@@ -30,7 +30,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.qsar.result.IntegerResult;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * TestSuite that runs all QSAR tests.
@@ -57,7 +57,7 @@ public class AromaticBondsCountDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     public void testViaFlags() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeBenzene();
+        IAtomContainer molecule = TestMoleculeFactory.makeBenzene();
         for (Iterator bonds = molecule.bonds().iterator(); bonds.hasNext();) {
             ((IBond) bonds.next()).setFlag(CDKConstants.ISAROMATIC, true);
         }

--- a/descriptor/signature/pom.xml
+++ b/descriptor/signature/pom.xml
@@ -107,6 +107,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-fingerprint</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/descriptor/signature/src/test/java/org/openscience/cdk/signature/MoleculeSignatureTest.java
+++ b/descriptor/signature/src/test/java/org/openscience/cdk/signature/MoleculeSignatureTest.java
@@ -41,7 +41,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import signature.AbstractVertexSignature;
 
@@ -267,7 +267,7 @@ public class MoleculeSignatureTest extends CDKTestCase {
 
     @Test
     public void testCyclohexaneWithHydrogens() {
-        IAtomContainer cyclohexane = MoleculeFactory.makeCyclohexane();
+        IAtomContainer cyclohexane = TestMoleculeFactory.makeCyclohexane();
         for (int i = 0; i < 6; i++) {
             addHydrogens(cyclohexane, cyclohexane.getAtom(i), 2);
         }

--- a/descriptor/signature/src/test/java/org/openscience/cdk/similarity/SignatureFingerprintTanimotoTest.java
+++ b/descriptor/signature/src/test/java/org/openscience/cdk/similarity/SignatureFingerprintTanimotoTest.java
@@ -35,7 +35,7 @@ import org.openscience.cdk.fingerprint.SignatureFingerprinter;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -64,8 +64,8 @@ public class SignatureFingerprintTanimotoTest extends CDKTestCase {
 
     @Test
     public void testICountFingerprintComparison() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makeIndole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makeIndole();
         SignatureFingerprinter fingerprinter = new SignatureFingerprinter();
         ICountFingerprint fp1 = fingerprinter.getCountFingerprint(mol1);
         ICountFingerprint fp2 = fingerprinter.getCountFingerprint(mol2);
@@ -76,8 +76,8 @@ public class SignatureFingerprintTanimotoTest extends CDKTestCase {
 
     @Test
     public void compareCountFingerprintAndRawFingerprintTanimoto() throws CDKException {
-        IAtomContainer mol1 = MoleculeFactory.make123Triazole();
-        IAtomContainer mol2 = MoleculeFactory.makeImidazole();
+        IAtomContainer mol1 = TestMoleculeFactory.make123Triazole();
+        IAtomContainer mol2 = TestMoleculeFactory.makeImidazole();
         SignatureFingerprinter fingerprinter = new SignatureFingerprinter(1);
         ICountFingerprint countFp1 = fingerprinter.getCountFingerprint(mol1);
         ICountFingerprint countFp2 = fingerprinter.getCountFingerprint(mol2);
@@ -105,8 +105,8 @@ public class SignatureFingerprintTanimotoTest extends CDKTestCase {
         Assert.assertEquals(0.923, Tanimoto.method1(fp1, fp2), 0.001);
         Assert.assertEquals(0.75, Tanimoto.method2(fp1, fp2), 0.001);
 
-        IAtomContainer mol1 = MoleculeFactory.makeIndole();
-        IAtomContainer mol2 = MoleculeFactory.makeIndole();
+        IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
+        IAtomContainer mol2 = TestMoleculeFactory.makeIndole();
         SignatureFingerprinter fingerprinter = new SignatureFingerprinter();
         fp1 = fingerprinter.getCountFingerprint(mol1);
         fp2 = fingerprinter.getCountFingerprint(mol2);
@@ -116,8 +116,8 @@ public class SignatureFingerprintTanimotoTest extends CDKTestCase {
 
     @Test
     public void testComparingBitFingerprintAndCountBehavingAsBit() throws Exception {
-        IAtomContainer mol1 = MoleculeFactory.make123Triazole();
-        IAtomContainer mol2 = MoleculeFactory.makeImidazole();
+        IAtomContainer mol1 = TestMoleculeFactory.make123Triazole();
+        IAtomContainer mol2 = TestMoleculeFactory.makeImidazole();
 
         SignatureFingerprinter fingerprinter = new SignatureFingerprinter(1);
         ICountFingerprint countFp1 = fingerprinter.getCountFingerprint(mol1);

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -122,6 +122,13 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.openscience.cdk</groupId>
             <artifactId>cdk-qsar</artifactId>
             <version>${project.version}</version>

--- a/legacy/src/main/java/org/openscience/cdk/iupac/parser/MoleculeBuilder.java
+++ b/legacy/src/main/java/org/openscience/cdk/iupac/parser/MoleculeBuilder.java
@@ -21,9 +21,8 @@
 
 package org.openscience.cdk.iupac.parser;
 
-import java.util.Iterator;
-import java.util.List;
-
+import org.openscience.cdk.Atom;
+import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.atomtype.CDKAtomTypeMatcher;
@@ -35,10 +34,12 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IRing;
-import org.openscience.cdk.templates.MoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.AtomTypeManipulator;
+
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Takes in parsed Tokens from NomParser and contains rules
@@ -86,7 +87,7 @@ public class MoleculeBuilder {
                 currentChain.add(currentMolecule.getBuilder().newInstance(IRing.class, length, "C"));
             } //Else must not be cyclic
             else {
-                currentChain = MoleculeFactory.makeAlkane(length);
+                currentChain = makeAlkane(length);
             }
         } else {
             currentChain = currentMolecule.getBuilder().newInstance(IAtomContainer.class);
@@ -248,7 +249,7 @@ public class MoleculeBuilder {
         }
         //Benzene
         else if ("phenyl".equals(funGroupToken)) {
-            IAtomContainer benzene = MoleculeFactory.makeBenzene();
+            IAtomContainer benzene = makeBenzene();
             //Detect Aromacity in the benzene ring.
             try {
                 AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(benzene);
@@ -459,5 +460,48 @@ public class MoleculeBuilder {
         hAdder.addImplicitHydrogens(currentMolecule);
 
         return currentMolecule;
+    }
+
+    private static IAtomContainer makeBenzene() {
+        IAtomContainer mol = new AtomContainer();
+        mol.addAtom(new Atom("C")); // 0
+        mol.addAtom(new Atom("C")); // 1
+        mol.addAtom(new Atom("C")); // 2
+        mol.addAtom(new Atom("C")); // 3
+        mol.addAtom(new Atom("C")); // 4
+        mol.addAtom(new Atom("C")); // 5
+
+        mol.addBond(0, 1, IBond.Order.SINGLE); // 1
+        mol.addBond(1, 2, IBond.Order.DOUBLE); // 2
+        mol.addBond(2, 3, IBond.Order.SINGLE); // 3
+        mol.addBond(3, 4, IBond.Order.DOUBLE); // 4
+        mol.addBond(4, 5, IBond.Order.SINGLE); // 5
+        mol.addBond(5, 0, IBond.Order.DOUBLE); // 6
+        return mol;
+    }
+
+    /**
+     * Generate an Alkane (chain of carbons with no hydrogens) of a given length.
+     *
+     * <p>This method was written by Stephen Tomkinson.
+     *
+     * @param chainLength The number of carbon atoms to have in the chain.
+     * @return A molecule containing a bonded chain of carbons.
+     *
+     * @cdk.created 2003-08-15
+     */
+    private static IAtomContainer makeAlkane(int chainLength) {
+        IAtomContainer currentChain = new AtomContainer();
+
+        //Add the initial atom
+        currentChain.addAtom(new Atom("C"));
+
+        //Add further atoms and bonds as needed, a pair at a time.
+        for (int atomCount = 1; atomCount < chainLength; atomCount++) {
+            currentChain.addAtom(new Atom("C"));
+            currentChain.addBond(atomCount, atomCount - 1, IBond.Order.SINGLE);
+        }
+
+        return currentChain;
     }
 }

--- a/legacy/src/test/java/org/openscience/cdk/aromaticity/CDKHueckelAromaticityDetectorTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/aromaticity/CDKHueckelAromaticityDetectorTest.java
@@ -46,7 +46,7 @@ import org.openscience.cdk.ringsearch.AllRingsFinder;
 import org.openscience.cdk.ringsearch.SSSRFinder;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.RingSetManipulator;
@@ -163,14 +163,14 @@ public class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
 
     @Test
     public void testPyridineOxide() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makePyridineOxide();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridineOxide();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Assert.assertTrue(Aromaticity.cdkLegacy().apply(molecule));
     }
 
     @Test
     public void testPyridineOxide_SP2() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makePyridineOxide();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridineOxide();
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext())
             bonds.next().setOrder(Order.SINGLE);
@@ -233,7 +233,7 @@ public class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
     @Test
     public void testAzulene() throws Exception {
         boolean[] testResults = {true, true, true, true, true, true, true, true, true, true};
-        IAtomContainer molecule = MoleculeFactory.makeAzulene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAzulene();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Assert.assertTrue("Expected the molecule to be aromatic.", Aromaticity.cdkLegacy().apply(molecule));
         for (int f = 0; f < molecule.getAtomCount(); f++) {
@@ -247,7 +247,7 @@ public class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testIndole() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeIndole();
+        IAtomContainer molecule = TestMoleculeFactory.makeIndole();
         boolean testResults[] = {true, true, true, true, true, true, true, true, true};
         //boolean isAromatic = false;
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
@@ -263,7 +263,7 @@ public class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testPyrrole() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makePyrrole();
+        IAtomContainer molecule = TestMoleculeFactory.makePyrrole();
         boolean testResults[] = {true, true, true, true, true};
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Assert.assertTrue("Expected the molecule to be aromatic.", Aromaticity.cdkLegacy().apply(molecule));
@@ -278,7 +278,7 @@ public class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testThiazole() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeThiazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeThiazole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Assert.assertTrue("Molecule is not detected as aromatic", Aromaticity.cdkLegacy().apply(molecule));
 
@@ -447,7 +447,7 @@ public class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testQuinone() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeQuinone();
+        IAtomContainer molecule = TestMoleculeFactory.makeQuinone();
         boolean[] testResults = {false, false, false, false, false, false, false, false};
 
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
@@ -487,7 +487,7 @@ public class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testBenzene() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeBenzene();
+        IAtomContainer molecule = TestMoleculeFactory.makeBenzene();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Aromaticity.cdkLegacy().apply(molecule);
         for (int f = 0; f < molecule.getAtomCount(); f++) {
@@ -498,7 +498,7 @@ public class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
     @Test
     public void testCyclobutadiene() throws Exception {
         // anti-aromatic
-        IAtomContainer molecule = MoleculeFactory.makeCyclobutadiene();
+        IAtomContainer molecule = TestMoleculeFactory.makeCyclobutadiene();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
 
         Assert.assertFalse(Aromaticity.cdkLegacy().apply(molecule));

--- a/legacy/src/test/java/org/openscience/cdk/aromaticity/DoubleBondAcceptingAromaticityDetectorTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/aromaticity/DoubleBondAcceptingAromaticityDetectorTest.java
@@ -46,7 +46,7 @@ import org.openscience.cdk.ringsearch.AllRingsFinder;
 import org.openscience.cdk.ringsearch.SSSRFinder;
 import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.RingSetManipulator;
@@ -165,14 +165,14 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
 
     @Test
     public void testPyridineOxide() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makePyridineOxide();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridineOxide();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Assert.assertTrue(DoubleBondAcceptingAromaticityDetector.detectAromaticity(molecule));
     }
 
     @Test
     public void testPyridineOxide_SP2() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makePyridineOxide();
+        IAtomContainer molecule = TestMoleculeFactory.makePyridineOxide();
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext())
             bonds.next().setOrder(Order.SINGLE);
@@ -208,7 +208,7 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
     @Test
     public void testAzulene() throws Exception {
         boolean[] testResults = {true, true, true, true, true, true, true, true, true, true};
-        IAtomContainer molecule = MoleculeFactory.makeAzulene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAzulene();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Assert.assertTrue("Expected the molecule to be aromatic.",
                 DoubleBondAcceptingAromaticityDetector.detectAromaticity(molecule));
@@ -223,7 +223,7 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testIndole() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeIndole();
+        IAtomContainer molecule = TestMoleculeFactory.makeIndole();
         boolean testResults[] = {true, true, true, true, true, true, true, true, true};
         //boolean isAromatic = false;
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
@@ -240,7 +240,7 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testPyrrole() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makePyrrole();
+        IAtomContainer molecule = TestMoleculeFactory.makePyrrole();
         boolean testResults[] = {true, true, true, true, true};
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Assert.assertTrue("Expected the molecule to be aromatic.",
@@ -256,7 +256,7 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testThiazole() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeThiazole();
+        IAtomContainer molecule = TestMoleculeFactory.makeThiazole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         Assert.assertTrue("Molecule is not detected as aromatic",
                 DoubleBondAcceptingAromaticityDetector.detectAromaticity(molecule));
@@ -399,7 +399,7 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testQuinone() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeQuinone();
+        IAtomContainer molecule = TestMoleculeFactory.makeQuinone();
         boolean[] testResults = {false, true, true, true, true, true, true, false};
 
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
@@ -439,7 +439,7 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
      */
     @Test
     public void testBenzene() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeBenzene();
+        IAtomContainer molecule = TestMoleculeFactory.makeBenzene();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         DoubleBondAcceptingAromaticityDetector.detectAromaticity(molecule);
         for (int f = 0; f < molecule.getAtomCount(); f++) {
@@ -450,7 +450,7 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
     @Test
     public void testCyclobutadiene() throws Exception {
         // anti-aromatic
-        IAtomContainer molecule = MoleculeFactory.makeCyclobutadiene();
+        IAtomContainer molecule = TestMoleculeFactory.makeCyclobutadiene();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
 
         Assert.assertFalse(DoubleBondAcceptingAromaticityDetector.detectAromaticity(molecule));
@@ -849,7 +849,7 @@ public class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
 
         IChemObjectBuilder builder = DefaultChemObjectBuilder.getInstance();
 
-        IAtomContainer benzoquinone = MoleculeFactory.makeCyclohexane();
+        IAtomContainer benzoquinone = TestMoleculeFactory.makeCyclohexane();
 
         benzoquinone.getBond(1).setOrder(IBond.Order.DOUBLE);
         benzoquinone.getBond(4).setOrder(IBond.Order.DOUBLE);

--- a/legacy/src/test/java/org/openscience/cdk/graph/BFSShortestPathTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/graph/BFSShortestPathTest.java
@@ -25,7 +25,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * @cdk.module test-standard
@@ -38,7 +38,7 @@ public class BFSShortestPathTest extends CDKTestCase {
 
     @Test
     public void testFindPathBetween_Graph_Object_Object() {
-        IAtomContainer apinene = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer apinene = TestMoleculeFactory.makeAlphaPinene();
         SimpleGraph graph = MoleculeGraphs.getMoleculeGraph(apinene);
         Object startVertex = graph.vertexSet().toArray()[0];
         Object endVertex = graph.vertexSet().toArray()[5];

--- a/legacy/src/test/java/org/openscience/cdk/graph/MoleculeGraphsTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/graph/MoleculeGraphsTest.java
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * @cdk.module test-standard
@@ -40,7 +40,7 @@ public class MoleculeGraphsTest extends CDKTestCase {
      */
     @Test
     public void testGetMoleculeGraph_IAtomContainer() {
-        IAtomContainer apinene = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer apinene = TestMoleculeFactory.makeAlphaPinene();
         SimpleGraph graph = MoleculeGraphs.getMoleculeGraph(apinene);
         Assert.assertEquals(apinene.getAtomCount(), graph.vertexSet().size());
         Assert.assertEquals(apinene.getBondCount(), graph.edgeSet().size());

--- a/legacy/src/test/java/org/openscience/cdk/iupac/ParserTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/iupac/ParserTest.java
@@ -27,7 +27,7 @@ import org.openscience.cdk.iupac.parser.NomParser;
 import org.openscience.cdk.iupac.parser.ParseException;
 import org.openscience.cdk.iupac.parser.TokenMgrError;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * JUnit test routines for the core parser.
@@ -52,7 +52,7 @@ public class ParserTest extends CDKTestCase {
         } catch (CDKException exception) {
             Assert.fail(exception.getMessage());
         }
-        IAtomContainer correctMolecule = MoleculeFactory.makeAlkane(2);
+        IAtomContainer correctMolecule = TestMoleculeFactory.makeAlkane(2);
 
         Assert.assertTrue("The molecule built by the parser isn't the same as the expected one",
                 comparer.isIsomorphic(parserMolecule, correctMolecule));
@@ -66,7 +66,7 @@ public class ParserTest extends CDKTestCase {
         } catch (CDKException exception) {
             Assert.fail(exception.getMessage());
         }
-        IAtomContainer correctMolecule = MoleculeFactory.makeAlkane(5);
+        IAtomContainer correctMolecule = TestMoleculeFactory.makeAlkane(5);
 
         Assert.assertTrue("The molecule built by the parser isn't the same as the expected one",
                 comparer.isIsomorphic(parserMolecule, correctMolecule));
@@ -80,7 +80,7 @@ public class ParserTest extends CDKTestCase {
         } catch (CDKException exception) {
             Assert.fail(exception.getMessage());
         }
-        IAtomContainer correctMolecule = MoleculeFactory.makeAlkane(7);
+        IAtomContainer correctMolecule = TestMoleculeFactory.makeAlkane(7);
 
         Assert.assertTrue("The molecule built by the parser isn't the same as the expected one",
                 comparer.isIsomorphic(parserMolecule, correctMolecule));
@@ -89,7 +89,7 @@ public class ParserTest extends CDKTestCase {
     @Test
     public void testEicosane() throws Exception {
         IAtomContainer parserMolecule = NomParser.generate("Eicosane", SilentChemObjectBuilder.getInstance());
-        IAtomContainer correctMolecule = MoleculeFactory.makeAlkane(20);
+        IAtomContainer correctMolecule = TestMoleculeFactory.makeAlkane(20);
 
         Assert.assertTrue("The molecule built by the parser isn't the same as the expected one",
                 comparer.isIsomorphic(parserMolecule, correctMolecule));

--- a/legacy/src/test/java/org/openscience/cdk/ringsearch/SSSRFinderTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/ringsearch/SSSRFinderTest.java
@@ -40,7 +40,7 @@ import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
@@ -57,21 +57,21 @@ public class SSSRFinderTest extends CDKTestCase {
 
     @Test
     public void testSSSRFinder_IAtomContainer() {
-        IAtomContainer molecule = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAlphaPinene();
         SSSRFinder finder = new SSSRFinder(molecule);
         Assert.assertNotNull(finder);
     }
 
     @Test
     public void testFindSSSR() {
-        IAtomContainer molecule = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAlphaPinene();
         IRingSet ringSet = new SSSRFinder(molecule).findSSSR();
         Assert.assertEquals(2, ringSet.getAtomContainerCount());
     }
 
     @Test
     public void testFindSSSR_IAtomContainer() {
-        IAtomContainer molecule = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAlphaPinene();
         SSSRFinder sssrFinder = new SSSRFinder(molecule);
         IRingSet ringSet = sssrFinder.findSSSR();
         Assert.assertEquals(2, ringSet.getAtomContainerCount());

--- a/misc/extra/src/main/java/org/openscience/cdk/templates/MoleculeFactory.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/templates/MoleculeFactory.java
@@ -44,7 +44,9 @@ import org.openscience.cdk.tools.LoggingToolFactory;
  *
  * @cdk.keyword templates
  * @cdk.githash
+ * @deprecated Old CDK class primarily for testing, for CDK Tests please use TestMoleculeFactory in cdk-data (testjar).
  */
+@Deprecated
 public class MoleculeFactory {
 
     private static ILoggingTool logger = LoggingToolFactory.createLoggingTool(MoleculeFactory.class);

--- a/misc/test-extra/src/test/java/org/openscience/cdk/CloneAtomContainerTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/CloneAtomContainerTest.java
@@ -25,7 +25,7 @@ package org.openscience.cdk;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * TestCase for the AtomContainer class.
@@ -39,7 +39,7 @@ public class CloneAtomContainerTest extends CDKTestCase {
 
     @Test
     public void testClone() throws Exception {
-        IAtomContainer molecule = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAlphaPinene();
         IAtomContainer clonedMol = (IAtomContainer) molecule.clone();
         Assert.assertTrue(molecule.getAtomCount() == clonedMol.getAtomCount());
         for (int f = 0; f < molecule.getAtomCount(); f++) {

--- a/misc/test-extra/src/test/java/org/openscience/cdk/graph/invariant/EquivalentClassPartitionerTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/graph/invariant/EquivalentClassPartitionerTest.java
@@ -32,7 +32,7 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 import java.io.InputStream;
@@ -282,7 +282,7 @@ public class EquivalentClassPartitionerTest extends CDKTestCase {
     @Test
     public void testAromaticSystem() throws Exception {
 
-        IAtomContainer mol = MoleculeFactory.makeAzulene();
+        IAtomContainer mol = TestMoleculeFactory.makeAzulene();
         Assert.assertNotNull("Created molecule was null", mol);
 
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
@@ -307,7 +307,7 @@ public class EquivalentClassPartitionerTest extends CDKTestCase {
      */
     @Test
     public void testAlphaPinene() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer mol = TestMoleculeFactory.makeAlphaPinene();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         Aromaticity.cdkLegacy().apply(mol);
         Assert.assertNotNull("Created molecule was null", mol);
@@ -331,7 +331,7 @@ public class EquivalentClassPartitionerTest extends CDKTestCase {
      */
     @Test
     public void testPyrimidine() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makePyrimidine();
+        IAtomContainer mol = TestMoleculeFactory.makePyrimidine();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         Aromaticity.cdkLegacy().apply(mol);
         Assert.assertNotNull("Created molecule was null", mol);
@@ -354,7 +354,7 @@ public class EquivalentClassPartitionerTest extends CDKTestCase {
      */
     @Test
     public void testBiphenyl() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeBiphenyl();
+        IAtomContainer mol = TestMoleculeFactory.makeBiphenyl();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         Aromaticity.cdkLegacy().apply(mol);
         Assert.assertNotNull("Created molecule was null", mol);
@@ -379,7 +379,7 @@ public class EquivalentClassPartitionerTest extends CDKTestCase {
      */
     @Test
     public void testImidazole() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeImidazole();
+        IAtomContainer mol = TestMoleculeFactory.makeImidazole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         Aromaticity.cdkLegacy().apply(mol);
         Assert.assertNotNull("Created molecule was null", mol);

--- a/misc/test-extra/src/test/java/org/openscience/cdk/limitations/tools/SaturationCheckerTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/limitations/tools/SaturationCheckerTest.java
@@ -32,7 +32,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IRing;
 import org.openscience.cdk.interfaces.IRingSet;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.SaturationChecker;
 
 /**
@@ -302,7 +302,7 @@ public class SaturationCheckerTest extends CDKTestCase {
 
     @Test
     public void testCalculateMissingHydrogens_Aromatic() throws Exception {
-        IAtomContainer pyrrole = MoleculeFactory.makePyrrole();
+        IAtomContainer pyrrole = TestMoleculeFactory.makePyrrole();
         IAtom n = pyrrole.getAtom(1);
         IRingSet rs = Cycles.sssr(pyrrole).toRingSet();
         IRing ring = (IRing) rs.getAtomContainer(0);

--- a/tool/builder3d/pom.xml
+++ b/tool/builder3d/pom.xml
@@ -138,6 +138,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-testdata</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/FurtherAtomPlacer3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/FurtherAtomPlacer3DTest.java
@@ -32,10 +32,9 @@ import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.templates.MoleculeFactory;
 import org.openscience.cdk.smiles.SmilesParser;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
-import org.openscience.cdk.modeling.builder3d.AtomPlacer3D;
 
 /**
  * Tests not-yet-tested functionalities of {@link AtomPlacer3D}.
@@ -51,7 +50,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Test
     public void testAllHeavyAtomsPlaced_benzene() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
         for (IAtom atom : benzene.atoms()) {
             atom.setFlag(CDKConstants.ISPLACED, true);
         }
@@ -61,7 +60,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Test
     @Override
     public void testNumberOfUnplacedHeavyAtoms_IAtomContainer() {
-        IAtomContainer molecule = MoleculeFactory.makeAlkane(5);
+        IAtomContainer molecule = TestMoleculeFactory.makeAlkane(5);
         for (int i = 0; i < 3; i++) {
             (molecule.getAtom(i)).setFlag(CDKConstants.ISPLACED, true);
         }
@@ -73,7 +72,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Override
     public void testGetPlacedHeavyAtoms_IAtomContainer_IAtom() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer molecule = MoleculeFactory.makeBenzene();
+        IAtomContainer molecule = TestMoleculeFactory.makeBenzene();
         for (int j = 0; j < 3; j++) {
             (molecule.getAtom(j)).setFlag(CDKConstants.ISPLACED, true);
         }
@@ -91,7 +90,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Override
     public void testGetPlacedHeavyAtom_IAtomContainer_IAtom_IAtom() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer molecule = MoleculeFactory.makeAlkane(7);
+        IAtomContainer molecule = TestMoleculeFactory.makeAlkane(7);
         for (int j = 0; j < 5; j++) {
             molecule.getAtom(j).setFlag(CDKConstants.ISPLACED, true);
         }
@@ -108,7 +107,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Override
     public void testGetPlacedHeavyAtom_IAtomContainer_IAtom() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer molecule = MoleculeFactory.makeCyclohexane();
+        IAtomContainer molecule = TestMoleculeFactory.makeCyclohexane();
         //		for(IAtom a : m.atoms()) a.setFlag(CDKConstants.ISPLACED, true);
         for (int i = 0; i < 3; i++) {
             molecule.getAtom(i).setFlag(CDKConstants.ISPLACED, true);
@@ -127,7 +126,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Override
     public void testGeometricCenterAllPlacedAtoms_IAtomContainer() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer molecule = MoleculeFactory.makeAlkane(2);
+        IAtomContainer molecule = TestMoleculeFactory.makeAlkane(2);
         for (IAtom atom : molecule.atoms()) {
             atom.setFlag(CDKConstants.ISPLACED, true);
         }
@@ -144,7 +143,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Test
     public void testGetUnplacedRingHeavyAtom_IAtomContainer_IAtom() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer molecule = MoleculeFactory.makeCyclopentane();
+        IAtomContainer molecule = TestMoleculeFactory.makeCyclopentane();
 
         for (IAtom atom : molecule.atoms())
             atom.setFlag(CDKConstants.ISINRING, true);
@@ -175,7 +174,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Test
     public void testGetFarthestAtom_Point3d_IAtomContainer() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer molecule = MoleculeFactory.makeBenzene();
+        IAtomContainer molecule = TestMoleculeFactory.makeBenzene();
 
         molecule.getAtom(0).setPoint3d(new Point3d(0.0, 0.0, 0.0));
         molecule.getAtom(1).setPoint3d(new Point3d(1.0, 1.0, 1.0));
@@ -193,10 +192,10 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Test
     public void testGetNextPlacedHeavyAtomWithUnplacedRingNeighbour_IAtomContainer() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer acyclicAlkane = MoleculeFactory.makeAlkane(3);
-        IAtomContainer cycloPentane = MoleculeFactory.makeCyclopentane();
+        IAtomContainer acyclicAlkane = TestMoleculeFactory.makeAlkane(3);
+        IAtomContainer cycloPentane = TestMoleculeFactory.makeCyclopentane();
 
-        //MoleculeFactory does not set ISINRING flags for cyclic molecules
+        //TestMoleculeFactory does not set ISINRING flags for cyclic molecules
         Assert.assertEquals(false, cycloPentane.getAtom(0).getFlag(CDKConstants.ISINRING));
         for (IAtom atom : cycloPentane.atoms()) {
             atom.setFlag(CDKConstants.ISINRING, true);
@@ -219,8 +218,8 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Test
     public void testGetNextPlacedHeavyAtomWithUnplacedAliphaticNeighbour_IAtomContainer() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer benzene = MoleculeFactory.makeBenzene();
-        IAtomContainer acyclicAlkane = MoleculeFactory.makeAlkane(5);
+        IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
+        IAtomContainer acyclicAlkane = TestMoleculeFactory.makeAlkane(5);
 
         for (IAtom atom : benzene.atoms())
             atom.setFlag(CDKConstants.ISINRING, true);
@@ -251,8 +250,8 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Test
     public void testGetNextUnplacedHeavyAtomWithAliphaticPlacedNeighbour_IAtomContainer() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer cyclobutane = MoleculeFactory.makeCyclobutane();
-        IAtomContainer acyclicAlkane = MoleculeFactory.makeAlkane(6);
+        IAtomContainer cyclobutane = TestMoleculeFactory.makeCyclobutane();
+        IAtomContainer acyclicAlkane = TestMoleculeFactory.makeAlkane(6);
 
         for (IAtom atom : cyclobutane.atoms()) {
             atom.setFlag(CDKConstants.ISINRING, true);
@@ -362,7 +361,7 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
     @Test
     public void testMarkPlaced_IAtomContainer() {
         AtomPlacer3D atmplacer = new AtomPlacer3D();
-        IAtomContainer molecule = MoleculeFactory.makeAlkane(5);
+        IAtomContainer molecule = TestMoleculeFactory.makeAlkane(5);
         IAtomContainer placedMolecule = atmplacer.markPlaced(molecule);
         for (IAtom atom : placedMolecule.atoms()) {
             Assert.assertTrue(atom.getFlag(CDKConstants.ISPLACED));

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/TemplateHandler3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/TemplateHandler3DTest.java
@@ -37,7 +37,7 @@ import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.isomorphism.matchers.QueryChemObject;
 import org.openscience.cdk.ringsearch.RingPartitioner;
 import org.openscience.cdk.silent.AtomContainer;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.RingSetManipulator;
 
 /**
@@ -89,7 +89,7 @@ public class TemplateHandler3DTest extends CDKTestCase {
 
     @Test
     public void testMapTemplates_IAtomContainer_double() throws Exception {
-        IAtomContainer ac = MoleculeFactory.makeBicycloRings();
+        IAtomContainer ac = TestMoleculeFactory.makeBicycloRings();
         TemplateHandler3D th3d = TemplateHandler3D.getInstance();
         ForceFieldConfigurator ffc = new ForceFieldConfigurator();
         ffc.setForceFieldConfigurator("mm2", ac.getBuilder());

--- a/tool/fragment/pom.xml
+++ b/tool/fragment/pom.xml
@@ -98,6 +98,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-io</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/MurckoFragmenterTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/MurckoFragmenterTest.java
@@ -31,7 +31,7 @@ import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
@@ -297,7 +297,7 @@ public class MurckoFragmenterTest extends CDKTestCase {
     @Test
     public void testGetFragmentsAsContainers() throws Exception {
 
-        IAtomContainer biphenyl = MoleculeFactory.makeBiphenyl();
+        IAtomContainer biphenyl = TestMoleculeFactory.makeBiphenyl();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(biphenyl);
         Aromaticity.cdkLegacy().apply(biphenyl);
 

--- a/tool/smarts/pom.xml
+++ b/tool/smarts/pom.xml
@@ -112,6 +112,13 @@
             <type>test-jar</type>
             <scope>test</scope>            
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/SMARTSTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/SMARTSTest.java
@@ -43,7 +43,7 @@ import org.openscience.cdk.isomorphism.matchers.smarts.AnyOrderQueryBond;
 import org.openscience.cdk.isomorphism.matchers.smarts.ImplicitHCountAtom;
 import org.openscience.cdk.isomorphism.matchers.smarts.SMARTSAtom;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * @cdk.module  test-smarts
@@ -142,7 +142,7 @@ public class SMARTSTest extends CDKTestCase {
             SymbolQueryAtom c1 = new SymbolQueryAtom(new org.openscience.cdk.Atom("C"));
             SymbolAndChargeQueryAtom c2 = new SymbolAndChargeQueryAtom(new org.openscience.cdk.Atom("C"));
 
-            IAtomContainer c = MoleculeFactory.makeAlkane(2);
+            IAtomContainer c = TestMoleculeFactory.makeAlkane(2);
 
             QueryAtomContainer query1 = new QueryAtomContainer(builder);
             query1.addAtom(c1);

--- a/tool/smarts/src/test/java/org/openscience/cdk/smiles/smarts/SMARTSQueryToolTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smiles/smarts/SMARTSQueryToolTest.java
@@ -39,7 +39,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 /**
@@ -179,7 +179,7 @@ public class SMARTSQueryToolTest extends CDKTestCase {
     @Test
     public void testIndoleAgainstItself() throws Exception {
 
-        IAtomContainer indole = MoleculeFactory.makeIndole();
+        IAtomContainer indole = TestMoleculeFactory.makeIndole();
         addImplicitHydrogens(indole);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(indole);
         Aromaticity.cdkLegacy().apply(indole);

--- a/tool/smsd/pom.xml
+++ b/tool/smsd/pom.xml
@@ -108,6 +108,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-smarts</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/tool/smsd/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSTest.java
+++ b/tool/smsd/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSTest.java
@@ -51,7 +51,7 @@ import org.openscience.cdk.isomorphism.matchers.SymbolQueryAtom;
 import org.openscience.cdk.isomorphism.matchers.smarts.AnyAtom;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.smsd.tools.TimeManager;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
@@ -66,8 +66,8 @@ public class CDKMCSTest extends CDKTestCase {
 
     @Test
     public void testIsSubgraph_IAtomContainer_IAtomContainer() throws java.lang.Exception {
-        IAtomContainer mol = MoleculeFactory.makeAlphaPinene();
-        IAtomContainer frag1 = MoleculeFactory.makeCyclohexene(); //one double bond in ring
+        IAtomContainer mol = TestMoleculeFactory.makeAlphaPinene();
+        IAtomContainer frag1 = TestMoleculeFactory.makeCyclohexene(); //one double bond in ring
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(mol.getBuilder());
@@ -124,8 +124,8 @@ public class CDKMCSTest extends CDKTestCase {
 
     @Test
     public void test2() throws java.lang.Exception {
-        IAtomContainer mol = MoleculeFactory.makeAlphaPinene();
-        IAtomContainer frag1 = MoleculeFactory.makeCyclohexane(); // no double bond in ring
+        IAtomContainer mol = TestMoleculeFactory.makeAlphaPinene();
+        IAtomContainer frag1 = TestMoleculeFactory.makeCyclohexane(); // no double bond in ring
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         Aromaticity.cdkLegacy().apply(mol);
@@ -140,8 +140,8 @@ public class CDKMCSTest extends CDKTestCase {
 
     @Test
     public void test3() throws java.lang.Exception {
-        IAtomContainer mol = MoleculeFactory.makeIndole();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(mol.getBuilder());
@@ -173,8 +173,8 @@ public class CDKMCSTest extends CDKTestCase {
         int[] result1 = {6, 5, 7, 8, 0};
         int[] result2 = {3, 4, 2, 1, 0};
 
-        IAtomContainer mol = MoleculeFactory.makeIndole();
-        IAtomContainer frag1 = MoleculeFactory.makePyrrole();
+        IAtomContainer mol = TestMoleculeFactory.makeIndole();
+        IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(frag1);
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(mol.getBuilder());

--- a/tool/structgen/pom.xml
+++ b/tool/structgen/pom.xml
@@ -103,6 +103,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-test-core</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>

--- a/tool/structgen/src/test/java/org/openscience/cdk/structgen/RandomStructureGeneratorTest.java
+++ b/tool/structgen/src/test/java/org/openscience/cdk/structgen/RandomStructureGeneratorTest.java
@@ -24,7 +24,7 @@ import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.graph.ConnectivityChecker;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.layout.StructureDiagramGenerator;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import javax.vecmath.Vector2d;
 import java.util.Vector;
@@ -43,7 +43,7 @@ public class RandomStructureGeneratorTest extends CDKTestCase {
 
     @Test
     public void testTwentyRandomStructures() {
-        IAtomContainer molecule = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAlphaPinene();
         RandomGenerator rg = new RandomGenerator(molecule);
         IAtomContainer result = null;
         for (int f = 0; f < 50; f++) {

--- a/tool/structgen/src/test/java/org/openscience/cdk/structgen/SingleStructureRandomGeneratorTest.java
+++ b/tool/structgen/src/test/java/org/openscience/cdk/structgen/SingleStructureRandomGeneratorTest.java
@@ -27,7 +27,7 @@ import javax.vecmath.Vector2d;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.layout.StructureDiagramGenerator;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 /**
@@ -57,7 +57,7 @@ public class SingleStructureRandomGeneratorTest {
     }
 
     private AtomContainer getBunchOfUnbondedAtoms() {
-        IAtomContainer molecule = MoleculeFactory.makeAlphaPinene();
+        IAtomContainer molecule = TestMoleculeFactory.makeAlphaPinene();
         fixCarbonHCount(molecule);
         molecule.removeAllElectronContainers();
         return (AtomContainer) molecule;

--- a/tool/structgen/src/test/java/org/openscience/cdk/structgen/VicinitySamplerTest.java
+++ b/tool/structgen/src/test/java/org/openscience/cdk/structgen/VicinitySamplerTest.java
@@ -34,7 +34,7 @@ import org.openscience.cdk.graph.ConnectivityChecker;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.openscience.cdk.templates.MoleculeFactory;
+import org.openscience.cdk.templates.TestMoleculeFactory;
 
 /**
  * @cdk.module test-structgen
@@ -50,7 +50,7 @@ public class VicinitySamplerTest extends CDKTestCase {
 
     @Test
     public void testVicinitySampler_sample() throws Exception {
-        IAtomContainer mol = MoleculeFactory.makeEthylPropylPhenantren();
+        IAtomContainer mol = TestMoleculeFactory.makeEthylPropylPhenantren();
 
         Isotopes.getInstance().configureAtoms(mol);
         addImplicitHydrogens(mol);


### PR DESCRIPTION
…eFactory. The only non-test usage was in the legacy module where the required methods were lifted out.