### PR TITLE
Hydrogens should not be suppress on pseudo atoms.

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -845,7 +845,8 @@ public class AtomContainerManipulator {
         if (atom.getImplicitHydrogenCount() != null && atom.getImplicitHydrogenCount() != 0) return false;
         // molecule hydrogen
         List<IAtom> neighbors = container.getConnectedAtomsList(atom);
-        if (neighbors.size() == 1 && neighbors.get(0).getSymbol().equals("H")) return false;
+        if (neighbors.size() == 1 && (neighbors.get(0).getSymbol().equals("H") ||
+                                      neighbors.get(0) instanceof IPseudoAtom)) return false;
         // what about bridging hydrogens?
         // hydrogens with atom-atom mapping?
         return true;
@@ -894,9 +895,14 @@ public class AtomContainerManipulator {
         // hydrogen is either not attached to 0 or 2 neighbors
         if (graph[v].length != 1) return false;
 
-        // okay the hydrogen has one neighbor, if that neighbor is not a
-        // hydrogen (i.e. molecular hydrogen) then we can suppress it
-        return !"H".equals(container.getAtom(graph[v][0]).getSymbol());
+        // okay the hydrogen has one neighbor, if that neighbor is a
+        // hydrogen (i.e. molecular hydrogen) then we can not suppress it
+        if ("H".equals(container.getAtom(graph[v][0]).getSymbol()))
+            return false;
+        // can not nicely suppress hydrogens on pseudo atoms
+        if (container.getAtom(graph[v][0]) instanceof IPseudoAtom)
+            return false;
+        return true;
     }
 
     /**

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -55,6 +55,7 @@ import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.io.ISimpleChemObjectReader;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.isomorphism.UniversalIsomorphismTester;
+import org.openscience.cdk.silent.PseudoAtom;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
@@ -218,6 +219,19 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
         IAtomContainer ac = AtomContainerManipulator.removeHydrogens(mol);
         Assert.assertEquals(2, ac.getAtomCount());
         Assert.assertTrue(ac.getFlag(CDKConstants.ISAROMATIC));
+    }
+
+    @Test
+    public void dontSuppressHydrogensOnPseudoAtoms() throws Exception {
+        IAtomContainer mol = new AtomContainer(); // *[H]
+        mol.addAtom(new PseudoAtom("*"));
+        mol.addAtom(new Atom("H"));
+        mol.getAtom(0).setImplicitHydrogenCount(0);
+        mol.getAtom(1).setImplicitHydrogenCount(1);
+        mol.addBond(0, 1, Order.SINGLE);
+        Assert.assertEquals(2, mol.getAtomCount());
+        IAtomContainer ac = AtomContainerManipulator.removeHydrogens(mol);
+        Assert.assertEquals(2, ac.getAtomCount());
     }
 
     private IAtomContainer getChiralMolTemplate() {


### PR DESCRIPTION
```*[H]``` should stay as ```*[H]```, ```[*H]``` is nasty to depict.