### PR TITLE
Patched a bug in IsotopePatternGenerator

### DIFF
--- a/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternGenerator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternGenerator.java
@@ -92,16 +92,11 @@ public class IsotopePatternGenerator {
         }
         String mf = MolecularFormulaManipulator.getString(molFor, true);
 
-        // Divide the chemical formula into tokens (element and coefficients)
-        HashMap<String, Integer> tokens = new HashMap<String, Integer>();
         IMolecularFormula molecularFormula = MolecularFormulaManipulator.getMajorIsotopeMolecularFormula(mf, builder);
-        for (IIsotope isos : molecularFormula.isotopes())
-            tokens.put(isos.getSymbol(), molecularFormula.getIsotopeCount(isos));
 
-        int atomCount;
         for (IIsotope isos : molecularFormula.isotopes()) {
             String elementSymbol = isos.getSymbol();
-            atomCount = tokens.get(elementSymbol);
+            int atomCount = molecularFormula.getIsotopeCount(isos);
 
             for (int i = 0; i < atomCount; i++) {
                 if (!calculateAbundanceAndMass(elementSymbol)) {
@@ -112,7 +107,6 @@ public class IsotopePatternGenerator {
         IsotopePattern isoP = IsotopePatternManipulator.sortAndNormalizedByIntensity(abundance_Mass);
         isoP = cleanAbundance(isoP, minAbundance);
         IsotopePattern isoPattern = IsotopePatternManipulator.sortByMass(isoP);
-
         return isoPattern;
 
     }
@@ -167,7 +161,7 @@ public class IsotopePatternGenerator {
 
                     if (abundance == 0) continue;
 
-                    newAbundance = totalAbundance * abundance * 0.01f;
+                    newAbundance = totalAbundance * abundance * 0.01;
                     mass += currentISOPattern.getIsotopes().get(j).getMass();
 
                     // Filter duplicated masses
@@ -178,7 +172,7 @@ public class IsotopePatternGenerator {
                     }
 
                     // Filter isotopes too small
-                    if (isNotZero(newAbundance)) {
+                    if (newAbundance > 1E-10) {
                         isotopeMassAndAbundance.put(mass, newAbundance);
                     }
                     previousMass = 0;

--- a/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternGenerator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternGenerator.java
@@ -210,21 +210,6 @@ public class IsotopePatternGenerator {
     }
 
     /**
-     * Detection if the value is zero.
-     *
-     * @param number The number to analyze
-     * @return       TRUE, if it zero
-     */
-    private boolean isNotZero(double number) {
-        double pow = (double) Math.pow(10, 6);
-        int fraction = (int) (number * pow);
-
-        if (fraction <= 0) return false;
-
-        return true;
-    }
-
-    /**
      * Normalize the intensity (relative abundance) of all isotopes in relation
      * of the most abundant isotope.
      *

--- a/tool/formula/src/test/java/org/openscience/cdk/formula/IsotopePatternGeneratorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/formula/IsotopePatternGeneratorTest.java
@@ -268,4 +268,16 @@ public class IsotopePatternGeneratorTest extends CDKTestCase {
         for (int i = 0; i < isos.getNumberOfIsotopes(); i++)
             Assert.assertTrue(isos.getIsotope(i).getMass() > 120085);
     }
+    
+    /**
+     * Calculate isotopes for C20H30Fe2P2S4Cl4 (in CDK 1.5.12, this call 
+     * sometimes returns 34 and sometimes 35 isotopes, non-deterministically).
+     */
+    @Test
+    public void testCalculateIsotopesC20H30Fe2P2S4Cl4() {
+        IMolecularFormula molFor = MolecularFormulaManipulator.getMajorIsotopeMolecularFormula("C20H30Fe2P2S4Cl4", builder);
+        IsotopePatternGenerator isotopeGe = new IsotopePatternGenerator(.01);
+        IsotopePattern isos = isotopeGe.getIsotopes(molFor);
+        Assert.assertEquals(35, isos.getNumberOfIsotopes());
+    }
 }


### PR DESCRIPTION
I found this curious bug - running IsotopePatternGenerator on C20H30Fe2P2S4Cl4 returned sometimes 34 and sometimes 35 entries. Such non-deterministic behavior is not ideal for a library.

By tracking deeper I found the bug is caused by this: MolecularFormula.isotopes() returns an iterator of a Set, which is by definition unordered, and iterates the elements in random order (not sure how JRE manages this internally). The elements are therefore added to the growing isotope pattern in non-deterministic order. See https://github.com/cdk/cdk/blob/master/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternGenerator.java#L102

The method than does strange heuristics to decide whether to remove certain low-abundance isotopes. See
https://github.com/cdk/cdk/blob/master/tool/formula/src/main/java/org/openscience/cdk/formula/IsotopePatternGenerator.java#L224
However, whether the isotopes are low-abundant will depend on the order in which these are added to the calculation, which is random. Hence, the result is non-deterministic.

I added a junit test, which fails roughly in 50% of runs with CDK 1.5.12. I also added a patch for this bug, by reducing the threshold of what is considered low-abundance. Note: this does not fix the bug, only reduces its visibility (at the cost of increased computation time). Basically, I think the heuristics that is used is wrong, and the results of IsotopePatternGenerator are probably not 100% correct.
