### PR TITLE
Fixes the LargestChainDescriptor to correctly find all paths

### DIFF
--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LargestChainDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LargestChainDescriptor.java
@@ -210,13 +210,11 @@ public class LargestChainDescriptor extends AbstractMolecularDescriptor implemen
         //IAtom[] atoms = container.getAtoms();
         ArrayList<IAtom> startSphere;
         ArrayList<IAtom> path;
-        //Set all VisitedFlags to False
-        for (int i = 0; i < container.getAtomCount(); i++) {
-            container.getAtom(i).setFlag(CDKConstants.VISITED, false);
-        }
 
         //logger.debug("Set all atoms to Visited False");
         for (int i = 0; i < container.getAtomCount(); i++) {
+            for (IAtom a : container.atoms()) a.setFlag(CDKConstants.VISITED, false);
+
             IAtom atomi = container.getAtom(i);
             // chain sp3
             //logger.debug("atom:"+i+" maxBondOrder:"+container.getMaximumBondOrder(atoms[i])+" Aromatic:"+atoms[i].getFlag(CDKConstants.ISAROMATIC)+" Ring:"+atoms[i].getFlag(CDKConstants.ISINRING)+" FormalCharge:"+atoms[i].getFormalCharge()+" Charge:"+atoms[i].getCharge()+" Flag:"+atoms[i].getFlag(CDKConstants.VISITED));

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/LargestChainDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/LargestChainDescriptorTest.java
@@ -115,4 +115,40 @@ public class LargestChainDescriptorTest extends MolecularDescriptorTest {
         Assert.assertEquals(0, ((IntegerResult) descriptor.calculate(mol).getValue()).intValue());
     }
 
+    @Test
+    public void test8LargestChainDescriptor() throws ClassNotFoundException, CDKException, java.lang.Exception {
+        Object[] params = {new Boolean(true), new Boolean(true)};
+        descriptor.setParameters(params);
+        SmilesParser sp = new SmilesParser(DefaultChemObjectBuilder.getInstance());
+        IAtomContainer mol = sp.parseSmiles("Cc1nn(c(c1)N)c1nc2c(s1)cccc2");
+        Assert.assertEquals(0, ((IntegerResult) descriptor.calculate(mol).getValue()).intValue());
+    }
+
+    @Test
+    public void test9LargestChainDescriptor() throws ClassNotFoundException, CDKException, java.lang.Exception {
+        Object[] params = {new Boolean(true), new Boolean(true)};
+        descriptor.setParameters(params);
+        SmilesParser sp = new SmilesParser(DefaultChemObjectBuilder.getInstance());
+        IAtomContainer mol = sp.parseSmiles("Nc1c(cn[nH]1)C#N");
+        Assert.assertEquals(2, ((IntegerResult) descriptor.calculate(mol).getValue()).intValue());
+    }
+
+    @Test
+    public void test10LargestChainDescriptor() throws ClassNotFoundException, CDKException, java.lang.Exception {
+        Object[] params = {new Boolean(true), new Boolean(true)};
+        descriptor.setParameters(params);
+        SmilesParser sp = new SmilesParser(DefaultChemObjectBuilder.getInstance());
+        IAtomContainer mol = sp.parseSmiles("OCc1ccccc1CN");
+        Assert.assertEquals(2, ((IntegerResult) descriptor.calculate(mol).getValue()).intValue());
+    }
+
+    @Test
+    public void test11LargestChainDescriptor() throws ClassNotFoundException, CDKException, java.lang.Exception {
+        Object[] params = {new Boolean(true), new Boolean(true)};
+        descriptor.setParameters(params);
+        SmilesParser sp = new SmilesParser(DefaultChemObjectBuilder.getInstance());
+        IAtomContainer mol = sp.parseSmiles("COc1ccc(cc1)c1noc(c1)Cn1nc(C)c(c(c1=O)C#N)C");
+        Assert.assertEquals(2, ((IntegerResult) descriptor.calculate(mol).getValue()).intValue());
+    }
+
 }


### PR DESCRIPTION
Ensure that we reset visited flag each time we start path search from new atom

Added test cases