### PR TITLE
The IFingerprinter API can be made backwards compatible with CDK 1.4.…

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/fingerprint/IFingerprinter.java
+++ b/base/core/src/main/java/org/openscience/cdk/fingerprint/IFingerprinter.java
@@ -23,6 +23,7 @@
  */
 package org.openscience.cdk.fingerprint;
 
+import java.util.BitSet;
 import java.util.Map;
 
 import org.openscience.cdk.exception.CDKException;
@@ -39,6 +40,17 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 public interface IFingerprinter {
 
     /**
+     * Generate a binary fingerprint as a bit. This method will usually delegate to
+     * {@link #getBitFingerprint(IAtomContainer)} and invoke
+     * {@link IBitFingerprint#asBitSet()}, it is included for backwards compatibility.
+     *
+     * @param mol molecule
+     * @return BitSet
+     * @throws CDKException problem generating fingerprint
+     */
+    BitSet getFingerprint(IAtomContainer mol) throws CDKException;
+
+    /**
      * Returns the bit fingerprint for the given {@link IAtomContainer}.
      *
      * @param  container {@link IAtomContainer} for which the fingerprint should be calculated.
@@ -47,7 +59,7 @@ public interface IFingerprinter {
      * or (for key based fingerprints) if there is a SMARTS parsing error
      * @throws UnsupportedOperationException if the Fingerprinter can not produce bit fingerprints
      */
-    public IBitFingerprint getBitFingerprint(IAtomContainer container) throws CDKException;
+    IBitFingerprint getBitFingerprint(IAtomContainer container) throws CDKException;
 
     /**
      * Returns the count fingerprint for the given {@link IAtomContainer}.
@@ -58,7 +70,7 @@ public interface IFingerprinter {
      * or (for key based fingerprints) if there is a SMARTS parsing error.
      * @throws UnsupportedOperationException if the Fingerprinter can not produce count fingerprints
      */
-    public ICountFingerprint getCountFingerprint(IAtomContainer container) throws CDKException;
+    ICountFingerprint getCountFingerprint(IAtomContainer container) throws CDKException;
 
     /**
      * Returns the raw representation of the fingerprint for the given IAtomContainer. The raw representation contains
@@ -68,13 +80,12 @@ public interface IFingerprinter {
      * @return the raw fingerprint
      * @throws CDKException
      */
-    public Map<String, Integer> getRawFingerprint(IAtomContainer container) throws CDKException;
+    Map<String, Integer> getRawFingerprint(IAtomContainer container) throws CDKException;
 
     /**
-     * Returns the size of the fingerprints calculated.
+     * Returns the size (or length) of the fingerprint.
      *
      * @return the size of the fingerprint
      */
-    public int getSize();
-
+    int getSize();
 }

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/AbstractFingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/AbstractFingerprinter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 John May <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.fingerprint;
+
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtomContainer;
+
+import java.util.BitSet;
+
+public abstract class AbstractFingerprinter implements IFingerprinter {
+
+    /** {@inheritDoc} */
+    @Override
+    public BitSet getFingerprint(IAtomContainer mol) throws CDKException {
+        return getBitFingerprint(mol).asBitSet();
+    }
+}

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -90,7 +90,7 @@ import java.util.Set;
  * @cdk.module     standard
  * @cdk.githash
  */
