### PR TITLE
Patch/wedgebondpriority

### DIFF
--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -338,17 +338,31 @@ final class NonplanarBonds {
         }
 
         // set the label for the highest priority and available bond
+        IBond.Stereo firstlabel = null;
         for (int v : priority(atomToIndex.get(focus), atoms, n)) {
             IBond bond = bonds[v];
-            if (bond.getStereo() == NONE && bond.getOrder() == SINGLE) {
+            if (bond.getStereo() != NONE || bond.getOrder() != SINGLE)
+                continue;
+            // first label
+            if (firstlabel == null) {
                 bond.setAtoms(new IAtom[]{focus, atoms[v]}); // avoids UP_INVERTED/DOWN_INVERTED
                 bond.setStereo(labels[v]);
-                return;
+                firstlabel = labels[v];
+                // don't assign a second label when there are only three ligands
+                if (labels.length == 3)
+                    break;
+            }
+            // second label
+            else if (labels[v] != firstlabel) {
+                bond.setAtoms(new IAtom[]{focus, atoms[v]}); // avoids UP_INVERTED/DOWN_INVERTED
+                bond.setStereo(labels[v]);
+                break;
             }
         }
 
         // it should be possible to always assign labels somewhere -> unchecked exception
-        throw new IllegalArgumentException("could not assign non-planar (up/down) labels");
+        if (firstlabel == null)
+            throw new IllegalArgumentException("could not assign non-planar (up/down) labels");
     }
 
     /**

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -466,20 +466,23 @@ final class NonplanarBonds {
             return false;
 
         final int iDegree = graph[i].length;
-        final int iElem   = iAtom.getAtomicNumber();
+        int iElem   = iAtom.getAtomicNumber();
         final int jDegree = graph[j].length;
-        final int jElem   = jAtom.getAtomicNumber();
+        int jElem   = jAtom.getAtomicNumber();
 
+        // rank carbon's last
+        if (iElem == 6) iElem = 256;
+        if (jElem == 6) jElem = 256;
 
-        // prioritise atoms with fewer neighbors
-        if (iDegree < jDegree) return true;
-        if (iDegree > jDegree) return false;
-
-        // prioritise by atomic number
+        // prioritise by atomic number, H < N < O < ... < C
         if (iElem < jElem)
             return true;
         if (iElem > jElem)
             return false;
+
+        // prioritise atoms with fewer neighbors
+        if (iDegree < jDegree) return true;
+        if (iDegree > jDegree) return false;
 
         return false;
     }

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -465,14 +465,20 @@ final class NonplanarBonds {
         if (iAtom.getAtomicNumber() == 0 && jAtom.getAtomicNumber() > 0)
             return false;
 
+        final int iDegree = graph[i].length;
+        final int iElem   = iAtom.getAtomicNumber();
+        final int jDegree = graph[j].length;
+        final int jElem   = jAtom.getAtomicNumber();
+
+
         // prioritise atoms with fewer neighbors
-        if (graph[i].length < graph[j].length) return true;
-        if (graph[i].length > graph[j].length) return false;
+        if (iDegree < jDegree) return true;
+        if (iDegree > jDegree) return false;
 
         // prioritise by atomic number
-        if (iAtom.getAtomicNumber() < jAtom.getAtomicNumber())
+        if (iElem < jElem)
             return true;
-        if (iAtom.getAtomicNumber() > jAtom.getAtomicNumber())
+        if (iElem > jElem)
             return false;
 
         return false;

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
@@ -157,7 +157,7 @@ public class NonPlanarBondsTest {
         assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.NONE));
         assertThat(m.getBond(3).getStereo(), is(IBond.Stereo.NONE));
         assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.UP));
-        assertThat(m.getBond(5).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(5).getStereo(), is(IBond.Stereo.DOWN));
     }
 
     // [C@@](CCC)(C1)(C)C1 (favour acyclic)
@@ -183,7 +183,7 @@ public class NonPlanarBondsTest {
         m.addStereoElement(new TetrahedralChirality(m.getAtom(0), new IAtom[]{m.getAtom(1), m.getAtom(4), m.getAtom(5),
                 m.getAtom(6)}, ITetrahedralChirality.Stereo.CLOCKWISE));
         NonplanarBonds.assign(m);
-        assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.UP));
         assertThat(m.getBond(3).getStereo(), is(IBond.Stereo.NONE));
         assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.DOWN));
         assertThat(m.getBond(5).getStereo(), is(IBond.Stereo.NONE));
@@ -212,7 +212,7 @@ public class NonPlanarBondsTest {
         assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.NONE));
         assertThat(m.getBond(3).getStereo(), is(IBond.Stereo.NONE));
         assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.DOWN));
-        assertThat(m.getBond(5).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(5).getStereo(), is(IBond.Stereo.UP));
     }
 
     // [C@](CCC)(C1)(C)C1 (favour acyclic)
@@ -238,7 +238,7 @@ public class NonPlanarBondsTest {
         m.addStereoElement(new TetrahedralChirality(m.getAtom(0), new IAtom[]{m.getAtom(1), m.getAtom(4), m.getAtom(5),
                 m.getAtom(6)}, ITetrahedralChirality.Stereo.ANTI_CLOCKWISE));
         NonplanarBonds.assign(m);
-        assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.DOWN));
         assertThat(m.getBond(3).getStereo(), is(IBond.Stereo.NONE));
         assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.UP));
         assertThat(m.getBond(5).getStereo(), is(IBond.Stereo.NONE));

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
@@ -64,8 +64,8 @@ public class NonPlanarBondsTest {
         m.addStereoElement(new TetrahedralChirality(m.getAtom(0), new IAtom[]{m.getAtom(0), m.getAtom(1), m.getAtom(2),
                 m.getAtom(3)}, ITetrahedralChirality.Stereo.CLOCKWISE));
         NonplanarBonds.assign(m);
-        assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.DOWN));
-        assertThat(m.getBond(1).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(1).getStereo(), is(IBond.Stereo.DOWN));
         assertThat(m.getBond(2).getStereo(), is(IBond.Stereo.NONE));
     }
 
@@ -106,8 +106,8 @@ public class NonPlanarBondsTest {
         m.addStereoElement(new TetrahedralChirality(m.getAtom(0), new IAtom[]{m.getAtom(0), m.getAtom(1), m.getAtom(2),
                 m.getAtom(3)}, ITetrahedralChirality.Stereo.ANTI_CLOCKWISE));
         NonplanarBonds.assign(m);
-        assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.UP));
-        assertThat(m.getBond(1).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(1).getStereo(), is(IBond.Stereo.UP));
         assertThat(m.getBond(2).getStereo(), is(IBond.Stereo.NONE));
     }
 
@@ -155,8 +155,8 @@ public class NonPlanarBondsTest {
                 m.getAtom(6)}, ITetrahedralChirality.Stereo.CLOCKWISE));
         NonplanarBonds.assign(m);
         assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.NONE));
-        assertThat(m.getBond(3).getStereo(), is(IBond.Stereo.UP));
-        assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(3).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.UP));
         assertThat(m.getBond(5).getStereo(), is(IBond.Stereo.NONE));
     }
 
@@ -210,8 +210,8 @@ public class NonPlanarBondsTest {
                 m.getAtom(6)}, ITetrahedralChirality.Stereo.ANTI_CLOCKWISE));
         NonplanarBonds.assign(m);
         assertThat(m.getBond(0).getStereo(), is(IBond.Stereo.NONE));
-        assertThat(m.getBond(3).getStereo(), is(IBond.Stereo.DOWN));
-        assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(3).getStereo(), is(IBond.Stereo.NONE));
+        assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.DOWN));
         assertThat(m.getBond(5).getStereo(), is(IBond.Stereo.NONE));
     }
 
@@ -311,7 +311,7 @@ public class NonPlanarBondsTest {
         m.addStereoElement(new TetrahedralChirality(m.getAtom(0), new IAtom[]{m.getAtom(2), m.getAtom(4), m.getAtom(6),
                 m.getAtom(3),}, ITetrahedralChirality.Stereo.ANTI_CLOCKWISE));
         NonplanarBonds.assign(m);
-        assertThat(m.getBond(4).getStereo(), is(IBond.Stereo.DOWN));
+        assertThat(m.getBond(2).getStereo(), is(IBond.Stereo.UP));
     }
     
     


### PR DESCRIPTION
Tweaking wedge bond assignment following some discussions on twitter over last few months. Tetrahedral centres with 4 bonds will now have 2 wedges assigned (up+down). Centres with 3 bonds are all the same direction (e.g. all down or all up) and so do not get two assigned.

![image](https://cloud.githubusercontent.com/assets/983232/25175585/3ffcfaf4-24f3-11e7-94b9-e45957141618.png)
![image](https://cloud.githubusercontent.com/assets/983232/25175588/440e14b6-24f3-11e7-9cbe-3cb130de2add.png)
![image](https://cloud.githubusercontent.com/assets/983232/25175590/48b8eb62-24f3-11e7-8e03-34dcfabf441a.png)
