### PR TITLE
Patch/renderingbug

### DIFF
--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -359,7 +359,7 @@ final class StandardBondGenerator {
 
                 final double theta = refVector.angle(unit);
 
-                if (theta > threshold) {
+                if (theta > threshold && theta + threshold + threshold < Math.PI) {
                     c = intersection(b, newUnitVector(b, c), toPoint, refVector);
                     d = intersection(a, newUnitVector(a, d), toPoint, refVector);
 
@@ -444,7 +444,8 @@ final class StandardBondGenerator {
             }
 
             // only slant if the angle isn't shallow
-            if (refVector.angle(unit) > threshold) {
+            double theta = refVector.angle(unit);
+            if (theta > threshold && theta + threshold + threshold < Math.PI) {
                 hatchAngle = refVector;
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
             <id>ebi-repo</id>
             <name>EBI Maven Repository</name>
             <url>
-                http://www.ebi.ac.uk/intact/maven/nexus/content/repositories/ebi-repo/
+                http://www.ebi.ac.uk/~maven/m2repo
             </url>
             <releases>
                 <enabled>true</enabled>

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -420,6 +420,14 @@ public class AtomPlacer {
             logger.debug("Arguments are atom: " + atom + ", previousAtom: " + previousAtom + ", distanceMeasure: "
                     + distanceMeasure);
         }
+
+        final Point2d a = previousAtom.getPoint2d();
+        final Point2d b = atom.getPoint2d();
+
+        if (isColinear(atom, molecule.getConnectedBondsList(atom))) {
+            return new Vector2d(b.x-a.x, b.y-a.y);
+        }
+
         double angle = GeometryUtil.getAngle(previousAtom.getPoint2d().x - atom.getPoint2d().x,
                 previousAtom.getPoint2d().y - atom.getPoint2d().y);
         double addAngle = Math.toRadians(120);


### PR DESCRIPTION
A bug in the layout caused co-linear chains to be inverted. The existing code tried to point the direction away from the centre of the molecule, valid when the chain is kinked but not when co-linear. Here we now just return the vector. An artefact of this folding back on it's self caused a problem with the rendering make an SVG file that was 1.4 light years tall :-).

![image](https://cloud.githubusercontent.com/assets/983232/21146862/0d6b2cde-c14b-11e6-8692-2884c4e02e7a.png)
![image](https://cloud.githubusercontent.com/assets/983232/21146865/0ef7cb48-c14b-11e6-9ec7-73fd815aa59b.png)

The huge SVG: [here](https://cdkdepict-openchem.rhcloud.com/depict/bow/svg?smi=OC12CC3CC(C1)CC(C3)(C2)NCC(=O)N1CCC[C@H]1C%23N&abbr=false&suppressh=true&showtitle=false&zoom=1.3&annotate=none).