### PR TITLE
more MIME-Types for chemical formats

### DIFF
--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/CTXFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/CTXFormat.java
@@ -44,7 +44,7 @@ public class CTXFormat extends SimpleChemFormatMatcher implements IChemFormatMat
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-ctx";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Chem3D_Cartesian_1Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Chem3D_Cartesian_1Format.java
@@ -47,7 +47,7 @@ public class Chem3D_Cartesian_1Format extends AbstractResourceFormat implements 
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-chem3d";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Chem3D_Cartesian_2Format.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/Chem3D_Cartesian_2Format.java
@@ -45,7 +45,7 @@ public class Chem3D_Cartesian_2Format extends AbstractResourceFormat implements 
 
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-chem3d";
     }
 
     @Override

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/ChemtoolFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/ChemtoolFormat.java
@@ -48,7 +48,7 @@ public class ChemtoolFormat extends AbstractResourceFormat implements IChemForma
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "application/x-chemtool";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/GhemicalMMFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/GhemicalMMFormat.java
@@ -46,7 +46,7 @@ public class GhemicalMMFormat extends SimpleChemFormatMatcher implements IChemFo
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "application/x-ghemical";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/INChIFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/INChIFormat.java
@@ -46,7 +46,7 @@ public class INChIFormat extends SimpleChemFormatMatcher implements IChemFormatM
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-inchi-xml";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/INChIPlainTextFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/INChIPlainTextFormat.java
@@ -44,7 +44,7 @@ public class INChIPlainTextFormat extends SimpleChemFormatMatcher implements ICh
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-inchi";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/SVGFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/SVGFormat.java
@@ -42,7 +42,7 @@ public class SVGFormat extends AbstractResourceFormat implements IResourceFormat
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "image/svg+xml";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/ShelXFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/ShelXFormat.java
@@ -46,7 +46,7 @@ public class ShelXFormat extends SimpleChemFormatMatcher implements IChemFormatM
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-shelx";
     }
 
     /** {@inheritDoc} */

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/TurboMoleFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/TurboMoleFormat.java
@@ -48,7 +48,7 @@ public class TurboMoleFormat extends AbstractResourceFormat implements IChemForm
     /** {@inheritDoc} */
     @Override
     public String getMIMEType() {
-        return null;
+        return "chemical/x-turbomole-coord";
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Followup on PR #261:

I've added all MIME-types I could find for CDK supported formats.

Sources:
[1] https://en.wikipedia.org/wiki/Chemical_file_format#The_Chemical_MIME_Project
[2] http://chemical-mime.sourceforge.net/chemical-mime-data.html