### PR TITLE
Patch/improved abbr labels

### DIFF
--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -23,8 +23,10 @@
 
 package org.openscience.cdk.depict;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupType;
@@ -167,6 +169,82 @@ public class AbbreviationsTest {
         mol.setProperty(CDKConstants.CTAB_SGROUPS, Collections.singletonList(sgroup));
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(0));
+    }
+
+    @Test public void NHBocFromHeteroCollapse() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*C(=O)OC(C)(C)C Boc");
+        IAtomContainer mol = smi("c1ccccc1NC(=O)OC(C)(C)C");
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("NHBoc"));
+        assertThat(sgroups.get(0).getBonds().size(), is(1));
+        assertThat(sgroups.get(0).getAtoms().size(), is(8));
+    }
+
+    @Test public void NHBocFromHeteroCollapseExplicitH() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*C(=O)OC(C)(C)C Boc");
+        IAtomContainer mol = smi("c1ccccc1N([H])C(=O)OC(C)(C)C");
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("NHBoc"));
+        assertThat(sgroups.get(0).getBonds().size(), is(1));
+        assertThat(sgroups.get(0).getAtoms().size(), is(9));
+    }
+
+    @Test public void NBocClFromHeteroCollapseExplicit() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*C(=O)OC(C)(C)C Boc");
+        IAtomContainer mol = smi("c1ccccc1N(Cl)C(=O)OC(C)(C)C");
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("N(Cl)Boc"));
+        assertThat(sgroups.get(0).getBonds().size(), is(1));
+        assertThat(sgroups.get(0).getAtoms().size(), is(9));
+    }
+
+    @Test public void NBoc2FromHeteroCollapse() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*C(=O)OC(C)(C)C Boc");
+        IAtomContainer mol = smi("c1cc2ccccc2cc1N(C(=O)OC(C)(C)C)C(=O)OC(C)(C)C");
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("NBoc2"));
+        assertThat(sgroups.get(0).getBonds().size(), is(1));
+        assertThat(sgroups.get(0).getAtoms().size(), is(15));
+    }
+
+    @Test public void iPrFromHeteroCollapse() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*C(C)C iPr");
+        IAtomContainer mol = smi("[CH3:27][CH:19]([CH3:28])[C:20]1=[N:26][C:23](=[CH:22][S:21]1)[C:24](=[O:25])O");
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("iPr"));
+        assertThat(sgroups.get(0).getBonds().size(), is(1));
+        assertThat(sgroups.get(0).getAtoms().size(), is(3));
+    }
+
+    @Test public void NBocFromHeteroCollapseExplicitH() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*C(=O)OC(C)(C)C Boc");
+        IAtomContainer mol = smi("c1cc2ccccc2ccn1C(=O)OC(C)(C)C");
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("NBoc"));
+        assertThat(sgroups.get(0).getBonds().size(), is(2));
+        assertThat(sgroups.get(0).getAtoms().size(), is(8));
+    }
+
+    @Test public void SO3minusFromHeteroCollapseNone() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*S(=O)(=O)[O-] SO3-");
+        IAtomContainer mol = smi("c1ccccc1N(S(=O)(=O)[O-])S(=O)(=O)[O-]");
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(2));
+        assertThat(sgroups.get(0).getSubscript(), is("SO3-"));
+        assertThat(sgroups.get(1).getSubscript(), is("SO3-"));
     }
 
     @Test

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/AbbreviationLabel.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/AbbreviationLabel.java
@@ -25,8 +25,10 @@ package org.openscience.cdk.renderer.generators.standard;
 
 import org.openscience.cdk.config.Elements;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 
 /**
@@ -247,6 +249,13 @@ final class AbbreviationLabel {
         return false;
     }
 
+    private static boolean isNumber(String str) {
+        for (int i = 0; i < str.length(); i++)
+            if (!isDigit(str.charAt(i)))
+                return false;
+        return true;
+    }
+
     /**
      * Reverse a list of tokens for display, flipping
      * brackets as needed.
@@ -255,11 +264,24 @@ final class AbbreviationLabel {
      */
     static void reverse(List<String> tokens) {
         Collections.reverse(tokens);
-        // now flip brackets
+        // now flip brackets and move numbers
+        Deque<String> numbers = new ArrayDeque<>();
         for (int i = 0; i < tokens.size(); i++) {
             String token = tokens.get(i);
-            if (token.equals("(")) tokens.set(i, ")");
-            else if (token.equals(")")) tokens.set(i, "(");
+            if (token.equals("(")) {
+                tokens.set(i, ")");
+                tokens.add(i+1, numbers.pop());
+                i++;
+            }
+            else if (token.equals(")")) {
+                tokens.set(i, "(");
+                if (i>0 && isNumber(tokens.get(i - 1))) {
+                    numbers.push(tokens.remove(i - 1));
+                    i--;
+                } else {
+                    numbers.push("");
+                }
+            }
         }
     }
 

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/AbbreviationLabel.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/AbbreviationLabel.java
@@ -307,18 +307,23 @@ final class AbbreviationLabel {
             }
         }
 
