### PR TITLE
Minor quirk of beam internal, a recent update in CDK unsets the bond …

### DIFF
--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
@@ -108,13 +108,14 @@ final class BeamToCDK {
      * Convert a Beam ChemicalGraph to a CDK IAtomContainer.
      *
      * @param g Beam graph instance
+     * @param kekule the input has been kekulzied
      * @return the CDK {@link IAtomContainer} for the input
      * @throws IllegalArgumentException the Beam graph was not 'expanded' - and
      *                                  contained organic subset atoms. If this
      *                                  happens use the Beam Functions.expand()
      *                                  to
      */
-    IAtomContainer toAtomContainer(Graph g) {
+    IAtomContainer toAtomContainer(Graph g, boolean kekule) {
 
         IAtomContainer ac = emptyContainer();
         IAtom[] atoms = new IAtom[g.order()];
@@ -125,7 +126,7 @@ final class BeamToCDK {
         for (int i = 0; i < g.order(); i++)
             atoms[i] = toCDKAtom(g.atom(i), g.implHCount(i));
         for (Edge e : g.edges())
-            bonds[j++] = toCDKBond(e, atoms);
+            bonds[j++] = toCDKBond(e, atoms, kekule);
 
         // atom-centric stereo-specification (only tetrahedral ATM)
         for (int u = 0; u < g.order(); u++) {
@@ -422,7 +423,7 @@ final class BeamToCDK {
      * @param atoms the already converted atoms
      * @return new bond instance
      */
-    IBond toCDKBond(Edge edge, IAtom[] atoms) {
+    IBond toCDKBond(Edge edge, IAtom[] atoms, boolean kekule) {
 
         int u = edge.either();
         int v = edge.other(u);
@@ -439,7 +440,7 @@ final class BeamToCDK {
                 atoms[v].setIsAromatic(true);
                 break;
             case IMPLICIT:
-                if (atoms[u].isAromatic() && atoms[v].isAromatic()) {
+                if (!kekule && atoms[u].isAromatic() && atoms[v].isAromatic()) {
                     bond.setIsAromatic(true);
                     bond.setOrder(IBond.Order.UNSET);
                     atoms[u].setIsAromatic(true);

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -244,7 +244,8 @@ public final class SmilesParser {
 
             // convert the Beam object model to the CDK - note exception thrown
             // if a kekule structure could not be assigned.
-            IAtomContainer mol = beamToCDK.toAtomContainer(kekulise ? g.kekule() : g);
+            IAtomContainer mol = beamToCDK.toAtomContainer(kekulise ? g.kekule() : g,
+                                                           kekulise);
 
             if (!isRxnPart) {
                 try {

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/BeamToCDKTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/BeamToCDKTest.java
@@ -156,7 +156,7 @@ public class BeamToCDKTest {
     public void singleBondEdge() {
         IAtom[] atoms = new IAtom[]{mock(IAtom.class), mock(IAtom.class), mock(IAtom.class), mock(IAtom.class),
                 mock(IAtom.class), mock(IAtom.class)};
-        IBond b = g2c.toCDKBond(Bond.SINGLE.edge(0, 5), atoms);
+        IBond b = g2c.toCDKBond(Bond.SINGLE.edge(0, 5), atoms, true);
         assertThat(b.getOrder(), is(IBond.Order.SINGLE));
         assertFalse(b.getFlag(CDKConstants.ISAROMATIC));
         assertThat(b.getAtom(0), is(atoms[0]));
@@ -167,7 +167,7 @@ public class BeamToCDKTest {
     public void aromaticBondEdge() {
         IAtom[] atoms = new IAtom[]{mock(IAtom.class), mock(IAtom.class), mock(IAtom.class), mock(IAtom.class),
                 mock(IAtom.class), mock(IAtom.class)};
-        IBond b = g2c.toCDKBond(Bond.AROMATIC.edge(0, 5), atoms);
+        IBond b = g2c.toCDKBond(Bond.AROMATIC.edge(0, 5), atoms, true);
         assertThat(b.getOrder(), is(IBond.Order.SINGLE));
         assertTrue(b.getFlag(CDKConstants.ISAROMATIC));
         assertThat(b.getAtom(0), is(atoms[0]));
@@ -178,7 +178,7 @@ public class BeamToCDKTest {
     public void doubleBondEdge() {
         IAtom[] atoms = new IAtom[]{mock(IAtom.class), mock(IAtom.class), mock(IAtom.class), mock(IAtom.class),
                 mock(IAtom.class), mock(IAtom.class)};
-        IBond b = g2c.toCDKBond(Bond.DOUBLE.edge(0, 5), atoms);
+        IBond b = g2c.toCDKBond(Bond.DOUBLE.edge(0, 5), atoms, true);
         assertThat(b.getOrder(), is(IBond.Order.DOUBLE));
         assertFalse(b.getFlag(CDKConstants.ISAROMATIC));
         assertThat(b.getAtom(0), is(atoms[0]));
@@ -548,7 +548,7 @@ public class BeamToCDKTest {
     IAtomContainer convert(String smi) throws IOException {
         BeamToCDK g2c = new BeamToCDK(SilentChemObjectBuilder.getInstance());
         Graph g = Graph.fromSmiles(smi);
-        return g2c.toAtomContainer(g);
+        return g2c.toAtomContainer(g, false);
     }
 
 }

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -36,10 +36,12 @@ import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;
+import org.openscience.cdk.aromaticity.ElectronDonation;
 import org.openscience.cdk.atomtype.CDKAtomTypeMatcher;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.ConnectivityChecker;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -63,6 +65,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Please see the test.gui package for visual feedback on tests.
@@ -2516,6 +2519,15 @@ public class SmilesParserTest extends CDKTestCase {
     public void atomBasedDbStereoReversing() throws Exception {
         assertThat(SmilesGenerator.isomeric().create(load("[C@H](F)=[C@@H]F")),
                    is("C(\\F)=C\\F"));
+    }
+
+    @Test
+    public void azuleneHasAllBondOrdersSet() throws Exception {
+        IAtomContainer mol = load("c1ccc-2cccccc12");
+        for (IBond bond : mol.bonds()) {
+            if (bond.getOrder() == null || bond.getOrder() == IBond.Order.UNSET)
+                fail("Unset bond order");
+        }
     }
 
     /**


### PR DESCRIPTION
…order when reading non-kekulé SMILES, during the conversion we need to tell the converter this to avoid nulling out single bonds between aromatic atoms.

A regression from a recent change.