### PR TITLE
Convenience, return number of rings (circuit rank) when ring flags ar…

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
@@ -417,10 +417,12 @@ public final class Cycles {
      * @param mol molecule
      * @see IBond#isInRing()
      * @see IAtom#isInRing()
+     * @return Number of rings found (circuit rank)
+     * @see <a href="https://en.wikipedia.org/wiki/Circuit_rank">Circuit Rank</a>
      */
-    public static void markRingAtomsAndBonds(IAtomContainer mol) {
+    public static int markRingAtomsAndBonds(IAtomContainer mol) {
         EdgeToBondMap bonds = EdgeToBondMap.withSpaceFor(mol);
-        markRingAtomsAndBonds(mol, GraphUtil.toAdjList(mol, bonds), bonds);
+        return markRingAtomsAndBonds(mol, GraphUtil.toAdjList(mol, bonds), bonds);
     }
 
     /**
@@ -431,8 +433,10 @@ public final class Cycles {
      * @param mol molecule
      * @see IBond#isInRing()
      * @see IAtom#isInRing()
+     * @return Number of rings found (circuit rank)
+     * @see <a href="https://en.wikipedia.org/wiki/Circuit_rank">Circuit Rank</a>
      */
-    public static void markRingAtomsAndBonds(IAtomContainer mol, int[][] adjList, EdgeToBondMap bondMap) {
+    public static int markRingAtomsAndBonds(IAtomContainer mol, int[][] adjList, EdgeToBondMap bondMap) {
         RingSearch ringSearch = new RingSearch(mol, adjList);
         for (int v = 0; v < mol.getAtomCount(); v++) {
             mol.getAtom(v).setIsInRing(false);
@@ -448,6 +452,7 @@ public final class Cycles {
                 }
             }
         }
+        return ringSearch.numRings();
     }
 
     /**

--- a/base/core/src/main/java/org/openscience/cdk/ringsearch/CyclicVertexSearch.java
+++ b/base/core/src/main/java/org/openscience/cdk/ringsearch/CyclicVertexSearch.java
@@ -35,6 +35,13 @@ package org.openscience.cdk.ringsearch;
 public interface CyclicVertexSearch {
 
     /**
+     * Returns the number of cycles (circuit rank, frère jacques number, num SSSR).
+     *
+     * @return number of cycles
+     */
+    int numCycles();
+
+    /**
      * Returns true if the vertex <i>v</i> is in a cycle.
      *
      * @param v a vertex identifier by index

--- a/base/core/src/main/java/org/openscience/cdk/ringsearch/JumboCyclicVertexSearch.java
+++ b/base/core/src/main/java/org/openscience/cdk/ringsearch/JumboCyclicVertexSearch.java
@@ -56,6 +56,8 @@ class JumboCyclicVertexSearch implements CyclicVertexSearch {
     /** vertex colored by each component. */
     private int[]         colors;
 
+    private int numCycles = 0;
+
     /**
      * Create a new cyclic vertex search for the provided graph.
      *
@@ -116,6 +118,7 @@ class JumboCyclicVertexSearch implements CyclicVertexSearch {
             // we don't check out current state as this will always
             // include w - they are adjacent
             if (prev.get(w)) {
+                numCycles++;
                 // we have a cycle, xor the state when we last visited 'w'
                 // with our current state. this set is all the vertices
                 // we visited since then
@@ -134,6 +137,11 @@ class JumboCyclicVertexSearch implements CyclicVertexSearch {
 
     /** Synchronisation lock. */
     private final Object lock = new Object();
+
+    @Override
+    public int numCycles() {
+        return numCycles;
+    }
 
     /**
      * Lazily build an indexed lookup of vertex color. The vertex color

--- a/base/core/src/main/java/org/openscience/cdk/ringsearch/RegularCyclicVertexSearch.java
+++ b/base/core/src/main/java/org/openscience/cdk/ringsearch/RegularCyclicVertexSearch.java
@@ -56,6 +56,8 @@ class RegularCyclicVertexSearch implements CyclicVertexSearch {
     /** Vertex colors - which component does each vertex belong. */
     private volatile int[] colors;
 
+    private int numCycles = 0;
+
     /**
      * Create a new cyclic vertex search for the provided graph.
      *
@@ -113,6 +115,7 @@ class RegularCyclicVertexSearch implements CyclicVertexSearch {
                 // we don't check out current state as this will always
                 // include w - they are adjacent
                 if (isBitSet(prev, w)) {
+                    numCycles++;
 
                     // xor the state when we last visited 'w' with our current
                     // state. this set is all the vertices we visited since then
@@ -124,6 +127,11 @@ class RegularCyclicVertexSearch implements CyclicVertexSearch {
                 search(w, state[v], curr);
             }
         }
+    }
+
+    @Override
+    public int numCycles() {
+        return numCycles;
     }
 
     /**

--- a/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
+++ b/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
@@ -180,6 +180,16 @@ public final class RingSearch {
     }
 
     /**
+     * Access the number of rings found (aka. circuit rank, SSSR size).
+     *
+     * @return number of rings
+     * @see <a href="https://en.wikipedia.org/wiki/Circuit_rank">Circuit Rank</a>
+     */
+    public int numRings() {
+        return searcher.numCycles();
+    }
+
+    /**
      * Determine whether the edge between the vertices <i>u</i> and <i>v</i> is
      * cyclic.
      *

--- a/base/test-core/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest.java
@@ -364,6 +364,7 @@ public class RingSearchTest {
         IAtomContainer mol = diSpiroPentane();
         RingSearch rs = new RingSearch(mol);
         IAtomContainer frag = rs.ringFragments();
+        assertThat(rs.numRings(), is(4));
         assertThat(mol.getBondCount(), is(frag.getBondCount() + 1));
     }
 
@@ -372,6 +373,7 @@ public class RingSearchTest {
         IAtomContainer mol = triSpiroPentane();
         RingSearch rs = new RingSearch(mol);
         IAtomContainer frag = rs.ringFragments();
+        assertThat(rs.numRings(), is(5));
         assertThat(mol.getBondCount(), is(frag.getBondCount()));
     }
 


### PR DESCRIPTION
…x by re-adding and delegating the old method.

The number of rings can currently calculated by

```
Cycles.sssr(mol).numberOfCycles();
```

This is expensive requiring guass matrix elimination. If only the count is needed we can return that much faster. This patch adds the return value to the Cycles.markRingAtomsAndBonds(). You can now do quick filtering like the following:

```
if (Cycles.markRingAtomsAndBonds(mol) > 0) {
   // has ring
}
```
