### PR TITLE
Patch/unit test multiple single electrons

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/CDKConstants.java
+++ b/base/core/src/main/java/org/openscience/cdk/CDKConstants.java
@@ -386,6 +386,6 @@ public class CDKConstants {
     public static final String      LONE_PAIR_COUNT              = "cdk:Lone Pair Count";
 
     /** Used as property key for indicating the number of single electrons on the atom type. */
-    public static final String      SINGLE_ELECTRON_COUNT        = "cdk:Lone Pair Count";
+    public static final String      SINGLE_ELECTRON_COUNT        = "cdk:Single Electron Count";
 
 }

--- a/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
+++ b/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
@@ -2518,6 +2518,13 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
         if (atom.getFormalCharge() != CDKConstants.UNSET && !atom.getFormalCharge().equals(type.getFormalCharge()))
             return false;
 
+        // confirm single electron count
+        if (type.getProperty(CDKConstants.SINGLE_ELECTRON_COUNT) != null) {
+            int count = countSingleElectrons(container, atom);
+            if (count != type.getProperty(CDKConstants.SINGLE_ELECTRON_COUNT, Integer.class).intValue())
+                return false;
+        }
+
         return true;
     }
 

--- a/base/core/src/main/java/org/openscience/cdk/config/ImmutableAtomType.java
+++ b/base/core/src/main/java/org/openscience/cdk/config/ImmutableAtomType.java
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012-2015  Egon Willighagen <egonw@users.sf.net>
+/* Copyright (C) 2012-2016  Egon Willighagen <egonw@users.sf.net>
  *               2012-2014  John May <john.wilkinsonmay@gmail.com>
  *
  * Contact: cdk-devel@lists.sourceforge.net
@@ -348,4 +348,36 @@ final class ImmutableAtomType implements IAtomType {
 		return this.electronValency;
 	}
 
+    @Override
+    public String toString() {
+        StringBuffer resultString = new StringBuffer(64);
+        resultString.append("ImmutableAtomType(").append(hashCode());
+        if (getAtomTypeName() != null) {
+            resultString.append(", N:").append(getAtomTypeName());
+        }
+        if (getMaxBondOrder() != null) {
+            resultString.append(", MBO:").append(getMaxBondOrder());
+        }
+        if (getBondOrderSum() != null) {
+            resultString.append(", BOS:").append(getBondOrderSum());
+        }
+        if (getFormalCharge() != null) {
+            resultString.append(", FC:").append(getFormalCharge());
+        }
+        if (getHybridization() != null) {
+            resultString.append(", H:").append(getHybridization());
+        }
+        if (getFormalNeighbourCount() != null) {
+            resultString.append(", NC:").append(getFormalNeighbourCount());
+        }
+        if (getCovalentRadius() != null) {
+            resultString.append(", CR:").append(getCovalentRadius());
+        }
+        if (getValency() != null) {
+            resultString.append(", EV:").append(getValency());
+        }
+        resultString.append(", ").append(super.toString());
+        resultString.append(')');
+        return resultString.toString();
+    }
 }

--- a/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
@@ -3086,6 +3086,22 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
     }
 
+    /**
+     * @cdk.bug 1382
+     */
+    @Test
+    public void testCarbonDiradical() throws Exception {
+        IAtomContainer mol = new AtomContainer();
+        IAtom atom = new Atom("C");
+        mol.addAtom(atom);
+        mol.addSingleElectron(0);
+        mol.addSingleElectron(0);
+
+        IAtomTypeMatcher atm = getAtomTypeMatcher(mol.getBuilder());
+        IAtomType foundType = atm.findMatchingAtomType(mol, atom);
+        Assert.assertEquals("X", foundType.getAtomTypeName());
+    }
+
     @Test
     public void testEthoxyEthaneRadical() throws Exception {
         IAtomContainer mol = new AtomContainer();

--- a/base/test-core/src/test/java/org/openscience/cdk/config/ImmutableAtomTypeTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/config/ImmutableAtomTypeTest.java
@@ -1,0 +1,48 @@
+/* Copyright (C) 2016  Egon Willighagen <egon.willighagen@gmail.com>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.openscience.cdk.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openscience.cdk.CDKTestCase;
+import org.openscience.cdk.exception.NoSuchAtomTypeException;
+import org.openscience.cdk.interfaces.IAtomType;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+
+/**
+ * Checks the functionality of the {@link ImmutableAtomType}.
+ *
+ * @cdk.module test-core
+ */
+public class ImmutableAtomTypeTest extends CDKTestCase {
+
+	@Test
+	public void testToString() throws NoSuchAtomTypeException {
+		AtomTypeFactory factory = AtomTypeFactory.getInstance(
+			"org/openscience/cdk/dict/data/cdk-atom-types.owl",
+			SilentChemObjectBuilder.getInstance()
+		);
+		IAtomType type = factory.getAtomType("C.sp3");
+		Assert.assertTrue(type instanceof ImmutableAtomType);
+		String output = type.toString();
+		Assert.assertTrue(output.contains("ImmutableAtomType("));
+		Assert.assertTrue(output.contains("MBO:"));
+	}
+
+}


### PR DESCRIPTION
John, this PR is a mix of three things:

- unit test and fix for a bug: during atom typing, it did not check the number of single electrons
- added ImmutableAtomType.toString (which helped me debug)
- a fix for a grave bug (without unit test, but trivial)