### PR TITLE
Patch/itersdfopt

### DIFF
--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -433,8 +433,10 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
             else
                 outputContainer = new QueryAtomContainer(molecule.getBuilder());
 
-            outputContainer.setProperty(CDKConstants.TITLE, title);
-            outputContainer.setProperty(CDKConstants.REMARK, remark);
+            if (title != null)
+                outputContainer.setProperty(CDKConstants.TITLE, title);
+            if (remark != null)
+                outputContainer.setProperty(CDKConstants.REMARK, remark);
 
             // if the container is empty we can simply set the atoms/bonds
             // otherwise we add them to the end

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -109,6 +109,12 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
     }
 
     /**
+     * Default empty constructor.
+     */
+    public MDLV3000Writer() {
+    }
+
+    /**
      * Safely access nullable int fields by defaulting to zero.
      *
      * @param x value

--- a/storage/io/src/main/java/org/openscience/cdk/io/SDFWriter.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/SDFWriter.java
@@ -280,11 +280,17 @@ public class SDFWriter extends DefaultChemObjectWriter {
                                 String cleanHeaderKey = replaceInvalidHeaderChars(headerKey);
                                 if (!cleanHeaderKey.equals(headerKey))
                                     logger.info("Replaced characters in SDfile data header: ", headerKey, " written as: ", cleanHeaderKey);
-                                writer.write("> <" + cleanHeaderKey + ">");
-                                writer.newLine();
-                                writer.write("" + sdFields.get(propKey));
-                                writer.newLine();
-                                writer.newLine();
+
+                                Object val = sdFields.get(propKey);
+
+                                if (isPrimitiveDataValue(val)) {
+                                    writer.write("> <" + cleanHeaderKey + ">");
+                                    writer.newLine();
+                                    if (val != null)
+                                        writer.write(val.toString());
+                                    writer.newLine();
+                                    writer.newLine();
+                                }
                             }
                         }
                     }
@@ -294,6 +300,18 @@ public class SDFWriter extends DefaultChemObjectWriter {
         } catch (IOException exception) {
             throw new CDKException("Error while writing a SD file entry: " + exception.getMessage(), exception);
         }
+    }
+
+    private static boolean isPrimitiveDataValue(Object obj) {
+        return obj == null ||
+               obj.getClass() == String.class ||
+               obj.getClass() == Integer.class ||
+               obj.getClass() == Double.class ||
+               obj.getClass() == Boolean.class ||
+               obj.getClass() == Float.class ||
+               obj.getClass() == Byte.class ||
+               obj.getClass() == Short.class ||
+               obj.getClass() == Character.class;
     }
 
     private boolean writeV3000(IAtomContainer container) {

--- a/storage/io/src/main/java/org/openscience/cdk/io/SDFWriter.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/SDFWriter.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -244,6 +245,10 @@ public class SDFWriter extends DefaultChemObjectWriter {
         }
     }
 
+    private static String replaceInvalidHeaderChars(String headerKey) {
+        return headerKey.replaceAll("[-<>.=% ]", "_");
+    }
+
     private void writeMolecule(IAtomContainer container) throws CDKException {
         try {
             // write the MDL molfile bits
@@ -259,9 +264,13 @@ public class SDFWriter extends DefaultChemObjectWriter {
             boolean writeAllProperties = propertiesToWrite == null;
             if (sdFields != null) {
                 for (Object propKey : sdFields.keySet()) {
-                    if (!isCDKInternalProperty(propKey)) {
-                        if (writeAllProperties || propertiesToWrite.contains(propKey)) {
-                            writer.write("> <" + propKey + ">");
+                    String headerKey = propKey.toString();
+                    if (!isCDKInternalProperty(headerKey)) {
+                        if (writeAllProperties || propertiesToWrite.contains(headerKey)) {
+                            String cleanHeaderKey = replaceInvalidHeaderChars(headerKey);
+                            if (!cleanHeaderKey.equals(headerKey))
+                                logger.info("Replaced characters in SDfile data header: ", headerKey, " written as: ", cleanHeaderKey);
+                            writer.write("> <" + cleanHeaderKey + ">");
                             writer.newLine();
                             writer.write("" + sdFields.get(propKey));
                             writer.newLine();

--- a/storage/io/src/main/java/org/openscience/cdk/io/SDFWriter.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/SDFWriter.java
@@ -285,6 +285,10 @@ public class SDFWriter extends DefaultChemObjectWriter {
     static {
         cdkInternalProperties.add(InvPair.CANONICAL_LABEL);
         cdkInternalProperties.add(InvPair.INVARIANCE_PAIR);
+        cdkInternalProperties.add(CDKConstants.CTAB_SGROUPS);
+        // TITLE/REMARK written in Molfile header
+        cdkInternalProperties.add(CDKConstants.REMARK);
+        cdkInternalProperties.add(CDKConstants.TITLE);
         // I think there are a few more, but cannot find them right now
     }
 

--- a/storage/io/src/main/java/org/openscience/cdk/io/iterator/IteratingSDFReader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/iterator/IteratingSDFReader.java
@@ -102,7 +102,7 @@ public class IteratingSDFReader extends DefaultIteratingChemObjectReader<IAtomCo
     private boolean                                         skip                 = false;
 
     // buffer to store pre-read Mol records in
-    private StringBuffer                                    buffer               = new StringBuffer(10000);
+    private StringBuilder                                   buffer               = new StringBuilder(10000);
 
     private static final String                             LINE_SEPARATOR       = System.getProperty("line.separator");
 
@@ -218,7 +218,7 @@ public class IteratingSDFReader extends DefaultIteratingChemObjectReader<IAtomCo
 
         hasNext = false;
         nextMolecule = null;
-        buffer.delete(0, buffer.length());
+        buffer.setLength(0);
 
         // now try to parse the next Molecule
         try {

--- a/storage/io/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
@@ -238,6 +238,31 @@ public class SDFWriterTest extends ChemObjectWriterTest {
         assertThat(result, Matchers.containsString("V3000"));
     }
 
+    @Test
+    public void chooseFormatToWrite2() throws Exception {
+        StringWriter writer = new StringWriter();
+        SDFWriter sdfWriter = new SDFWriter(writer);
+        sdfWriter.setAlwaysV3000(true);
+
+        IAtomContainer molecule = new AtomContainer();
+        molecule.addAtom(new Atom("CH4"));
+        sdfWriter.write(molecule);
+
+        molecule = new AtomContainer();
+        for (int i = 0; i < 1000; i++)
+            molecule.addAtom(new Atom("CH4"));
+        sdfWriter.write(molecule);
+
+        molecule = new AtomContainer();
+        molecule.addAtom(new Atom("CH4"));
+        sdfWriter.write(molecule);
+
+        sdfWriter.close();
+        String result = writer.toString();
+        assertThat(result, Matchers.not(Matchers.containsString("V2000")));
+        assertThat(result, Matchers.containsString("V3000"));
+    }
+
     /**
      * @cdk.bug 3392485
      */

