### PR TITLE
added MIME-Types for a selection of formats

### DIFF
--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/GamessFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/GamessFormat.java
@@ -46,7 +46,7 @@ public class GamessFormat extends SimpleChemFormatMatcher implements IChemFormat
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return "chemical/x-gamess-input";
+        return "chemical/x-gamess-output";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian03Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian03Format.java
@@ -46,7 +46,7 @@ public class Gaussian03Format extends SimpleChemFormatMatcher implements IChemFo
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-gaussian-log";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian90Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian90Format.java
@@ -44,7 +44,7 @@ public class Gaussian90Format extends SimpleChemFormatMatcher implements IChemFo
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-gaussian-log";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian92Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian92Format.java
@@ -44,7 +44,7 @@ public class Gaussian92Format extends SimpleChemFormatMatcher implements IChemFo
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-gaussian-log";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian94Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian94Format.java
@@ -44,7 +44,7 @@ public class Gaussian94Format extends SimpleChemFormatMatcher implements IChemFo
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-gaussian-log";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian95Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian95Format.java
@@ -44,7 +44,7 @@ public class Gaussian95Format extends SimpleChemFormatMatcher implements IChemFo
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-gaussian-log";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian98Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Gaussian98Format.java
@@ -44,7 +44,7 @@ public class Gaussian98Format extends SimpleChemFormatMatcher implements IChemFo
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-gaussian-log";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/HINFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/HINFormat.java
@@ -48,7 +48,7 @@ public class HINFormat extends SimpleChemFormatMatcher implements IChemFormatMat
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-hin";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MDLV2000Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MDLV2000Format.java
@@ -44,7 +44,7 @@ public class MDLV2000Format extends SimpleChemFormatMatcher implements IChemForm
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mdl-molfile";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MDLV3000Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MDLV3000Format.java
@@ -44,7 +44,7 @@ public class MDLV3000Format extends SimpleChemFormatMatcher implements IChemForm
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mdl-molfile";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC2002Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC2002Format.java
@@ -44,7 +44,7 @@ public class MOPAC2002Format extends SimpleChemFormatMatcher implements IChemFor
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mopac-out";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC2007Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC2007Format.java
@@ -45,7 +45,7 @@ public class MOPAC2007Format extends SimpleChemFormatMatcher implements IChemFor
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mopac-out";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC2009Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC2009Format.java
@@ -45,7 +45,7 @@ public class MOPAC2009Format extends SimpleChemFormatMatcher implements IChemFor
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mopac-out";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC2012Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC2012Format.java
@@ -45,7 +45,7 @@ public class MOPAC2012Format extends SimpleChemFormatMatcher implements IChemFor
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mopac-out";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC7Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC7Format.java
@@ -44,7 +44,7 @@ public class MOPAC7Format extends SimpleChemFormatMatcher implements IChemFormat
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mopac-out";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC93Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC93Format.java
@@ -44,7 +44,7 @@ public class MOPAC93Format extends SimpleChemFormatMatcher implements IChemForma
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mopac-out";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC97Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/MOPAC97Format.java
@@ -44,7 +44,7 @@ public class MOPAC97Format extends SimpleChemFormatMatcher implements IChemForma
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-mopac-out";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/NWChemFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/NWChemFormat.java
@@ -46,7 +46,7 @@ public class NWChemFormat extends SimpleChemFormatMatcher implements IChemFormat
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-nwchem-output";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/QChemFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/QChemFormat.java
@@ -46,7 +46,7 @@ public class QChemFormat extends SimpleChemFormatMatcher implements IChemFormatM
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-qchem-output";
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
For my own project I need to detect MIME types of chemical file types. 
I found CDK filetype detection to work much better than a combination of Apache Tika + custom MIME types taken from the (Chemical MIME project)[1], however the CDK doesn't know the MIME types of many formats.

I've added the MIME types for all the filetypes that I expect to encounter in this PR. I would be willing to add MIME types (from Chemical MIME) for further formats, as well.


Most of these MIME types originate from the (Chemical MIME project)[1].
MIME type `chemical/x-nwchem-output` for NWChem output files was taken
from [2] (slide 12).

[1] http://chemical-mime.sourceforge.net/chemical-mime-data.html
[2] http://ecce.emsl.pnl.gov/docs/code_reg_slides.pdf