### PR TITLE
Perform SMARTS matching on a shallow copy.

### DIFF
--- a/tool/forcefield/src/main/java/org/openscience/cdk/forcefield/mmff/MmffAtomTypeMatcher.java
+++ b/tool/forcefield/src/main/java/org/openscience/cdk/forcefield/mmff/MmffAtomTypeMatcher.java
@@ -203,9 +203,11 @@ final class MmffAtomTypeMatcher {
      * @param symbs     symbolic atom types
      */
     private void assignPreliminaryTypes(IAtomContainer container, String[] symbs) {
-        SmartsMatchers.prepare(container, true);
+        // shallow copy
+        IAtomContainer cpy = container.getBuilder().newInstance(IAtomContainer.class, container);
+        SmartsMatchers.prepare(cpy, true);
         for (AtomTypePattern matcher : patterns) {
-            for (final int idx : matcher.matches(container)) {
+            for (final int idx : matcher.matches(cpy)) {
                 if (symbs[idx] == null) {
                     symbs[idx] = matcher.symb;
                 }


### PR DESCRIPTION
Fixes one of test regressions. We now cache adjlist computation in SMARTS matching on a mol property. This actually makes the Mmff code fast but an invariant I wanted was to clean off the MMFF props when finished.

Ultimately the caching in the matching will be removed once I finish the AtomRef stuff.