### PR TITLE
Patch/fpfixup

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -243,6 +243,19 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         return hash;
     }
 
+    private int hashRevPath(List<IAtom> apath, List<IBond> bpath) {
+        int hash = 0;
+        int last = apath.size() - 1;
+        hash = appendHash(hash, getAtomSymbol(apath.get(last)));
+        for (int i = last-1; i >= 0; i--) {
+            final IAtom next  = apath.get(i);
+            final IBond bond  = bpath.get(i);
+            hash = appendHash(hash, getBondSymbol(bond));
+            hash = appendHash(hash, getAtomSymbol(next));
+        }
+        return hash;
+    }
+
     private static final class State {
         private int    numPaths = 0;
         private Random rand     = new Random();
@@ -438,11 +451,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         if (compare(apath, bpath) >= 0) {
             x = hashPath(apath, bpath);
         } else {
-            Collections.reverse(bpath);
-            Collections.reverse(apath);
-            x = hashPath(apath, bpath);
-            Collections.reverse(bpath);
-            Collections.reverse(apath);
+            x = hashRevPath(apath, bpath);
         }
         return x;
     }

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -394,17 +394,18 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
      *@return       The bondSymbol value
      */
     protected String getBondSymbol(IBond bond) {
-        String bondSymbol = "";
-        if (bond.getFlag(CDKConstants.ISAROMATIC)) {
-            bondSymbol = ":";
-        } else if (bond.getOrder() == IBond.Order.SINGLE) {
-            bondSymbol = "-";
-        } else if (bond.getOrder() == IBond.Order.DOUBLE) {
-            bondSymbol = "=";
-        } else if (bond.getOrder() == IBond.Order.TRIPLE) {
-            bondSymbol = "#";
+        if (bond.isAromatic())
+            return ":";
+        switch (bond.getOrder()) {
+            case SINGLE:
+                return "-";
+            case DOUBLE:
+                return "=";
+            case TRIPLE:
+                return "#";
+            default:
+                return "";
         }
-        return bondSymbol;
     }
 
     public void setPathLimit(int limit) {

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  *  Generates a fingerprint for a given AtomContainer. Fingerprints are
@@ -200,7 +201,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         throw new UnsupportedOperationException();
     }
 
-    private StringBuffer encodePath(IAtomContainer mol, Map<IAtom, Map<IAtom, IBond>> cache, List<IAtom> path) {
+    private String encodePath(IAtomContainer mol, Map<IAtom, Map<IAtom, IBond>> cache, List<IAtom> path) {
         StringBuffer sb = new StringBuffer();
         IAtom x = path.get(0);
 
@@ -241,9 +242,9 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         StringBuffer revForm = new StringBuffer(sb);
         revForm.reverse();
         if (sb.toString().compareTo(revForm.toString()) <= 0)
-            return sb;
+            return revForm.toString();
         else
-            return revForm;
+            return sb.toString();
     }
 
     /**
@@ -258,31 +259,21 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
      */
     protected int[] findPathes(IAtomContainer container, int searchDepth) throws CDKException {
 
-        List<StringBuffer> allPaths = new ArrayList<StringBuffer>();
+        Set<String> paths = new TreeSet<>();
 
         Map<IAtom, Map<IAtom, IBond>> cache = new HashMap<IAtom, Map<IAtom, IBond>>();
 
         for (IAtom startAtom : container.atoms()) {
             List<List<IAtom>> p = PathTools.getLimitedPathsOfLengthUpto(container, startAtom, searchDepth, pathLimit);
             for (List<IAtom> path : p) {
-                allPaths.add(encodePath(container, cache, path));
+                paths.add(encodePath(container, cache, path));
             }
-        }
-        // now lets clean stuff up
-        Set<String> cleanPath = new HashSet<String>();
-        for (StringBuffer s : allPaths) {
-            String s1 = s.toString().trim();
-            if (s1.equals("")) continue;
-            if (cleanPath.contains(s1)) continue;
-            String s2 = s.reverse().toString().trim();
-            if (cleanPath.contains(s2)) continue;
-            cleanPath.add(s2);
         }
 
         // convert paths to hashes
-        int[] hashes = new int[cleanPath.size()];
+        int[] hashes = new int[paths.size()];
         int i = 0;
-        for (String s : cleanPath)
+        for (String s : paths)
             hashes[i++] = s.hashCode();
 
         return hashes;

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -224,6 +224,25 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         return buffer.toString();
     }
 
+    private int appendHash(int hash, String str) {
+        int len = str.length();
+        for (int i = 0; i < len; i++)
+            hash = 31 * hash + str.charAt(0);
+        return hash;
+    }
+
+    private int hashPath(List<IAtom> apath, List<IBond> bpath) {
+        int hash = 0;
+        hash = appendHash(hash, getAtomSymbol(apath.get(0)));
+        for (int i = 1; i < apath.size(); i++) {
+            final IAtom next  = apath.get(i);
+            final IBond bond  = bpath.get(i-1);
+            hash = appendHash(hash, getBondSymbol(bond));
+            hash = appendHash(hash, getAtomSymbol(next));
+        }
+        return hash;
+    }
+
     private static final class State {
         private int    numPaths = 0;
         private Random rand     = new Random();
@@ -417,11 +436,11 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
             return getAtomSymbol(apath.get(0)).hashCode();
         final int x;
         if (compare(apath, bpath) >= 0) {
-            x = encodePath(apath, bpath, buffer).hashCode();
+            x = hashPath(apath, bpath);
         } else {
             Collections.reverse(bpath);
             Collections.reverse(apath);
-            x = encodePath(apath, bpath, buffer).hashCode();
+            x = hashPath(apath, bpath);
             Collections.reverse(bpath);
             Collections.reverse(apath);
         }

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -157,8 +157,10 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         logger.debug("Entering Fingerprinter");
         logger.debug("Starting Aromaticity Detection");
         long before = System.currentTimeMillis();
-        AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(container);
-        Aromaticity.cdkLegacy().apply(container);
+        if (!hasPseudoAtom(container.atoms())) {
+            AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(container);
+            Aromaticity.cdkLegacy().apply(container);
+        }
         long after = System.currentTimeMillis();
         logger.debug("time for aromaticity calculation: " + (after - before) + " milliseconds");
         logger.debug("Finished Aromaticity Detection");
@@ -386,7 +388,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         return getElem(a) == 0;
     }
 
-    private static boolean hasPseudoAtom(List<IAtom> path) {
+    private static boolean hasPseudoAtom(Iterable<IAtom> path) {
         for (IAtom atom : path)
             if (isPseudo(atom))
                 return true;

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -259,24 +259,23 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
      */
     protected int[] findPathes(IAtomContainer container, int searchDepth) throws CDKException {
 
-        Set<String> paths = new TreeSet<>();
+        Set<Integer> hashes = new HashSet<>();
 
         Map<IAtom, Map<IAtom, IBond>> cache = new HashMap<IAtom, Map<IAtom, IBond>>();
 
         for (IAtom startAtom : container.atoms()) {
             List<List<IAtom>> p = PathTools.getLimitedPathsOfLengthUpto(container, startAtom, searchDepth, pathLimit);
             for (List<IAtom> path : p) {
-                paths.add(encodePath(container, cache, path));
+                hashes.add(encodePath(container, cache, path).hashCode());
             }
         }
 
-        // convert paths to hashes
-        int[] hashes = new int[paths.size()];
-        int i = 0;
-        for (String s : paths)
-            hashes[i++] = s.hashCode();
+        int   pos = 0;
+        int[] result = new int[hashes.size()];
+        for (Integer hash : hashes)
+            result[pos++] = hash;
 
-        return hashes;
+        return result;
     }
 
     private String convertSymbol(String symbol) {

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -270,7 +270,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         if (atom instanceof IPseudoAtom ||
             atom.getAtomicNumber() == null ||
             atom.getAtomicNumber() == 0) {
-            return Integer.toString(PeriodicTable.getElementCount()+1);
+            return "*";
         } else {
             // XXX: backwards compatibility
             // This is completely random, I believe the intention is because

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -132,7 +132,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
      * depth.
      *
      * @param  size        The desired size of the fingerprint
-     * @param  searchDepth The desired depth of search
+     * @param  searchDepth The desired depth of search (number of bonds)
      */
     public Fingerprinter(int size, int searchDepth) {
         this.size = size;
@@ -319,7 +319,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         state.push(beg, prev);
         state.addHash(encodeUniquePath(state.apath, state.bpath, state.buffer));
         if (state.numPaths > pathLimit)
-            throw new CDKException("To many paths!");
+            throw new CDKException("Too many paths! Structure is likely a cage, reduce path length or increase path limit");
         if (state.apath.size() < state.maxDepth) {
             for (IBond bond : state.getBonds(beg)) {
                 if (bond == prev)

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -100,7 +100,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
     /** The default length of created fingerprints. */
     public final static int                  DEFAULT_SIZE         = 1024;
     /** The default search depth used to create the fingerprints. */
-    public final static int                  DEFAULT_SEARCH_DEPTH = 8;
+    public final static int                  DEFAULT_SEARCH_DEPTH = 7;
 
     private int                              size;
     private int                              searchDepth;

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -39,6 +39,7 @@ import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -211,14 +212,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
             prev = next;
         }
 
-        // we store the lexicographically lower one of the
-        // string and its reverse
-        StringBuilder revForm = new StringBuilder(sb);
-        revForm.reverse();
-        if (sb.toString().compareTo(revForm.toString()) <= 0)
-            return revForm.toString();
-        else
-            return sb.toString();
+        return sb.toString();
     }
 
     /**
@@ -263,7 +257,15 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
         for (IAtom startAtom : container.atoms()) {
             List<List<IAtom>> p = PathTools.getLimitedPathsOfLengthUpto(container, startAtom, searchDepth, pathLimit);
             for (List<IAtom> path : p) {
-                int x = encodePath(container, cache, path).hashCode();
+                String forward = encodePath(container, cache, path);
+                Collections.reverse(path);
+                String reverse = encodePath(container, cache, path);
+
+                final int x;
+                if (reverse.compareTo(forward) < 0)
+                    x = forward.hashCode();
+                else
+                    x = reverse.hashCode();
                 rand.setSeed(x);
                 // XXX: fp.set(x % size); would work just as well but would encode a
                 //      different bit

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/GraphOnlyFingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/GraphOnlyFingerprinter.java
@@ -72,11 +72,8 @@ public class GraphOnlyFingerprinter extends Fingerprinter {
     }
 
     public BitSet getBitFingerprint(IAtomContainer container, int size) throws Exception {
-        int[] hashes = findPathes(container, super.getSearchDepth());
         BitSet bitSet = new BitSet(size);
-        for (int hash : hashes) {
-            bitSet.set(new Random(hash).nextInt(size));
-        }
+        encodePaths(container, super.getSearchDepth(), bitSet, size);
         return bitSet;
     }
 }

--- a/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterTest.java
@@ -389,4 +389,22 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         assertFalse(FingerprinterTool.isSubset(fp4, fp3));
         assertFalse(FingerprinterTool.isSubset(fp3, fp4));
     }
+
+    @Test public void pseudoAtomFingerprintArom() throws CDKException {
+        final SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        final String query  = "*1cccc1";
+        final String indole = "o1cccc1";
+        IAtomContainer queryMol  = smipar.parseSmiles(query);
+        IAtomContainer indoleMol = smipar.parseSmiles(indole);
+        Fingerprinter fpr = new Fingerprinter();
+        BitSet fp1 = fpr.getFingerprint(queryMol);
+        BitSet fp2 = fpr.getFingerprint(indoleMol);
+        assertTrue(FingerprinterTool.isSubset(fp2, fp1));
+        assertFalse(FingerprinterTool.isSubset(fp1, fp2));
+        fpr.setHashPseudoAtoms(true);
+        BitSet fp3 = fpr.getFingerprint(queryMol);
+        BitSet fp4 = fpr.getFingerprint(indoleMol);
+        assertFalse(FingerprinterTool.isSubset(fp4, fp3));
+        assertFalse(FingerprinterTool.isSubset(fp3, fp4));
+    }
 }

--- a/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterTest.java
@@ -72,7 +72,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
     public void testRegression() throws Exception {
         IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
         IAtomContainer mol2 = TestMoleculeFactory.makePyrrole();
-        Fingerprinter fingerprinter = new Fingerprinter();
+        Fingerprinter fingerprinter = new Fingerprinter(1024, 8);
         IBitFingerprint bs1 = fingerprinter.getBitFingerprint(mol1);
         Assert.assertEquals(
                 "Seems the fingerprint code has changed. This will cause a number of other tests to fail too!", 33,

--- a/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/FingerprinterTest.java
@@ -35,6 +35,7 @@ import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.Reaction;
 import org.openscience.cdk.SlowTest;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.AtomContainerAtomPermutor;
 import org.openscience.cdk.graph.AtomContainerBondPermutor;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -44,10 +45,15 @@ import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.io.MDLRXNV2000Reader;
 import org.openscience.cdk.io.MDLV2000Reader;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.ChemFileManipulator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @cdk.module test-standard
@@ -110,7 +116,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
         IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
-        Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
+        assertTrue(FingerprinterTool.isSubset(bs, bs1));
     }
 
     @Test
@@ -122,7 +128,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
         IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
-        Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
+        assertTrue(FingerprinterTool.isSubset(bs, bs1));
     }
 
     @Test
@@ -134,7 +140,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         BitSet bs = fingerprinter.getBitFingerprint(mol).asBitSet();
         IAtomContainer frag1 = TestMoleculeFactory.makePyrrole();
         BitSet bs1 = fingerprinter.getBitFingerprint(frag1).asBitSet();
-        Assert.assertTrue(FingerprinterTool.isSubset(bs, bs1));
+        assertTrue(FingerprinterTool.isSubset(bs, bs1));
     }
 
     @Test
@@ -208,7 +214,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         while (acp.hasNext()) {
             IAtomContainer container = acp.next();
             IBitFingerprint bs2 = fp.getBitFingerprint(container);
-            Assert.assertTrue(bs1.equals(bs2));
+            assertTrue(bs1.equals(bs2));
         }
     }
 
@@ -222,7 +228,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         while (acp.hasNext()) {
             IAtomContainer container = acp.next();
             IBitFingerprint bs2 = fp.getBitFingerprint(container);
-            Assert.assertTrue(bs1.equals(bs2));
+            assertTrue(bs1.equals(bs2));
         }
     }
 
@@ -236,7 +242,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         while (acp.hasNext()) {
             IAtomContainer container = acp.next();
             IBitFingerprint bs2 = fp.getBitFingerprint(container);
-            Assert.assertTrue(bs1.equals(bs2));
+            assertTrue(bs1.equals(bs2));
         }
     }
 
@@ -250,7 +256,7 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         while (acp.hasNext()) {
             IAtomContainer container = acp.next();
             IBitFingerprint bs2 = fp.getBitFingerprint(container);
-            Assert.assertTrue(bs1.equals(bs2));
+            assertTrue(bs1.equals(bs2));
         }
     }
 
@@ -364,5 +370,23 @@ public class FingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         //fpt.testBug853254();
         //fpt.testBug931608();
         fpt.testBug934819();
+    }
+
+    @Test public void pseudoAtomFingerprint() throws CDKException {
+        final SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        final String query  = "*1CCCC1";
+        final String indole = "N1CCCC1";
+        IAtomContainer queryMol  = smipar.parseSmiles(query);
+        IAtomContainer indoleMol = smipar.parseSmiles(indole);
+        Fingerprinter fpr = new Fingerprinter();
+        BitSet fp1 = fpr.getFingerprint(queryMol);
+        BitSet fp2 = fpr.getFingerprint(indoleMol);
+        assertTrue(FingerprinterTool.isSubset(fp2, fp1));
+        assertFalse(FingerprinterTool.isSubset(fp1, fp2));
+        fpr.setHashPseudoAtoms(true);
+        BitSet fp3 = fpr.getFingerprint(queryMol);
+        BitSet fp4 = fpr.getFingerprint(indoleMol);
+        assertFalse(FingerprinterTool.isSubset(fp4, fp3));
+        assertFalse(FingerprinterTool.isSubset(fp3, fp4));
     }
 }

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/similarity/TanimotoTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/similarity/TanimotoTest.java
@@ -59,7 +59,7 @@ public class TanimotoTest extends CDKTestCase {
     public void testTanimoto1() throws java.lang.Exception {
         IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
         IAtomContainer mol2 = TestMoleculeFactory.makePyrrole();
-        Fingerprinter fingerprinter = new Fingerprinter();
+        Fingerprinter fingerprinter = new Fingerprinter(1024, 8);
         BitSet bs1 = fingerprinter.getBitFingerprint(mol1).asBitSet();
         BitSet bs2 = fingerprinter.getBitFingerprint(mol2).asBitSet();
         float tanimoto = Tanimoto.calculate(bs1, bs2);
@@ -83,7 +83,7 @@ public class TanimotoTest extends CDKTestCase {
     public void testCalculate_BitFingerprint() throws java.lang.Exception {
         IAtomContainer mol1 = TestMoleculeFactory.makeIndole();
         IAtomContainer mol2 = TestMoleculeFactory.makePyrrole();
-        Fingerprinter fp = new Fingerprinter();
+        Fingerprinter fp = new Fingerprinter(1024, 8);
         double similarity = Tanimoto.calculate(fp.getBitFingerprint(mol1), fp.getBitFingerprint(mol2));
         Assert.assertEquals(0.3939, similarity, 0.01);
     }
@@ -176,7 +176,7 @@ public class TanimotoTest extends CDKTestCase {
     public void testCompareBitSetandBitFingerprintTanimoto() throws Exception {
         IAtomContainer mol1 = TestMoleculeFactory.make123Triazole();
         IAtomContainer mol2 = TestMoleculeFactory.makeImidazole();
-        Fingerprinter fingerprinter = new Fingerprinter();
+        Fingerprinter fingerprinter = new Fingerprinter(1024, 8);
         BitSet bs1 = fingerprinter.getBitFingerprint(mol1).asBitSet();
         BitSet bs2 = fingerprinter.getBitFingerprint(mol2).asBitSet();
         float tanimoto = Tanimoto.calculate(bs1, bs2);


### PR DESCRIPTION
I've been meaning to do this for a while. Ultimately I wanted to rewrite the entire fingerprint stack it's  all a bit backwards at the moment but I digress. The default path based (i.e. Fingerprint) has some really odd quirks in it. I did the patches so it should be easy to step through the thought process and easy to follow. It will go even faster once I add in adjacency list but there's already enough here for a decent patch.

You can see in the commits but essentially it used to generate the path, reverse it, test uniqueness, reverse it again, test uniqueness, add it to an int[], then add it to a BitSet (unique set by design). On top of all of that the reversing wasn't even correct, the uniqueness is over-rated but it was meant to mean you only encode one bit for a path (e.g. NC=O and O=CN). However since the reversing was done by string manipulation you get some fun situations with two letter atom symbols. ``FeC`` should reverse to ``CFe`` (but they're ``CeF`` and ``eFC`` reversed) Doh!

I also made it so psuedo atoms are always encoded as '*' instead of max atomic number + 1 (this recently changed - :D). Oh and you don't normally want to include these in the fingerprint anyways so I added an option which skips all pseudo atoms.

After all these changes (and some very crafty cleverness) the fingerprint uses a lot less memory and is close to optimal without breaking backwards compatibility. Here are the times on my laptop for 10k molecules in ChEMBL 22, also shows there were no changes to the generated fingerprint.

```bash
[sovereign ~/workspace/github/cdk/cdk-paper-3/benchmark/cdk-2.0]: time head -n 10000 /data/chembl_22.smi | ./cdk fpgen --ifmt=smi --type=path -p > old.fps
Processing STDIN
[INFO] 10000 (261 per second)
Finished fpgen --ifmt=smi --type=path -p
 Elapsed Time: 38325
 Records       10000
 Processed:    10000
 Skipped:      0

real	0m38.980s
user	0m52.669s
sys	0m0.959s
[sovereign ~/workspace/github/cdk/cdk-paper-3/benchmark/cdk-2.0]: time head -n 10000 /data/chembl_22.smi | ./cdk fpgen --ifmt=smi --type=path -p > new.fps
Processing STDIN
[INFO] 10000 (2113 per second)
Finished fpgen --ifmt=smi --type=path -p
 Elapsed Time: 4734
 Records       10000
 Processed:    10000
 Skipped:      0

real	0m5.070s
user	0m13.885s
sys	0m0.375s
[sovereign ~/workspace/github/cdk/cdk-paper-3/benchmark/cdk-2.0]: diff old.fps new.fps 
5c5
< #date=2017-04-98T11:57:51
---
> #date=2017-04-98T11:59:32
```

Even faster