### PR TITLE
Patch/rendering 8 feb

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
@@ -1133,7 +1133,7 @@ public final class DepictionGenerator {
 
         public LayoutBackup(IAtomContainer mol) {
             final int numAtoms = mol.getAtomCount();
-            final int numBonds = mol.getAtomCount();
+            final int numBonds = mol.getBondCount();
             this.coords = new Point2d[numAtoms];
             this.btypes = new IBond.Stereo[numBonds];
             this.mol = mol;
@@ -1151,7 +1151,7 @@ public final class DepictionGenerator {
 
         void reset() {
             final int numAtoms = mol.getAtomCount();
-            final int numBonds = mol.getAtomCount();
+            final int numBonds = mol.getBondCount();
             for (int i = 0; i < numAtoms; i++)
                 mol.getAtom(i).setPoint2d(coords[i]);
             for (int i = 0; i < numBonds; i++)

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -238,8 +238,7 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
                 continue;
 
             Color highlight = getHighlightColor(atom, parameters);
-            Color color = highlight != null && style == HighlightStyle.Colored ? highlight : coloring
-                    .getAtomColor(atom);
+            Color color = getColorOfAtom(symbolRemap, coloring, foreground, style, atom, highlight);
 
             if (symbols[i] == null) {
                 // we add a 'ball' around atoms with no symbols (e.g. carbons)
@@ -286,6 +285,18 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
         group.add(frontLayer);
 
         return MarkedElement.markupMol(group, container);
+    }
+
+    private Color getColorOfAtom(Map<IAtom, String> symbolRemap, IAtomColorer coloring, Color foreground,
+                                 HighlightStyle style, IAtom atom, Color highlight) {
+        // atom is highlighted...?
+        if (highlight != null && style == HighlightStyle.Colored)
+            return highlight;
+        // abbreviations default to foreground color
+        if (symbolRemap.containsKey(atom))
+            return foreground;
+        // use the atom colorer
+        return coloring.getAtomColor(atom);
     }
 
     /**

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -52,6 +52,7 @@ import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupBracket;
 import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.sgroup.SgroupType;
+import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
@@ -1503,7 +1504,8 @@ public class StructureDiagramGenerator {
         int result = 0;
 
         // Check for an exact match (identity) on the entire ring system
-        if (!macro && lookupRingSystem(rs, molecule, rs.getAtomContainerCount() > 1)) {
+        // XXX: should avoid if we have db stereo in macrocycle!
+        if (lookupRingSystem(rs, molecule, rs.getAtomContainerCount() > 1)) {
             for (IAtomContainer container : rs.atomContainers())
                 container.setFlag(CDKConstants.ISPLACED, true);
             rs.setFlag(CDKConstants.ISPLACED, true);


### PR DESCRIPTION
Minor tweaks to rendering, at request the color from 'rooted' abbreviations are not used to color the contracted label.

![image](https://cloud.githubusercontent.com/assets/983232/22758710/c9ba8a14-ee47-11e6-9487-890699f2fbd2.png)
![image](https://cloud.githubusercontent.com/assets/983232/22758713/cd275ede-ee47-11e6-8daf-fcb9c3442f64.png)
