### PR TITLE
Read Optimised Data Structures

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/AtomContainerRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/AtomContainerRef.java
@@ -1,0 +1,891 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.interfaces.IChemObjectChangeEvent;
+import org.openscience.cdk.interfaces.IChemObjectListener;
+import org.openscience.cdk.interfaces.IElectronContainer;
+import org.openscience.cdk.interfaces.ILonePair;
+import org.openscience.cdk.interfaces.ISingleElectron;
+import org.openscience.cdk.interfaces.IStereoElement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * An AtomContainerRef wraps an existing {@link IAtomContainer} and
+ * manages {@link AtomRef}s and {@link BondRef}s and provides faster
+ * access methods.
+ * <br>
+ * Currently the AtomContainerRef is read-only and any attempt to modify
+ * the container will throw an {@link UnsupportedOperationException}.
+ *
+ * <pre>{@code
+ * IAtomContainer   ac    = ...;
+ *
+ * IAtom atom = ac.getAtom(0);
+ * ac.getConnectedBonds(atom); // linear, O(m)
+ * ac.getAtomNumber(atom); // linear, O(n)
+ *
+ * AtomContainerRef acref = new AtomContainerRef(mol);
+ *
+ * AtomRef atomref = ac.getAtom(0);
+ * acref.getConnectedBonds(atomref); // constant, O(~1)
+ * acref.getAtomNumber(atomref); // constant, O(~1)
+ *
+ * atomref.bonds(); // constant, O(1) - better
+ * atomref.getIndex(); // constant, O(1) - better
+ * }</pre>
+ *
+ */
+public final class AtomContainerRef implements IAtomContainer {
+
+    private       IAtomContainer      base;
+    private final Map<IAtom, AtomRef> amap;
+    private final AtomRef             arefs[];
+    private final BondRef             brefs[];
+
+    public AtomContainerRef(IAtomContainer base) {
+        this.base = base;
+        final int numAtoms = base.getAtomCount();
+        final int numBonds = base.getBondCount();
+        this.arefs = new AtomRef[numAtoms];
+        this.brefs = new BondRef[numBonds];
+
+        this.amap = new IdentityHashMap<>(base.getAtomCount());
+
+        for (int i = 0; i < numAtoms; i++) {
+            final IAtom atom = base.getAtom(i);
+            final AtomRef atomref = new AtomRef(i,
+                                                atom,
+                                                new ArrayList<BondRef>());
+            amap.put(atomref.atom, atomref);
+            arefs[i] = atomref;
+        }
+        for (int i = 0; i < numBonds; i++) {
+            final IBond   bond    = base.getBond(i);
+            AtomRef       beg     = amap.get(bond.getAtom(0));
+            AtomRef       end     = amap.get(bond.getAtom(1));
+            final BondRef bondref = new BondRef(bond, i, beg, end);
+            brefs[i] = bondref;
+            beg.bonds.add(bondref);
+            end.bonds.add(bondref);
+        }
+    }
+
+    private AtomRef getAtomRef(IAtom atom) {
+        AtomRef aref;
+        if (atom.getClass() == AtomRef.class) {
+            aref = (AtomRef) atom;
+        } else {
+            aref = amap.get(atom);
+            if (aref == null) throw new IllegalArgumentException("Atom does not belong to AtomContainer");
+        }
+        return aref;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getAtomCount() {
+        return arefs.length;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getBondCount() {
+        return brefs.length;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AtomRef getAtom(int i) {
+        return arefs[i];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public BondRef getBond(int i) {
+        return brefs[i];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getAtomNumber(IAtom atom) {
+        if (atom.getClass() == AtomRef.class)
+            return ((AtomRef) atom).getIndex();
+        AtomRef aref = amap.get(atom);
+        if (aref == null) return -1;
+        return aref.getIndex();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<IAtom> getConnectedAtomsList(IAtom atom) {
+        List<IBond> bonds = getConnectedBondsList(atom);
+        List<IAtom> atoms = new ArrayList<>(bonds.size());
+        for (IBond bond : bonds)
+            atoms.add(bond.getConnectedAtom(atom));
+        return atoms;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<IBond> getConnectedBondsList(IAtom atom) {
+        List<? extends IBond> brefs = getAtomRef(atom).bonds;
+        return (List<IBond>) Collections.unmodifiableList(brefs);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getConnectedAtomsCount(IAtom atom) {
+        return getConnectedBondsCount(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getConnectedBondsCount(int i) {
+        return arefs[i].getBondCount();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getConnectedBondsCount(IAtom atom) {
+        return getAtomRef(atom).getBondCount();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getBondNumber(IAtom beg, IAtom end) {
+        AtomRef aref = getAtomRef(beg);
+        for (BondRef bond : aref.bonds())
+            if (bond.contains(end))
+                return bond.getIndex();
+        return -1;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getBondNumber(IBond bond) {
+        if (bond.getClass() == BondRef.class)
+            return ((BondRef) bond).getIndex();
+        return getBondNumber(bond.getAtom(0), bond.getAtom(1));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public IBond getBond(IAtom beg, IAtom end) {
+        AtomRef aref = getAtomRef(beg);
+        for (BondRef bond : aref.bonds())
+            if (bond.contains(end))
+                return bond;
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public IChemObjectBuilder getBuilder() {
+        return base.getBuilder();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterable<IAtom> atoms() {
+        return new Iterable<IAtom>() {
+            @Override
+            public Iterator<IAtom> iterator() {
+                return new Iterator<IAtom>() {
+                    int pos = 0;
+                    @Override
+                    public boolean hasNext() {
+                        return pos < arefs.length;
+                    }
+
+                    @Override
+                    public AtomRef next() {
+                        return arefs[pos++];
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+                    }
+                };
+            }
+        };
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterable<IBond> bonds() {
+        return new Iterable<IBond>() {
+            @Override
+            public Iterator<IBond> iterator() {
+                return new Iterator<IBond>() {
+                    int pos = 0;
+                    @Override
+                    public boolean hasNext() {
+                        return pos < brefs.length;
+                    }
+
+                    @Override
+                    public BondRef next() {
+                        return brefs[pos++];
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+                    }
+                };
+            }
+        };
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterable<IStereoElement> stereoElements() {
+        return base.stereoElements();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setProperty(Object description, Object property) {
+        base.setProperty(description, property);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ILonePair getLonePair(int number) {
+        return base.getLonePair(number);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void removeProperty(Object description) {
+        base.removeProperty(description);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ISingleElectron getSingleElectron(int number) {
+        return base.getSingleElectron(number);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterable<ILonePair> lonePairs() {
+        return base.lonePairs();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterable<ISingleElectron> singleElectrons() {
+        return base.singleElectrons();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterable<IElectronContainer> electronContainers() {
+        return base.electronContainers();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AtomRef getFirstAtom() {
+        if (arefs.length == 0) throw new NoSuchElementException("AtomContainer has no atoms!");
+        return arefs[0];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public IAtom getLastAtom() {
+        if (arefs.length == 0) throw new NoSuchElementException("AtomContainer has no atoms!");
+        return arefs[arefs.length-1];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <T> T getProperty(Object description) {
+        return base.getProperty(description);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<Object, Object> getProperties() {
+        return base.getProperties();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <T> T getProperty(Object description, Class<T> c) {
+        return base.getProperty(description, c);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getLonePairNumber(ILonePair lonePair) {
+        return base.getLonePairNumber(lonePair);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getID() {
+        return base.getID();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getSingleElectronNumber(ISingleElectron singleElectron) {
+        return base.getSingleElectronNumber(singleElectron);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setID(String identifier) {
+        base.setID(identifier);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public IElectronContainer getElectronContainer(int number) {
+        return base.getElectronContainer(number);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getLonePairCount() {
+        return base.getLonePairCount();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getSingleElectronCount() {
+        return base.getSingleElectronCount();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setFlag(int mask, boolean value) {
+        base.setFlag(mask, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean getFlag(int mask) {
+        return base.getFlag(mask);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setFlags(boolean[] newFlags) {
+        base.setFlags(newFlags);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean[] getFlags() {
+        return base.getFlags();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getElectronContainerCount() {
+        return base.getElectronContainerCount();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setProperties(Map<Object, Object> properties) {
+        base.setProperties(properties);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void addProperties(Map<Object, Object> properties) {
+        base.addProperties(properties);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<ILonePair> getConnectedLonePairsList(IAtom atom) {
+        return base.getConnectedLonePairsList(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<ISingleElectron> getConnectedSingleElectronsList(IAtom atom) {
+        return base.getConnectedSingleElectronsList(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<IElectronContainer> getConnectedElectronContainersList(IAtom atom) {
+        return base.getConnectedElectronContainersList(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Number getFlagValue() {
+        return base.getFlagValue();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getConnectedLonePairsCount(IAtom atom) {
+        return base.getConnectedLonePairsCount(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getConnectedSingleElectronsCount(IAtom atom) {
+        return base.getConnectedSingleElectronsCount(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double getBondOrderSum(IAtom atom) {
+        return base.getBondOrderSum(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public IBond.Order getMaximumBondOrder(IAtom atom) {
+        return base.getMaximumBondOrder(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public IBond.Order getMinimumBondOrder(IAtom atom) {
+        return base.getMinimumBondOrder(atom);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean contains(IAtom atom) {
+        return getAtomNumber(atom) >= 0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean contains(IBond bond) {
+        return getBondNumber(bond) >= 0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean contains(ILonePair lonePair) {
+        return base.contains(lonePair);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean contains(ISingleElectron singleElectron) {
+        return base.contains(singleElectron);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean contains(IElectronContainer electronContainer) {
+        return base.contains(electronContainer);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isEmpty() {
+        return base.isEmpty();
+    }
+
+    /* Connection Table, Set/Append/Delete Methods */
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void add(IAtomContainer atomContainer) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void setBonds(IBond[] bonds) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void setAtoms(IAtom[] atoms) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void setAtom(int number, IAtom atom) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addAtom(IAtom atom) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addBond(IBond bond) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addLonePair(ILonePair lonePair) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addSingleElectron(ISingleElectron singleElectron) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addElectronContainer(IElectronContainer electronContainer) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addBond(int atom1, int atom2, IBond.Order order, IBond.Stereo stereo) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addBond(int atom1, int atom2, IBond.Order order) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addLonePair(int atomID) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addSingleElectron(int atomID) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addStereoElement(IStereoElement element) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void setStereoElements(List<IStereoElement> elements) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void remove(IAtomContainer atomContainer) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeAtom(int position) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeAtom(IAtom atom) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public IBond removeBond(int position) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public IBond removeBond(IAtom atom1, IAtom atom2) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeBond(IBond bond) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public ILonePair removeLonePair(int position) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeLonePair(ILonePair lonePair) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public ISingleElectron removeSingleElectron(int position) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeSingleElectron(ISingleElectron singleElectron) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public IElectronContainer removeElectronContainer(int position) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeElectronContainer(IElectronContainer electronContainer) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeAtomAndConnectedElectronContainers(IAtom atom) {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeAllElements() {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeAllElectronContainers() {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeAllBonds() {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public IAtomContainer clone() throws CloneNotSupportedException {
+        throw new UnsupportedOperationException("AtomContainerRef is read-only!");
+    }
+
+    /* Notifications */
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addListener(IChemObjectListener col) {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void stateChanged(IChemObjectChangeEvent event) {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public int getListenerCount() {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void setNotification(boolean bool) {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public boolean getNotification() {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void notifyChanged() {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeListener(IChemObjectListener col) {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void notifyChanged(IChemObjectChangeEvent evt) {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/AtomRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/AtomRef.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2017 John May <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.interfaces.IChemObjectChangeEvent;
+import org.openscience.cdk.interfaces.IChemObjectListener;
+
+import javax.vecmath.Point2d;
+import javax.vecmath.Point3d;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A container atom offers a snapshot view of an atom that belongs
+ * to an atom container. In addition to the normal methods of an
+ * atom this class provides the index ({@link #getIndex()}) in
+ * the parent {@link IAtomContainer} and the connected
+ * bonds ({@link #getBonds()}).
+ */
+public final class AtomRef implements IAtom {
+
+    final IAtom                 atom;
+    private final int           idx;
+    private final List<BondRef> bonds;
+
+    private AtomRef(int idx, IAtom atom, List<BondRef> bonds) {
+        this.idx   = idx;
+        this.atom  = atom;
+        this.bonds = bonds;
+    }
+
+    public static AtomRef[] getAtomRefs(IAtomContainer mol) {
+
+        final int numAtoms = mol.getAtomCount();
+        final int numBonds = mol.getBondCount();
+        AtomRef[] atoms    = new AtomRef[numAtoms];
+
+        final Map<IAtom,AtomRef> atomCache = new HashMap<>();
+
+        for (int i = 0; i < numAtoms; i++) {
+            atoms[i] = new AtomRef(i,
+                                   mol.getAtom(i),
+                                   new ArrayList<BondRef>());
+            atomCache.put(atoms[i].atom, atoms[i]);
+        }
+        for (int i = 0; i < numBonds; i++){
+            IBond bond = mol.getBond(i);
+            for (IAtom batom : bond.atoms()) {
+                atomCache.get(batom).bonds.add(new BondRef(bond, i, atomCache));
+            }
+        }
+
+        return atoms;
+    }
+
+    public int getIndex() {
+        return idx;
+    }
+
+    public <T extends IBond> List<T> getBonds() {
+        return (List<T>) bonds;
+    }
+
+    @Override
+    public IChemObjectBuilder getBuilder() {
+        return atom.getBuilder();
+    }
+
+    @Override
+    public void setCharge(Double charge) {
+        atom.setCharge(charge);
+    }
+
+    @Override
+    public void setNaturalAbundance(Double naturalAbundance) {
+        atom.setNaturalAbundance(naturalAbundance);
+    }
+
+    @Override
+    public Double getCharge() {
+        return atom.getCharge();
+    }
+
+    @Override
+    public void setExactMass(Double exactMass) {
+        atom.setExactMass(exactMass);
+    }
+
+    @Override
+    public Integer getAtomicNumber() {
+        return atom.getAtomicNumber();
+    }
+
+    @Override
+    public void setImplicitHydrogenCount(Integer hydrogenCount) {
+        atom.setImplicitHydrogenCount(hydrogenCount);
+    }
+
+    @Override
+    public Double getNaturalAbundance() {
+        return atom.getNaturalAbundance();
+    }
+
+    @Override
+    public void setAtomicNumber(Integer atomicNumber) {
+        atom.setAtomicNumber(atomicNumber);
+    }
+
+    @Override
+    public Integer getImplicitHydrogenCount() {
+        return atom.getImplicitHydrogenCount();
+    }
+
+    @Override
+    public void addListener(IChemObjectListener col) {
+        atom.addListener(col);
+    }
+
+    @Override
+    public void removeListener(IChemObjectListener col) {
+        atom.removeListener(col);
+    }
+
+    @Override
+    public int getListenerCount() {
+        return atom.getListenerCount();
+    }
+
+    @Override
+    public void setNotification(boolean bool) {
+        atom.setNotification(bool);
+    }
+
+    @Override
+    public boolean getNotification() {
+        return atom.getNotification();
+    }
+
+    @Override
+    public void notifyChanged() {
+        atom.notifyChanged();
+    }
+
+    @Override
+    public void notifyChanged(IChemObjectChangeEvent evt) {
+        atom.notifyChanged(evt);
+    }
+
+    @Override
+    public Double getExactMass() {
+        return atom.getExactMass();
+    }
+
+    @Override
+    public void setMaxBondOrder(IBond.Order maxBondOrder) {
+        atom.setMaxBondOrder(maxBondOrder);
+    }
+
+    @Override
+    public String getSymbol() {
+        return atom.getSymbol();
+    }
+
+    @Override
+    public void setSymbol(String symbol) {
+        atom.setSymbol(symbol);
+    }
+
+    @Override
+    public Integer getMassNumber() {
+        return atom.getMassNumber();
+    }
+
+    @Override
+    public Point2d getPoint2d() {
+        return atom.getPoint2d();
+    }
+
+    @Override
+    public void setPoint2d(Point2d point2d) {
+        atom.setPoint2d(point2d);
+    }
+
+    @Override
+    public Point3d getPoint3d() {
+        return atom.getPoint3d();
+    }
+
+    @Override
+    public void setPoint3d(Point3d point3d) {
+        atom.setPoint3d(point3d);
+    }
+
+    @Override
+    public void setFractionalPoint3d(Point3d point3d) {
+        atom.setFractionalPoint3d(point3d);
+    }
+
+    @Override
+    public Point3d getFractionalPoint3d() {
+        return atom.getFractionalPoint3d();
+    }
+
+    @Override
+    public void setBondOrderSum(Double bondOrderSum) {
+        atom.setBondOrderSum(bondOrderSum);
+    }
+
+    @Override
+    public void setMassNumber(Integer massNumber) {
+        atom.setMassNumber(massNumber);
+    }
+
+    @Override
+    public void setAtomTypeName(String identifier) {
+        atom.setAtomTypeName(identifier);
+    }
+
+    @Override
+    public String getAtomTypeName() {
+        return atom.getAtomTypeName();
+    }
+
+    @Override
+    public IBond.Order getMaxBondOrder() {
+        return atom.getMaxBondOrder();
+    }
+
+    @Override
+    public Double getBondOrderSum() {
+        return atom.getBondOrderSum();
+    }
+
+    @Override
+    public Integer getStereoParity() {
+        return atom.getStereoParity();
+    }
+
+    @Override
+    public void setStereoParity(Integer stereoParity) {
+        atom.setStereoParity(stereoParity);
+    }
+
+    @Override
+    public void setFormalCharge(Integer charge) {
+        atom.setFormalCharge(charge);
+    }
+
+    @Override
+    public Integer getFormalCharge() {
+        return atom.getFormalCharge();
+    }
+
+    @Override
+    public void setProperty(Object description, Object property) {
+        atom.setProperty(description, getFractionalPoint3d());
+    }
+
+    @Override
+    public void setFormalNeighbourCount(Integer count) {
+        atom.setFormalNeighbourCount(count);
+    }
+
+    @Override
+    public Integer getFormalNeighbourCount() {
+        return atom.getFormalNeighbourCount();
+    }
+
+    @Override
+    public void removeProperty(Object description) {
+        atom.removeProperty(description);
+    }
+
+    @Override
+    public void setHybridization(Hybridization hybridization) {
+        atom.setHybridization(hybridization);
+    }
+
+    @Override
+    public Hybridization getHybridization() {
+        return atom.getHybridization();
+    }
+
+    @Override
+    public void setCovalentRadius(Double radius) {
+        atom.setCovalentRadius(radius);
+    }
+
+    @Override
+    public boolean isAromatic() {
+        return atom.isAromatic();
+    }
+
+    @Override
+    public void setIsAromatic(boolean arom) {
+        atom.setIsAromatic(arom);
+    }
+
+    @Override
+    public Double getCovalentRadius() {
+        return atom.getCovalentRadius();
+    }
+
+    @Override
+    public void setValency(Integer valency) {
+        atom.setValency(valency);
+    }
+
+    @Override
+    public Integer getValency() {
+        return atom.getValency();
+    }
+
+    @Override
+    public boolean isInRing() {
+        return atom.isInRing();
+    }
+
+    @Override
+    public void setIsInRing(boolean ring) {
+        atom.setIsInRing(ring);
+    }
+
+    @Override
+    public IAtom clone() throws CloneNotSupportedException {
+        throw new CloneNotSupportedException();
+    }
+
+    @Override
+    public <T> T getProperty(Object description) {
+        return atom.getProperty(description);
+    }
+
+    @Override
+    public <T> T getProperty(Object description, Class<T> c) {
+        return atom.getProperty(description, c);
+    }
+
+    @Override
+    public Map<Object, Object> getProperties() {
+        return atom.getProperties();
+    }
+
+    @Override
+    public String getID() {
+        return atom.getID();
+    }
+
+    @Override
+    public void setID(String identifier) {
+        atom.setID(identifier);
+    }
+
+    @Override
+    public void setFlag(int mask, boolean value) {
+        atom.setFlag(mask, value);
+    }
+
+    @Override
+    public boolean getFlag(int mask) {
+        return atom.getFlag(mask);
+    }
+
+    @Override
+    public void setProperties(Map<Object, Object> properties) {
+        atom.setProperties(properties);
+    }
+
+    @Override
+    public void addProperties(Map<Object, Object> properties) {
+        atom.setProperties(properties);
+    }
+
+    @Override
+    public void setFlags(boolean[] newFlags) {
+        atom.setFlags(newFlags);
+    }
+
+    @Override
+    public boolean[] getFlags() {
+        return atom.getFlags();
+    }
+
+    @Override
+    public Number getFlagValue() {
+        return atom.getFlagValue();
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/AtomRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/AtomRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 John May <jwmay@users.sf.net>
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
  *
  * Contact: cdk-devel@lists.sourceforge.net
  *
@@ -32,19 +32,30 @@ import org.openscience.cdk.interfaces.IChemObjectListener;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * A container atom offers a snapshot view of an atom that belongs
- * to an atom container. In addition to the normal methods of an
- * atom this class provides the index ({@link #getIndex()}) in
+ * A AtomRef offers a view of an atom that belongs
+ * to an particular {@link IAtomContainer}. In addition to the normal methods
+ * of an atom this class provides the index ({@link #getIndex()}) in
  * the parent {@link IAtomContainer} and the connected
- * bonds ({@link #getBonds()}).
+ * bonds ({@link #bonds()}).
+ * <br>
+ * Modifications to the atom (e.g. {@link #setAtomicNumber(Integer)} are passed
+ * through to the underlying {@link IAtom}.
+ * <br>
+ * AtomRefs are created and accessed by an {@link AtomContainerRef}.
+ * <pre>
+ * {@code
+ * IAtomContainer   ac    = ...;
+ * AtomContainerRef acref = new AtomContainerRef(ac);
+ *
+ * AtomRef aref = acref.getAtom(0);
+ * }
+ * </pre>
+ *
+ * @see AtomContainerRef
  */
 public final class AtomRef implements IAtom {
 
@@ -58,364 +69,443 @@ public final class AtomRef implements IAtom {
         this.bonds = bonds;
     }
 
-    public static AtomRef[] getAtomRefs(IAtomContainer mol) {
-
-        final int numAtoms = mol.getAtomCount();
-        final int numBonds = mol.getBondCount();
-        AtomRef[] atoms    = new AtomRef[numAtoms];
-
-        final Map<IAtom, AtomRef> atomCache = new IdentityHashMap<>(mol.getAtomCount());
-
-        for (int i = 0; i < numAtoms; i++) {
-            final IAtom atom = mol.getAtom(i);
-            final AtomRef atomrf = new AtomRef(i,
-                                               atom,
-                                               new ArrayList<BondRef>());
-            atomCache.put(atomrf.atom, atomrf);
-            atoms[i] = atomrf;
-        }
-        for (int i = 0; i < numBonds; i++) {
-            final IBond   bond    = mol.getBond(i);
-            AtomRef       beg     = atomCache.get(bond.getAtom(0));
-            AtomRef       end     = atomCache.get(bond.getAtom(1));
-            final BondRef bondref = new BondRef(bond, i, beg, end);
-            beg.bonds.add(bondref);
-            end.bonds.add(bondref);
-        }
-
-        return atoms;
-    }
-
+    /**
+     * The index of the atoms in the 'owning' {@link IAtomContainer}.
+     * @return atom index
+     */
     public int getIndex() {
         return idx;
     }
 
-    public List<BondRef> getBonds() {
+    /**
+     * The bonds connected to this atom.
+     *
+     * @return iterable over the bonds
+     */
+    public Iterable<BondRef> bonds() {
         return bonds;
     }
 
+    /**
+     * The number of bonds connected to this atom (degree).
+     * @return connected bond count
+     */
+    public int getBondCount() {
+        return bonds.size();
+    }
+
+    /** {@inheritDoc} */
     @Override
     public IChemObjectBuilder getBuilder() {
         return atom.getBuilder();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setCharge(Double charge) {
         atom.setCharge(charge);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setNaturalAbundance(Double naturalAbundance) {
         atom.setNaturalAbundance(naturalAbundance);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Double getCharge() {
         return atom.getCharge();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setExactMass(Double exactMass) {
         atom.setExactMass(exactMass);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Integer getAtomicNumber() {
         return atom.getAtomicNumber();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setImplicitHydrogenCount(Integer hydrogenCount) {
         atom.setImplicitHydrogenCount(hydrogenCount);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Double getNaturalAbundance() {
         return atom.getNaturalAbundance();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setAtomicNumber(Integer atomicNumber) {
         atom.setAtomicNumber(atomicNumber);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Integer getImplicitHydrogenCount() {
         return atom.getImplicitHydrogenCount();
     }
 
-    @Override
-    public void addListener(IChemObjectListener col) {
-        atom.addListener(col);
-    }
-
-    @Override
-    public void removeListener(IChemObjectListener col) {
-        atom.removeListener(col);
-    }
-
-    @Override
-    public int getListenerCount() {
-        return atom.getListenerCount();
-    }
-
-    @Override
-    public void setNotification(boolean bool) {
-        atom.setNotification(bool);
-    }
-
-    @Override
-    public boolean getNotification() {
-        return atom.getNotification();
-    }
-
-    @Override
-    public void notifyChanged() {
-        atom.notifyChanged();
-    }
-
-    @Override
-    public void notifyChanged(IChemObjectChangeEvent evt) {
-        atom.notifyChanged(evt);
-    }
-
+    /** {@inheritDoc} */
     @Override
     public Double getExactMass() {
         return atom.getExactMass();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setMaxBondOrder(IBond.Order maxBondOrder) {
         atom.setMaxBondOrder(maxBondOrder);
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getSymbol() {
         return atom.getSymbol();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setSymbol(String symbol) {
         atom.setSymbol(symbol);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Integer getMassNumber() {
         return atom.getMassNumber();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Point2d getPoint2d() {
         return atom.getPoint2d();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setPoint2d(Point2d point2d) {
         atom.setPoint2d(point2d);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Point3d getPoint3d() {
         return atom.getPoint3d();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setPoint3d(Point3d point3d) {
         atom.setPoint3d(point3d);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setFractionalPoint3d(Point3d point3d) {
         atom.setFractionalPoint3d(point3d);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Point3d getFractionalPoint3d() {
         return atom.getFractionalPoint3d();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setBondOrderSum(Double bondOrderSum) {
         atom.setBondOrderSum(bondOrderSum);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setMassNumber(Integer massNumber) {
         atom.setMassNumber(massNumber);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setAtomTypeName(String identifier) {
         atom.setAtomTypeName(identifier);
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getAtomTypeName() {
         return atom.getAtomTypeName();
     }
 
+    /** {@inheritDoc} */
     @Override
     public IBond.Order getMaxBondOrder() {
         return atom.getMaxBondOrder();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Double getBondOrderSum() {
         return atom.getBondOrderSum();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Integer getStereoParity() {
         return atom.getStereoParity();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setStereoParity(Integer stereoParity) {
         atom.setStereoParity(stereoParity);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setFormalCharge(Integer charge) {
         atom.setFormalCharge(charge);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Integer getFormalCharge() {
         return atom.getFormalCharge();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setProperty(Object description, Object property) {
         atom.setProperty(description, getFractionalPoint3d());
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setFormalNeighbourCount(Integer count) {
         atom.setFormalNeighbourCount(count);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Integer getFormalNeighbourCount() {
         return atom.getFormalNeighbourCount();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void removeProperty(Object description) {
         atom.removeProperty(description);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setHybridization(Hybridization hybridization) {
         atom.setHybridization(hybridization);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Hybridization getHybridization() {
         return atom.getHybridization();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setCovalentRadius(Double radius) {
         atom.setCovalentRadius(radius);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isAromatic() {
         return atom.isAromatic();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setIsAromatic(boolean arom) {
         atom.setIsAromatic(arom);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Double getCovalentRadius() {
         return atom.getCovalentRadius();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setValency(Integer valency) {
         atom.setValency(valency);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Integer getValency() {
         return atom.getValency();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isInRing() {
         return atom.isInRing();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setIsInRing(boolean ring) {
         atom.setIsInRing(ring);
     }
 
+    /**
+     * <b>Not supported</b>
+     * {@inheritDoc}
+     * @throws CloneNotSupportedException
+     */
     @Override
     public IAtom clone() throws CloneNotSupportedException {
         throw new CloneNotSupportedException();
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T> T getProperty(Object description) {
         return atom.getProperty(description);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T> T getProperty(Object description, Class<T> c) {
         return atom.getProperty(description, c);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Map<Object, Object> getProperties() {
         return atom.getProperties();
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getID() {
         return atom.getID();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setID(String identifier) {
         atom.setID(identifier);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setFlag(int mask, boolean value) {
         atom.setFlag(mask, value);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean getFlag(int mask) {
         return atom.getFlag(mask);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setProperties(Map<Object, Object> properties) {
         atom.setProperties(properties);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void addProperties(Map<Object, Object> properties) {
         atom.setProperties(properties);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setFlags(boolean[] newFlags) {
         atom.setFlags(newFlags);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean[] getFlags() {
         return atom.getFlags();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Number getFlagValue() {
         return atom.getFlagValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void addListener(IChemObjectListener col) {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public int getListenerCount() {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void setNotification(boolean bool) {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public boolean getNotification() {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void notifyChanged() {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void removeListener(IChemObjectListener col) {
+        throw new UnsupportedOperationException("Notifications not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws UnsupportedOperationException not supported
+     */
+    @Override
+    public void notifyChanged(IChemObjectChangeEvent evt) {
+        throw new UnsupportedOperationException("Notifications not supported");
     }
 }

--- a/base/core/src/main/java/org/openscience/cdk/BondRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/BondRef.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2017 John May <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk;
+
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.interfaces.IChemObjectChangeEvent;
+import org.openscience.cdk.interfaces.IChemObjectListener;
+
+import javax.vecmath.Point2d;
+import javax.vecmath.Point3d;
+import java.util.Map;
+
+public class BondRef implements IBond {
+
+    private final IBond              bond;
+    private final int                idx;
+    private final Map<IAtom,AtomRef> atomCache;
+
+    BondRef(IBond bond, int idx, Map<IAtom, AtomRef> atomCache) {
+        this.bond = bond;
+        this.idx = idx;
+        this.atomCache = atomCache;
+    }
+
+    public int getIndex() {
+        return idx;
+    }
+
+    @Override
+    public void setElectronCount(Integer electronCount) {
+        bond.setElectronCount(electronCount);
+    }
+
+    @Override
+    public IChemObjectBuilder getBuilder() {
+        return bond.getBuilder();
+    }
+
+    @Override
+    public Integer getElectronCount() {
+        return bond.getElectronCount();
+    }
+
+    @Override
+    public void addListener(IChemObjectListener col) {
+        bond.addListener(col);
+    }
+
+    @Override
+    public int getListenerCount() {
+        return bond.getListenerCount();
+    }
+
+    @Override
+    public void removeListener(IChemObjectListener col) {
+        bond.removeListener(col);
+    }
+
+    @Override
+    public void setNotification(boolean bool) {
+        bond.setNotification(bool);
+    }
+
+    @Override
+    public boolean getNotification() {
+        return bond.getNotification();
+    }
+
+    @Override
+    public void notifyChanged() {
+        bond.notifyChanged();
+    }
+
+    @Override
+    public void notifyChanged(IChemObjectChangeEvent evt) {
+        bond.notifyChanged(evt);
+    }
+
+    @Override
+    public void setProperty(Object description, Object property) {
+        bond.setProperty(description, property);
+    }
+
+    @Override
+    public void removeProperty(Object description) {
+        bond.removeProperty(description);
+    }
+
+    @Override
+    public Iterable<IAtom> atoms() {
+        return FluentIterable.from(bond.atoms()).transform(new Function<IAtom, IAtom>() {
+            @Override
+            public IAtom apply(IAtom input) {
+                return atomCache.get(input);
+            }
+        });
+    }
+
+    @Override
+    public void setAtoms(IAtom[] atoms) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getAtomCount() {
+        return bond.getAtomCount();
+    }
+
+    @Override
+    public AtomRef getAtom(int position) {
+        return atomCache.get(bond.getAtom(position));
+    }
+
+    @Override
+    public IAtom getConnectedAtom(IAtom atom) {
+        AtomRef beg = atomCache.get(bond.getAtom(0));
+        AtomRef end = atomCache.get(bond.getAtom(1));
+        if (atom == beg || atom == beg.atom)
+            return end;
+        else if (atom == end || atom == end.atom)
+            return beg;
+        throw new IllegalArgumentException("Atom");
+    }
+
+    @Override
+    public <T> T getProperty(Object description) {
+        return bond.getProperty(description);
+    }
+
+    @Override
+    public IAtom[] getConnectedAtoms(IAtom atom) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean contains(IAtom atom) {
+        int numAtoms = bond.getAtomCount();
+        for (int i = 0; i < numAtoms; i++) {
+            if (bond.getAtom(i) == atom ||
+                atomCache.get(bond.getAtom(i)) == atom)
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void setAtom(IAtom atom, int position) {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public Order getOrder() {
+        return bond.getOrder();
+    }
+
+    @Override
+    public <T> T getProperty(Object description, Class<T> c) {
+        return bond.getProperty(description, c);
+    }
+
+    @Override
+    public void setOrder(Order order) {
+        bond.setOrder(order);
+    }
+
+    @Override
+    public Stereo getStereo() {
+        return bond.getStereo();
+    }
+
+    @Override
+    public Map<Object, Object> getProperties() {
+        return bond.getProperties();
+    }
+
+    @Override
+    public String getID() {
+        return bond.getID();
+    }
+
+    @Override
+    public void setStereo(Stereo stereo) {
+        bond.setStereo(stereo);
+    }
+
+    @Override
+    public Point2d get2DCenter() {
+        return bond.get2DCenter();
+    }
+
+    @Override
+    public void setID(String identifier) {
+        bond.setID(identifier);
+    }
+
+    @Override
+    public Point3d get3DCenter() {
+        return bond.get3DCenter();
+    }
+
+    @Override
+    public boolean compare(Object object) {
+        return bond.compare(object);
+    }
+
+    @Override
+    public boolean isConnectedTo(IBond bond) {
+        return bond.isConnectedTo(bond);
+    }
+
+    @Override
+    public void setFlag(int mask, boolean value) {
+        bond.setFlag(mask, value);
+    }
+
+    @Override
+    public boolean isAromatic() {
+        return bond.isAromatic();
+    }
+
+    @Override
+    public void setIsAromatic(boolean arom) {
+        bond.setIsAromatic(arom);
+    }
+
+    @Override
+    public boolean getFlag(int mask) {
+        return bond.getFlag(mask);
+    }
+
+    @Override
+    public boolean isInRing() {
+        return bond.isInRing();
+    }
+
+    @Override
+    public void setIsInRing(boolean ring) {
+        bond.setIsInRing(ring);
+    }
+
+    @Override
+    public void setProperties(Map<Object, Object> properties) {
+        bond.setProperties(properties);
+    }
+
+    @Override
+    public IBond clone() throws CloneNotSupportedException {
+        throw new CloneNotSupportedException();
+    }
+
+    @Override
+    public void addProperties(Map<Object, Object> properties) {
+        bond.addProperties(properties);
+    }
+
+    @Override
+    public void setFlags(boolean[] newFlags) {
+        bond.setFlags(newFlags);
+    }
+
+    @Override
+    public boolean[] getFlags() {
+        return bond.getFlags();
+    }
+
+    @Override
+    public Number getFlagValue() {
+        return bond.getFlagValue();
+    }
+}


### PR DESCRIPTION
**IMPORTANT: Proof of concept only (do not apply)**

The CDK data structures are write optimised - neither atoms or bonds no about the molecule which they belong and their index. This is efficient for generating structures as atoms and bonds can be re-usued. However this makes traversal painfully inefficient |E|^2 instead of |V|.

In practise object creation is cheap having to re-create atoms/bonds should not be optimised - unfortunately this would be a very destructive change (/rewrite). To avoid the inefficient traversals in the past I introduced and the [GraphUtil](http://cdk.github.io/cdk/2.0/docs/api/index.html?org/openscience/cdk/graph/GraphUtil.html) API. This is still less efficient than just storing the connection table like this but reduces and |E|^2 traversal to an |E|+|V| (|E|=build cost).

This has worked successfully for many algorithms but is clunky to use, accessing bonds was also nasty by a secondary map instance:
  
```java

IAtomContainer mol = ...; // plain old molecule
GraphUtil.EdgeToBondMap bondsmap = GraphUtil.EdgeToBondMap.withSpaceFor(mol);
int[][] adjlist = GraphUtil.toAdjList(mol, bondsmap);

void dfs(boolean[] mark, int[][] adjlist, int src, int prev) {
  mark[src] = true;
  for (int dst : adjlist[src]) {
    if (dst != prev)
      dfs(mark, adjlist, src, prev);
  }
}

// dfs bond info
void dfs(boolean[] mark, int[][] adjlist, GraphUtil.EdgeToBondMap bondmap, int src, int prev) {
  mark[src] = true;
  for (int dst : adjlist[src]) {
    IBond bond = bondmap.get(src, dst);
    if (dst != prev)
      dfs(mark, adjlist, src, prev);
  }
}
```

This patch introduces two new class ``AtomRef`` and ``BondRef`` that *reference* atoms and bonds in an ``AtomContainer`` instance. Each ref stores the index in the container and the adjacency of the bonds. The class implement the ``IBond`` and ``IAtom`` interfaces and pass all methods through to an underlying implementation. This means you can use the atoms and bonds with existing method.

```java
AtomRef[] arefs = AtomRef.getAtomRefs(mol); // non-final

void dfs(boolean[] mark, AtomRef a, BondRef last) {
  mark[a.getIndex()] = true;
  for (BondRef b : a.getBonds()) {
  if (b != last)
     dfs(mark, a, last);
  }
}
```

I think I also want to integrate stereo chemistry and may well also provide an ``AtomContainerRef``.

@egonw @rajarshi let me know your thoughts then will put it to mailing list. I know in particularly Till of Scaffold Hunter use to have a fork with faster traversal - this should help him but providing a standard API to do it.

