### PR TITLE
Fixes two incorrect unit tests

### DIFF
--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -209,8 +209,8 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
         mol.addBond(0, 1, IBond.Order.DOUBLE);
         mol.addBond(0, 2, IBond.Order.SINGLE);
         mol.addBond(0, 3, IBond.Order.SINGLE);
-        mol.addBond(1, 4, IBond.Order.DOUBLE);
-        mol.addBond(1, 5, IBond.Order.DOUBLE);
+        mol.addBond(1, 4, IBond.Order.SINGLE);
+        mol.addBond(1, 5, IBond.Order.SINGLE);
         for (IAtom atom : mol.atoms())
             atom.setImplicitHydrogenCount(0);
         mol.setFlag(CDKConstants.ISAROMATIC, true);
@@ -326,8 +326,8 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
         mol.addBond(0, 1, IBond.Order.DOUBLE);
         mol.addBond(0, 2, IBond.Order.SINGLE);
         mol.addBond(0, 3, IBond.Order.SINGLE);
-        mol.addBond(1, 4, IBond.Order.DOUBLE);
-        mol.addBond(1, 5, IBond.Order.DOUBLE);
+        mol.addBond(1, 4, IBond.Order.SINGLE);
+        mol.addBond(1, 5, IBond.Order.SINGLE);
 
         mol.getAtom(0).setImplicitHydrogenCount(0);
         mol.getAtom(1).setImplicitHydrogenCount(0);


### PR DESCRIPTION
I guess these hydrogens were meant to be singly bound; a recent change was more picky on removing double bonds, causing double bonded hydrogens to not be removed