### PR TITLE
NPE fix: implicit hydrogen counts can be unset too (addresses #282)

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
+++ b/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
@@ -2513,7 +2513,8 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
         // confirm correct valency
         if (type.getValency() != CDKConstants.UNSET) {
             double valence = container.getBondOrderSum(atom);
-            if (atom.getImplicitHydrogenCount() != 0)
+            if (atom.getImplicitHydrogenCount() != null &&
+            	atom.getImplicitHydrogenCount() != 0)
                 valence += atom.getImplicitHydrogenCount();
             if (valence > type.getValency())
                 return false;


### PR DESCRIPTION
A recent change in the atom typer causes this. The code actually checks for non-zero values, and null can be interpreted as zero.