### PR TITLE
Added a test+fix for isotope pattern generation for C10000

### DIFF
--- a/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePattern.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePattern.java
@@ -29,12 +29,14 @@ public class IsotopePattern {
     }
 
     /**
-     * Set the mono isotope object.
+     * Set the mono isotope object. Adds the isoContainer to the isotope 
+     *                  pattern, if it is not already added. 
      *
      *  @param isoContainer   The IsotopeContainer object
      */
     public void setMonoIsotope(IsotopeContainer isoContainer) {
-        isotopeCList.add(isoContainer);
+        if (!isotopeCList.contains(isoContainer)) 
+            isotopeCList.add(isoContainer);
         monoIsotopePosition = isotopeCList.indexOf(isoContainer);
     }
 

--- a/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternGenerator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternGenerator.java
@@ -55,7 +55,8 @@ public class IsotopePatternGenerator {
     private double             minAbundance   = .1;
 
     /**
-     *  Constructor for the IsotopeGenerator.
+     *  Constructor for the IsotopeGenerator. The minimum abundance is set to 
+     *                          0.1 (10% abundance) by default. 
      */
     public IsotopePatternGenerator() {
         this(0.1);
@@ -65,7 +66,7 @@ public class IsotopePatternGenerator {
      * Constructor for the IsotopeGenerator.
      *
      * @param minAb Minimal abundance of the isotopes to be added
-     * 				in the combinatorial search
+     * 				in the combinatorial search (scale 0.0 to 1.0)
      *
      */
     public IsotopePatternGenerator(double minAb) {

--- a/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternManipulator.java
@@ -119,7 +119,7 @@ public class IsotopePatternManipulator {
 
             int length = listISO.size() - 1;
             for (int i = length; i >= 0; i--) {
-                double mass = 100000;
+                double mass = Double.MAX_VALUE;
                 IsotopeContainer isoHighest = null;
                 for (IsotopeContainer isoContainer : listISO) {
                     if (isoContainer.getMass() < mass) {

--- a/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternManipulator.java
@@ -1,5 +1,7 @@
 package org.openscience.cdk.formula;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -73,29 +75,25 @@ public class IsotopePatternManipulator {
      */
     public static IsotopePattern sortByIntensity(IsotopePattern isotopeP) {
         try {
-            IsotopePattern isoSort = new IsotopePattern();
-            List<IsotopeContainer> listISO = ((IsotopePattern) isotopeP.clone()).getIsotopes();
+            
+            IsotopePattern isoSort = (IsotopePattern) isotopeP.clone();
+            
+            // Do nothing for empty isotope pattern
+            if (isoSort.getNumberOfIsotopes() == 0)
+                return isoSort;
 
-            int length = listISO.size() - 1;
-            for (int i = length; i >= 0; i--) {
-                double intensity = 0;
-                IsotopeContainer isoHighest = null;
-                for (IsotopeContainer isoContainer : listISO) {
-                    if (isoContainer.getIntensity() > intensity) {
-                        isoHighest = isoContainer;
-                        intensity = isoContainer.getIntensity();
-                    }
+            // Sort the isotopes
+            List<IsotopeContainer> listISO = isoSort.getIsotopes();
+            Collections.sort(listISO, new Comparator<IsotopeContainer>() {
+                @Override
+                public int compare(IsotopeContainer o1, IsotopeContainer o2) {
+                    return Double.compare(o2.getIntensity(),o1.getIntensity());
                 }
-                if (isoHighest != null) {
-                    if (i == length)
-                        isoSort.setMonoIsotope((IsotopeContainer) isoHighest.clone());
-                    else
-                        isoSort.addIsotope((IsotopeContainer) isoHighest.clone());
-                }
-                listISO.remove(isoHighest);
-
-            }
-            isoSort.setCharge(isotopeP.getCharge());
+            });
+           
+            // Set the monoisotopic peak to the one with highest intensity
+            isoSort.setMonoIsotope(listISO.get(0));
+            
             return isoSort;
 
         } catch (CloneNotSupportedException e) {
@@ -114,28 +112,24 @@ public class IsotopePatternManipulator {
      */
     public static IsotopePattern sortByMass(IsotopePattern isotopeP) {
         try {
-            IsotopePattern isoSort = new IsotopePattern();
-            List<IsotopeContainer> listISO = ((IsotopePattern) isotopeP.clone()).getIsotopes();
+            IsotopePattern isoSort = (IsotopePattern) isotopeP.clone();
+            
+            // Do nothing for empty isotope pattern
+            if (isoSort.getNumberOfIsotopes() == 0) 
+                return isoSort;
 
-            int length = listISO.size() - 1;
-            for (int i = length; i >= 0; i--) {
-                double mass = Double.MAX_VALUE;
-                IsotopeContainer isoHighest = null;
-                for (IsotopeContainer isoContainer : listISO) {
-                    if (isoContainer.getMass() < mass) {
-                        isoHighest = isoContainer;
-                        mass = isoContainer.getMass();
-                    }
+            // Sort the isotopes
+            List<IsotopeContainer> listISO = isoSort.getIsotopes();
+            Collections.sort(listISO, new Comparator<IsotopeContainer>() {
+                @Override
+                public int compare(IsotopeContainer o1, IsotopeContainer o2) {
+                    return Double.compare(o1.getMass(),o2.getMass());
                 }
-                if (i == length)
-                    isoSort.setMonoIsotope((IsotopeContainer) isoHighest.clone());
-                else
-                    isoSort.addIsotope((IsotopeContainer) isoHighest.clone());
-
-                listISO.remove(isoHighest);
-
-            }
-            isoSort.setCharge(isotopeP.getCharge());
+            });
+           
+            // Set the monoisotopic peak to the one with lowest mass
+            isoSort.setMonoIsotope(listISO.get(0));
+            
             return isoSort;
 
         } catch (CloneNotSupportedException e) {

--- a/tool/formula/src/test/java/org/openscience/cdk/formula/IsotopePatternGeneratorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/formula/IsotopePatternGeneratorTest.java
@@ -255,4 +255,17 @@ public class IsotopePatternGeneratorTest extends CDKTestCase {
         Assert.assertEquals(1, isoPattern.getNumberOfIsotopes());
 
     }
+    
+    /**
+     * Calculate isotopes for C10000.
+     */
+    @Test
+    public void testCalculateIsotopesC10000() {
+        IMolecularFormula molFor = MolecularFormulaManipulator.getMajorIsotopeMolecularFormula("C10000", builder);
+        IsotopePatternGenerator isotopeGe = new IsotopePatternGenerator(.1);
+        IsotopePattern isos = isotopeGe.getIsotopes(molFor);
+        Assert.assertEquals(98, isos.getNumberOfIsotopes());
+        for (int i = 0; i < isos.getNumberOfIsotopes(); i++)
+            Assert.assertTrue(isos.getIsotope(i).getMass() > 120085);
+    }
 }

--- a/tool/formula/src/test/java/org/openscience/cdk/formula/IsotopePatternGeneratorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/formula/IsotopePatternGeneratorTest.java
@@ -257,14 +257,14 @@ public class IsotopePatternGeneratorTest extends CDKTestCase {
     }
     
     /**
-     * Calculate isotopes for C10000.
+     * Calculate isotopes for C10000 (failed in CDK 1.5.12).
      */
     @Test
     public void testCalculateIsotopesC10000() {
         IMolecularFormula molFor = MolecularFormulaManipulator.getMajorIsotopeMolecularFormula("C10000", builder);
         IsotopePatternGenerator isotopeGe = new IsotopePatternGenerator(.1);
         IsotopePattern isos = isotopeGe.getIsotopes(molFor);
-        Assert.assertEquals(98, isos.getNumberOfIsotopes());
+        Assert.assertEquals(44, isos.getNumberOfIsotopes());
         for (int i = 0; i < isos.getNumberOfIsotopes(); i++)
             Assert.assertTrue(isos.getIsotope(i).getMass() > 120085);
     }


### PR DESCRIPTION
The test is failing at the moment due to NullPointerException somewhere in IsotopePatternManipulator

```
java.lang.NullPointerException
	at org.openscience.cdk.formula.IsotopePatternManipulator.sortByMass(IsotopePatternManipulator.java:131)
	at org.openscience.cdk.formula.IsotopePatternGenerator.getIsotopes(IsotopePatternGenerator.java:113)
	at org.openscience.cdk.formula.IsotopePatternGeneratorTest.testCalculateIsotopesC10000(IsotopePatternGeneratorTest.java:266)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
```