-public class Fingerprinter implements IFingerprinter {
+public class Fingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     /** Throw an exception if too many paths (per atom) are generated. */
     private final static int                 DEFAULT_PATH_LIMIT   = 1500;
@@ -163,7 +163,6 @@ public class Fingerprinter implements IFingerprinter {
      *                         perception
      * @return A {@link BitSet} representing the fingerprint
      */
-
     public IBitFingerprint getBitFingerprint(IAtomContainer container, AllRingsFinder ringFinder) throws CDKException {
         int position = -1;
         logger.debug("Entering Fingerprinter");

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/HybridizationFingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/HybridizationFingerprinter.java
@@ -73,7 +73,7 @@ import org.openscience.cdk.tools.periodictable.PeriodicTable;
  * @cdk.module     standard
  * @cdk.githash
  */
-public class HybridizationFingerprinter implements IFingerprinter {
+public class HybridizationFingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     /** The default length of created fingerprints. */
     public final static int                  DEFAULT_SIZE         = 1024;

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -90,7 +90,7 @@ import org.openscience.cdk.interfaces.IBond;
  * @cdk.module     standard
  * @cdk.githash
  */
-public class CircularFingerprinter implements IFingerprinter {
+public class CircularFingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     // ------------ constants ------------
 

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/EStateFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/EStateFingerprinter.java
@@ -60,7 +60,7 @@ import java.util.Map;
  * @cdk.module fingerprint
  * @cdk.githash
  */
-public class EStateFingerprinter implements IFingerprinter {
+public class EStateFingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     private static final String[] PATTERNS = EStateFragments.getSmarts();
 

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/ExtendedFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/ExtendedFingerprinter.java
@@ -46,7 +46,7 @@ import java.util.Map;
  *
  * @see            org.openscience.cdk.fingerprint.Fingerprinter
  */
-public class ExtendedFingerprinter implements IFingerprinter {
+public class ExtendedFingerprinter extends Fingerprinter implements IFingerprinter {
 
     private final int     RESERVED_BITS = 25;
 

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/MACCSFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/MACCSFingerprinter.java
@@ -28,11 +28,9 @@ import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
-import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.isomorphism.Pattern;
 import org.openscience.cdk.isomorphism.VentoFoggia;
 import org.openscience.cdk.isomorphism.matchers.smarts.SmartsMatchers;
-import org.openscience.cdk.ringsearch.AllRingsFinder;
 import org.openscience.cdk.smiles.smarts.parser.SMARTSParser;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
@@ -72,7 +70,7 @@ import java.util.Map;
  * @cdk.module  fingerprint
  * @cdk.githash
  */
-public class MACCSFingerprinter implements IFingerprinter {
+public class MACCSFingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     private static ILoggingTool logger          = LoggingToolFactory.createLoggingTool(MACCSFingerprinter.class);
 

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/PubchemFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/PubchemFingerprinter.java
@@ -84,7 +84,7 @@ import java.util.Map;
  * @cdk.githash
  * @cdk.threadnonsafe
  */
-public class PubchemFingerprinter implements IFingerprinter {
+public class PubchemFingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     /**
      * Number of bits in this fingerprint.

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/ShortestPathFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/ShortestPathFingerprinter.java
@@ -80,7 +80,7 @@ import org.openscience.cdk.tools.periodictable.PeriodicTable;
  * @cdk.githash
  *
  */
-public class ShortestPathFingerprinter extends RandomNumber implements IFingerprinter, Serializable {
+public class ShortestPathFingerprinter extends AbstractFingerprinter implements IFingerprinter, Serializable {
 
     /**
      * The default length of created fingerprints.
@@ -93,6 +93,8 @@ public class ShortestPathFingerprinter extends RandomNumber implements IFingerpr
     private int                 fingerprintLength;
     private static ILoggingTool logger           = LoggingToolFactory
                                                          .createLoggingTool(ShortestPathFingerprinter.class);
+
+    private final RandomNumber rand = new RandomNumber();
 
     /**
      * Creates a fingerprint generator of length
@@ -264,6 +266,6 @@ public class ShortestPathFingerprinter extends RandomNumber implements IFingerpr
      * Returns a random number for a given object
      */
     private int getRandomNumber(Integer hashValue) {
-        return generateMersenneTwisterRandomNumber(fingerprintLength, hashValue);
+        return rand.generateMersenneTwisterRandomNumber(fingerprintLength, hashValue);
     }
 }

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/SubstructureFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/SubstructureFingerprinter.java
@@ -364,7 +364,7 @@ import java.util.Map;
  * @cdk.module   fingerprint
  * @cdk.githash
  */
-public class SubstructureFingerprinter implements IFingerprinter {
+public class SubstructureFingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     private String[] smarts;
 

--- a/descriptor/signature/src/main/java/org/openscience/cdk/fingerprint/SignatureFingerprinter.java
+++ b/descriptor/signature/src/main/java/org/openscience/cdk/fingerprint/SignatureFingerprinter.java
@@ -37,7 +37,7 @@ import org.openscience.cdk.signature.AtomSignature;
  * @cdk.keyword fingerprint
  * @cdk.githash
  */
-public class SignatureFingerprinter implements IFingerprinter {
+public class SignatureFingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     private int signatureDepth;
 

--- a/storage/smiles/src/main/java/org/openscience/cdk/fingerprint/LingoFingerprinter.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/fingerprint/LingoFingerprinter.java
@@ -49,7 +49,7 @@ import static org.openscience.cdk.graph.Cycles.relevant;
  * @cdk.keyword hologram
  * @cdk.githash
  */
-public class LingoFingerprinter implements IFingerprinter {
+public class LingoFingerprinter extends AbstractFingerprinter implements IFingerprinter {
 
     private final int n;
     private final SmilesGenerator gen    = SmilesGenerator.unique().aromatic();


### PR DESCRIPTION
…x by re-adding and delegating the old method.

From writing the benchmarks for CDK 1.4 vs 2.0 it's clear to see where APIs have been broken unnecessarily. This patch re-adds the old IFingerprinter method reducing the barrier to code porting.
 