--- a/storage/io/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
@@ -27,6 +27,7 @@ import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Properties;
 
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -196,6 +197,20 @@ public class SDFWriterTest extends ChemObjectWriterTest {
         Assert.assertTrue(writer.toString().indexOf("toys") != -1);
         Assert.assertTrue(writer.toString().indexOf("r-us") != -1);
         Assert.assertTrue(writer.toString().indexOf("$$$$") != -1);
+    }
+
+    @Test
+    public void invalidSDfileHeaderTags() throws Exception {
+        StringWriter writer = new StringWriter();
+        SDFWriter sdfWriter = new SDFWriter(writer);
+
+        IAtomContainer molecule = new AtomContainer();
+        molecule.addAtom(new Atom("C"));
+        molecule.setProperty("http://not-valid.com", "URL");
+        sdfWriter.write(molecule);
+
+        sdfWriter.close();
+        Assert.assertThat(writer.toString(), Matchers.containsString("> <http://not_valid_com>"));
     }
 
     /**

--- a/storage/io/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
@@ -94,8 +94,8 @@ public class SDFWriterTest extends ChemObjectWriterTest {
         sdfWriter.customizeJob();
         sdfWriter.write(molSet);
         sdfWriter.close();
-        Assert.assertTrue(writer.toString().indexOf("<foo>") != -1);
-        Assert.assertTrue(writer.toString().indexOf("bar") != -1);
+        String result = writer.toString();
+        Assert.assertFalse(result.contains("<foo>"));
     }
 
     /**

--- a/storage/io/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
@@ -47,6 +47,7 @@ import org.openscience.cdk.io.listener.PropertiesListener;
 import org.openscience.cdk.smiles.InvPair;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 
+import static org.junit.Assert.assertThat;
 import static org.openscience.cdk.CDKConstants.ISAROMATIC;
 
 import static org.junit.Assert.assertFalse;
@@ -211,6 +212,30 @@ public class SDFWriterTest extends ChemObjectWriterTest {
 
         sdfWriter.close();
         Assert.assertThat(writer.toString(), Matchers.containsString("> <http://not_valid_com>"));
+    }
+
+    @Test
+    public void chooseFormatToWrite() throws Exception {
+        StringWriter writer = new StringWriter();
+        SDFWriter sdfWriter = new SDFWriter(writer);
+
+        IAtomContainer molecule = new AtomContainer();
+        molecule.addAtom(new Atom("CH4"));
+        sdfWriter.write(molecule);
+
+        molecule = new AtomContainer();
+        for (int i = 0; i < 1000; i++)
+            molecule.addAtom(new Atom("CH4"));
+        sdfWriter.write(molecule);
+
+        molecule = new AtomContainer();
+        molecule.addAtom(new Atom("CH4"));
+        sdfWriter.write(molecule);
+
+        sdfWriter.close();
+        String result = writer.toString();
+        assertThat(result, Matchers.containsString("V2000"));
+        assertThat(result, Matchers.containsString("V3000"));
     }
 
     /**


### PR DESCRIPTION
Should of done these patches ages. I've long trumped it faster to read an SDfile as follows in CDK 1.5/2.0:

```
IAtomContainer mol;
while ((mol = mdlr.read(new AtomContainer(0,0,0,0)) != null) {
  // do stuff
}
```

This is fast but is unfortunately not fault tolerant. In real life SDfile have junk in them and so we fall back to the slower `IteratingSDFReader`.

ChEBI 149 with MDLV2000Reader
```
real	0m9.367s
user	0m18.152s
sys	0m1.280s
```
ChEBI 149 with IteratingSDFReader
```
real	0m14.085s
user	0m26.541s
sys	0m1.820s
```
IteratingSDFReader actually contains some of the first patches I made to CDK. Looking at it 5 years wiser I realised some simple changes could bring this down to the same speed.

Step 1. Replace the synchronized StringBuffer with StringBuilder:
```
real	0m12.892s
user	0m23.833s
sys	0m1.536s
```
Step 2. Avoid redundant memcpy (string.getBytes()), use string prefix matching instead of REGEX, and only check the V2000/V3000 line on the line it must be in:
```
real	0m10.840s
user	0m22.426s
sys	0m1.422s
```

I think tweaked the data header/block reading a little. Hopefully Greg Landrums push towards an Open Molfile push. Technically you can have an SDF record separator not be counted as such when it's in a data value:

```
> <HEADER>
$$$$

> <Next>
```

However I can not see a genuine use case for that, whilst I can see this happening by accidient:

```
> <HEADER>
$$$$

   CDK

999999 0 0 0 0 V2000 etc..
```
