### PR TITLE
Improved API for atom creation.

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -532,6 +532,10 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             mass = (str.charAt(pos++) - '0');
             while (pos < len && isDigit(str.charAt(pos)))
                 mass = 10 * mass + (str.charAt(pos++) - '0');
+        } else if ("R".equals(str)) {
+            atom.setAtomicNumber(0);
+            atom.setSymbol("R");
+            return true;
         }
 
         // atom symbol

--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -536,6 +536,16 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             atom.setAtomicNumber(0);
             atom.setSymbol("R");
             return true;
+        } else if ("D".equals(str)) {
+            atom.setAtomicNumber(1);
+            atom.setMassNumber(2);
+            atom.setSymbol("H");
+            return true;
+        } else if ("T".equals(str)) {
+            atom.setAtomicNumber(1);
+            atom.setMassNumber(3);
+            atom.setSymbol("H");
+            return true;
         }
 
         // atom symbol

--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -22,6 +22,7 @@
  */
 package org.openscience.cdk;
 
+import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.tools.periodictable.PeriodicTable;
@@ -113,14 +114,66 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
     }
 
     /**
-     * Constructs an Atom from a String containing an element symbol.
+     * Create a new atom with of the specified element.
      *
-     * @param elementSymbol The String describing the element for the Atom
+     * @param elem atomic number
      */