-        // merge adjacent text together if it is of the same style
-        List<FormattedText> res = new ArrayList<>(texts.size());
+        return texts;
+    }
+
+    static void reduce(List<FormattedText> texts, int from, int to) {
+        List<FormattedText> tmp = new ArrayList<>(texts.size());
         FormattedText prev = null;
-        for (FormattedText curr : texts) {
+        tmp.addAll(texts.subList(0, from));
+        for (FormattedText curr : texts.subList(from, to)) {
             if (prev == null || prev.style != curr.style) {
-                res.add(prev = curr);
+                tmp.add(prev = curr);
             } else {
                 prev.text += curr.text;
             }
         }
-
-        return res;
+        tmp.addAll(texts.subList(to, texts.size()));
+        texts.clear();
+        texts.addAll(tmp);
     }
 
     /**

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardAtomGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardAtomGenerator.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.openscience.cdk.renderer.generators.standard.HydrogenPosition.Above;
+import static org.openscience.cdk.renderer.generators.standard.HydrogenPosition.Below;
 import static org.openscience.cdk.renderer.generators.standard.HydrogenPosition.Left;
 import static org.openscience.cdk.renderer.generators.standard.HydrogenPosition.Right;
 
@@ -279,6 +280,11 @@ final class StandardAtomGenerator {
 
         final Font italicFont = font.deriveFont(Font.ITALIC);
 
+        if (position == Below || position == Above)
+            AbbreviationLabel.reduce(fTexts, 1, fTexts.size());
+        else
+            AbbreviationLabel.reduce(fTexts, 0, fTexts.size());
+
         // convert to outlines
         final List<TextOutline> outlines = new ArrayList<>(fTexts.size());
         for (FormattedText fText : fTexts) {
@@ -321,7 +327,18 @@ final class StandardAtomGenerator {
             for (index = 0; index < outlines.size(); index++)
                 if ((fTexts.get(index).style & 0x1) == 0) break;
         }
+
         TextOutline primary = outlines.remove(index);
+
+        if (position == Below || position == Above) {
+            double offsetX = primary.getBounds().getX() - outlines.get(0).getBounds().getX();
+            double offsetY = position == Below
+                             ? padding + primary.getBounds().getHeight()
+                             : -primary.getBounds().getHeight() - padding;
+            for (int i = 0; i < outlines.size(); i++) {
+                outlines.set(i, outlines.get(i).translate(offsetX, offsetY));
+            }
+        }
 
         return new AtomSymbol(primary, outlines);
     }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -367,7 +367,7 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
 
                     // defines how the element is aligned on the atom point, when
                     // aligned to the left, the first character 'e.g. Cl' is used.
-                    if (visNeighbors.size() == 1) {
+                    if (visNeighbors.size() > 0) {
                         if (hPosition == Left) {
                             symbols[i] = symbols[i].alignTo(AtomSymbol.SymbolAlignment.Right);
                         } else {

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
@@ -236,9 +236,21 @@ final class StandardSgroupGenerator {
         final Set<IBond> crossing = sgroup.getBonds();
         final Set<IAtom> atoms = sgroup.getAtoms();
 
-        // only do 0,1 attachments for now
-        if (crossing.size() > 1)
-            return;
+        // only do 0,1 attachments for now unless they're all connected to the same atom
+        if (crossing.size() > 1) {
+            IAtom internal = null;
+            for (IBond bond : crossing) {
+                IAtom beg = bond.getAtom(0);
+                IAtom end = bond.getAtom(1);
+                if (atoms.contains(beg)) {
+                    if (internal != null && internal != beg) return; // can't do it
+                    internal = beg;
+                } else if (atoms.contains(end)) {
+                    if (internal != null && internal != end) return; // can't do it
+                    internal = end;
+                }
+            }
+        }
 
         for (IAtom atom : atoms) {
             StandardGenerator.hide(atom);

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/AbbreviationLabelTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/AbbreviationLabelTest.java
@@ -101,6 +101,7 @@ public class AbbreviationLabelTest {
         List<String> tokens = new ArrayList<>();
         assertTrue(AbbreviationLabel.parse("Fe(acac)3", tokens));
         List<AbbreviationLabel.FormattedText> formatted = AbbreviationLabel.format(tokens);
+        AbbreviationLabel.reduce(formatted, 0, formatted.size());
         assertThat(formatted.get(0).text, is("Fe(acac)"));
         assertThat(formatted.get(0).style, is(0));
         assertThat(formatted.get(1).text, is("3"));
@@ -133,6 +134,14 @@ public class AbbreviationLabelTest {
     }
 
     @Test
+    public void reversingBracketsWithNumbers() {
+        List<String> tokens = new ArrayList<>();
+        assertTrue(AbbreviationLabel.parse("B(OH)2", tokens));
+        AbbreviationLabel.reverse(tokens);
+        assertThat(Joiner.on("").join(tokens), is("(HO)2B"));
+    }
+
+    @Test
     public void nonAbbreviationLabel() {
         List<String> tokens = new ArrayList<>();
         assertFalse(AbbreviationLabel.parse("A Random Label - Don't Reverse", tokens));
@@ -143,6 +152,7 @@ public class AbbreviationLabelTest {
     public void formatOPO3() {
         List<String> tokens = Arrays.asList("O", "P", "O3", "-2");
         List<AbbreviationLabel.FormattedText> texts = AbbreviationLabel.format(tokens);
+        AbbreviationLabel.reduce(texts, 0, texts.size());
         assertThat(texts.size(), is(3));
         assertThat(texts.get(0).text, is("OPO"));
         assertThat(texts.get(0).style, is(AbbreviationLabel.STYLE_NORMAL));
@@ -167,6 +177,7 @@ public class AbbreviationLabelTest {
     public void formatOPO3H2() {
         List<String> tokens = Arrays.asList("O", "P", "O3", "H2");
         List<AbbreviationLabel.FormattedText> texts = AbbreviationLabel.format(tokens);
+        AbbreviationLabel.reduce(texts, 0, texts.size());
         assertThat(texts.size(), is(4));
         assertThat(texts.get(0).text, is("OPO"));
         assertThat(texts.get(0).style, is(0));


### PR DESCRIPTION
Some nice tweaks to abbreviations, I do want to replace the algorithm with a more general reduction one (currently dictionary based) but this is a step in the right direction. Added support for non-terminal labels, iff attachment is to single atom, PEG=no, SO2=yes. Further contract abbreviations next to other hetero atoms, Boc may be in the dictionary but not >NBoc, =NBoc, or NHBoc - we can now however generate these through relaxing adjacent abbreviations.

# OnBu
![image](https://cloud.githubusercontent.com/assets/983232/18582576/b02ad93a-7bfd-11e6-89a2-61b07a0722e3.png)
![image](https://cloud.githubusercontent.com/assets/983232/18582609/dc283744-7bfd-11e6-83aa-bb2d30ca80e9.png)

# SO2
![image](https://cloud.githubusercontent.com/assets/983232/18582584/b5ff4986-7bfd-11e6-88f4-7a2c509719a4.png)
![image](https://cloud.githubusercontent.com/assets/983232/18582610/e09aff5a-7bfd-11e6-86bd-68ef3ad164c8.png)

# NBoc
![image](https://cloud.githubusercontent.com/assets/983232/18582588/bb33312e-7bfd-11e6-94b8-85c47c0a0a99.png)
![image](https://cloud.githubusercontent.com/assets/983232/18582615/e549da12-7bfd-11e6-9362-ff8550b68e3e.png)

