### PR TITLE
Restore the API behaviour: throw an exception for null input

### DIFF
--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGeneratorFactory.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGeneratorFactory.java
@@ -168,6 +168,7 @@ public class InChIGeneratorFactory {
      * @throws CDKException  if the generator cannot be instantiated
      */
     public InChIGenerator getInChIGenerator(IAtomContainer container, List<INCHI_OPTION> options) throws CDKException {
+        if (options == null) throw new IllegalArgumentException("Null options");
         return (new InChIGenerator(container, options, ignoreAromaticBonds));
     }
 


### PR DESCRIPTION
Alternatively, the InChIGeneratorFactoryTest.testGetInChIGenerator_IAtomContainer_NullList() test should be updated.