-    public Atom(String elementSymbol) {
-        this(new Element(elementSymbol, PeriodicTable.getAtomicNumber(elementSymbol)));
-        this.formalCharge = 0;
+    public Atom(int elem) {
+        this(elem, 0, 0);
     }
+
+    /**
+     * Create a new atom with of the specified element and hydrogen count.
+     *
+     * @param elem atomic number
+     * @param hcnt hydrogen count
+     */
+    public Atom(int elem, int hcnt) {
+        this(elem, hcnt, 0);
+    }
+
+    /**
+     * Create a new atom with of the specified element, hydrogen count, and formal charge.
+     *
+     * @param elem atomic number
+     * @param hcnt hydrogen count
+     * @param fchg formal charge
+     */
+    public Atom(int elem, int hcnt, int fchg) {
+        super((String)null);
+        setAtomicNumber(elem);
+        setSymbol(Elements.ofNumber(elem).symbol());
+        setImplicitHydrogenCount(hcnt);
+        setFormalCharge(fchg);
+    }
+
+    /**
+     * Constructs an Atom from a string containing an element symbol and optionally
+     * the atomic mass, hydrogen count, and formal charge. The symbol grammar allows
+     * easy construction from common symbols, for example:
+     *
+     * <pre>
+     *     new Atom("NH+");   // nitrogen cation with one hydrogen
+     *     new Atom("OH");    // hydroxy
+     *     new Atom("O-");    // oxygen anion
+     *     new Atom("13CH3"); // methyl isotope 13
+     * </pre>
+     *
+     * <pre>
+     *     atom := {mass}? {symbol} {hcnt}? {fchg}?
+     *     mass := \d+
+     *     hcnt := 'H' \d+
+     *     fchg := '+' \d+? | '-' \d+?
+     * </pre>
+     *
+     * @param symbol string with the element symbol
+     */
+    public Atom(String symbol) {
+        super((String)null);
+        if (!parseAtomSymbol(this, symbol))
+            throw new IllegalArgumentException("Cannot pass atom symbol: " + symbol);
+    }
+
 
     /**
          * Constructs an Atom from an Element and a Point3d.
@@ -452,4 +505,96 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         return (IAtom) clone;
     }
 
+
+    private static boolean isUpper(char c) {
+        return c >= 'A' && c <= 'Z';
+    }
+
+    private static boolean isLower(char c) {
+        return c >= 'a' && c <= 'z';
+    }
+
+    private static boolean isDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private static boolean parseAtomSymbol(IAtom atom, String str) {
+        final int len = str.length();
+        int pos = 0;
+
+        int mass = -1;
+        int anum = 0;
+        int hcnt = 0;
+        int chg = 0;
+
+        // optional mass
+        if (pos < len && isDigit(str.charAt(pos))) {
+            mass = (str.charAt(pos++) - '0');
+            while (pos < len && isDigit(str.charAt(pos)))
+                mass = 10 * mass + (str.charAt(pos++) - '0');
+        }
+
+        // atom symbol
+        if (pos < len && isUpper(str.charAt(pos))) {
+            int beg = pos;
+            pos++;
+            while (pos < len && isLower(str.charAt(pos)))
+                pos++;
+            Elements elem = Elements.ofString(str.substring(beg, pos));
+            if (elem == Elements.Unknown)
+                return false;
+            anum = elem.number();
+
+            // optional fields after atom symbol
+            while (pos < len) {
+                switch (str.charAt(pos)) {
+                    case 'H':
+                        pos++;
+                        if (pos < len && isDigit(str.charAt(pos))) {
+                            while (pos < len && isDigit(str.charAt(pos)))
+                                hcnt = 10 * hcnt + (str.charAt(pos++) - '0');
+                        } else {
+                            hcnt = 1;
+                        }
+                        break;
+                    case '+':
+                        pos++;
+                        if (pos < len && isDigit(str.charAt(pos))) {
+                            chg = (str.charAt(pos++) - '0');
+                            while (pos < len && isDigit(str.charAt(pos)))
+                                chg = 10 * chg + (str.charAt(pos++) - '0');
+                        } else {
+                            chg = +1;
+                        }
+                        break;
+                    case '-':
+                        pos++;
+                        if (pos < len && isDigit(str.charAt(pos))) {
+                            chg = (str.charAt(pos++) - '0');
+                            while (pos < len && isDigit(str.charAt(pos)))
+                                chg = 10 * chg + (str.charAt(pos++) - '0');
+                            chg *= -1;
+                        } else {
+                            chg = -1;
+                        }
+                        break;
+                    default:
+                        return false;
+                }
+            }
+        } else {
+            return false;
+        }
+
+        if (mass < 0)
+            atom.setMassNumber(null);
+        else
+            atom.setMassNumber(mass);
+        atom.setAtomicNumber(anum);
+        atom.setSymbol(Elements.ofNumber(anum).symbol());
+        atom.setImplicitHydrogenCount(hcnt);
+        atom.setFormalCharge(chg);
+
+        return pos == len && len > 0;
+    }
 }

--- a/base/data/src/main/java/org/openscience/cdk/protein/data/PDBAtom.java
+++ b/base/data/src/main/java/org/openscience/cdk/protein/data/PDBAtom.java
@@ -110,6 +110,7 @@ public class PDBAtom extends Atom implements Cloneable, IPDBAtom {
         oxt = false;
         hetAtom = false;
 
+        super.hydrogenCount = null;
         super.charge = Double.valueOf(0.0);
         super.formalCharge = Integer.valueOf(0);
     }

--- a/base/data/src/test/java/org/openscience/cdk/AtomTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/AtomTest.java
@@ -77,6 +77,92 @@ public class AtomTest extends AbstractAtomTest {
         Assert.assertNull(a.getFractionalPoint3d());
     }
 
+    @Test
+    public void testAtom_NH4plus_direct() {
+        IAtom a = new Atom(7, 4, +1);
+        Assert.assertEquals("N", a.getSymbol());
+        Assert.assertEquals((Integer) 7, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 4, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 1, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_CH3_direct() {
+        IAtom a = new Atom(6, 3);
+        Assert.assertEquals("C", a.getSymbol());
+        Assert.assertEquals((Integer) 6, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 3, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 0, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_Cl_direct() {
+        IAtom a = new Atom(17);
+        Assert.assertEquals("Cl", a.getSymbol());
+        Assert.assertEquals((Integer) 17, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 0, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_NH4plus() {
+        IAtom a = new Atom("NH4+");
+        Assert.assertEquals("N", a.getSymbol());
+        Assert.assertEquals((Integer) 7, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 4, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 1, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_Ominus() {
+        IAtom a = new Atom("O-");
+        Assert.assertEquals("O", a.getSymbol());
+        Assert.assertEquals((Integer) 8, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals(Integer.valueOf(-1), a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_Ca2plus() {
+        IAtom a = new Atom("Ca+2");
+        Assert.assertEquals("Ca", a.getSymbol());
+        Assert.assertEquals((Integer) 20, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals(Integer.valueOf(+2), a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_13CH3() {
+        IAtom a = new Atom("13CH3");
+        Assert.assertEquals("C", a.getSymbol());
+        Assert.assertEquals((Integer) 13, a.getMassNumber());
+        Assert.assertEquals((Integer) 6, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 3, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 0, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+
     /**
      * Method to test the Atom(String symbol, javax.vecmath.Point3d point3D) method.
      */

--- a/base/data/src/test/java/org/openscience/cdk/BioPolymerTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/BioPolymerTest.java
@@ -66,11 +66,11 @@ public class BioPolymerTest extends AbstractBioPolymerTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C3");
-        IAtom oAtom4 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C4");
-        IAtom oAtom5 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C5");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom4 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom5 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
 
         oBioPolymer.addAtom(oAtom1);
         oBioPolymer.addAtom(oAtom2, oStrand1);

--- a/base/data/src/test/java/org/openscience/cdk/StrandTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/StrandTest.java
@@ -64,11 +64,11 @@ public class StrandTest extends AbstractStrandTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
-        IAtom oAtom4 = oStrand.getBuilder().newInstance(IAtom.class, "C4");
-        IAtom oAtom5 = oStrand.getBuilder().newInstance(IAtom.class, "C5");
+        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom4 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom5 = oStrand.getBuilder().newInstance(IAtom.class, "C");
 
         oStrand.addAtom(oAtom1);
         oStrand.addAtom(oAtom2);

--- a/base/data/src/test/java/org/openscience/cdk/protein/data/PDBPolymerTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/protein/data/PDBPolymerTest.java
@@ -68,11 +68,11 @@ public class PDBPolymerTest extends AbstractPDBPolymerTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
-        IPDBAtom oPDBAtom4 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C4");
-        IPDBAtom oPDBAtom5 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C5");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom4 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom5 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
 
         pdbPolymer.addAtom(oPDBAtom1);
         pdbPolymer.addAtom(oPDBAtom2, oStrand1);
@@ -117,8 +117,8 @@ public class PDBPolymerTest extends AbstractPDBPolymerTest {
         oMono1.setMonomerName("TRP279");
         IMonomer oMono2 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName("CYS280");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom2, oMono1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom3, oMono2, oStrand1);
         Assert.assertNotNull(pdbPolymer.getAtom(0));

--- a/base/data/src/test/java/org/openscience/cdk/templates/TestMoleculeFactory.java
+++ b/base/data/src/test/java/org/openscience/cdk/templates/TestMoleculeFactory.java
@@ -1870,6 +1870,8 @@ public class TestMoleculeFactory {
 
     private static void configureAtoms(IAtomContainer mol) {
         try {
+            for (IAtom atom : mol.atoms())
+                atom.setImplicitHydrogenCount(null);
             Isotopes.getInstance().configureAtoms(mol);
         } catch (Exception exc) {
             logger.error("Could not configure molecule!");

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugAtom.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugAtom.java
@@ -45,7 +45,7 @@ public class DebugAtom extends Atom implements IAtom {
 
     private static final long serialVersionUID = 188945429187084868L;
 
-    ILoggingTool              logger           = LoggingToolFactory.createLoggingTool(DebugAtom.class);
+    private static final ILoggingTool logger = LoggingToolFactory.createLoggingTool(DebugAtom.class);
 
     public DebugAtom() {
         super();

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugFragmentAtom.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugFragmentAtom.java
@@ -51,7 +51,7 @@ public class DebugFragmentAtom extends FragmentAtom {
 
     private static final long serialVersionUID = 0L;
 
-    ILoggingTool              logger           = LoggingToolFactory.createLoggingTool(DebugFragmentAtom.class);
+    private static final ILoggingTool              logger           = LoggingToolFactory.createLoggingTool(DebugFragmentAtom.class);
 
     public DebugFragmentAtom() {
         super();

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugPDBAtom.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugPDBAtom.java
@@ -37,7 +37,7 @@ public class DebugPDBAtom extends PDBAtom implements IPDBAtom {
 
     private static final long serialVersionUID = -2432127382224382452L;
 
-    ILoggingTool              logger           = LoggingToolFactory.createLoggingTool(DebugPDBAtom.class);
+    private static final ILoggingTool              logger           = LoggingToolFactory.createLoggingTool(DebugPDBAtom.class);
 
     public DebugPDBAtom(IElement element) {
         super(element);

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugPseudoAtom.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugPseudoAtom.java
@@ -45,7 +45,7 @@ public class DebugPseudoAtom extends PseudoAtom implements IPseudoAtom {
 
     private static final long serialVersionUID = -5935090219383862070L;
 
-    ILoggingTool              logger           = LoggingToolFactory.createLoggingTool(DebugPseudoAtom.class);
+    private static final ILoggingTool              logger           = LoggingToolFactory.createLoggingTool(DebugPseudoAtom.class);
 
     public DebugPseudoAtom() {
         super();

--- a/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugBioPolymerTest.java
+++ b/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugBioPolymerTest.java
@@ -64,11 +64,11 @@ public class DebugBioPolymerTest extends AbstractBioPolymerTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C3");
-        IAtom oAtom4 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C4");
-        IAtom oAtom5 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C5");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom4 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom5 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
 
         oBioPolymer.addAtom(oAtom1);
         oBioPolymer.addAtom(oAtom2, oStrand1);

--- a/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugPDBPolymerTest.java
+++ b/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugPDBPolymerTest.java
@@ -64,11 +64,11 @@ public class DebugPDBPolymerTest extends AbstractPDBPolymerTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
-        IPDBAtom oPDBAtom4 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C4");
-        IPDBAtom oPDBAtom5 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C5");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom4 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom5 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
 
         pdbPolymer.addAtom(oPDBAtom1);
         pdbPolymer.addAtom(oPDBAtom2, oStrand1);

--- a/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugStrandTest.java
+++ b/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugStrandTest.java
@@ -59,11 +59,11 @@ public class DebugStrandTest extends AbstractStrandTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
-        IAtom oAtom4 = oStrand.getBuilder().newInstance(IAtom.class, "C4");
-        IAtom oAtom5 = oStrand.getBuilder().newInstance(IAtom.class, "C5");
+        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom4 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom5 = oStrand.getBuilder().newInstance(IAtom.class, "C");
 
         oStrand.addAtom(oAtom1);
         oStrand.addAtom(oAtom2);

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -523,6 +523,16 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             atom.setAtomicNumber(0);
             atom.setSymbol("R");
             return true;
+        } else if ("D".equals(str)) {
+            atom.setAtomicNumber(1);
+            atom.setMassNumber(2);
+            atom.setSymbol("H");
+            return true;
+        } else if ("T".equals(str)) {
+            atom.setAtomicNumber(1);
+            atom.setMassNumber(3);
+            atom.setSymbol("H");
+            return true;
         }
 
         final int len = str.length();

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -519,6 +519,10 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             atom.setAtomicNumber(elem.number());
             atom.setSymbol(elem.symbol());
             return true;
+        } else if ("R".equals(str)) {
+            atom.setAtomicNumber(0);
+            atom.setSymbol("R");
+            return true;
         }
 
         final int len = str.length();

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -28,6 +28,7 @@ import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.tools.periodictable.PeriodicTable;
@@ -115,21 +116,72 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
     }
 
     /**
-     * Constructs an Atom from a String containing an element symbol.
+     * Create a new atom with of the specified element.
      *
-     * @param elementSymbol The String describing the element for the Atom
+     * @param elem atomic number
      */
-    public Atom(String elementSymbol) {
-        this(new Element(elementSymbol, PeriodicTable.getAtomicNumber(elementSymbol)));
-        this.formalCharge = 0;
+    public Atom(int elem) {
+        this(elem, 0, 0);
     }
 
     /**
-         * Constructs an Atom from an Element and a Point3d.
-         *
-         * @param   elementSymbol   The symbol of the atom
-         * @param   point3d         The 3D coordinates of the atom
-         */
+     * Create a new atom with of the specified element and hydrogen count.
+     *
+     * @param elem atomic number
+     * @param hcnt hydrogen count
+     */
+    public Atom(int elem, int hcnt) {
+        this(elem, hcnt, 0);
+    }
+
+    /**
+     * Create a new atom with of the specified element, hydrogen count, and formal charge.
+     *
+     * @param elem atomic number
+     * @param hcnt hydrogen count
+     * @param fchg formal charge
+     */
+    public Atom(int elem, int hcnt, int fchg) {
+        super((String)null);
+        setAtomicNumber(elem);
+        setSymbol(Elements.ofNumber(elem).symbol());
+        setImplicitHydrogenCount(hcnt);
+        setFormalCharge(fchg);
+    }
+
+    /**
+     * Constructs an Atom from a string containing an element symbol and optionally
+     * the atomic mass, hydrogen count, and formal charge. The symbol grammar allows
+     * easy construction from common symbols, for example:
+     *
+     * <pre>
+     *     new Atom("NH+");   // nitrogen cation with one hydrogen
+     *     new Atom("OH");    // hydroxy
+     *     new Atom("O-");    // oxygen anion
+     *     new Atom("13CH3"); // methyl isotope 13
+     * </pre>
+     *
+     * <pre>
+     *     atom := {mass}? {symbol} {hcnt}? {fchg}?
+     *     mass := \d+
+     *     hcnt := 'H' \d+
+     *     fchg := '+' \d+? | '-' \d+?
+     * </pre>
+     *
+     * @param symbol string with the element symbol
+     */
+    public Atom(String symbol) {
+        super((String)null);
+        if (!parseAtomSymbol(this, symbol))
+            throw new IllegalArgumentException("Cannot pass atom symbol: " + symbol);
+    }
+
+    /**
+     * Constructs an Atom from an Element and a Point3d.
+     *
+     * @param   elementSymbol   The symbol of the atom
+     * @param   point3d         The 3D coordinates of the atom
+     */
     public Atom(String elementSymbol, Point3d point3d) {
         this(elementSymbol);
         this.point3d = point3d;
@@ -448,4 +500,103 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         return (IAtom) clone;
     }
 
+    private static boolean isUpper(char c) {
+        return c >= 'A' && c <= 'Z';
+    }
+
+    private static boolean isLower(char c) {
+        return c >= 'a' && c <= 'z';
+    }
+
+    private static boolean isDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private static boolean parseAtomSymbol(IAtom atom, String str) {
+
+        Elements elem = Elements.ofString(str);
+        if (elem != Elements.Unknown) {
+            atom.setAtomicNumber(elem.number());
+            atom.setSymbol(elem.symbol());
+            return true;
+        }
+
+        final int len = str.length();
+        int pos = 0;
+
+        int mass = -1;
+        int anum = 0;
+        int hcnt = 0;
+        int chg = 0;
+
+        // optional mass
+        if (pos < len && isDigit(str.charAt(pos))) {
+            mass = (str.charAt(pos++) - '0');
+            while (pos < len && isDigit(str.charAt(pos)))
+                mass = 10 * mass + (str.charAt(pos++) - '0');
+        }
+
+        // atom symbol
+        if (pos < len && isUpper(str.charAt(pos))) {
+            int beg = pos;
+            pos++;
+            while (pos < len && isLower(str.charAt(pos)))
+                pos++;
+            elem = Elements.ofString(str.substring(beg, pos));
+            if (elem == Elements.Unknown)
+                return false;
+            anum = elem.number();
+
+            // optional fields after atom symbol
+            while (pos < len) {
+                switch (str.charAt(pos)) {
+                    case 'H':
+                        pos++;
+                        if (pos < len && isDigit(str.charAt(pos))) {
+                            while (pos < len && isDigit(str.charAt(pos)))
+                                hcnt = 10 * hcnt + (str.charAt(pos++) - '0');
+                        } else {
+                            hcnt = 1;
+                        }
+                        break;
+                    case '+':
+                        pos++;
+                        if (pos < len && isDigit(str.charAt(pos))) {
+                            chg = (str.charAt(pos++) - '0');
+                            while (pos < len && isDigit(str.charAt(pos)))
+                                chg = 10 * chg + (str.charAt(pos++) - '0');
+                        } else {
+                            chg = +1;
+                        }
+                        break;
+                    case '-':
+                        pos++;
+                        if (pos < len && isDigit(str.charAt(pos))) {
+                            chg = (str.charAt(pos++) - '0');
+                            while (pos < len && isDigit(str.charAt(pos)))
+                                chg = 10 * chg + (str.charAt(pos++) - '0');
+                            chg *= -1;
+                        } else {
+                            chg = -1;
+                        }
+                        break;
+                    default:
+                        return false;
+                }
+            }
+        } else {
+            return false;
+        }
+
+        if (mass < 0)
+            atom.setMassNumber(null);
+        else
+            atom.setMassNumber(mass);
+        atom.setAtomicNumber(anum);
+        atom.setSymbol(Elements.ofNumber(anum).symbol());
+        atom.setImplicitHydrogenCount(hcnt);
+        atom.setFormalCharge(chg);
+
+        return pos == len && len > 0;
+    }
 }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/PDBAtom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/PDBAtom.java
@@ -108,7 +108,7 @@ public class PDBAtom extends Atom implements Cloneable, IPDBAtom {
 
         oxt = false;
         hetAtom = false;
-
+        super.hydrogenCount = null;
         super.charge = Double.valueOf(0.0);
         super.formalCharge = Integer.valueOf(0);
     }

--- a/base/silent/src/test/java/org/openscience/cdk/silent/AtomTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/AtomTest.java
@@ -72,6 +72,91 @@ public class AtomTest extends AbstractAtomTest {
     }
 
     @Test
+    public void testAtom_NH4plus_direct() {
+        IAtom a = new Atom(7, 4, +1);
+        Assert.assertEquals("N", a.getSymbol());
+        Assert.assertEquals((Integer) 7, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 4, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 1, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_CH3_direct() {
+        IAtom a = new Atom(6, 3);
+        Assert.assertEquals("C", a.getSymbol());
+        Assert.assertEquals((Integer) 6, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 3, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 0, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_Cl_direct() {
+        IAtom a = new Atom(17);
+        Assert.assertEquals("Cl", a.getSymbol());
+        Assert.assertEquals((Integer) 17, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 0, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_NH4plus() {
+        IAtom a = new Atom("NH4+");
+        Assert.assertEquals("N", a.getSymbol());
+        Assert.assertEquals((Integer) 7, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 4, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 1, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_Ominus() {
+        IAtom a = new Atom("O-");
+        Assert.assertEquals("O", a.getSymbol());
+        Assert.assertEquals((Integer) 8, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals(Integer.valueOf(-1), a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_Ca2plus() {
+        IAtom a = new Atom("Ca+2");
+        Assert.assertEquals("Ca", a.getSymbol());
+        Assert.assertEquals((Integer) 20, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals(Integer.valueOf(+2), a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
+    public void testAtom_13CH3() {
+        IAtom a = new Atom("13CH3");
+        Assert.assertEquals("C", a.getSymbol());
+        Assert.assertEquals((Integer) 13, a.getMassNumber());
+        Assert.assertEquals((Integer) 6, a.getAtomicNumber());
+        Assert.assertEquals((Integer) 3, a.getImplicitHydrogenCount());
+        Assert.assertEquals((Integer) 0, a.getFormalCharge());
+        Assert.assertNull(a.getPoint2d());
+        Assert.assertNull(a.getPoint3d());
+        Assert.assertNull(a.getFractionalPoint3d());
+    }
+
+    @Test
     public void testAtom_String_Point3d() {
         Point3d point3d = new Point3d(1.0, 2.0, 3.0);
 

--- a/base/silent/src/test/java/org/openscience/cdk/silent/BioPolymerTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/BioPolymerTest.java
@@ -64,11 +64,11 @@ public class BioPolymerTest extends AbstractBioPolymerTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C3");
-        IAtom oAtom4 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C4");
-        IAtom oAtom5 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C5");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom4 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom5 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
 
         oBioPolymer.addAtom(oAtom1);
         oBioPolymer.addAtom(oAtom2, oStrand1);

--- a/base/silent/src/test/java/org/openscience/cdk/silent/PDBPolymerTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/PDBPolymerTest.java
@@ -66,11 +66,11 @@ public class PDBPolymerTest extends AbstractPDBPolymerTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
-        IPDBAtom oPDBAtom4 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C4");
-        IPDBAtom oPDBAtom5 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C5");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom4 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom5 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
 
         pdbPolymer.addAtom(oPDBAtom1);
         pdbPolymer.addAtom(oPDBAtom2, oStrand1);
@@ -115,8 +115,8 @@ public class PDBPolymerTest extends AbstractPDBPolymerTest {
         oMono1.setMonomerName("TRP279");
         IMonomer oMono2 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName("CYS280");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom2, oMono1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom3, oMono2, oStrand1);
         Assert.assertNotNull(pdbPolymer.getAtom(0));

--- a/base/silent/src/test/java/org/openscience/cdk/silent/StrandTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/StrandTest.java
@@ -59,11 +59,11 @@ public class StrandTest extends AbstractStrandTest {
         oMono2.setMonomerName(new String("HOH"));
         IMonomer oMono3 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono3.setMonomerName(new String("GLYA16"));
-        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
-        IAtom oAtom4 = oStrand.getBuilder().newInstance(IAtom.class, "C4");
-        IAtom oAtom5 = oStrand.getBuilder().newInstance(IAtom.class, "C5");
+        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom4 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom5 = oStrand.getBuilder().newInstance(IAtom.class, "C");
 
         oStrand.addAtom(oAtom1);
         oStrand.addAtom(oAtom2);

--- a/base/test-atomtype/src/test/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcherTest.java
+++ b/base/test-atomtype/src/test/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcherTest.java
@@ -191,7 +191,7 @@ public class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
     @Test
     public void testNonExistingType() throws Exception {
         IAtomContainer mol = new AtomContainer();
-        IAtom atom = new Atom("Error");
+        IAtom atom = new Atom();
         mol.addAtom(atom);
         SybylAtomTypeMatcher matcher = SybylAtomTypeMatcher.getInstance(mol.getBuilder());
         IAtomType type = matcher.findMatchingAtomType(mol, atom);

--- a/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
@@ -124,7 +124,7 @@ public class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     public void testNonExistingType() throws Exception {
         IAtomContainer mol = new AtomContainer();
-        IAtom atom = new Atom("Error");
+        IAtom atom = new Atom();
         mol.addAtom(atom);
         CDKAtomTypeMatcher matcher = CDKAtomTypeMatcher.getInstance(DefaultChemObjectBuilder.getInstance());
         IAtomType type = matcher.findMatchingAtomType(mol, atom);

--- a/base/test-core/src/test/java/org/openscience/cdk/config/AtomTypeFactoryTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/config/AtomTypeFactoryTest.java
@@ -235,7 +235,7 @@ public class AtomTypeFactoryTest extends CDKTestCase {
     @Test
     public void testConfigure_IAtom() throws Exception {
         IAtomType atomType;
-        IAtom atom = new org.openscience.cdk.Atom("X");
+        IAtom atom = new org.openscience.cdk.Atom();
         atom.setAtomTypeName("C.ar");
         AtomTypeFactory factory = AtomTypeFactory.getInstance("org/openscience/cdk/config/data/mol2_atomtypes.xml",
                 new ChemObject().getBuilder());

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/AbstractChemObjectBuilderTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/AbstractChemObjectBuilderTest.java
@@ -495,7 +495,7 @@ public abstract class AbstractChemObjectBuilderTest extends CDKTestCase {
     @Test
     public void testNewPDBAtom_String_Point3d() {
         IChemObjectBuilder builder = rootObject.getBuilder();
-        IPDBAtom atom = builder.newInstance(IPDBAtom.class, "Foo", new Point3d(1, 2, 3));
+        IPDBAtom atom = builder.newInstance(IPDBAtom.class, "C", new Point3d(1, 2, 3));
         Assert.assertNotNull(atom);
     }
 

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/AbstractChemObjectBuilderTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/AbstractChemObjectBuilderTest.java
@@ -418,14 +418,14 @@ public abstract class AbstractChemObjectBuilderTest extends CDKTestCase {
     @Test
     public void testNewPDBAtom_String() {
         IChemObjectBuilder builder = rootObject.getBuilder();
-        IPDBAtom atom = builder.newInstance(IPDBAtom.class, "O.3");
+        IPDBAtom atom = builder.newInstance(IPDBAtom.class, "O");
         Assert.assertNotNull(atom);
     }
 
     @Test
     public void testNewPDBAtom_String_Point3D() {
         IChemObjectBuilder builder = rootObject.getBuilder();
-        IPDBAtom atom = builder.newInstance(IPDBAtom.class, "O.3", new Point3d(1, 2, 3));
+        IPDBAtom atom = builder.newInstance(IPDBAtom.class, "O", new Point3d(1, 2, 3));
         Assert.assertNotNull(atom);
     }
 

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBioPolymerTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBioPolymerTest.java
@@ -46,9 +46,9 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1);
         oBioPolymer.addAtom(oAtom2, oMono1, oStrand1);
         oBioPolymer.addAtom(oAtom3, oMono2, oStrand2);
@@ -76,9 +76,9 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1);
         oBioPolymer.addAtom(oAtom2, oMono1, oStrand1);
         oBioPolymer.addAtom(oAtom3, oMono2, oStrand2);
@@ -106,9 +106,9 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1, oMono1, oStrand1);
         oBioPolymer.addAtom(oAtom2, oMono1, oStrand1);
         oBioPolymer.addAtom(oAtom3, oMono2, oStrand2);
@@ -122,8 +122,8 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
     public void testAddAtom_IAtom() {
         IBioPolymer oBioPolymer = (IBioPolymer) newChemObject();
 
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1);
         oBioPolymer.addAtom(oAtom2);
 
@@ -137,9 +137,9 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oStrand1.setStrandName("A");
         IMonomer oMono1 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1, oStrand1);
         oBioPolymer.addAtom(oAtom2, oStrand1);
         oBioPolymer.addAtom(oAtom3, oMono1, oStrand1);
@@ -156,8 +156,8 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oStrand1.setStrandName("A");
         IMonomer oMono1 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1, oMono1, oStrand1);
         oBioPolymer.addAtom(oAtom2, oMono1, oStrand1);
         oBioPolymer.addAtom(oAtom1, null, oStrand1);
@@ -173,7 +173,7 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oStrand1.setStrandName("A");
         IMonomer oMono1 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1, oMono1, oStrand1);
 
         Assert.assertEquals(1, oBioPolymer.getStrandCount());
@@ -186,7 +186,7 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oStrand1.setStrandName("A");
         IMonomer oMono1 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1, oMono1, oStrand1);
 
         Assert.assertEquals(oStrand1, oBioPolymer.getStrand("A"));
@@ -203,8 +203,8 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("GLY123"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1, oMono1, oStrand1);
         oBioPolymer.addAtom(oAtom2, oMono2, oStrand2);
         Map<String, IStrand> strands = new Hashtable<String, IStrand>();
@@ -221,7 +221,7 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oStrand1.setStrandName("A");
         IMonomer oMono1 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1, oMono1, oStrand1);
 
         Assert.assertTrue(oBioPolymer.getStrandNames().contains(oStrand1.getStrandName()));
@@ -242,8 +242,8 @@ public abstract class AbstractBioPolymerTest extends AbstractPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oBioPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("GLY123"));
-        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C2");
+        IAtom oAtom1 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oBioPolymer.getBuilder().newInstance(IAtom.class, "C");
         oBioPolymer.addAtom(oAtom1, oMono1, oStrand1);
         oBioPolymer.addAtom(oAtom2, oMono2, oStrand2);
         Map<String, IStrand> strands = new Hashtable<String, IStrand>();

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractPDBPolymerTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractPDBPolymerTest.java
@@ -63,9 +63,9 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1);
         pdbPolymer.addAtom(oPDBAtom2, oMono1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom3, oMono2, oStrand2);
@@ -93,9 +93,9 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1);
         pdbPolymer.addAtom(oPDBAtom2, oMono1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom3, oMono2, oStrand2);
@@ -124,9 +124,9 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oMono1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom2, oMono1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom3, oMono2, oStrand2);
@@ -139,8 +139,8 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
     public void testAddAtom_IPDBAtom() {
         IPDBPolymer pdbPolymer = (IPDBPolymer) newChemObject();
 
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1);
         pdbPolymer.addAtom(oPDBAtom2);
 
@@ -154,9 +154,9 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oStrand1.setStrandName("A");
         IPDBMonomer oMono1 = pdbPolymer.getBuilder().newInstance(IPDBMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom2, oStrand1);
         pdbPolymer.addAtom(oPDBAtom3, oMono1, oStrand1);
@@ -173,9 +173,9 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oStrand1.setStrandName("A");
         IPDBMonomer oMono1 = pdbPolymer.getBuilder().newInstance(IPDBMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
-        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C3");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom3 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom2, oStrand1);
         pdbPolymer.addAtom(oPDBAtom3, oMono1, oStrand1);
@@ -192,7 +192,7 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IStrand oStrand1 = pdbPolymer.getBuilder().newInstance(IStrand.class);
         oStrand1.setStrandName("A");
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oMono1, oStrand1);
 
         Assert.assertEquals(1, pdbPolymer.getMonomer("TRP279", "A").getAtomCount());
@@ -206,7 +206,7 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oStrand1.setStrandName("A");
         IMonomer oMono1 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oMono1, oStrand1);
 
         Assert.assertEquals(1, pdbPolymer.getStrandCount());
@@ -220,7 +220,7 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oStrand1.setStrandName("A");
         IMonomer oMono1 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oMono1, oStrand1);
 
         Assert.assertEquals(oStrand1, pdbPolymer.getStrand("A"));
@@ -238,8 +238,8 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("GLY123"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oMono1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom2, oMono2, oStrand2);
         Map<String, IStrand> strands = new Hashtable<String, IStrand>();
@@ -257,7 +257,7 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oStrand1.setStrandName("A");
         IMonomer oMono1 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oMono1, oStrand1);
 
         Assert.assertTrue(pdbPolymer.getStrandNames().contains(oStrand1.getStrandName()));
@@ -279,8 +279,8 @@ public abstract class AbstractPDBPolymerTest extends AbstractBioPolymerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = pdbPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("GLY123"));
-        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C1");
-        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C2");
+        IPDBAtom oPDBAtom1 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
+        IPDBAtom oPDBAtom2 = pdbPolymer.getBuilder().newInstance(IPDBAtom.class, "C");
         pdbPolymer.addAtom(oPDBAtom1, oMono1, oStrand1);
         pdbPolymer.addAtom(oPDBAtom2, oMono2, oStrand2);
         Map<String, IStrand> strands = new Hashtable<String, IStrand>();

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractPolymerTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractPolymerTest.java
@@ -43,8 +43,8 @@ public abstract class AbstractPolymerTest extends AbstractMoleculeTest {
     public void testAddAtom_IAtom() {
         IPolymer oPolymer = (IPolymer) newChemObject();
 
-        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C2");
+        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
         oPolymer.addAtom(oAtom1);
         oPolymer.addAtom(oAtom2);
 
@@ -58,9 +58,9 @@ public abstract class AbstractPolymerTest extends AbstractMoleculeTest {
         IMonomer oMono1 = oPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = null;
-        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oPolymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
 
         oPolymer.addAtom(oAtom1);
         oPolymer.addAtom(oAtom2, oMono1);
@@ -88,9 +88,9 @@ public abstract class AbstractPolymerTest extends AbstractMoleculeTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oPolymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
         oPolymer.addAtom(oAtom1);
         oPolymer.addAtom(oAtom2, oMono1);
         oPolymer.addAtom(oAtom3, oMono2);
@@ -107,9 +107,9 @@ public abstract class AbstractPolymerTest extends AbstractMoleculeTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oPolymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
         oPolymer.addAtom(oAtom1, oMono1);
         oPolymer.addAtom(oAtom2, oMono1);
         oPolymer.addAtom(oAtom3, oMono2);
@@ -128,9 +128,9 @@ public abstract class AbstractPolymerTest extends AbstractMoleculeTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oPolymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oPolymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
         oPolymer.addAtom(oAtom1);
         oPolymer.addAtom(oAtom2, oMono1);
         oPolymer.addAtom(oAtom3, oMono2);
@@ -150,7 +150,7 @@ public abstract class AbstractPolymerTest extends AbstractMoleculeTest {
         IPolymer oPolymer = (IPolymer) newChemObject();
         IMonomer oMono1 = oPolymer.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C1");
+        IAtom oAtom1 = oPolymer.getBuilder().newInstance(IAtom.class, "C");
         oPolymer.addAtom(oAtom1, oMono1);
         Assert.assertTrue(oPolymer.getMonomerNames().contains(oMono1.getMonomerName()));
         Assert.assertEquals(1, oPolymer.getAtomCount());
@@ -171,8 +171,8 @@ public abstract class AbstractPolymerTest extends AbstractMoleculeTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = polymer.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom2 = polymer.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = polymer.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom2 = polymer.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = polymer.getBuilder().newInstance(IAtom.class, "C");
         polymer.addAtom(oAtom2, oMono1);
         polymer.addAtom(oAtom3, oMono2);
         Map<String, IMonomer> monomers = new Hashtable<String, IMonomer>();

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractStrandTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractStrandTest.java
@@ -77,8 +77,8 @@ public abstract class AbstractStrandTest extends AbstractAtomContainerTest {
     @Override
     public void testAddAtom_IAtom() {
         IStrand oStrand = (IStrand) newChemObject();
-        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
+        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
         oStrand.addAtom(oAtom1);
         oStrand.addAtom(oAtom2);
 
@@ -90,9 +90,9 @@ public abstract class AbstractStrandTest extends AbstractAtomContainerTest {
         IStrand oStrand = (IStrand) newChemObject();
         IMonomer oMono1 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C1");
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
         oStrand.addAtom(oAtom1);
         oStrand.addAtom(oAtom2);
         oStrand.addAtom(oAtom3, oMono1);
@@ -108,8 +108,8 @@ public abstract class AbstractStrandTest extends AbstractAtomContainerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
         oStrand.addAtom(oAtom2, oMono1);
         oStrand.addAtom(oAtom3, oMono2);
 
@@ -123,8 +123,8 @@ public abstract class AbstractStrandTest extends AbstractAtomContainerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
         oStrand.addAtom(oAtom2, oMono1);
         oStrand.addAtom(oAtom3, oMono2);
 
@@ -140,8 +140,8 @@ public abstract class AbstractStrandTest extends AbstractAtomContainerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
         oStrand.addAtom(oAtom2, oMono1);
         oStrand.addAtom(oAtom3, oMono2);
         Map<String, IMonomer> monomers = new Hashtable<String, IMonomer>();
@@ -168,7 +168,7 @@ public abstract class AbstractStrandTest extends AbstractAtomContainerTest {
         IStrand oStrand = (IStrand) newChemObject();
         IMonomer oMono1 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono1.setMonomerName(new String("TRP279"));
-        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C1");
+        IAtom oAtom1 = oStrand.getBuilder().newInstance(IAtom.class, "C");
         oStrand.addAtom(oAtom1, oMono1);
         Assert.assertTrue(oStrand.getMonomerNames().contains(oMono1.getMonomerName()));
         Assert.assertEquals(1, oStrand.getAtomCount());
@@ -184,8 +184,8 @@ public abstract class AbstractStrandTest extends AbstractAtomContainerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
         oStrand.addAtom(oAtom2, oMono1);
         oStrand.addAtom(oAtom3, oMono2);
         Map<String, IMonomer> monomers = new Hashtable<String, IMonomer>();
@@ -210,8 +210,8 @@ public abstract class AbstractStrandTest extends AbstractAtomContainerTest {
         oMono1.setMonomerName(new String("TRP279"));
         IMonomer oMono2 = oStrand.getBuilder().newInstance(IMonomer.class);
         oMono2.setMonomerName(new String("HOH"));
-        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C2");
-        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C3");
+        IAtom oAtom2 = oStrand.getBuilder().newInstance(IAtom.class, "C");
+        IAtom oAtom3 = oStrand.getBuilder().newInstance(IAtom.class, "C");
         oStrand.addAtom(oAtom2, oMono1);
         oStrand.addAtom(oAtom3, oMono2);
         Map<String, IMonomer> monomers = new Hashtable<String, IMonomer>();

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -565,7 +565,9 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void getNaturalExactMassNeedsHydrogens() {
         IAtomContainer mol = new AtomContainer();
-        mol.addAtom(new Atom("C"));
+        IAtom atom = new Atom("C");
+        atom.setImplicitHydrogenCount(null);
+        mol.addAtom(atom);
         AtomContainerManipulator.getNaturalExactMass(mol);
     }
 
@@ -1031,7 +1033,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
         assertThat(anonymous.getAtom(0).getSymbol(), is("C"));
         assertThat(anonymous.getAtom(2).getSymbol(), is("C"));
         assertNull(anonymous.getAtom(1).getAtomTypeName());
-        assertNull(anonymous.getAtom(4).getImplicitHydrogenCount());
+        assertThat(anonymous.getAtom(4).getImplicitHydrogenCount(), is(0));
         assertFalse(anonymous.getAtom(3).getFlag(CDKConstants.ISAROMATIC));
 
         assertFalse(anonymous.getBond(1).getFlag(CDKConstants.ISAROMATIC));

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKHydrogenAdderTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKHydrogenAdderTest.java
@@ -214,7 +214,7 @@ public class CDKHydrogenAdderTest extends CDKTestCase {
         Assert.assertNotNull(type);
         AtomTypeManipulator.configure(atom, type);
 
-        Assert.assertNull(atom.getImplicitHydrogenCount());
+        Assert.assertNotEquals((Integer) 2, atom.getImplicitHydrogenCount());
         adder.addImplicitHydrogens(mol);
         Assert.assertEquals(1, mol.getAtomCount());
         Assert.assertNotNull(atom.getImplicitHydrogenCount());

--- a/display/render/src/test/java/org/openscience/cdk/renderer/SymbolVisibilityTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/SymbolVisibilityTest.java
@@ -77,6 +77,8 @@ public class SymbolVisibilityTest {
     public void iupacMethylAcceptable() {
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
+        a1.setImplicitHydrogenCount(null);
+        a1.setImplicitHydrogenCount(null);
         IBond bond = new Bond(a1, a2);
         a1.setPoint2d(new Point2d(0, 0));
         a2.setPoint2d(new Point2d(0, 0));

--- a/display/render/src/test/java/org/openscience/cdk/renderer/color/CDK2DAtomColorsTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/color/CDK2DAtomColorsTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKTestCase;
+import org.openscience.cdk.PseudoAtom;
 import org.openscience.cdk.interfaces.IAtom;
 
 /**
@@ -51,7 +52,7 @@ public class CDK2DAtomColorsTest extends CDKTestCase {
         CDK2DAtomColors colors = new CDK2DAtomColors();
 
         Assert.assertNotNull(colors);
-        IAtom imaginary = new Atom("Ix");
+        IAtom imaginary = new PseudoAtom("Ix");
         Assert.assertEquals(new Color(0, 0, 0), colors.getAtomColor(imaginary, Color.BLACK));
     }
 }

--- a/display/render/src/test/java/org/openscience/cdk/renderer/color/CDKAtomColorsTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/color/CDKAtomColorsTest.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKTestCase;
+import org.openscience.cdk.PseudoAtom;
 import org.openscience.cdk.interfaces.IAtom;
 
 /**
@@ -52,7 +53,7 @@ public class CDKAtomColorsTest extends CDKTestCase {
         CDKAtomColors colors = new CDKAtomColors();
 
         Assert.assertNotNull(colors);
-        IAtom imaginary = new Atom("Ix");
+        IAtom imaginary = new PseudoAtom("Ix");
         Assert.assertEquals(Color.ORANGE, colors.getAtomColor(imaginary, Color.ORANGE));
     }
 }

--- a/display/render/src/test/java/org/openscience/cdk/renderer/color/CPKAtomColorsTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/color/CPKAtomColorsTest.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKTestCase;
+import org.openscience.cdk.PseudoAtom;
 import org.openscience.cdk.interfaces.IAtom;
 
 /**
@@ -48,7 +49,7 @@ public class CPKAtomColorsTest extends CDKTestCase {
         CPKAtomColors colors = new CPKAtomColors();
 
         Assert.assertNotNull(colors);
-        IAtom imaginary = new Atom("Ix");
+        IAtom imaginary = new PseudoAtom("Ix");
         Assert.assertEquals(Color.ORANGE, colors.getAtomColor(imaginary, Color.ORANGE));
     }
 }

--- a/display/render/src/test/java/org/openscience/cdk/renderer/color/PartialAtomicChargeColorsTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/color/PartialAtomicChargeColorsTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKTestCase;
+import org.openscience.cdk.PseudoAtom;
 import org.openscience.cdk.interfaces.IAtom;
 
 /**
@@ -51,7 +52,7 @@ public class PartialAtomicChargeColorsTest extends CDKTestCase {
         PartialAtomicChargeColors colors = new PartialAtomicChargeColors();
 
         Assert.assertNotNull(colors);
-        IAtom imaginary = new Atom("Ix");
+        IAtom imaginary = new PseudoAtom("Ix");
         Assert.assertEquals(Color.ORANGE, colors.getAtomColor(imaginary, Color.ORANGE));
     }
 }

--- a/display/render/src/test/java/org/openscience/cdk/renderer/color/RasmolColorsTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/color/RasmolColorsTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKTestCase;
+import org.openscience.cdk.PseudoAtom;
 import org.openscience.cdk.interfaces.IAtom;
 
 /**
@@ -51,7 +52,7 @@ public class RasmolColorsTest extends CDKTestCase {
         RasmolColors colors = new RasmolColors();
 
         Assert.assertNotNull(colors);
-        IAtom imaginary = new Atom("Ix");
+        IAtom imaginary = new PseudoAtom("Ix");
         Assert.assertEquals(Color.ORANGE, colors.getAtomColor(imaginary, Color.ORANGE));
     }
 

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorFactoryTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorFactoryTest.java
@@ -177,6 +177,8 @@ public class InChIGeneratorFactoryTest {
         try {
             // create a fairly complex aromatic molecule
             IAtomContainer tetrazole = TestMoleculeFactory.makeTetrazole();
+            for (IAtom atom : tetrazole.atoms())
+                atom.setImplicitHydrogenCount(null);
             AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(tetrazole);
             Aromaticity.cdkLegacy().apply(tetrazole);
 

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
@@ -81,7 +81,7 @@ public class InChIGeneratorTest extends CDKTestCase {
     @Test
     public void testGetInchiFromChlorineAtom() throws Exception {
         IAtomContainer ac = new AtomContainer();
-        ac.addAtom(new Atom("Cl"));
+        ac.addAtom(new Atom("ClH"));
         InChIGenerator gen = getFactory().getInChIGenerator(ac, "FixedH");
         Assert.assertEquals(gen.getReturnStatus(), INCHI_RET.OKAY);
         Assert.assertEquals("InChI=1/ClH/h1H", gen.getInchi());
@@ -153,7 +153,7 @@ public class InChIGeneratorTest extends CDKTestCase {
     @Test
     public void testGetInchiFromChlorine37Atom() throws Exception {
         IAtomContainer ac = new AtomContainer();
-        IAtom a = new Atom("Cl");
+        IAtom a = new Atom("ClH");
         a.setMassNumber(37);
         ac.addAtom(a);
         InChIGenerator gen = getFactory().getInChIGenerator(ac, "FixedH");
@@ -394,7 +394,7 @@ public class InChIGeneratorTest extends CDKTestCase {
     @Test
     public void testGetStandardInchiFromChlorineAtom() throws Exception {
         IAtomContainer ac = new AtomContainer();
-        ac.addAtom(new Atom("Cl"));
+        ac.addAtom(new Atom("ClH"));
         InChIGenerator gen = getFactory().getInChIGenerator(ac);
         Assert.assertEquals(INCHI_RET.OKAY, gen.getReturnStatus());
         Assert.assertEquals("InChI=1S/ClH/h1H", gen.getInchi());
@@ -424,7 +424,7 @@ public class InChIGeneratorTest extends CDKTestCase {
     @Test
     public void testGetStandardInchiFromChlorine37Atom() throws Exception {
         IAtomContainer ac = new AtomContainer();
-        IAtom a = new Atom("Cl");
+        IAtom a = new Atom("ClH");
         a.setMassNumber(37);
         ac.addAtom(a);
         InChIGenerator gen = getFactory().getInChIGenerator(ac);
@@ -738,11 +738,11 @@ public class InChIGeneratorTest extends CDKTestCase {
     @Test
     public void r_penta_2_3_diene_impl_h() throws Exception {
         IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        m.addAtom(new Atom("CH3"));
+        m.addAtom(new Atom("CH"));
         m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
+        m.addAtom(new Atom("CH"));
+        m.addAtom(new Atom("CH3"));
         m.addBond(0, 1, IBond.Order.SINGLE);
         m.addBond(1, 2, IBond.Order.DOUBLE);
         m.addBond(2, 3, IBond.Order.DOUBLE);
@@ -767,11 +767,11 @@ public class InChIGeneratorTest extends CDKTestCase {
     @Test
     public void s_penta_2_3_diene_impl_h() throws Exception {
         IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        m.addAtom(new Atom("CH3"));
+        m.addAtom(new Atom("CH"));
         m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
+        m.addAtom(new Atom("CH"));
+        m.addAtom(new Atom("CH3"));
         m.addBond(0, 1, IBond.Order.SINGLE);
         m.addBond(1, 2, IBond.Order.DOUBLE);
         m.addBond(2, 3, IBond.Order.DOUBLE);
@@ -797,11 +797,11 @@ public class InChIGeneratorTest extends CDKTestCase {
     @Test
     public void r_penta_2_3_diene_expl_h() throws Exception {
         IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        m.addAtom(new Atom("CH3"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
+        m.addAtom(new Atom("CH3"));
         m.addAtom(new Atom("H"));
         m.addAtom(new Atom("H"));
         m.addBond(0, 1, IBond.Order.SINGLE);
@@ -831,11 +831,11 @@ public class InChIGeneratorTest extends CDKTestCase {
     @Test
     public void s_penta_2_3_diene_expl_h() throws Exception {
         IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        m.addAtom(new Atom("CH3"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
-        m.addAtom(new Atom("C"));
+        m.addAtom(new Atom("CH3"));
         m.addAtom(new Atom("H"));
         m.addAtom(new Atom("H"));
         m.addBond(0, 1, IBond.Order.SINGLE);

--- a/storage/io/src/main/java/org/openscience/cdk/io/Mol2Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/Mol2Reader.java
@@ -316,7 +316,7 @@ public class Mol2Reader extends DefaultChemObjectReader {
                         if (ATOM_TYPE_ALIASES.containsKey(atomTypeStr))
                             atomTypeStr = ATOM_TYPE_ALIASES.get(atomTypeStr);
 
-                        IAtom atom = molecule.getBuilder().newInstance(IAtom.class, "X");
+                        IAtom atom = molecule.getBuilder().newInstance(IAtom.class);
                         IAtomType atomType;
                         try {
                             atomType = atFactory.getAtomType(atomTypeStr);

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
@@ -508,7 +508,7 @@ public class CMLRoundTripTest extends CDKTestCase {
 
         IAtomContainer product = reaction.getBuilder().newInstance(IAtomContainer.class);
         product.setID("product");
-        atom = reaction.getBuilder().newInstance(IAtom.class, "X");
+        atom = reaction.getBuilder().newInstance(IAtom.class, "R");
         product.addAtom(atom);
         reaction.addProduct(product);
 
@@ -725,6 +725,7 @@ public class CMLRoundTripTest extends CDKTestCase {
     public void testUnsetHydrogenCount() throws Exception {
         IAtomContainer mol = new AtomContainer();
         Atom atom = new Atom("C");
+        atom.setImplicitHydrogenCount(null);
         Assert.assertNull(atom.getImplicitHydrogenCount());
         mol.addAtom(atom);
 

--- a/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
+++ b/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
@@ -104,8 +104,6 @@ public class PDBReader extends DefaultChemObjectReader {
      */
     private List<IBond>            bondsFromConnectRecords;
 
-    private static AtomTypeFactory pdbFactory;
-
     /**
      * A mapping between HETATM 3-letter codes + atomNames to CDK atom type
      * names; for example "RFB.N13" maps to "N.planar3".
@@ -139,7 +137,6 @@ public class PDBReader extends DefaultChemObjectReader {
     public PDBReader(Reader oIn) {
         _oInput = new BufferedReader(oIn);
         initIOSettings();
-        pdbFactory = null;
         hetDictionary = null;
         cdkAtomTypeFactory = null;
     }
@@ -194,16 +191,6 @@ public class PDBReader extends DefaultChemObjectReader {
     @Override
     public <T extends IChemObject> T read(T oObj) throws CDKException {
         if (oObj instanceof IChemFile) {
-            if (pdbFactory == null) {
-                try {
-                    pdbFactory = AtomTypeFactory.getInstance("org/openscience/cdk/config/data/pdb_atomtypes.xml",
-                            ((IChemFile) oObj).getBuilder());
-                } catch (Exception exception) {
-                    logger.debug(exception);
-                    throw new CDKException("Could not setup list of PDB atom types! " + exception.getMessage(),
-                            exception);
-                }
-            }
             return (T) readChemFile((IChemFile) oObj);
         } else {
             throw new CDKException("Only supported is reading of ChemFile objects.");
@@ -483,7 +470,7 @@ public class PDBReader extends DefaultChemObjectReader {
                     } // ignore all other commands
                 }
             } while (_oInput.ready() && (cRead != null));
-        } catch (IOException | IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException | CDKException e) {
             logger.error("Found a problem at line:");
             logger.error(cRead);
             logger.error("01234567890123456789012345678901234567890123456789012345678901234567890123456789");
@@ -559,6 +546,20 @@ public class PDBReader extends DefaultChemObjectReader {
         return true;
     }
 
+    private static boolean isUpper(char c) {
+        return c >= 'A' && c <= 'Z';
+    }
+
+    private String parseAtomSymbol(String str) {
+        if (str == null || str.isEmpty())
+            return null;
+        int pos = 0;
+        final int len = str.length();
+        while (pos < len && isUpper(str.charAt(pos)))
+            pos++;
+        return str.substring(0, pos);
+    }
+
     /**
      * Creates an <code>Atom</code> and sets properties to their values from
      * the ATOM or HETATM record. If the line is shorter than 80 characters, the
@@ -569,7 +570,7 @@ public class PDBReader extends DefaultChemObjectReader {
      * @return the <code>Atom</code> created from the record.
      * @throws RuntimeException if the line is too short (less than 59 characters).
      */
-    private PDBAtom readAtom(String cLine, int lineLength) {
+    private PDBAtom readAtom(String cLine, int lineLength) throws CDKException {
         // a line can look like (two in old format, then two in new format):
         //
         //           1         2         3         4         5         6         7
@@ -586,62 +587,41 @@ public class PDBReader extends DefaultChemObjectReader {
         if (lineLength < 59) {
             throw new RuntimeException("PDBReader error during readAtom(): line too short");
         }
-        String elementSymbol;
-        if (cLine.length() > 78) {
-            elementSymbol = cLine.substring(76, 78).trim();
-            if (elementSymbol.length() == 0) {
-                elementSymbol = cLine.substring(12, 14).trim();
-            }
-        } else {
-            elementSymbol = cLine.substring(12, 14).trim();
-        }
 
-        if (elementSymbol.length() == 2) {
-            // ensure that the second char is lower case
-            if (Character.isDigit(elementSymbol.charAt(0))) {
-                elementSymbol = elementSymbol.substring(1);
-            } else {
-                elementSymbol = elementSymbol.charAt(0) + elementSymbol.substring(1).toLowerCase();
-            }
-        }
+        boolean isHetatm = cLine.substring(0, 6).equals("HETATM");
+        String  atomName = cLine.substring(12, 16).trim();
+        String  resName  = cLine.substring(17, 20).trim();
+        String  symbol   = parseAtomSymbol(atomName);
 
-        String rawAtomName = cLine.substring(12, 16).trim();
-        String resName = cLine.substring(17, 20).trim();
-        boolean isHetatm;
-        try {
-            IAtomType type = pdbFactory.getAtomType(resName + "." + rawAtomName);
-            elementSymbol = type.getSymbol();
-            isHetatm = false;
-        } catch (NoSuchAtomTypeException e) {
-            logger.error("Did not recognize PDB atom type: " + resName + "." + rawAtomName);
-            isHetatm = true;
-        }
-        PDBAtom oAtom = new PDBAtom(elementSymbol, new Point3d(Double.parseDouble(cLine.substring(30, 38)),
+        if (symbol == null)
+            handleError("Cannot parse symbol from " + atomName);
+
+        PDBAtom oAtom = new PDBAtom(symbol, new Point3d(Double.parseDouble(cLine.substring(30, 38)),
                 Double.parseDouble(cLine.substring(38, 46)), Double.parseDouble(cLine.substring(46, 54))));
         if (useHetDictionary.isSet() && isHetatm) {
-            String cdkType = typeHetatm(resName, rawAtomName);
+            String cdkType = typeHetatm(resName, atomName);
             oAtom.setAtomTypeName(cdkType);
             if (cdkType != null) {
                 try {
                     cdkAtomTypeFactory.configure(oAtom);
                 } catch (CDKException cdke) {
-                    logger.warn("Could not configure", resName, " ", rawAtomName);
+                    logger.warn("Could not configure", resName, " ", atomName);
                 }
             }
         }
 
         oAtom.setRecord(cLine);
         oAtom.setSerial(Integer.parseInt(cLine.substring(6, 11).trim()));
-        oAtom.setName(rawAtomName.trim());
+        oAtom.setName(atomName.trim());
         oAtom.setAltLoc(cLine.substring(16, 17).trim());
         oAtom.setResName(resName);
         oAtom.setChainID(cLine.substring(21, 22).trim());
         oAtom.setResSeq(cLine.substring(22, 26).trim());
         oAtom.setICode(cLine.substring(26, 27).trim());
         if (useHetDictionary.isSet() && isHetatm) {
-            oAtom.setID(oAtom.getResName() + "." + rawAtomName);
+            oAtom.setID(oAtom.getResName() + "." + atomName);
         } else {
-            oAtom.setAtomTypeName(oAtom.getResName() + "." + rawAtomName);
+            oAtom.setAtomTypeName(oAtom.getResName() + "." + atomName);
         }
         if (lineLength >= 59) {
             String frag = cLine.substring(54, Math.min(lineLength, 60)).trim();

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CDKToBeamTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CDKToBeamTest.java
@@ -85,7 +85,7 @@ public class CDKToBeamTest {
 
     @Test
     public void unknownSymbol() throws Exception {
-        IAtom a = new Atom("ALA");
+        IAtom a = new PseudoAtom("ALA");
         a.setImplicitHydrogenCount(0);
         assertThat(new CDKToBeam().toBeamAtom(a).element(), is(Element.Unknown));
     }
@@ -165,9 +165,9 @@ public class CDKToBeamTest {
     // the hydrogens are set to null
     @Test
     public void pseudoAtom_nullH() throws Exception {
-        assertThat(new CDKToBeam().toBeamAtom(new Atom("R")).hydrogens(), is(0));
-        assertThat(new CDKToBeam().toBeamAtom(new Atom("*")).hydrogens(), is(0));
-        assertThat(new CDKToBeam().toBeamAtom(new Atom("R1")).hydrogens(), is(0));
+        assertThat(new CDKToBeam().toBeamAtom(new PseudoAtom("R")).hydrogens(), is(0));
+        assertThat(new CDKToBeam().toBeamAtom(new PseudoAtom("*")).hydrogens(), is(0));
+        assertThat(new CDKToBeam().toBeamAtom(new PseudoAtom("R1")).hydrogens(), is(0));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
I've wanted the element/hydrogen count int one for a while. Writing up some documentation recently I realised extending the string one would make things much easier for beginners, and is quite efficient so can be used in tests.

```
new Atom(6, 3); // Me direct
new Atom("CH3"); // Me verbose
```