### PR TITLE
Patch/apicleanup2

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -213,8 +213,8 @@ public class Abbreviations implements Iterable<String> {
     private static List<IAtomContainer> makeCut(IBond cut, IAtomContainer mol, Map<IAtom, Integer> idx,
                                                 int[][] adjlist) {
 
-        IAtom beg = cut.getAtom(0);
-        IAtom end = cut.getAtom(1);
+        IAtom beg = cut.getBeg();
+        IAtom end = cut.getEnd();
 
         Set<IAtom> bvisit = new LinkedHashSet<>();
         Set<IAtom> evisit = new LinkedHashSet<>();
@@ -452,10 +452,10 @@ public class Abbreviations implements Iterable<String> {
                     IAtom atom = frag.getAtom(i);
                     usedAtoms.add(atom);
                     sgroup.addAtom(atom);
-                    if (attachBond.getAtom(0) == atom)
-                        attachAtom = attachBond.getAtom(1);
-                    else if (attachBond.getAtom(1) == atom)
-                        attachAtom = attachBond.getAtom(0);
+                    if (attachBond.getBeg() == atom)
+                        attachAtom = attachBond.getEnd();
+                    else if (attachBond.getEnd() == atom)
+                        attachAtom = attachBond.getBeg();
                 }
 
                 if (attachAtom != null)

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -24,13 +24,11 @@
 package org.openscience.cdk.depict;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Multimap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
-import org.openscience.cdk.graph.ConnectedComponents;
 import org.openscience.cdk.graph.ConnectivityChecker;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.graph.GraphUtil;
@@ -55,7 +53,6 @@ import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
-import uk.ac.ebi.beam.Element;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -66,8 +63,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
@@ -498,7 +493,7 @@ public class Abbreviations implements Iterable<String> {
             int numSGrpNbrs = nbrSymbols.size();
             for (IBond bond : mol.getConnectedBondsList(attach)) {
                 if (!xbonds.contains(bond)) {
-                    IAtom nbr = bond.getConnectedAtom(attach);
+                    IAtom nbr = bond.getOther(attach);
                     // contract terminal bonds
                     if (mol.getConnectedBondsCount(nbr) == 1) {
                         if (nbr.getMassNumber() != null ||
@@ -689,7 +684,7 @@ public class Abbreviations implements Iterable<String> {
         for (IBond bond : mol.getConnectedBondsList(atom)) {
             val += bond.getOrder().numeric();
             con++;
-            if (bond.getConnectedAtom(atom).getAtomicNumber() == 1)
+            if (bond.getOther(atom).getAtomicNumber() == 1)
                 hcnt++;
         }
 

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -277,8 +277,8 @@ public class Abbreviations implements Iterable<String> {
         }
 
         for (IBond bond : mol.bonds()) {
-            IAtom a1 = bond.getAtom(0);
-            IAtom a2 = bond.getAtom(1);
+            IAtom a1 = bond.getBeg();
+            IAtom a2 = bond.getEnd();
             if (bvisit.contains(a1) && bvisit.contains(a2))
                 bfrag.addBond(bond);
             else if (evisit.contains(a1) && evisit.contains(a2))
@@ -722,8 +722,8 @@ public class Abbreviations implements Iterable<String> {
         }
 
         for (IBond bond : mol.bonds()) {
-            final IAtom beg = atmmap.get(bond.getAtom(0));
-            final IAtom end = atmmap.get(bond.getAtom(1));
+            final IAtom beg = atmmap.get(bond.getBeg());
+            final IAtom end = atmmap.get(bond.getEnd());
 
             // attach bond skipped
             if (beg == null || end == null)

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -208,7 +208,7 @@ public class Abbreviations implements Iterable<String> {
     private static List<IAtomContainer> makeCut(IBond cut, IAtomContainer mol, Map<IAtom, Integer> idx,
                                                 int[][] adjlist) {
 
-        IAtom beg = cut.getBeg();
+        IAtom beg = cut.getBegin();
         IAtom end = cut.getEnd();
 
         Set<IAtom> bvisit = new LinkedHashSet<>();
@@ -272,7 +272,7 @@ public class Abbreviations implements Iterable<String> {
         }
 
         for (IBond bond : mol.bonds()) {
-            IAtom a1 = bond.getBeg();
+            IAtom a1 = bond.getBegin();
             IAtom a2 = bond.getEnd();
             if (bvisit.contains(a1) && bvisit.contains(a2))
                 bfrag.addBond(bond);
@@ -447,10 +447,10 @@ public class Abbreviations implements Iterable<String> {
                     IAtom atom = frag.getAtom(i);
                     usedAtoms.add(atom);
                     sgroup.addAtom(atom);
-                    if (attachBond.getBeg() == atom)
+                    if (attachBond.getBegin() == atom)
                         attachAtom = attachBond.getEnd();
                     else if (attachBond.getEnd() == atom)
-                        attachAtom = attachBond.getBeg();
+                        attachAtom = attachBond.getBegin();
                 }
 
                 if (attachAtom != null)
@@ -717,7 +717,7 @@ public class Abbreviations implements Iterable<String> {
         }
 
         for (IBond bond : mol.bonds()) {
-            final IAtom beg = atmmap.get(bond.getBeg());
+            final IAtom beg = atmmap.get(bond.getBegin());
             final IAtom end = atmmap.get(bond.getEnd());
 
             // attach bond skipped

--- a/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.depict;
 import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
-import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.geometry.GeometryUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -44,21 +43,17 @@ import org.openscience.cdk.renderer.generators.IGenerator;
 import org.openscience.cdk.renderer.generators.IGeneratorParameter;
 import org.openscience.cdk.renderer.generators.standard.SelectionVisibility;
 import org.openscience.cdk.renderer.generators.standard.StandardGenerator;
-import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
 import javax.vecmath.Point2d;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -532,7 +527,7 @@ public final class DepictionGenerator {
             }
             if (colorIdx > prevPalletIdx) {
                 for (IBond bond : mol.bonds()) {
-                    IAtom a1 = bond.getBeg();
+                    IAtom a1 = bond.getBegin();
                     IAtom a2 = bond.getEnd();
                     Color c1 = colorMap.get(a1);
                     Color c2 = colorMap.get(a2);
@@ -550,7 +545,7 @@ public final class DepictionGenerator {
                 }
             }
             for (IBond bond : mol.bonds()) {
-                IAtom a1 = bond.getBeg();
+                IAtom a1 = bond.getBegin();
                 IAtom a2 = bond.getEnd();
                 Color c1 = colorMap.get(a1);
                 Color c2 = colorMap.get(a2);
@@ -1106,7 +1101,7 @@ public final class DepictionGenerator {
         int nBonds = 0;
         double[] lengths = new double[bonds.size()];
         for (IBond bond : bonds) {
-            Point2d p1 = bond.getBeg().getPoint2d();
+            Point2d p1 = bond.getBegin().getPoint2d();
             Point2d p2 = bond.getEnd().getPoint2d();
             // watch out for overlaid atoms (occur in multiple group Sgroups)
             if (!p1.equals(p2))

--- a/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
@@ -532,8 +532,8 @@ public final class DepictionGenerator {
             }
             if (colorIdx > prevPalletIdx) {
                 for (IBond bond : mol.bonds()) {
-                    IAtom a1 = bond.getAtom(0);
-                    IAtom a2 = bond.getAtom(1);
+                    IAtom a1 = bond.getBeg();
+                    IAtom a2 = bond.getEnd();
                     Color c1 = colorMap.get(a1);
                     Color c2 = colorMap.get(a2);
                     if (c1 != null && c1 == c2)
@@ -550,8 +550,8 @@ public final class DepictionGenerator {
                 }
             }
             for (IBond bond : mol.bonds()) {
-                IAtom a1 = bond.getAtom(0);
-                IAtom a2 = bond.getAtom(1);
+                IAtom a1 = bond.getBeg();
+                IAtom a2 = bond.getEnd();
                 Color c1 = colorMap.get(a1);
                 Color c2 = colorMap.get(a2);
                 if (c1 != null && c1 == c2)
@@ -1106,8 +1106,8 @@ public final class DepictionGenerator {
         int nBonds = 0;
         double[] lengths = new double[bonds.size()];
         for (IBond bond : bonds) {
-            Point2d p1 = bond.getAtom(0).getPoint2d();
-            Point2d p2 = bond.getAtom(1).getPoint2d();
+            Point2d p1 = bond.getBeg().getPoint2d();
+            Point2d p2 = bond.getEnd().getPoint2d();
             // watch out for overlaid atoms (occur in multiple group Sgroups)
             if (!p1.equals(p2))
                 lengths[nBonds++] = p1.distance(p2);

--- a/base/atomtype/src/main/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcher.java
+++ b/base/atomtype/src/main/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcher.java
@@ -139,7 +139,7 @@ public class SybylAtomTypeMatcher implements IAtomTypeMatcher {
         List<IBond> neighbors = atomContainer.getConnectedBondsList(atom);
         if (neighbors.size() != 1) return false;
         IBond neighbor = neighbors.get(0);
-        IAtom neighborAtom = neighbor.getConnectedAtom(atom);
+        IAtom neighborAtom = neighbor.getOther(atom);
         if (neighborAtom.getSymbol().equals("C")) {
             if (neighbor.getOrder() == IBond.Order.SINGLE) {
                 if (countAttachedBonds(atomContainer, neighborAtom, IBond.Order.DOUBLE, "O") == 1) return true;
@@ -168,7 +168,7 @@ public class SybylAtomTypeMatcher implements IAtomTypeMatcher {
             if (bond.getOrder() == order) {
                 if (bond.getAtomCount() == 2 && bond.contains(atom)) {
                     if (symbol != null) {
-                        IAtom neighbor = bond.getConnectedAtom(atom);
+                        IAtom neighbor = bond.getOther(atom);
                         if (neighbor.getSymbol().equals(symbol)) {
                             doubleBondedAtoms++;
                         }

--- a/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
+++ b/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
@@ -1063,7 +1063,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
     private List<IBond> heavyBonds(final List<IBond> bonds) {
         final List<IBond> heavy = new ArrayList<IBond>(bonds.size());
         for (final IBond bond : bonds) {
-            if (!(bond.getBeg().getSymbol().equals("H") && bond.getEnd().getSymbol().equals("H"))) {
+            if (!(bond.getBegin().getSymbol().equals("H") && bond.getEnd().getSymbol().equals("H"))) {
                 heavy.add(bond);
             }
         }

--- a/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
+++ b/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
@@ -658,7 +658,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
     private boolean isCarboxylate(IAtomContainer container, IAtom atom, List<IBond> connectedBonds) {
         // assumes that the oxygen only has one neighbor (C=O, or C-[O-])
         if (connectedBonds.size() != 1) return false;
-        IAtom carbon = connectedBonds.get(0).getConnectedAtom(atom);
+        IAtom carbon = connectedBonds.get(0).getOther(atom);
         if (!"C".equals(carbon.getSymbol())) return false;
 
         List<IBond> carbonBonds = container.getConnectedBondsList(carbon);
@@ -667,7 +667,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
         int singleBondedNegativeOxygenCount = 0;
         int doubleBondedOxygenCount = 0;
         for (IBond cBond : carbonBonds) {
-            IAtom neighbor = cBond.getConnectedAtom(carbon);
+            IAtom neighbor = cBond.getOther(carbon);
             if ("O".equals(neighbor.getSymbol())) {
                 oxygenCount++;
                 IBond.Order order = cBond.getOrder();
@@ -688,7 +688,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
     		if (bond.getOrder() == Order.DOUBLE || bond.isAromatic()) {
     			count++;
     		} else {
-    			IAtom nextAtom = bond.getConnectedAtom(atom);
+    			IAtom nextAtom = bond.getOther(atom);
     			if (nextAtom.getHybridization() != CDKConstants.UNSET &&
     					nextAtom.getHybridization() == Hybridization.SP2) {
     				// OK, it's SP2
@@ -1024,7 +1024,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
     private boolean isAmide(IAtom atom, IAtomContainer atomContainer, List<IBond> connectedBonds) {
     	if (connectedBonds.size() < 1) return false;
         for (IBond bond : connectedBonds) {
-        	IAtom neighbor = bond.getConnectedAtom(atom);
+        	IAtom neighbor = bond.getOther(atom);
             if (neighbor.getSymbol().equals("C")) {
                 if (countAttachedDoubleBonds(atomContainer.getConnectedBondsList(neighbor), neighbor, "O") == 1) return true;
             }
@@ -1035,7 +1035,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
     private boolean isThioAmide(IAtom atom, IAtomContainer atomContainer, List<IBond> connectedBonds) {
     	if (connectedBonds.size() < 1) return false;
         for (IBond bond : connectedBonds) {
-        	IAtom neighbor = bond.getConnectedAtom(atom);
+        	IAtom neighbor = bond.getOther(atom);
             if (neighbor.getSymbol().equals("C")) {
                 if (countAttachedDoubleBonds(atomContainer.getConnectedBondsList(neighbor), neighbor, "S") == 1) return true;
             }
@@ -1046,7 +1046,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
     private int countExplicitHydrogens(IAtom atom, List<IBond> connectedBonds) {
         int count = 0;
         for (IBond bond : connectedBonds) {
-        	IAtom aAtom = bond.getConnectedAtom(atom);
+        	IAtom aAtom = bond.getOther(atom);
             if (aAtom.getSymbol().equals("H")) {
                 count++;
             }
@@ -2458,7 +2458,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
                 if (bond.getAtomCount() == 2) {
                     if (symbol != null) {
                         // if other atom is of the given element (by its symbol)
-                        if (bond.getConnectedAtom(atom).getSymbol().equals(symbol)) {
+                        if (bond.getOther(atom).getSymbol().equals(symbol)) {
                             doubleBondedAtoms++;
                         }
                     } else {

--- a/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
+++ b/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
@@ -1063,7 +1063,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
     private List<IBond> heavyBonds(final List<IBond> bonds) {
         final List<IBond> heavy = new ArrayList<IBond>(bonds.size());
         for (final IBond bond : bonds) {
-            if (!(bond.getAtom(0).getSymbol().equals("H") && bond.getAtom(1).getSymbol().equals("H"))) {
+            if (!(bond.getBeg().getSymbol().equals("H") && bond.getEnd().getSymbol().equals("H"))) {
                 heavy.add(bond);
             }
         }

--- a/base/core/src/main/java/org/openscience/cdk/graph/GraphUtil.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/GraphUtil.java
@@ -71,8 +71,8 @@ public class GraphUtil {
 
         for (IBond bond : container.bonds()) {
 
-            int v = container.indexOf(bond.getAtom(0));
-            int w = container.indexOf(bond.getAtom(1));
+            int v = container.indexOf(bond.getBeg());
+            int w = container.indexOf(bond.getEnd());
 
             if (v < 0 || w < 0)
                 throw new IllegalArgumentException("bond at index " + container.indexOf(bond)
@@ -117,8 +117,8 @@ public class GraphUtil {
             if (!include.contains(bond))
                 continue;
 
-            int v = container.indexOf(bond.getAtom(0));
-            int w = container.indexOf(bond.getAtom(1));
+            int v = container.indexOf(bond.getBeg());
+            int w = container.indexOf(bond.getEnd());
 
             if (v < 0 || w < 0)
                 throw new IllegalArgumentException("bond at index " + container.indexOf(bond)
@@ -161,8 +161,8 @@ public class GraphUtil {
 
         for (IBond bond : container.bonds()) {
 
-            int v = container.indexOf(bond.getAtom(0));
-            int w = container.indexOf(bond.getAtom(1));
+            int v = container.indexOf(bond.getBeg());
+            int w = container.indexOf(bond.getEnd());
 
             if (v < 0 || w < 0)
                 throw new IllegalArgumentException("bond at index " + container.indexOf(bond)

--- a/base/core/src/main/java/org/openscience/cdk/graph/GraphUtil.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/GraphUtil.java
@@ -24,11 +24,9 @@
 package org.openscience.cdk.graph;
 
 import com.google.common.collect.Maps;
-import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -71,7 +69,7 @@ public class GraphUtil {
 
         for (IBond bond : container.bonds()) {
 
-            int v = container.indexOf(bond.getBeg());
+            int v = container.indexOf(bond.getBegin());
             int w = container.indexOf(bond.getEnd());
 
             if (v < 0 || w < 0)
@@ -117,7 +115,7 @@ public class GraphUtil {
             if (!include.contains(bond))
                 continue;
 
-            int v = container.indexOf(bond.getBeg());
+            int v = container.indexOf(bond.getBegin());
             int w = container.indexOf(bond.getEnd());
 
             if (v < 0 || w < 0)
@@ -161,7 +159,7 @@ public class GraphUtil {
 
         for (IBond bond : container.bonds()) {
 
-            int v = container.indexOf(bond.getBeg());
+            int v = container.indexOf(bond.getBegin());
             int w = container.indexOf(bond.getEnd());
 
             if (v < 0 || w < 0)

--- a/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
@@ -156,7 +156,7 @@ public class PathTools {
         IAtom nextAtom;
         root.setFlag(CDKConstants.VISITED, true);
         for (IBond bond : bonds) {
-            nextAtom = bond.getConnectedAtom(root);
+            nextAtom = bond.getOther(root);
             if (!nextAtom.getFlag(CDKConstants.VISITED)) {
                 path.addAtom(nextAtom);
                 path.addBond(bond);
@@ -267,7 +267,7 @@ public class PathTools {
                     molecule.addBond(bond);
                     bond.setFlag(CDKConstants.VISITED, true);
                 }
-                nextAtom = bond.getConnectedAtom(atom);
+                nextAtom = bond.getOther(atom);
                 if (!nextAtom.getFlag(CDKConstants.VISITED)) {
                     //					logger.debug("wie oft???");
                     newSphere.add(nextAtom);
@@ -313,7 +313,7 @@ public class PathTools {
                 if (!bond.getFlag(CDKConstants.VISITED)) {
                     bond.setFlag(CDKConstants.VISITED, true);
                 }
-                nextAtom = bond.getConnectedAtom(atom);
+                nextAtom = bond.getOther(atom);
                 if (!nextAtom.getFlag(CDKConstants.VISITED)) {
                     if (nextAtom == target) {
                         return pathLength;

--- a/base/core/src/main/java/org/openscience/cdk/graph/SpanningTree.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/SpanningTree.java
@@ -140,7 +140,7 @@ public class SpanningTree {
         for (int b = 0; b < totalEdgeCount; b++) {
             bondsInTree[b] = false;
             bond = atomContainer.getBond(b);
-            vertex1 = Integer.parseInt((bond.getBeg()).getProperty(ATOM_NUMBER).toString());
+            vertex1 = Integer.parseInt((bond.getBegin()).getProperty(ATOM_NUMBER).toString());
             vertex2 = Integer.parseInt((bond.getEnd()).getProperty(ATOM_NUMBER).toString());
             //this below is a little bit  slower
             //v1 = atomContainer.indexOf(bond.getAtomAt(0))+1;
@@ -209,8 +209,8 @@ public class SpanningTree {
     private IRing getRing(IAtomContainer spt, IBond bond) {
         IRing ring = spt.getBuilder().newInstance(IRing.class);
         PathTools.resetFlags(spt);
-        ring.addAtom(bond.getBeg());
-        PathTools.depthFirstTargetSearch(spt, bond.getBeg(), bond.getEnd(), ring);
+        ring.addAtom(bond.getBegin());
+        PathTools.depthFirstTargetSearch(spt, bond.getBegin(), bond.getEnd(), ring);
         ring.addBond(bond);
         return ring;
     }

--- a/base/core/src/main/java/org/openscience/cdk/graph/SpanningTree.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/SpanningTree.java
@@ -140,8 +140,8 @@ public class SpanningTree {
         for (int b = 0; b < totalEdgeCount; b++) {
             bondsInTree[b] = false;
             bond = atomContainer.getBond(b);
-            vertex1 = Integer.parseInt((bond.getAtom(0)).getProperty(ATOM_NUMBER).toString());
-            vertex2 = Integer.parseInt((bond.getAtom(1)).getProperty(ATOM_NUMBER).toString());
+            vertex1 = Integer.parseInt((bond.getBeg()).getProperty(ATOM_NUMBER).toString());
+            vertex2 = Integer.parseInt((bond.getEnd()).getProperty(ATOM_NUMBER).toString());
             //this below is a little bit  slower
             //v1 = atomContainer.indexOf(bond.getAtomAt(0))+1;
             //v2 = atomContainer.indexOf(bond.getAtomAt(1))+1;
@@ -209,8 +209,8 @@ public class SpanningTree {
     private IRing getRing(IAtomContainer spt, IBond bond) {
         IRing ring = spt.getBuilder().newInstance(IRing.class);
         PathTools.resetFlags(spt);
-        ring.addAtom(bond.getAtom(0));
-        PathTools.depthFirstTargetSearch(spt, bond.getAtom(0), bond.getAtom(1), ring);
+        ring.addAtom(bond.getBeg());
+        PathTools.depthFirstTargetSearch(spt, bond.getBeg(), bond.getEnd(), ring);
         ring.addBond(bond);
         return ring;
     }

--- a/base/core/src/main/java/org/openscience/cdk/graph/matrix/AdjacencyMatrix.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/matrix/AdjacencyMatrix.java
@@ -51,7 +51,7 @@ public class AdjacencyMatrix implements IGraphMatrix {
         int[][] conMat = new int[container.getAtomCount()][container.getAtomCount()];
         for (int f = 0; f < container.getBondCount(); f++) {
             bond = container.getBond(f);
-            indexAtom1 = container.indexOf(bond.getBeg());
+            indexAtom1 = container.indexOf(bond.getBegin());
             indexAtom2 = container.indexOf(bond.getEnd());
             conMat[indexAtom1][indexAtom2] = 1;
             conMat[indexAtom2][indexAtom1] = 1;

--- a/base/core/src/main/java/org/openscience/cdk/graph/matrix/AdjacencyMatrix.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/matrix/AdjacencyMatrix.java
@@ -51,8 +51,8 @@ public class AdjacencyMatrix implements IGraphMatrix {
         int[][] conMat = new int[container.getAtomCount()][container.getAtomCount()];
         for (int f = 0; f < container.getBondCount(); f++) {
             bond = container.getBond(f);
-            indexAtom1 = container.indexOf(bond.getAtom(0));
-            indexAtom2 = container.indexOf(bond.getAtom(1));
+            indexAtom1 = container.indexOf(bond.getBeg());
+            indexAtom2 = container.indexOf(bond.getEnd());
             conMat[indexAtom1][indexAtom2] = 1;
             conMat[indexAtom2][indexAtom1] = 1;
         }

--- a/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
+++ b/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
@@ -234,7 +234,7 @@ public final class RingSearch {
      */
     public boolean cyclic(IBond bond) {
         // XXX: linear search - but okay for now
-        int u = container.indexOf(bond.getBeg());
+        int u = container.indexOf(bond.getBegin());
         int v = container.indexOf(bond.getEnd());
         if (u < 0 || v < 0) throw new NoSuchElementException("atoms of the bond are not found in the container");
         return searcher.cyclic(u, v);
@@ -339,7 +339,7 @@ public final class RingSearch {
 
         for (IBond bond : container.bonds()) {
 
-            IAtom either = bond.getBeg();
+            IAtom either = bond.getBegin();
             IAtom other = bond.getEnd();
 
             int u = container.indexOf(either);
@@ -438,7 +438,7 @@ public final class RingSearch {
 
         // include bonds that have both atoms in the atoms set
         for (IBond bond : container.bonds()) {
-            IAtom either = bond.getBeg();
+            IAtom either = bond.getBegin();
             IAtom other = bond.getEnd();
             if (atoms.contains(either) && atoms.contains(other)) {
                 bonds.add(bond);

--- a/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
+++ b/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
@@ -234,8 +234,8 @@ public final class RingSearch {
      */
     public boolean cyclic(IBond bond) {
         // XXX: linear search - but okay for now
-        int u = container.indexOf(bond.getAtom(0));
-        int v = container.indexOf(bond.getAtom(1));
+        int u = container.indexOf(bond.getBeg());
+        int v = container.indexOf(bond.getEnd());
         if (u < 0 || v < 0) throw new NoSuchElementException("atoms of the bond are not found in the container");
         return searcher.cyclic(u, v);
     }
@@ -339,8 +339,8 @@ public final class RingSearch {
 
         for (IBond bond : container.bonds()) {
 
-            IAtom either = bond.getAtom(0);
-            IAtom other = bond.getAtom(1);
+            IAtom either = bond.getBeg();
+            IAtom other = bond.getEnd();
 
             int u = container.indexOf(either);
             int v = container.indexOf(other);
@@ -438,8 +438,8 @@ public final class RingSearch {
 
         // include bonds that have both atoms in the atoms set
         for (IBond bond : container.bonds()) {
-            IAtom either = bond.getAtom(0);
-            IAtom other = bond.getAtom(1);
+            IAtom either = bond.getBeg();
+            IAtom other = bond.getEnd();
             if (atoms.contains(either) && atoms.contains(other)) {
                 bonds.add(bond);
             }

--- a/base/core/src/main/java/org/openscience/cdk/stereo/ExtendedTetrahedral.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/ExtendedTetrahedral.java
@@ -147,8 +147,8 @@ public final class ExtendedTetrahedral implements IStereoElement {
 
         if (focusBonds.size() != 2) throw new IllegalArgumentException("focus must have exactly 2 neighbors");
 
-        IAtom left = focusBonds.get(0).getConnectedAtom(focus);
-        IAtom right = focusBonds.get(1).getConnectedAtom(focus);
+        IAtom left = focusBonds.get(0).getOther(focus);
+        IAtom right = focusBonds.get(1).getOther(focus);
 
         return new IAtom[]{left, right};
     }
@@ -167,8 +167,8 @@ public final class ExtendedTetrahedral implements IStereoElement {
 
         if (focusBonds.size() != 2) throw new IllegalArgumentException("focus must have exactly 2 neighbors");
 
-        final IAtom left = focusBonds.get(0).getConnectedAtom(focus);
-        final IAtom right = focusBonds.get(1).getConnectedAtom(focus);
+        final IAtom left = focusBonds.get(0).getOther(focus);
+        final IAtom right = focusBonds.get(1).getOther(focus);
 
         List<IAtom> leftAtoms = container.getConnectedAtomsList(left);
 

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -741,7 +741,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public IBond getBond(IAtom atom1, IAtom atom2) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bonds[i].contains(atom1) && bonds[i].getConnectedAtom(atom1) == atom2) {
+            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1) == atom2) {
                 return bonds[i];
             }
         }
@@ -808,7 +808,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     public List<IAtom> getConnectedAtomsList(IAtom atom) {
         List<IAtom> atomsList = new ArrayList<IAtom>();
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i].contains(atom)) atomsList.add(bonds[i].getConnectedAtom(atom));
+            if (bonds[i].contains(atom)) atomsList.add(bonds[i].getOther(atom));
         }
         return atomsList;
     }

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -279,6 +279,8 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
      */
     @Override
     public void setAtom(int number, IAtom atom) {
+        if (atoms[number] != null)
+            atoms[number].removeListener(this);
         atom.addListener(this);
         atoms[number] = atom;
         notifyChanged();

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -222,9 +222,9 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public void setAtoms(IAtom[] atoms) {
         // unregister this as listener with the old atoms
-        for (IAtom atom : this.atoms)
-            if (atom != null) atom.removeListener(this);
-
+        for (int i = 0; i < atomCount; i++) {
+            this.atoms[i].removeListener(this);
+        }
         this.atoms = atoms;
         for (IAtom atom : atoms) {
             atom.addListener(this);
@@ -242,6 +242,9 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
      */
     @Override
     public void setBonds(IBond[] bonds) {
+        for (int i = 0; i < bondCount; i++) {
+            this.bonds[i].removeListener(this);
+        }
         this.bonds = bonds;
         for (IBond bond : bonds) {
             bond.addListener(this);

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -248,28 +248,26 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     }
 
     /**
-     * Returns the atom connected to the given atom.
-     * 
-     * This method is only strictly relevant for 2-center bonds
-     * since in multi-center bonds, a given atom will be connected
-     * to multiple atoms.
-     * 
-     * If called for a multi-center bond, then the next atom in the
-     * atom list is returned. This is probably not what is expected and
-     * hence the user should instead call
-     * {@link #getConnectedAtoms(org.openscience.cdk.interfaces.IAtom)}
-     *
-     * @param atom The atom the bond partner is searched of
-     * @return the connected atom or null  if the atom is not part of the bond
-     * @see #getConnectedAtoms(org.openscience.cdk.interfaces.IAtom)
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom getOther(IAtom atom) {
+        if (atoms[0] == atom)
+            return atoms[1];
+        else if (atoms[1] == atom)
+            return atoms[0];
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public IAtom getConnectedAtom(IAtom atom) {
-        if (atoms[0] == atom) {
+        if (atoms[0] == atom)
             return atoms[1];
-        } else if (atoms[1] == atom) {
+        else if (atoms[1] == atom)
             return atoms[0];
-        }
         return null;
     }
 
@@ -282,7 +280,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      *
      * @param atom The atom whose partners are to be searched for
      * @return An array of the connected atoms, null if the atom is not part of the bond
-     * @see #getConnectedAtom(org.openscience.cdk.interfaces.IAtom)
+     * @see #getOther(org.openscience.cdk.interfaces.IAtom)
      */
     @Override
     public IAtom[] getConnectedAtoms(IAtom atom) {

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -234,6 +234,20 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public IAtom getBeg() {
+        return atoms[0];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IAtom getEnd() {
+        return atoms[1];
+    }
+
+    /**
      * Returns the atom connected to the given atom.
      * 
      * This method is only strictly relevant for 2-center bonds

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -25,9 +25,7 @@ import org.openscience.cdk.interfaces.IBond;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Implements the concept of a covalent bond between two or more atoms. A bond is

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -272,32 +272,21 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     }
 
     /**
-     * Returns all the atoms in the bond connected to the specified atom.
-     * 
-     * Though this can be used for traditional 2-center bonds, it is oriented
-     * towards multi-center bonds, where a single atom is connected to multiple
-     * atoms.
-     *
-     * @param atom The atom whose partners are to be searched for
-     * @return An array of the connected atoms, null if the atom is not part of the bond
-     * @see #getOther(org.openscience.cdk.interfaces.IAtom)
+     * {@inheritDoc}
      */
     @Override
     public IAtom[] getConnectedAtoms(IAtom atom) {
-        boolean atomIsInBond = false;
-        for (IAtom localAtom : atoms) {
-            if (localAtom == atom) {
-                atomIsInBond = true;
-                break;
+        if (atomCount < 1) return null;
+        IAtom[] connected = new IAtom[atomCount-1];
+        int j = 0;
+        for (int i = 0; i < atomCount; i++) {
+            if (this.atoms[i] != atom) {
+                if (j >= connected.length)
+                    return null;
+                connected[j++] = this.atoms[i];
             }
         }
-        if (!atomIsInBond) return null;
-
-        List<IAtom> conAtoms = new ArrayList<IAtom>();
-        for (IAtom localAtom : atoms) {
-            if (localAtom != atom) conAtoms.add(localAtom);
-        }
-        return conAtoms.toArray(new IAtom[]{});
+        return connected;
     }
 
     /**

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -234,7 +234,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     /**
      * {@inheritDoc}
      */
-    public IAtom getBeg() {
+    public IAtom getBegin() {
         return atoms[0];
     }
 

--- a/base/data/src/test/java/org/openscience/cdk/BondTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/BondTest.java
@@ -51,7 +51,7 @@ public class BondTest extends AbstractBondTest {
     public void testBond() {
         IBond bond = new Bond();
         Assert.assertEquals(0, bond.getAtomCount());
-        Assert.assertNull(bond.getBeg());
+        Assert.assertNull(bond.getBegin());
         Assert.assertNull(bond.getEnd());
         Assert.assertNull(bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -68,7 +68,7 @@ public class BondTest extends AbstractBondTest {
 
         IBond bond1 = new Bond(new IAtom[]{atom1, atom2, atom3, atom4, atom5});
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom1, bond1.getBegin());
         Assert.assertEquals(atom2, bond1.getEnd());
     }
 
@@ -83,7 +83,7 @@ public class BondTest extends AbstractBondTest {
 
         IBond bond1 = new Bond(new IAtom[]{atom1, atom2, atom3, atom4, atom5}, IBond.Order.SINGLE);
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom1, bond1.getBegin());
         Assert.assertEquals(atom2, bond1.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond1.getOrder());
     }
@@ -96,7 +96,7 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -110,7 +110,7 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o, IBond.Order.DOUBLE);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.DOUBLE);
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -124,7 +124,7 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o, IBond.Order.SINGLE, IBond.Stereo.UP);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.SINGLE);
         Assert.assertEquals(IBond.Stereo.UP, bond.getStereo());

--- a/base/data/src/test/java/org/openscience/cdk/BondTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/BondTest.java
@@ -68,8 +68,8 @@ public class BondTest extends AbstractBondTest {
 
         IBond bond1 = new Bond(new IAtom[]{atom1, atom2, atom3, atom4, atom5});
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getAtom(0));
-        Assert.assertEquals(atom2, bond1.getAtom(1));
+        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom2, bond1.getEnd());
     }
 
     @Test
@@ -83,8 +83,8 @@ public class BondTest extends AbstractBondTest {
 
         IBond bond1 = new Bond(new IAtom[]{atom1, atom2, atom3, atom4, atom5}, IBond.Order.SINGLE);
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getAtom(0));
-        Assert.assertEquals(atom2, bond1.getAtom(1));
+        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom2, bond1.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond1.getOrder());
     }
 

--- a/base/data/src/test/java/org/openscience/cdk/BondTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/BondTest.java
@@ -51,8 +51,8 @@ public class BondTest extends AbstractBondTest {
     public void testBond() {
         IBond bond = new Bond();
         Assert.assertEquals(0, bond.getAtomCount());
-        Assert.assertNull(bond.getAtom(0));
-        Assert.assertNull(bond.getAtom(1));
+        Assert.assertNull(bond.getBeg());
+        Assert.assertNull(bond.getEnd());
         Assert.assertNull(bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -96,8 +96,8 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -110,8 +110,8 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o, IBond.Order.DOUBLE);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.DOUBLE);
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -124,8 +124,8 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o, IBond.Order.SINGLE, IBond.Stereo.UP);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.SINGLE);
         Assert.assertEquals(IBond.Stereo.UP, bond.getStereo());
     }

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugBond.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugBond.java
@@ -260,9 +260,9 @@ public class DebugBond extends Bond implements IBond {
 
     /** {@inheritDoc} */
     @Override
-    public IAtom getConnectedAtom(IAtom atom) {
+    public IAtom getOther(IAtom atom) {
         logger.debug("Getting connected atom to atom: ", atom);
-        return super.getConnectedAtom(atom);
+        return super.getOther(atom);
     }
 
     /** {@inheritDoc} */

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugBond.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugBond.java
@@ -245,9 +245,9 @@ public class DebugBond extends Bond implements IBond {
     /**
      * {@inheritDoc}
      */
-    public IAtom getBeg() {
+    public IAtom getBegin() {
         logger.debug("Getting begin atom");
-        return super.getBeg();
+        return super.getBegin();
     }
 
     /**

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugBond.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugBond.java
@@ -242,6 +242,22 @@ public class DebugBond extends Bond implements IBond {
         return super.getAtom(position);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public IAtom getBeg() {
+        logger.debug("Getting begin atom");
+        return super.getBeg();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IAtom getEnd() {
+        logger.debug("Getting end atom");
+        return super.getEnd();
+    }
+
     /** {@inheritDoc} */
     @Override
     public IAtom getConnectedAtom(IAtom atom) {

--- a/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugBondTest.java
+++ b/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugBondTest.java
@@ -50,8 +50,8 @@ public class DebugBondTest extends AbstractBondTest {
     public void testDebugBond() {
         IBond bond = new DebugBond();
         Assert.assertEquals(0, bond.getAtomCount());
-        Assert.assertNull(bond.getAtom(0));
-        Assert.assertNull(bond.getAtom(1));
+        Assert.assertNull(bond.getBeg());
+        Assert.assertNull(bond.getEnd());
         Assert.assertNull(bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -95,8 +95,8 @@ public class DebugBondTest extends AbstractBondTest {
         IBond bond = new DebugBond(c, o);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -109,8 +109,8 @@ public class DebugBondTest extends AbstractBondTest {
         IBond bond = new DebugBond(c, o, IBond.Order.DOUBLE);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.DOUBLE);
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -123,8 +123,8 @@ public class DebugBondTest extends AbstractBondTest {
         IBond bond = new DebugBond(c, o, IBond.Order.SINGLE, IBond.Stereo.UP);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.SINGLE);
         Assert.assertEquals(IBond.Stereo.UP, bond.getStereo());
     }

--- a/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugBondTest.java
+++ b/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugBondTest.java
@@ -67,8 +67,8 @@ public class DebugBondTest extends AbstractBondTest {
 
         IBond bond1 = new DebugBond(new IAtom[]{atom1, atom2, atom3, atom4, atom5});
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getAtom(0));
-        Assert.assertEquals(atom2, bond1.getAtom(1));
+        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom2, bond1.getEnd());
     }
 
     @Test
@@ -82,8 +82,8 @@ public class DebugBondTest extends AbstractBondTest {
 
         IBond bond1 = new DebugBond(new IAtom[]{atom1, atom2, atom3, atom4, atom5}, IBond.Order.SINGLE);
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getAtom(0));
-        Assert.assertEquals(atom2, bond1.getAtom(1));
+        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom2, bond1.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond1.getOrder());
     }
 

--- a/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugBondTest.java
+++ b/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugBondTest.java
@@ -50,7 +50,7 @@ public class DebugBondTest extends AbstractBondTest {
     public void testDebugBond() {
         IBond bond = new DebugBond();
         Assert.assertEquals(0, bond.getAtomCount());
-        Assert.assertNull(bond.getBeg());
+        Assert.assertNull(bond.getBegin());
         Assert.assertNull(bond.getEnd());
         Assert.assertNull(bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -67,7 +67,7 @@ public class DebugBondTest extends AbstractBondTest {
 
         IBond bond1 = new DebugBond(new IAtom[]{atom1, atom2, atom3, atom4, atom5});
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom1, bond1.getBegin());
         Assert.assertEquals(atom2, bond1.getEnd());
     }
 
@@ -82,7 +82,7 @@ public class DebugBondTest extends AbstractBondTest {
 
         IBond bond1 = new DebugBond(new IAtom[]{atom1, atom2, atom3, atom4, atom5}, IBond.Order.SINGLE);
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom1, bond1.getBegin());
         Assert.assertEquals(atom2, bond1.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond1.getOrder());
     }
@@ -95,7 +95,7 @@ public class DebugBondTest extends AbstractBondTest {
         IBond bond = new DebugBond(c, o);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -109,7 +109,7 @@ public class DebugBondTest extends AbstractBondTest {
         IBond bond = new DebugBond(c, o, IBond.Order.DOUBLE);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.DOUBLE);
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -123,7 +123,7 @@ public class DebugBondTest extends AbstractBondTest {
         IBond bond = new DebugBond(c, o, IBond.Order.SINGLE, IBond.Stereo.UP);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.SINGLE);
         Assert.assertEquals(IBond.Stereo.UP, bond.getStereo());

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
@@ -24,9 +24,8 @@ import javax.vecmath.Point3d;
 /**
  * Represents the idea of an chemical atom.
  *
- * @cdk.module  interfaces
- *
- * @author      egonw
+ * @author egonw
+ * @cdk.module interfaces
  * @cdk.created 2005-08-24
  * @cdk.keyword atom
  * @cdk.githash
@@ -36,8 +35,8 @@ public interface IAtom extends IAtomType {
     /**
      * Sets the partial charge of this atom.
      *
-     * @param  charge  The partial charge
-     * @see    #getCharge
+     * @param charge The partial charge
+     * @see #getCharge
      */
     void setCharge(Double charge);
 
@@ -45,23 +44,23 @@ public interface IAtom extends IAtomType {
      * Returns the partial charge of this atom.
      *
      * @return the charge of this atom
-     * @see    #setCharge
+     * @see #setCharge
      */
     Double getCharge();
 
     /**
      * Sets the implicit hydrogen count of this atom.
      *
-     * @param  hydrogenCount  The number of hydrogen atoms bonded to this atom.
-     * @see    #getImplicitHydrogenCount
+     * @param hydrogenCount The number of hydrogen atoms bonded to this atom.
+     * @see #getImplicitHydrogenCount
      */
     void setImplicitHydrogenCount(Integer hydrogenCount);
 
     /**
      * Returns the implicit hydrogen count of this atom.
      *
-     * @return    The hydrogen count of this atom.
-     * @see       #setImplicitHydrogenCount
+     * @return The hydrogen count of this atom.
+     * @see #setImplicitHydrogenCount
      */
     Integer getImplicitHydrogenCount();
 
@@ -69,8 +68,8 @@ public interface IAtom extends IAtomType {
      * Sets a point specifying the location of this
      * atom in a 2D space.
      *
-     * @param  point2d  A point in a 2D plane
-     * @see    #getPoint2d
+     * @param point2d A point in a 2D plane
+     * @see #getPoint2d
      */
     void setPoint2d(Point2d point2d);
 
@@ -78,8 +77,8 @@ public interface IAtom extends IAtomType {
      * Sets a point specifying the location of this
      * atom in 3D space.
      *
-     * @param  point3d  A point in a 3-dimensional space
-     * @see    #getPoint3d
+     * @param point3d A point in a 3-dimensional space
+     * @see #getPoint3d
      */
     void setPoint3d(Point3d point3d);
 
@@ -87,18 +86,18 @@ public interface IAtom extends IAtomType {
      * Sets a point specifying the location of this
      * atom in a Crystal unit cell.
      *
-     * @param  point3d  A point in a 3d fractional unit cell space
-     * @see    #getFractionalPoint3d
-     * @see    org.openscience.cdk.Crystal
+     * @param point3d A point in a 3d fractional unit cell space
+     * @see #getFractionalPoint3d
+     * @see org.openscience.cdk.Crystal
      */
     void setFractionalPoint3d(Point3d point3d);
 
     /**
      * Sets the stereo parity for this atom.
      *
-     * @param  stereoParity  The stereo parity for this atom
-     * @see    org.openscience.cdk.CDKConstants for predefined values.
-     * @see    #getStereoParity
+     * @param stereoParity The stereo parity for this atom
+     * @see org.openscience.cdk.CDKConstants for predefined values.
+     * @see #getStereoParity
      * @deprecated use {@link IStereoElement}s for storing stereochemistry
      */
     @Deprecated
@@ -108,8 +107,8 @@ public interface IAtom extends IAtomType {
      * Returns a point specifying the location of this
      * atom in a 2D space.
      *
-     * @return    A point in a 2D plane. Null if unset.
-     * @see       #setPoint2d
+     * @return A point in a 2D plane. Null if unset.
+     * @see #setPoint2d
      */
     Point2d getPoint2d();
 
@@ -117,8 +116,8 @@ public interface IAtom extends IAtomType {
      * Returns a point specifying the location of this
      * atom in a 3D space.
      *
-     * @return    A point in 3-dimensional space. Null if unset.
-     * @see       #setPoint3d
+     * @return A point in 3-dimensional space. Null if unset.
+     * @see #setPoint3d
      */
     Point3d getPoint3d();
 
@@ -126,9 +125,9 @@ public interface IAtom extends IAtomType {
      * Returns a point specifying the location of this
      * atom in a Crystal unit cell.
      *
-     * @return    A point in 3d fractional unit cell space. Null if unset.
-     * @see       #setFractionalPoint3d
-     * @see       org.openscience.cdk.CDKConstants for predefined values.
+     * @return A point in 3d fractional unit cell space. Null if unset.
+     * @see #setFractionalPoint3d
+     * @see org.openscience.cdk.CDKConstants for predefined values.
      */
     Point3d getFractionalPoint3d();
 
@@ -136,9 +135,9 @@ public interface IAtom extends IAtomType {
      * Returns the stereo parity of this atom. It uses the predefined values
      * found in CDKConstants.
      *
-     * @return    The stereo parity for this atom
-     * @see       org.openscience.cdk.CDKConstants
-     * @see       #setStereoParity
+     * @return The stereo parity for this atom
+     * @see org.openscience.cdk.CDKConstants
+     * @see #setStereoParity
      * @deprecated use {@link IStereoElement}s for storing stereochemistry
      */
     @Deprecated
@@ -182,7 +181,7 @@ public interface IAtom extends IAtomType {
     void setIsInRing(boolean ring);
 
     /**
-     *{@inheritDoc}
+     * {@inheritDoc}
      */
     @Override
     IAtom clone() throws CloneNotSupportedException;

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
@@ -39,7 +39,7 @@ public interface IAtom extends IAtomType {
      * @param  charge  The partial charge
      * @see    #getCharge
      */
-    public void setCharge(Double charge);
+    void setCharge(Double charge);
 
     /**
      * Returns the partial charge of this atom.
@@ -47,7 +47,7 @@ public interface IAtom extends IAtomType {
      * @return the charge of this atom
      * @see    #setCharge
      */
-    public Double getCharge();
+    Double getCharge();
 
     /**
      * Sets the implicit hydrogen count of this atom.
@@ -55,7 +55,7 @@ public interface IAtom extends IAtomType {
      * @param  hydrogenCount  The number of hydrogen atoms bonded to this atom.
      * @see    #getImplicitHydrogenCount
      */
-    public void setImplicitHydrogenCount(Integer hydrogenCount);
+    void setImplicitHydrogenCount(Integer hydrogenCount);
 
     /**
      * Returns the implicit hydrogen count of this atom.
@@ -63,7 +63,7 @@ public interface IAtom extends IAtomType {
      * @return    The hydrogen count of this atom.
      * @see       #setImplicitHydrogenCount
      */
-    public Integer getImplicitHydrogenCount();
+    Integer getImplicitHydrogenCount();
 
     /**
      * Sets a point specifying the location of this
@@ -72,7 +72,7 @@ public interface IAtom extends IAtomType {
      * @param  point2d  A point in a 2D plane
      * @see    #getPoint2d
      */
-    public void setPoint2d(Point2d point2d);
+    void setPoint2d(Point2d point2d);
 
     /**
      * Sets a point specifying the location of this
@@ -81,7 +81,7 @@ public interface IAtom extends IAtomType {
      * @param  point3d  A point in a 3-dimensional space
      * @see    #getPoint3d
      */
-    public void setPoint3d(Point3d point3d);
+    void setPoint3d(Point3d point3d);
 
     /**
      * Sets a point specifying the location of this
@@ -91,7 +91,7 @@ public interface IAtom extends IAtomType {
      * @see    #getFractionalPoint3d
      * @see    org.openscience.cdk.Crystal
      */
-    public void setFractionalPoint3d(Point3d point3d);
+    void setFractionalPoint3d(Point3d point3d);
 
     /**
      * Sets the stereo parity for this atom.
@@ -102,7 +102,7 @@ public interface IAtom extends IAtomType {
      * @deprecated use {@link IStereoElement}s for storing stereochemistry
      */
     @Deprecated
-    public void setStereoParity(Integer stereoParity);
+    void setStereoParity(Integer stereoParity);
 
     /**
      * Returns a point specifying the location of this
@@ -111,7 +111,7 @@ public interface IAtom extends IAtomType {
      * @return    A point in a 2D plane. Null if unset.
      * @see       #setPoint2d
      */
-    public Point2d getPoint2d();
+    Point2d getPoint2d();
 
     /**
      * Returns a point specifying the location of this
@@ -120,7 +120,7 @@ public interface IAtom extends IAtomType {
      * @return    A point in 3-dimensional space. Null if unset.
      * @see       #setPoint3d
      */
-    public Point3d getPoint3d();
+    Point3d getPoint3d();
 
     /**
      * Returns a point specifying the location of this
@@ -130,7 +130,7 @@ public interface IAtom extends IAtomType {
      * @see       #setFractionalPoint3d
      * @see       org.openscience.cdk.CDKConstants for predefined values.
      */
-    public Point3d getFractionalPoint3d();
+    Point3d getFractionalPoint3d();
 
     /**
      * Returns the stereo parity of this atom. It uses the predefined values
@@ -142,7 +142,7 @@ public interface IAtom extends IAtomType {
      * @deprecated use {@link IStereoElement}s for storing stereochemistry
      */
     @Deprecated
-    public Integer getStereoParity();
+    Integer getStereoParity();
 
     /**
      * Access whether this atom has been marked as aromatic. The default
@@ -185,6 +185,6 @@ public interface IAtom extends IAtomType {
      *{@inheritDoc}
      */
     @Override
-    public IAtom clone() throws CloneNotSupportedException;
+    IAtom clone() throws CloneNotSupportedException;
 
 }

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -163,12 +163,40 @@ public interface IBond extends IElectronContainer {
     IAtom getAtom(int position);
 
     /**
-     * Returns the atom connected to the given atom.
+     * Returns the other atom in the bond, the atom is connected to the given atom. This
+     * method is only correct for two-centre bonds, for n-centre bonds the behaviour is undefined
+     * and the more correct {@link #getConnectedAtoms(IAtom)} should be used.
+     *
+     * <pre>{@code
+     * IAtom beg = bond.getBeg();
+     * IAtom end = bond.getEnd();
+     * // bond.getConnectedAtom(beg) == end
+     * // bond.getConnectedAtom(end) == beg
+     * }</pre>
+     *
+     * @param  atom  The atom the bond partner is searched of
+     * @return       the connected atom or null if the given atom is not part of the bond
+     * @deprecated use the method {@link #getOther(IAtom)}
+     */
+    @Deprecated
+    IAtom getConnectedAtom(IAtom atom);
+
+    /**
+     * Returns the other atom in the bond, the atom is connected to the given atom.This
+     * method is only correct for two-centre bonds, for n-centre bonds the behaviour is undefined
+     * and the more correct {@link #getConnectedAtoms(IAtom)} should be used.
+     *
+     * <pre>{@code
+     * IAtom beg = bond.getBeg();
+     * IAtom end = bond.getEnd();
+     * // bond.getOther(beg) == end
+     * // bond.getOther(end) == beg
+     * }</pre>
      *
      * @param  atom  The atom the bond partner is searched of
      * @return       the connected atom or null if the given atom is not part of the bond
      */
-    IAtom getConnectedAtom(IAtom atom);
+    IAtom getOther(IAtom atom);
 
     /**
      * Returns all the atoms in the bond connected to the given atom.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -152,7 +152,7 @@ public interface IBond extends IElectronContainer {
      *
      * @return the begin atom
      */
-    IAtom getBeg();
+    IAtom getBegin();
 
     /**
      * Access the end (or second) atom of the bond.
@@ -183,7 +183,7 @@ public interface IBond extends IElectronContainer {
      * and the more correct {@link #getConnectedAtoms(IAtom)} should be used.
      * <p>
      * <pre>{@code
-     * IAtom beg = bond.getBeg();
+     * IAtom beg = bond.getBegin();
      * IAtom end = bond.getEnd();
      * // bond.getConnectedAtom(beg) == end
      * // bond.getConnectedAtom(end) == beg
@@ -202,7 +202,7 @@ public interface IBond extends IElectronContainer {
      * and the more correct {@link #getConnectedAtoms(IAtom)} should be used.
      * <p>
      * <pre>{@code
-     * IAtom beg = bond.getBeg();
+     * IAtom beg = bond.getBegin();
      * IAtom end = bond.getEnd();
      * // bond.getOther(beg) == end
      * // bond.getOther(end) == beg

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -40,7 +40,7 @@ public interface IBond extends IElectronContainer {
      * A list of permissible bond orders.
      *
      */
-    public enum Order {
+    enum Order {
         SINGLE(1), DOUBLE(2), TRIPLE(3), QUADRUPLE(4), QUINTUPLE(5), SEXTUPLE(6), UNSET(0);
 
         private final Integer bondedElectronPairs;
@@ -77,7 +77,7 @@ public interface IBond extends IElectronContainer {
      * The first atom in the IBond (index = 0) is the <i>start</i> atom, while
      * the second atom (index = 1) is the <i>end</i> atom.
      */
-    public enum Stereo {
+    enum Stereo {
         /** A bond for which there is no stereochemistry. */
         NONE,
         /** A bond pointing up of which the start atom is the stereocenter and
@@ -122,7 +122,7 @@ public interface IBond extends IElectronContainer {
      *@return    An Iterable to atoms participating in this bond
      *@see       #setAtoms
      */
-    public Iterable<IAtom> atoms();
+    Iterable<IAtom> atoms();
 
     /**
      * Sets the array of atoms making up this bond.
@@ -130,7 +130,7 @@ public interface IBond extends IElectronContainer {
      * @param  atoms  An array of atoms that forms this bond
      * @see           #atoms
      */
-    public void setAtoms(IAtom[] atoms);
+    void setAtoms(IAtom[] atoms);
 
     /**
      * Access the begin (or first) atom of the bond.
@@ -151,7 +151,7 @@ public interface IBond extends IElectronContainer {
      *
      * @return    The number of Atoms in this Bond
      */
-    public int getAtomCount();
+    int getAtomCount();
 
     /**
      * Returns an Atom from this bond.
@@ -160,7 +160,7 @@ public interface IBond extends IElectronContainer {
      * @return           The atom at the specified position
      * @see              #setAtom
      */
-    public IAtom getAtom(int position);
+    IAtom getAtom(int position);
 
     /**
      * Returns the atom connected to the given atom.
@@ -168,7 +168,7 @@ public interface IBond extends IElectronContainer {
      * @param  atom  The atom the bond partner is searched of
      * @return       the connected atom or null if the given atom is not part of the bond
      */
-    public IAtom getConnectedAtom(IAtom atom);
+    IAtom getConnectedAtom(IAtom atom);
 
     /**
      * Returns all the atoms in the bond connected to the given atom.
@@ -176,7 +176,7 @@ public interface IBond extends IElectronContainer {
      * @param atom The atoms the bond partner is searched of
      * @return the connected atoms or null  if the given atom is not part of the bond
      */
-    public IAtom[] getConnectedAtoms(IAtom atom);
+    IAtom[] getConnectedAtoms(IAtom atom);
 
     /**
      * Returns true if the given atom participates in this bond.
@@ -184,7 +184,7 @@ public interface IBond extends IElectronContainer {
      * @param  atom  The atom to be tested if it participates in this bond
      * @return       true if the atom participates in this bond
      */
-    public boolean contains(IAtom atom);
+    boolean contains(IAtom atom);
 
     /**
      * Sets an Atom in this bond.
@@ -193,7 +193,7 @@ public interface IBond extends IElectronContainer {
      * @param  position  The position in this bond where the atom is to be inserted
      * @see              #getAtom
      */
-    public void setAtom(IAtom atom, int position);
+    void setAtom(IAtom atom, int position);
 
     /**
      * Returns the bond order of this bond.
@@ -203,7 +203,7 @@ public interface IBond extends IElectronContainer {
      *         for predefined values.
      * @see    #setOrder
      */
-    public Order getOrder();
+    Order getOrder();
 
     /**
      * Sets the bond order of this bond.
@@ -212,7 +212,7 @@ public interface IBond extends IElectronContainer {
      * @see          org.openscience.cdk.CDKConstants for predefined values.
      * @see          #getOrder
      */
-    public void setOrder(Order order);
+    void setOrder(Order order);
 
     /**
      * Returns the stereo descriptor for this bond.
@@ -220,7 +220,7 @@ public interface IBond extends IElectronContainer {
      * @return    The stereo descriptor for this bond
      * @see       #setStereo
      */
-    public IBond.Stereo getStereo();
+    IBond.Stereo getStereo();
 
     /**
      * Sets the stereo descriptor for this bond.
@@ -228,21 +228,21 @@ public interface IBond extends IElectronContainer {
      * @param  stereo  The stereo descriptor to be assigned to this bond.
      * @see            #getStereo
      */
-    public void setStereo(IBond.Stereo stereo);
+    void setStereo(IBond.Stereo stereo);
 
     /**
      * Returns the geometric 2D center of the bond.
      *
      * @return    The geometric 2D center of the bond
      */
-    public Point2d get2DCenter();
+    Point2d get2DCenter();
 
     /**
      * Returns the geometric 3D center of the bond.
      *
      * @return    The geometric 3D center of the bond
      */
-    public Point3d get3DCenter();
+    Point3d get3DCenter();
 
     /**
      * Compares a bond with this bond.
@@ -250,7 +250,7 @@ public interface IBond extends IElectronContainer {
      * @param  object  Object of type Bond
      * @return         Return true, if the bond is equal to this bond
      */
-    public boolean compare(Object object);
+    boolean compare(Object object);
 
     /**
      * Checks whether a bond is connected to another one.
@@ -259,7 +259,7 @@ public interface IBond extends IElectronContainer {
      * @param  bond  The bond which is checked to be connect with this one
      * @return       True, if the bonds share an atom, otherwise false
      */
-    public boolean isConnectedTo(IBond bond);
+    boolean isConnectedTo(IBond bond);
 
     /**
      * Access whether this bond has been marked as aromatic. The default
@@ -300,5 +300,5 @@ public interface IBond extends IElectronContainer {
 
     /**{@inheritDoc} */
     @Override
-    public IBond clone() throws CloneNotSupportedException;
+    IBond clone() throws CloneNotSupportedException;
 }

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -24,11 +24,11 @@ import javax.vecmath.Point3d;
 /**
  * Implements the concept of a covalent bond between two or more atoms. A bond is
  * considered to be a number of electrons connecting two ore more atoms.
- *type filter text
+ * type filter text
+ *
+ * @author egonw
  * @cdk.module interfaces
  * @cdk.githash
- *
- * @author      egonw
  * @cdk.created 2005-08-24
  * @cdk.keyword bond
  * @cdk.keyword atom
@@ -38,7 +38,6 @@ public interface IBond extends IElectronContainer {
 
     /**
      * A list of permissible bond orders.
-     *
      */
     enum Order {
         SINGLE(1), DOUBLE(2), TRIPLE(3), QUADRUPLE(4), QUINTUPLE(5), SEXTUPLE(6), UNSET(0);
@@ -51,7 +50,7 @@ public interface IBond extends IElectronContainer {
 
         /**
          * Access a numeric value for the number of bonded electron pairs.
-         * 
+         * <p>
          * <pre>{@code
          * Order.SINGLE.numeric()    // 1
          * Order.DOUBLE.numeric()    // 2
@@ -78,57 +77,73 @@ public interface IBond extends IElectronContainer {
      * the second atom (index = 1) is the <i>end</i> atom.
      */
     enum Stereo {
-        /** A bond for which there is no stereochemistry. */
+        /**
+         * A bond for which there is no stereochemistry.
+         */
         NONE,
-        /** A bond pointing up of which the start atom is the stereocenter and
-         * the end atom is above the drawing plane. */
+        /**
+         * A bond pointing up of which the start atom is the stereocenter and
+         * the end atom is above the drawing plane.
+         */
         UP,
-        /** A bond pointing up of which the end atom is the stereocenter and
-         * the start atom is above the drawing plane. */
+        /**
+         * A bond pointing up of which the end atom is the stereocenter and
+         * the start atom is above the drawing plane.
+         */
         UP_INVERTED,
-        /** A bond pointing down of which the start atom is the stereocenter
-         * and the end atom is below the drawing plane. */
+        /**
+         * A bond pointing down of which the start atom is the stereocenter
+         * and the end atom is below the drawing plane.
+         */
         DOWN,
-        /** A bond pointing down of which the end atom is the stereocenter and
-         * the start atom is below the drawing plane. */
+        /**
+         * A bond pointing down of which the end atom is the stereocenter and
+         * the start atom is below the drawing plane.
+         */
         DOWN_INVERTED,
-        /** A bond for which there is stereochemistry, we just do not know
-         *  if it is UP or DOWN. The start atom is the stereocenter.
+        /**
+         * A bond for which there is stereochemistry, we just do not know
+         * if it is UP or DOWN. The start atom is the stereocenter.
          */
         UP_OR_DOWN,
-        /** A bond for which there is stereochemistry, we just do not know
-         *  if it is UP or DOWN. The end atom is the stereocenter.
+        /**
+         * A bond for which there is stereochemistry, we just do not know
+         * if it is UP or DOWN. The end atom is the stereocenter.
          */
         UP_OR_DOWN_INVERTED,
-        /** Indication that this double bond has a fixed, but unknown E/Z
+        /**
+         * Indication that this double bond has a fixed, but unknown E/Z
          * configuration.
          */
         E_OR_Z,
-        /** Indication that this double bond has a E configuration.
+        /**
+         * Indication that this double bond has a E configuration.
          */
         E,
-        /** Indication that this double bond has a Z configuration.
+        /**
+         * Indication that this double bond has a Z configuration.
          */
         Z,
-        /** Indication that this double bond has a fixed configuration, defined
+        /**
+         * Indication that this double bond has a fixed configuration, defined
          * by the 2D and/or 3D coordinates.
          */
         E_Z_BY_COORDINATES
     }
 
     /**
-     *  Returns the Iterable to atoms making up this bond.
+     * Returns the Iterable to atoms making up this bond.
      *
-     *@return    An Iterable to atoms participating in this bond
-     *@see       #setAtoms
+     * @return An Iterable to atoms participating in this bond
+     * @see #setAtoms
      */
     Iterable<IAtom> atoms();
 
     /**
      * Sets the array of atoms making up this bond.
      *
-     * @param  atoms  An array of atoms that forms this bond
-     * @see           #atoms
+     * @param atoms An array of atoms that forms this bond
+     * @see #atoms
      */
     void setAtoms(IAtom[] atoms);
 
@@ -149,16 +164,16 @@ public interface IBond extends IElectronContainer {
     /**
      * Returns the number of Atoms in this Bond.
      *
-     * @return    The number of Atoms in this Bond
+     * @return The number of Atoms in this Bond
      */
     int getAtomCount();
 
     /**
      * Returns an Atom from this bond.
      *
-     * @param  position  The position in this bond where the atom is
-     * @return           The atom at the specified position
-     * @see              #setAtom
+     * @param position The position in this bond where the atom is
+     * @return The atom at the specified position
+     * @see #setAtom
      */
     IAtom getAtom(int position);
 
@@ -166,7 +181,7 @@ public interface IBond extends IElectronContainer {
      * Returns the other atom in the bond, the atom is connected to the given atom. This
      * method is only correct for two-centre bonds, for n-centre bonds the behaviour is undefined
      * and the more correct {@link #getConnectedAtoms(IAtom)} should be used.
-     *
+     * <p>
      * <pre>{@code
      * IAtom beg = bond.getBeg();
      * IAtom end = bond.getEnd();
@@ -174,8 +189,8 @@ public interface IBond extends IElectronContainer {
      * // bond.getConnectedAtom(end) == beg
      * }</pre>
      *
-     * @param  atom  The atom the bond partner is searched of
-     * @return       the connected atom or null if the given atom is not part of the bond
+     * @param atom The atom the bond partner is searched of
+     * @return the connected atom or null if the given atom is not part of the bond
      * @deprecated use the method {@link #getOther(IAtom)}
      */
     @Deprecated
@@ -185,7 +200,7 @@ public interface IBond extends IElectronContainer {
      * Returns the other atom in the bond, the atom is connected to the given atom.This
      * method is only correct for two-centre bonds, for n-centre bonds the behaviour is undefined
      * and the more correct {@link #getConnectedAtoms(IAtom)} should be used.
-     *
+     * <p>
      * <pre>{@code
      * IAtom beg = bond.getBeg();
      * IAtom end = bond.getEnd();
@@ -193,8 +208,8 @@ public interface IBond extends IElectronContainer {
      * // bond.getOther(end) == beg
      * }</pre>
      *
-     * @param  atom  The atom the bond partner is searched of
-     * @return       the connected atom or null if the given atom is not part of the bond
+     * @param atom The atom the bond partner is searched of
+     * @return the connected atom or null if the given atom is not part of the bond
      */
     IAtom getOther(IAtom atom);
 
@@ -209,17 +224,17 @@ public interface IBond extends IElectronContainer {
     /**
      * Returns true if the given atom participates in this bond.
      *
-     * @param  atom  The atom to be tested if it participates in this bond
-     * @return       true if the atom participates in this bond
+     * @param atom The atom to be tested if it participates in this bond
+     * @return true if the atom participates in this bond
      */
     boolean contains(IAtom atom);
 
     /**
      * Sets an Atom in this bond.
      *
-     * @param  atom      The atom to be set
-     * @param  position  The position in this bond where the atom is to be inserted
-     * @see              #getAtom
+     * @param atom     The atom to be set
+     * @param position The position in this bond where the atom is to be inserted
+     * @see #getAtom
      */
     void setAtom(IAtom atom, int position);
 
@@ -227,56 +242,56 @@ public interface IBond extends IElectronContainer {
      * Returns the bond order of this bond.
      *
      * @return The bond order of this bond
-     * @see    org.openscience.cdk.CDKConstants org.openscience.cdk.CDKConstants
-     *         for predefined values.
-     * @see    #setOrder
+     * @see org.openscience.cdk.CDKConstants org.openscience.cdk.CDKConstants
+     * for predefined values.
+     * @see #setOrder
      */
     Order getOrder();
 
     /**
      * Sets the bond order of this bond.
      *
-     * @param  order The bond order to be assigned to this bond
-     * @see          org.openscience.cdk.CDKConstants for predefined values.
-     * @see          #getOrder
+     * @param order The bond order to be assigned to this bond
+     * @see org.openscience.cdk.CDKConstants for predefined values.
+     * @see #getOrder
      */
     void setOrder(Order order);
 
     /**
      * Returns the stereo descriptor for this bond.
      *
-     * @return    The stereo descriptor for this bond
-     * @see       #setStereo
+     * @return The stereo descriptor for this bond
+     * @see #setStereo
      */
     IBond.Stereo getStereo();
 
     /**
      * Sets the stereo descriptor for this bond.
      *
-     * @param  stereo  The stereo descriptor to be assigned to this bond.
-     * @see            #getStereo
+     * @param stereo The stereo descriptor to be assigned to this bond.
+     * @see #getStereo
      */
     void setStereo(IBond.Stereo stereo);
 
     /**
      * Returns the geometric 2D center of the bond.
      *
-     * @return    The geometric 2D center of the bond
+     * @return The geometric 2D center of the bond
      */
     Point2d get2DCenter();
 
     /**
      * Returns the geometric 3D center of the bond.
      *
-     * @return    The geometric 3D center of the bond
+     * @return The geometric 3D center of the bond
      */
     Point3d get3DCenter();
 
     /**
      * Compares a bond with this bond.
      *
-     * @param  object  Object of type Bond
-     * @return         Return true, if the bond is equal to this bond
+     * @param object Object of type Bond
+     * @return Return true, if the bond is equal to this bond
      */
     boolean compare(Object object);
 
@@ -284,8 +299,8 @@ public interface IBond extends IElectronContainer {
      * Checks whether a bond is connected to another one.
      * This can only be true if the bonds have an Atom in common.
      *
-     * @param  bond  The bond which is checked to be connect with this one
-     * @return       True, if the bonds share an atom, otherwise false
+     * @param bond The bond which is checked to be connect with this one
+     * @return True, if the bonds share an atom, otherwise false
      */
     boolean isConnectedTo(IBond bond);
 
@@ -326,7 +341,9 @@ public interface IBond extends IElectronContainer {
      */
     void setIsInRing(boolean ring);
 
-    /**{@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     IBond clone() throws CloneNotSupportedException;
 }

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -133,6 +133,20 @@ public interface IBond extends IElectronContainer {
     public void setAtoms(IAtom[] atoms);
 
     /**
+     * Access the begin (or first) atom of the bond.
+     *
+     * @return the begin atom
+     */
+    IAtom getBeg();
+
+    /**
+     * Access the end (or second) atom of the bond.
+     *
+     * @return the end atom
+     */
+    IAtom getEnd();
+
+    /**
      * Returns the number of Atoms in this Bond.
      *
      * @return    The number of Atoms in this Bond

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
@@ -208,7 +208,7 @@ final class StereoMatch implements Predicate<int[]> {
         // bond is undirected so we need to ensure v1 is the first atom in the bond
         // we also need to to swap the substituents later
         boolean swap = false;
-        if (targetElement.getStereoBond().getBeg() != target.getAtom(v1)) {
+        if (targetElement.getStereoBond().getBegin() != target.getAtom(v1)) {
             int tmp = v1;
             v1 = v2;
             v2 = tmp;
@@ -332,7 +332,7 @@ final class StereoMatch implements Predicate<int[]> {
                 indices[nElements++] = idx;
             } else if (element instanceof IDoubleBondStereochemistry) {
                 IDoubleBondStereochemistry dbs = (IDoubleBondStereochemistry) element;
-                int idx1 = map.get(dbs.getStereoBond().getBeg());
+                int idx1 = map.get(dbs.getStereoBond().getBegin());
                 int idx2 = map.get(dbs.getStereoBond().getEnd());
                 elements[idx2] = elements[idx1] = element;
                 types[idx1] = types[idx2] = Type.Geometric;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
@@ -332,8 +332,8 @@ final class StereoMatch implements Predicate<int[]> {
                 indices[nElements++] = idx;
             } else if (element instanceof IDoubleBondStereochemistry) {
                 IDoubleBondStereochemistry dbs = (IDoubleBondStereochemistry) element;
-                int idx1 = map.get(dbs.getStereoBond().getAtom(0));
-                int idx2 = map.get(dbs.getStereoBond().getAtom(1));
+                int idx1 = map.get(dbs.getStereoBond().getBeg());
+                int idx2 = map.get(dbs.getStereoBond().getEnd());
                 elements[idx2] = elements[idx1] = element;
                 types[idx1] = types[idx2] = Type.Geometric;
                 indices[nElements++] = idx1; // only visit the first atom

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
@@ -208,7 +208,7 @@ final class StereoMatch implements Predicate<int[]> {
         // bond is undirected so we need to ensure v1 is the first atom in the bond
         // we also need to to swap the substituents later
         boolean swap = false;
-        if (targetElement.getStereoBond().getAtom(0) != target.getAtom(v1)) {
+        if (targetElement.getStereoBond().getBeg() != target.getAtom(v1)) {
             int tmp = v1;
             v1 = v2;
             v2 = tmp;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
@@ -221,11 +221,11 @@ final class StereoMatch implements Predicate<int[]> {
         int p = parity(queryElement.getStereo());
         int q = parity(targetElement.getStereo());
 
-        int uLeft = queryMap.get(queryBonds[0].getConnectedAtom(query.getAtom(u1)));
-        int uRight = queryMap.get(queryBonds[1].getConnectedAtom(query.getAtom(u2)));
+        int uLeft = queryMap.get(queryBonds[0].getOther(query.getAtom(u1)));
+        int uRight = queryMap.get(queryBonds[1].getOther(query.getAtom(u2)));
 
-        int vLeft = targetMap.get(targetBonds[0].getConnectedAtom(target.getAtom(v1)));
-        int vRight = targetMap.get(targetBonds[1].getConnectedAtom(target.getAtom(v2)));
+        int vLeft = targetMap.get(targetBonds[0].getOther(target.getAtom(v1)));
+        int vRight = targetMap.get(targetBonds[1].getOther(target.getAtom(v2)));
 
         if (swap) {
             int tmp = vLeft;
@@ -292,7 +292,7 @@ final class StereoMatch implements Predicate<int[]> {
      */
     private int otherIndex(int i) {
         IDoubleBondStereochemistry element = (IDoubleBondStereochemistry) queryElements[i];
-        return queryMap.get(element.getStereoBond().getConnectedAtom(query.getAtom(i)));
+        return queryMap.get(element.getStereoBond().getOther(query.getAtom(i)));
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/CTFileQueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/CTFileQueryBond.java
@@ -86,7 +86,7 @@ public class CTFileQueryBond extends QueryBond implements IQueryBond {
     public static CTFileQueryBond ofType(IBond bond, int type) {
         CTFileQueryBond queryBond = new CTFileQueryBond(bond.getBuilder());
         queryBond.setOrder(Order.UNSET);
-        queryBond.setAtoms(new IAtom[]{bond.getAtom(0), bond.getAtom(1)});
+        queryBond.setAtoms(new IAtom[]{bond.getBeg(), bond.getEnd()});
         switch (type) {
             case 1:
                 queryBond.setType(Type.SINGLE);

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/CTFileQueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/CTFileQueryBond.java
@@ -86,7 +86,7 @@ public class CTFileQueryBond extends QueryBond implements IQueryBond {
     public static CTFileQueryBond ofType(IBond bond, int type) {
         CTFileQueryBond queryBond = new CTFileQueryBond(bond.getBuilder());
         queryBond.setOrder(Order.UNSET);
-        queryBond.setAtoms(new IAtom[]{bond.getBeg(), bond.getEnd()});
+        queryBond.setAtoms(new IAtom[]{bond.getBegin(), bond.getEnd()});
         switch (type) {
             case 1:
                 queryBond.setType(Type.SINGLE);

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
@@ -652,7 +652,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     @Override
     public IBond getBond(IAtom atom1, IAtom atom2) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bonds[i].contains(atom1) && bonds[i].getConnectedAtom(atom1) == atom2) {
+            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1) == atom2) {
                 return bonds[i];
             }
         }
@@ -719,7 +719,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     public List<IAtom> getConnectedAtomsList(IAtom atom) {
         List<IAtom> atomsList = new ArrayList<IAtom>();
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i].contains(atom)) atomsList.add(bonds[i].getConnectedAtom(atom));
+            if (bonds[i].contains(atom)) atomsList.add(bonds[i].getOther(atom));
         }
         return atomsList;
     }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainerCreator.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainerCreator.java
@@ -50,7 +50,7 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBeg());
+            int index1 = container.indexOf(bond.getBegin());
             int index2 = container.indexOf(bond.getEnd());
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
@@ -78,7 +78,7 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = (IBond) bonds.next();
-            int index1 = container.indexOf(bond.getBeg());
+            int index1 = container.indexOf(bond.getBegin());
             int index2 = container.indexOf(bond.getEnd());
             queryContainer.addBond(new OrderQueryBondOrderOnly((IQueryAtom) queryContainer.getAtom(index1),
                     (IQueryAtom) queryContainer.getAtom(index2), bond.getOrder(), container.getBuilder()));
@@ -101,7 +101,7 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBeg());
+            int index1 = container.indexOf(bond.getBegin());
             int index2 = container.indexOf(bond.getEnd());
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
@@ -122,7 +122,7 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBeg());
+            int index1 = container.indexOf(bond.getBegin());
             int index2 = container.indexOf(bond.getEnd());
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
@@ -157,7 +157,7 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBeg());
+            int index1 = container.indexOf(bond.getBegin());
             int index2 = container.indexOf(bond.getEnd());
             if (aromaticity && bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
@@ -194,7 +194,7 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBeg());
+            int index1 = container.indexOf(bond.getBegin());
             int index2 = container.indexOf(bond.getEnd());
             queryContainer.addBond(new AnyOrderBond(queryContainer.getAtom(index1), queryContainer.getAtom(index2),
                     container.getBuilder()));
@@ -223,7 +223,7 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBeg());
+            int index1 = container.indexOf(bond.getBegin());
             int index2 = container.indexOf(bond.getEnd());
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainerCreator.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainerCreator.java
@@ -50,8 +50,8 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getAtom(0));
-            int index2 = container.indexOf(bond.getAtom(1));
+            int index1 = container.indexOf(bond.getBeg());
+            int index2 = container.indexOf(bond.getEnd());
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
                         (IQueryAtom) queryContainer.getAtom(index2), container.getBuilder()));
@@ -78,8 +78,8 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = (IBond) bonds.next();
-            int index1 = container.indexOf(bond.getAtom(0));
-            int index2 = container.indexOf(bond.getAtom(1));
+            int index1 = container.indexOf(bond.getBeg());
+            int index2 = container.indexOf(bond.getEnd());
             queryContainer.addBond(new OrderQueryBondOrderOnly((IQueryAtom) queryContainer.getAtom(index1),
                     (IQueryAtom) queryContainer.getAtom(index2), bond.getOrder(), container.getBuilder()));
         }
@@ -101,8 +101,8 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getAtom(0));
-            int index2 = container.indexOf(bond.getAtom(1));
+            int index1 = container.indexOf(bond.getBeg());
+            int index2 = container.indexOf(bond.getEnd());
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
                         (IQueryAtom) queryContainer.getAtom(index2), container.getBuilder()));
@@ -122,8 +122,8 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getAtom(0));
-            int index2 = container.indexOf(bond.getAtom(1));
+            int index1 = container.indexOf(bond.getBeg());
+            int index2 = container.indexOf(bond.getEnd());
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
                         (IQueryAtom) queryContainer.getAtom(index2), container.getBuilder()));
@@ -157,8 +157,8 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getAtom(0));
-            int index2 = container.indexOf(bond.getAtom(1));
+            int index1 = container.indexOf(bond.getBeg());
+            int index2 = container.indexOf(bond.getEnd());
             if (aromaticity && bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
                         (IQueryAtom) queryContainer.getAtom(index2), container.getBuilder()));
@@ -194,8 +194,8 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getAtom(0));
-            int index2 = container.indexOf(bond.getAtom(1));
+            int index1 = container.indexOf(bond.getBeg());
+            int index2 = container.indexOf(bond.getEnd());
             queryContainer.addBond(new AnyOrderBond(queryContainer.getAtom(index1), queryContainer.getAtom(index2),
                     container.getBuilder()));
         }
@@ -223,8 +223,8 @@ public class QueryAtomContainerCreator {
         Iterator<IBond> bonds = container.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getAtom(0));
-            int index2 = container.indexOf(bond.getAtom(1));
+            int index1 = container.indexOf(bond.getBeg());
+            int index2 = container.indexOf(bond.getEnd());
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 queryContainer.addBond(new AromaticQueryBond((IQueryAtom) queryContainer.getAtom(index1),
                         (IQueryAtom) queryContainer.getAtom(index2), container.getBuilder()));

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -252,32 +252,21 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
     }
 
     /**
-     * Returns all the atoms in the query bond connected to the specified atom.
-     * 
-     * Though this can be used for traditional 2-center query bonds, it is oriented
-     * towards multi-center query bonds, where a single atom is connected to multiple
-     * atoms.
-     *
-     * @param atom The atom whose partners are to be searched for
-     * @return An array of the connected atoms, null if the atom is not part of the query bond
-     * @see #getOther(org.openscience.cdk.interfaces.IAtom)
+     * {@inheritDoc}
      */
     @Override
     public IAtom[] getConnectedAtoms(IAtom atom) {
-        boolean atomIsInBond = false;
-        for (IAtom localAtom : atoms) {
-            if (localAtom == atom) {
-                atomIsInBond = true;
-                break;
+        if (atomCount < 1) return null;
+        IAtom[] connected = new IAtom[atomCount-1];
+        int j = 0;
+        for (int i = 0; i < atomCount; i++) {
+            if (this.atoms[i] != atom) {
+                if (j >= connected.length)
+                    return null;
+                connected[j++] = this.atoms[i];
             }
         }
-        if (!atomIsInBond) return null;
-
-        List<IAtom> conAtoms = new ArrayList<IAtom>();
-        for (IAtom localAtom : atoms) {
-            if (localAtom != atom) conAtoms.add(localAtom);
-        }
-        return conAtoms.toArray(new IAtom[]{});
+        return connected;
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -228,28 +228,26 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
     }
 
     /**
-     * Returns the atom connected to the given atom.
-     * 
-     * This method is only strictly relevant for 2-center query bonds
-     * since in multi-center query bonds, a given atom will be connected
-     * to multiple atoms.
-     * 
-     * If called for a multi-center query bond, then the next atom in the
-     * atom list is returned. This is probably not what is expected and
-     * hence the user should instead call
-     * {@link #getConnectedAtoms(org.openscience.cdk.interfaces.IAtom)}
-     *
-     * @param atom The atom the query bond partner is searched of
-     * @return the connected atom or null  if the atom is not part of the query bond
-     * @see #getConnectedAtoms(org.openscience.cdk.interfaces.IAtom)
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom getOther(IAtom atom) {
+        if (atoms[0] == atom)
+            return atoms[1];
+        else if (atoms[1] == atom)
+            return atoms[0];
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public IAtom getConnectedAtom(IAtom atom) {
-        if (atoms[0] == atom) {
+        if (atoms[0] == atom)
             return atoms[1];
-        } else if (atoms[1] == atom) {
+        else if (atoms[1] == atom)
             return atoms[0];
-        }
         return null;
     }
 
@@ -262,7 +260,7 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
      *
      * @param atom The atom whose partners are to be searched for
      * @return An array of the connected atoms, null if the atom is not part of the query bond
-     * @see #getConnectedAtom(org.openscience.cdk.interfaces.IAtom)
+     * @see #getOther(org.openscience.cdk.interfaces.IAtom)
      */
     @Override
     public IAtom[] getConnectedAtoms(IAtom atom) {

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -214,6 +214,20 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public IAtom getBeg() {
+        return atoms[0];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IAtom getEnd() {
+        return atoms[1];
+    }
+
+    /**
      * Returns the atom connected to the given atom.
      * 
      * This method is only strictly relevant for 2-center query bonds

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -214,7 +214,7 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
     /**
      * {@inheritDoc}
      */
-    public IAtom getBeg() {
+    public IAtom getBegin() {
         return atoms[0];
     }
 

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -18,9 +18,7 @@
  */
 package org.openscience.cdk.isomorphism.matchers;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/RGroupQuery.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/RGroupQuery.java
@@ -295,7 +295,7 @@ public class RGroupQuery extends QueryChemObject implements IChemObject, Seriali
                                 IBond bond = rAttachmentPoints.get(apo + 1);
                                 //Check how R# is attached to bond
                                 int whichAtomInBond = 0;
-                                if (bond.getAtom(1).equals(rAtom)) whichAtomInBond = 1;
+                                if (bond.getEnd().equals(rAtom)) whichAtomInBond = 1;
                                 IAtom subsAt = null;
                                 if (apo == 0)
                                     subsAt = substitute.getFirstAttachmentPoint();

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/RGroupQuery.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/RGroupQuery.java
@@ -350,11 +350,11 @@ public class RGroupQuery extends QueryChemObject implements IChemObject, Seriali
             while (confHasRGroupBonds) {
                 for (IBond cloneBond : rootClone.bonds()) {
                     boolean removeBond = false;
-                    if (cloneBond.getAtom(0) instanceof IPseudoAtom
-                            && isValidRgroupQueryLabel(((IPseudoAtom) cloneBond.getAtom(0)).getLabel()))
+                    if (cloneBond.getBeg() instanceof IPseudoAtom
+                            && isValidRgroupQueryLabel(((IPseudoAtom) cloneBond.getBeg()).getLabel()))
                         removeBond = true;
-                    else if (cloneBond.getAtom(1) instanceof IPseudoAtom
-                            && isValidRgroupQueryLabel(((IPseudoAtom) cloneBond.getAtom(1)).getLabel()))
+                    else if (cloneBond.getEnd() instanceof IPseudoAtom
+                            && isValidRgroupQueryLabel(((IPseudoAtom) cloneBond.getEnd()).getLabel()))
                         removeBond = true;
 
                     if (removeBond) {

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/RGroupQuery.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/RGroupQuery.java
@@ -350,8 +350,8 @@ public class RGroupQuery extends QueryChemObject implements IChemObject, Seriali
             while (confHasRGroupBonds) {
                 for (IBond cloneBond : rootClone.bonds()) {
                     boolean removeBond = false;
-                    if (cloneBond.getBeg() instanceof IPseudoAtom
-                            && isValidRgroupQueryLabel(((IPseudoAtom) cloneBond.getBeg()).getLabel()))
+                    if (cloneBond.getBegin() instanceof IPseudoAtom
+                            && isValidRgroupQueryLabel(((IPseudoAtom) cloneBond.getBegin()).getLabel()))
                         removeBond = true;
                     else if (cloneBond.getEnd() instanceof IPseudoAtom
                             && isValidRgroupQueryLabel(((IPseudoAtom) cloneBond.getEnd()).getLabel()))

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/AdductionProtonPBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/AdductionProtonPBReaction.java
@@ -136,14 +136,14 @@ public class AdductionProtonPBReaction extends ReactionEngine implements IReacti
 
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER)
                     && ((bondi.getOrder() == IBond.Order.DOUBLE) || (bondi.getOrder() == IBond.Order.TRIPLE))
-                    && bondi.getBeg().getFlag(CDKConstants.REACTIVE_CENTER)
+                    && bondi.getBegin().getFlag(CDKConstants.REACTIVE_CENTER)
                     && bondi.getEnd().getFlag(CDKConstants.REACTIVE_CENTER)) {
-                int chargeAtom0 = bondi.getBeg().getFormalCharge() == null ? 0 : bondi.getBeg().getFormalCharge();
+                int chargeAtom0 = bondi.getBegin().getFormalCharge() == null ? 0 : bondi.getBegin().getFormalCharge();
                 int chargeAtom1 = bondi.getEnd().getFormalCharge() == null ? 0 : bondi.getEnd().getFormalCharge();
                 if (chargeAtom0 >= 0 && chargeAtom1 >= 0
-                        && reactant.getConnectedSingleElectronsCount(bondi.getBeg()) == 0
+                        && reactant.getConnectedSingleElectronsCount(bondi.getBegin()) == 0
                         && reactant.getConnectedSingleElectronsCount(bondi.getEnd()) == 0
-                        && reactant.getConnectedLonePairsCount(bondi.getBeg()) == 0
+                        && reactant.getConnectedLonePairsCount(bondi.getBegin()) == 0
                         && reactant.getConnectedLonePairsCount(bondi.getEnd()) == 0) {
 
                     /**/
@@ -151,11 +151,11 @@ public class AdductionProtonPBReaction extends ReactionEngine implements IReacti
 
                         ArrayList<IAtom> atomList = new ArrayList<IAtom>();
                         if (j == 0) {
-                            atomList.add(bondi.getBeg());
+                            atomList.add(bondi.getBegin());
                             atomList.add(bondi.getEnd());
                         } else {
                             atomList.add(bondi.getEnd());
-                            atomList.add(bondi.getBeg());
+                            atomList.add(bondi.getBegin());
                         }
                         IAtom atomH = reactant.getBuilder().newInstance(IAtom.class, "H");
                         atomH.setFormalCharge(1);
@@ -201,15 +201,15 @@ public class AdductionProtonPBReaction extends ReactionEngine implements IReacti
             IBond bondi = bondis.next();
 
             if (((bondi.getOrder() == IBond.Order.DOUBLE) || (bondi.getOrder() == IBond.Order.TRIPLE))) {
-                int chargeAtom0 = bondi.getBeg().getFormalCharge() == null ? 0 : bondi.getBeg().getFormalCharge();
+                int chargeAtom0 = bondi.getBegin().getFormalCharge() == null ? 0 : bondi.getBegin().getFormalCharge();
                 int chargeAtom1 = bondi.getEnd().getFormalCharge() == null ? 0 : bondi.getEnd().getFormalCharge();
                 if (chargeAtom0 >= 0 && chargeAtom1 >= 0
-                        && reactant.getConnectedSingleElectronsCount(bondi.getBeg()) == 0
+                        && reactant.getConnectedSingleElectronsCount(bondi.getBegin()) == 0
                         && reactant.getConnectedSingleElectronsCount(bondi.getEnd()) == 0
-                        && reactant.getConnectedLonePairsCount(bondi.getBeg()) == 0
+                        && reactant.getConnectedLonePairsCount(bondi.getBegin()) == 0
                         && reactant.getConnectedLonePairsCount(bondi.getEnd()) == 0) {
                     bondi.setFlag(CDKConstants.REACTIVE_CENTER, true);
-                    bondi.getBeg().setFlag(CDKConstants.REACTIVE_CENTER, true);
+                    bondi.getBegin().setFlag(CDKConstants.REACTIVE_CENTER, true);
                     bondi.getEnd().setFlag(CDKConstants.REACTIVE_CENTER, true);
                 }
             }

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/AdductionProtonPBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/AdductionProtonPBReaction.java
@@ -136,26 +136,26 @@ public class AdductionProtonPBReaction extends ReactionEngine implements IReacti
 
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER)
                     && ((bondi.getOrder() == IBond.Order.DOUBLE) || (bondi.getOrder() == IBond.Order.TRIPLE))
-                    && bondi.getAtom(0).getFlag(CDKConstants.REACTIVE_CENTER)
-                    && bondi.getAtom(1).getFlag(CDKConstants.REACTIVE_CENTER)) {
-                int chargeAtom0 = bondi.getAtom(0).getFormalCharge() == null ? 0 : bondi.getAtom(0).getFormalCharge();
-                int chargeAtom1 = bondi.getAtom(1).getFormalCharge() == null ? 0 : bondi.getAtom(1).getFormalCharge();
+                    && bondi.getBeg().getFlag(CDKConstants.REACTIVE_CENTER)
+                    && bondi.getEnd().getFlag(CDKConstants.REACTIVE_CENTER)) {
+                int chargeAtom0 = bondi.getBeg().getFormalCharge() == null ? 0 : bondi.getBeg().getFormalCharge();
+                int chargeAtom1 = bondi.getEnd().getFormalCharge() == null ? 0 : bondi.getEnd().getFormalCharge();
                 if (chargeAtom0 >= 0 && chargeAtom1 >= 0
-                        && reactant.getConnectedSingleElectronsCount(bondi.getAtom(0)) == 0
-                        && reactant.getConnectedSingleElectronsCount(bondi.getAtom(1)) == 0
-                        && reactant.getConnectedLonePairsCount(bondi.getAtom(0)) == 0
-                        && reactant.getConnectedLonePairsCount(bondi.getAtom(1)) == 0) {
+                        && reactant.getConnectedSingleElectronsCount(bondi.getBeg()) == 0
+                        && reactant.getConnectedSingleElectronsCount(bondi.getEnd()) == 0
+                        && reactant.getConnectedLonePairsCount(bondi.getBeg()) == 0
+                        && reactant.getConnectedLonePairsCount(bondi.getEnd()) == 0) {
 
                     /**/
                     for (int j = 0; j < 2; j++) {
 
                         ArrayList<IAtom> atomList = new ArrayList<IAtom>();
                         if (j == 0) {
-                            atomList.add(bondi.getAtom(0));
-                            atomList.add(bondi.getAtom(1));
+                            atomList.add(bondi.getBeg());
+                            atomList.add(bondi.getEnd());
                         } else {
-                            atomList.add(bondi.getAtom(1));
-                            atomList.add(bondi.getAtom(0));
+                            atomList.add(bondi.getEnd());
+                            atomList.add(bondi.getBeg());
                         }
                         IAtom atomH = reactant.getBuilder().newInstance(IAtom.class, "H");
                         atomH.setFormalCharge(1);
@@ -201,16 +201,16 @@ public class AdductionProtonPBReaction extends ReactionEngine implements IReacti
             IBond bondi = bondis.next();
 
             if (((bondi.getOrder() == IBond.Order.DOUBLE) || (bondi.getOrder() == IBond.Order.TRIPLE))) {
-                int chargeAtom0 = bondi.getAtom(0).getFormalCharge() == null ? 0 : bondi.getAtom(0).getFormalCharge();
-                int chargeAtom1 = bondi.getAtom(1).getFormalCharge() == null ? 0 : bondi.getAtom(1).getFormalCharge();
+                int chargeAtom0 = bondi.getBeg().getFormalCharge() == null ? 0 : bondi.getBeg().getFormalCharge();
+                int chargeAtom1 = bondi.getEnd().getFormalCharge() == null ? 0 : bondi.getEnd().getFormalCharge();
                 if (chargeAtom0 >= 0 && chargeAtom1 >= 0
-                        && reactant.getConnectedSingleElectronsCount(bondi.getAtom(0)) == 0
-                        && reactant.getConnectedSingleElectronsCount(bondi.getAtom(1)) == 0
-                        && reactant.getConnectedLonePairsCount(bondi.getAtom(0)) == 0
-                        && reactant.getConnectedLonePairsCount(bondi.getAtom(1)) == 0) {
+                        && reactant.getConnectedSingleElectronsCount(bondi.getBeg()) == 0
+                        && reactant.getConnectedSingleElectronsCount(bondi.getEnd()) == 0
+                        && reactant.getConnectedLonePairsCount(bondi.getBeg()) == 0
+                        && reactant.getConnectedLonePairsCount(bondi.getEnd()) == 0) {
                     bondi.setFlag(CDKConstants.REACTIVE_CENTER, true);
-                    bondi.getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
-                    bondi.getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, true);
+                    bondi.getBeg().setFlag(CDKConstants.REACTIVE_CENTER, true);
+                    bondi.getEnd().setFlag(CDKConstants.REACTIVE_CENTER, true);
                 }
             }
         }

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/CarbonylEliminationReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/CarbonylEliminationReaction.java
@@ -133,7 +133,7 @@ public class CarbonylEliminationReaction extends ReactionEngine implements IReac
                     IBond bondi = bondis.next();
 
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.TRIPLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER)) {
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
                             while (bondjs.hasNext()) {
@@ -144,7 +144,7 @@ public class CarbonylEliminationReaction extends ReactionEngine implements IReac
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER) && atomk.getFormalCharge() == 0) {
 
                                         ArrayList<IAtom> atomList = new ArrayList<IAtom>();
@@ -199,7 +199,7 @@ public class CarbonylEliminationReaction extends ReactionEngine implements IReac
                     IBond bondi = bondis.next();
 
                     if (bondi.getOrder() == IBond.Order.TRIPLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
                         while (bondjs.hasNext()) {
                             IBond bondj = bondjs.next();
@@ -208,7 +208,7 @@ public class CarbonylEliminationReaction extends ReactionEngine implements IReac
 
                             if (bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                IAtom atomk = bondj.getConnectedAtom(atomj);
+                                IAtom atomk = bondj.getOther(atomj);
                                 if (atomk.getFormalCharge() == 0) {
                                     atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                                     bondi.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/ElectronImpactPDBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/ElectronImpactPDBReaction.java
@@ -127,8 +127,8 @@ public class ElectronImpactPDBReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bondi = bonds.next();
-            IAtom atom1 = bondi.getAtom(0);
-            IAtom atom2 = bondi.getAtom(1);
+            IAtom atom1 = bondi.getBeg();
+            IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER)
                     && (bondi.getOrder() == IBond.Order.DOUBLE || bondi.getOrder() == IBond.Order.TRIPLE)
                     && atom1.getFlag(CDKConstants.REACTIVE_CENTER) && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
@@ -176,8 +176,8 @@ public class ElectronImpactPDBReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bondi = bonds.next();
-            IAtom atom1 = bondi.getAtom(0);
-            IAtom atom2 = bondi.getAtom(1);
+            IAtom atom1 = bondi.getBeg();
+            IAtom atom2 = bondi.getEnd();
             if ((bondi.getOrder() == IBond.Order.DOUBLE || bondi.getOrder() == IBond.Order.TRIPLE)
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0
                     && (atom2.getFormalCharge() == CDKConstants.UNSET ? 0 : atom2.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/ElectronImpactPDBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/ElectronImpactPDBReaction.java
@@ -127,7 +127,7 @@ public class ElectronImpactPDBReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bondi = bonds.next();
-            IAtom atom1 = bondi.getBeg();
+            IAtom atom1 = bondi.getBegin();
             IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER)
                     && (bondi.getOrder() == IBond.Order.DOUBLE || bondi.getOrder() == IBond.Order.TRIPLE)
@@ -176,7 +176,7 @@ public class ElectronImpactPDBReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bondi = bonds.next();
-            IAtom atom1 = bondi.getBeg();
+            IAtom atom1 = bondi.getBegin();
             IAtom atom2 = bondi.getEnd();
             if ((bondi.getOrder() == IBond.Order.DOUBLE || bondi.getOrder() == IBond.Order.TRIPLE)
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/ElectronImpactSDBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/ElectronImpactSDBReaction.java
@@ -125,8 +125,8 @@ public class ElectronImpactSDBReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bondi = bonds.next();
-            IAtom atom1 = bondi.getAtom(0);
-            IAtom atom2 = bondi.getAtom(1);
+            IAtom atom1 = bondi.getBeg();
+            IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE
                     && atom1.getFlag(CDKConstants.REACTIVE_CENTER) && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0
@@ -173,8 +173,8 @@ public class ElectronImpactSDBReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bondi = bonds.next();
-            IAtom atom1 = bondi.getAtom(0);
-            IAtom atom2 = bondi.getAtom(1);
+            IAtom atom1 = bondi.getBeg();
+            IAtom atom2 = bondi.getEnd();
             if (bondi.getOrder() == IBond.Order.SINGLE
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0
                     && (atom2.getFormalCharge() == CDKConstants.UNSET ? 0 : atom2.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/ElectronImpactSDBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/ElectronImpactSDBReaction.java
@@ -125,7 +125,7 @@ public class ElectronImpactSDBReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bondi = bonds.next();
-            IAtom atom1 = bondi.getBeg();
+            IAtom atom1 = bondi.getBegin();
             IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE
                     && atom1.getFlag(CDKConstants.REACTIVE_CENTER) && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
@@ -173,7 +173,7 @@ public class ElectronImpactSDBReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bondi = bonds.next();
-            IAtom atom1 = bondi.getBeg();
+            IAtom atom1 = bondi.getBegin();
             IAtom atom2 = bondi.getEnd();
             if (bondi.getOrder() == IBond.Order.SINGLE
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavagePBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavagePBReaction.java
@@ -134,8 +134,8 @@ public class HeterolyticCleavagePBReaction extends ReactionEngine implements IRe
         Iterator<IBond> bondis = reactant.bonds().iterator();
         while (bondis.hasNext()) {
             IBond bondi = bondis.next();
-            IAtom atom1 = bondi.getAtom(0);
-            IAtom atom2 = bondi.getAtom(1);
+            IAtom atom1 = bondi.getBeg();
+            IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() != IBond.Order.SINGLE
                     && atom1.getFlag(CDKConstants.REACTIVE_CENTER) && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavagePBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavagePBReaction.java
@@ -187,8 +187,8 @@ public class HeterolyticCleavagePBReaction extends ReactionEngine implements IRe
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (bond.getOrder() != IBond.Order.SINGLE
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0
                     && (atom2.getFormalCharge() == CDKConstants.UNSET ? 0 : atom2.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavagePBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavagePBReaction.java
@@ -134,7 +134,7 @@ public class HeterolyticCleavagePBReaction extends ReactionEngine implements IRe
         Iterator<IBond> bondis = reactant.bonds().iterator();
         while (bondis.hasNext()) {
             IBond bondi = bondis.next();
-            IAtom atom1 = bondi.getBeg();
+            IAtom atom1 = bondi.getBegin();
             IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() != IBond.Order.SINGLE
                     && atom1.getFlag(CDKConstants.REACTIVE_CENTER) && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
@@ -187,7 +187,7 @@ public class HeterolyticCleavagePBReaction extends ReactionEngine implements IRe
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (bond.getOrder() != IBond.Order.SINGLE
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavageSBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavageSBReaction.java
@@ -134,7 +134,7 @@ public class HeterolyticCleavageSBReaction extends ReactionEngine implements IRe
         Iterator<IBond> bondis = reactant.bonds().iterator();
         while (bondis.hasNext()) {
             IBond bondi = bondis.next();
-            IAtom atom1 = bondi.getBeg();
+            IAtom atom1 = bondi.getBegin();
             IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE
                     && atom1.getFlag(CDKConstants.REACTIVE_CENTER) && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
@@ -187,7 +187,7 @@ public class HeterolyticCleavageSBReaction extends ReactionEngine implements IRe
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (bond.getOrder() == IBond.Order.SINGLE
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavageSBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavageSBReaction.java
@@ -187,8 +187,8 @@ public class HeterolyticCleavageSBReaction extends ReactionEngine implements IRe
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (bond.getOrder() == IBond.Order.SINGLE
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0
                     && (atom2.getFormalCharge() == CDKConstants.UNSET ? 0 : atom2.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavageSBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HeterolyticCleavageSBReaction.java
@@ -134,8 +134,8 @@ public class HeterolyticCleavageSBReaction extends ReactionEngine implements IRe
         Iterator<IBond> bondis = reactant.bonds().iterator();
         while (bondis.hasNext()) {
             IBond bondi = bondis.next();
-            IAtom atom1 = bondi.getAtom(0);
-            IAtom atom2 = bondi.getAtom(1);
+            IAtom atom1 = bondi.getBeg();
+            IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE
                     && atom1.getFlag(CDKConstants.REACTIVE_CENTER) && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HomolyticCleavageReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HomolyticCleavageReaction.java
@@ -126,8 +126,8 @@ public class HomolyticCleavageReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bondis = reactant.bonds().iterator();
         while (bondis.hasNext()) {
             IBond bondi = bondis.next();
-            IAtom atom1 = bondi.getAtom(0);
-            IAtom atom2 = bondi.getAtom(1);
+            IAtom atom1 = bondi.getBeg();
+            IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && atom1.getFlag(CDKConstants.REACTIVE_CENTER)
                     && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
                     && (atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HomolyticCleavageReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HomolyticCleavageReaction.java
@@ -172,8 +172,8 @@ public class HomolyticCleavageReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bondis = reactant.bonds().iterator();
         while (bondis.hasNext()) {
             IBond bond = bondis.next();
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if ((atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0
                     && (atom2.getFormalCharge() == CDKConstants.UNSET ? 0 : atom2.getFormalCharge()) == 0
                     && reactant.getConnectedSingleElectronsCount(atom1) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HomolyticCleavageReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HomolyticCleavageReaction.java
@@ -126,7 +126,7 @@ public class HomolyticCleavageReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bondis = reactant.bonds().iterator();
         while (bondis.hasNext()) {
             IBond bondi = bondis.next();
-            IAtom atom1 = bondi.getBeg();
+            IAtom atom1 = bondi.getBegin();
             IAtom atom2 = bondi.getEnd();
             if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && atom1.getFlag(CDKConstants.REACTIVE_CENTER)
                     && atom2.getFlag(CDKConstants.REACTIVE_CENTER)
@@ -172,7 +172,7 @@ public class HomolyticCleavageReaction extends ReactionEngine implements IReacti
         Iterator<IBond> bondis = reactant.bonds().iterator();
         while (bondis.hasNext()) {
             IBond bond = bondis.next();
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if ((atom1.getFormalCharge() == CDKConstants.UNSET ? 0 : atom1.getFormalCharge()) == 0
                     && (atom2.getFormalCharge() == CDKConstants.UNSET ? 0 : atom2.getFormalCharge()) == 0

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HyperconjugationReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/HyperconjugationReaction.java
@@ -136,7 +136,7 @@ public class HyperconjugationReaction extends ReactionEngine implements IReactio
 
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER)
                                 && (atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
@@ -148,7 +148,7 @@ public class HyperconjugationReaction extends ReactionEngine implements IReactio
 
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.SINGLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER)
                                             && reactant.getConnectedSingleElectronsCount(atomk) == 0
                                             && (atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk
@@ -206,7 +206,7 @@ public class HyperconjugationReaction extends ReactionEngine implements IReactio
 
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if ((atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -217,7 +217,7 @@ public class HyperconjugationReaction extends ReactionEngine implements IReactio
                                 if (bondj.equals(bondi)) continue;
 
                                 if (bondj.getOrder() == IBond.Order.SINGLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (reactant.getConnectedSingleElectronsCount(atomk) == 0
                                             && (atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk
                                                     .getFormalCharge()) == 0 && atomk.getSymbol().equals("H")) {

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalChargeSiteInitiationHReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalChargeSiteInitiationHReaction.java
@@ -136,7 +136,7 @@ public class RadicalChargeSiteInitiationHReaction extends ReactionEngine impleme
 
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER) && atomj.getFormalCharge() == 0) {
 
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -148,7 +148,7 @@ public class RadicalChargeSiteInitiationHReaction extends ReactionEngine impleme
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER) && atomk.getSymbol().equals("H")
                                             && atomk.getFormalCharge() == 0) {
 
@@ -206,7 +206,7 @@ public class RadicalChargeSiteInitiationHReaction extends ReactionEngine impleme
 
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFormalCharge() == 0) {
 
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -217,7 +217,7 @@ public class RadicalChargeSiteInitiationHReaction extends ReactionEngine impleme
 
                                 if (bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getSymbol().equals("H") && atomk.getFormalCharge() == 0) {
                                         atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                                         atomj.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalChargeSiteInitiationReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalChargeSiteInitiationReaction.java
@@ -136,7 +136,7 @@ public class RadicalChargeSiteInitiationReaction extends ReactionEngine implemen
 
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER) && atomj.getFormalCharge() == 0) {
 
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -148,7 +148,7 @@ public class RadicalChargeSiteInitiationReaction extends ReactionEngine implemen
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER) && atomk.getSymbol().equals("C")
                                             && atomk.getFormalCharge() == 0) {
 
@@ -209,7 +209,7 @@ public class RadicalChargeSiteInitiationReaction extends ReactionEngine implemen
 
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFormalCharge() == 0) {
 
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -220,7 +220,7 @@ public class RadicalChargeSiteInitiationReaction extends ReactionEngine implemen
 
                                 if (bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getSymbol().equals("C") && atomk.getFormalCharge() == 0) {
                                         atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                                         atomj.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteInitiationHReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteInitiationHReaction.java
@@ -135,7 +135,7 @@ public class RadicalSiteInitiationHReaction extends ReactionEngine implements IR
 
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER) && atomj.getFormalCharge() == 0) {
 
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -147,7 +147,7 @@ public class RadicalSiteInitiationHReaction extends ReactionEngine implements IR
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER) && atomk.getSymbol().equals("H")
                                             && atomk.getFormalCharge() == 0) {
 
@@ -205,7 +205,7 @@ public class RadicalSiteInitiationHReaction extends ReactionEngine implements IR
 
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFormalCharge() == 0) {
 
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -216,7 +216,7 @@ public class RadicalSiteInitiationHReaction extends ReactionEngine implements IR
 
                                 if (bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getSymbol().equals("H") && atomk.getFormalCharge() == 0) {
                                         atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                                         atomj.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteInitiationReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteInitiationReaction.java
@@ -135,7 +135,7 @@ public class RadicalSiteInitiationReaction extends ReactionEngine implements IRe
 
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER) && atomj.getFormalCharge() == 0) {
 
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -147,7 +147,7 @@ public class RadicalSiteInitiationReaction extends ReactionEngine implements IRe
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER) && atomk.getSymbol().equals("C")
                                             && atomk.getFormalCharge() == 0) {
 
@@ -208,7 +208,7 @@ public class RadicalSiteInitiationReaction extends ReactionEngine implements IRe
 
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFormalCharge() == 0) {
 
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -219,7 +219,7 @@ public class RadicalSiteInitiationReaction extends ReactionEngine implements IRe
 
                                 if (bondj.getOrder() == IBond.Order.SINGLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getSymbol().equals("C") && atomk.getFormalCharge() == 0) {
                                         atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                                         atomj.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RearrangementAnionReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RearrangementAnionReaction.java
@@ -134,7 +134,7 @@ public class RearrangementAnionReaction extends ReactionEngine implements IReact
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER)
                                 && (atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
@@ -146,7 +146,7 @@ public class RearrangementAnionReaction extends ReactionEngine implements IReact
 
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.DOUBLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
 
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER)
                                             && reactant.getConnectedSingleElectronsCount(atomk) == 0
@@ -205,7 +205,7 @@ public class RearrangementAnionReaction extends ReactionEngine implements IReact
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if ((atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -215,7 +215,7 @@ public class RearrangementAnionReaction extends ReactionEngine implements IReact
                                 if (bondj.equals(bondi)) continue;
 
                                 if (bondj.getOrder() == IBond.Order.DOUBLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
 
                                     if (reactant.getConnectedSingleElectronsCount(atomk) == 0
                                             && (atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RearrangementCationReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RearrangementCationReaction.java
@@ -137,7 +137,7 @@ public class RearrangementCationReaction extends ReactionEngine implements IReac
 
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER)
                                 && (atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
@@ -149,7 +149,7 @@ public class RearrangementCationReaction extends ReactionEngine implements IReac
 
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.DOUBLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER)
                                             && reactant.getConnectedSingleElectronsCount(atomk) == 0
                                             && (atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk
@@ -210,7 +210,7 @@ public class RearrangementCationReaction extends ReactionEngine implements IReac
 
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if ((atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -221,7 +221,7 @@ public class RearrangementCationReaction extends ReactionEngine implements IReac
                                 if (bondj.equals(bondi)) continue;
 
                                 if (bondj.getOrder() == IBond.Order.DOUBLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (reactant.getConnectedSingleElectronsCount(atomk) == 0
                                             && (atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk
                                                     .getFormalCharge()) == 0) {

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RearrangementLonePairReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RearrangementLonePairReaction.java
@@ -138,7 +138,7 @@ public class RearrangementLonePairReaction extends ReactionEngine implements IRe
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER)
                                 && (atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
@@ -150,7 +150,7 @@ public class RearrangementLonePairReaction extends ReactionEngine implements IRe
 
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.DOUBLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
 
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER)
                                             && reactant.getConnectedSingleElectronsCount(atomk) == 0
@@ -210,7 +210,7 @@ public class RearrangementLonePairReaction extends ReactionEngine implements IRe
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if ((atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -220,7 +220,7 @@ public class RearrangementLonePairReaction extends ReactionEngine implements IRe
                                 if (bondj.equals(bondi)) continue;
 
                                 if (bondj.getOrder() == IBond.Order.DOUBLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
 
                                     if (reactant.getConnectedSingleElectronsCount(atomk) == 0
                                             && (atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RearrangementRadicalReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RearrangementRadicalReaction.java
@@ -140,7 +140,7 @@ public class RearrangementRadicalReaction extends ReactionEngine implements IRea
 
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomi.getFlag(CDKConstants.REACTIVE_CENTER)
                                 && (atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
@@ -154,7 +154,7 @@ public class RearrangementRadicalReaction extends ReactionEngine implements IRea
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.DOUBLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER)
                                             && (atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk
                                                     .getFormalCharge()) == 0
@@ -226,7 +226,7 @@ public class RearrangementRadicalReaction extends ReactionEngine implements IRea
 
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if ((atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -238,7 +238,7 @@ public class RearrangementRadicalReaction extends ReactionEngine implements IRea
 
                                 if (bondj.getOrder() == IBond.Order.DOUBLE) {
 
-                                    IAtom atomk = bondj.getConnectedAtom(atomj);
+                                    IAtom atomk = bondj.getOther(atomj);
                                     if ((atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk.getFormalCharge()) == 0
                                             && reactant.getConnectedSingleElectronsCount(atomk) == 0) {
 

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/SharingAnionReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/SharingAnionReaction.java
@@ -134,7 +134,7 @@ public class SharingAnionReaction extends ReactionEngine implements IReactionPro
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER) && atomj.getFormalCharge() == 1
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -184,7 +184,7 @@ public class SharingAnionReaction extends ReactionEngine implements IReactionPro
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFormalCharge() == 1 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
                             atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                             atomj.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/SharingChargeDBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/SharingChargeDBReaction.java
@@ -136,7 +136,7 @@ public class SharingChargeDBReaction extends ReactionEngine implements IReaction
                     IBond bondi = bondis.next();
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() != IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER) && atomj.getFormalCharge() == 0)
                             if (reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -187,7 +187,7 @@ public class SharingChargeDBReaction extends ReactionEngine implements IReaction
                     IBond bondi = bondis.next();
                     if (bondi.getOrder() != IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFormalCharge() == 0) if (reactant.getConnectedSingleElectronsCount(atomj) == 0) {
                             atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                             bondi.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/SharingChargeSBReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/SharingChargeSBReaction.java
@@ -136,7 +136,7 @@ public class SharingChargeSBReaction extends ReactionEngine implements IReaction
                     IBond bondi = bondis.next();
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER) && atomj.getFormalCharge() == 0)
                             if (reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -187,7 +187,7 @@ public class SharingChargeSBReaction extends ReactionEngine implements IReaction
                     IBond bondi = bondis.next();
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
 
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFormalCharge() == 0) if (reactant.getConnectedSingleElectronsCount(atomj) == 0) {
                             atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                             bondi.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/SharingLonePairReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/SharingLonePairReaction.java
@@ -134,7 +134,7 @@ public class SharingLonePairReaction extends ReactionEngine implements IReaction
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.SINGLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER) && atomj.getFormalCharge() == 1
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
 
@@ -184,7 +184,7 @@ public class SharingLonePairReaction extends ReactionEngine implements IReaction
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getOrder() == IBond.Order.SINGLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi);
+                        IAtom atomj = bondi.getOther(atomi);
                         if (atomj.getFormalCharge() == 1 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
                             atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                             atomj.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/TautomerizationReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/TautomerizationReaction.java
@@ -136,7 +136,7 @@ public class TautomerizationReaction extends ReactionEngine implements IReaction
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getFlag(CDKConstants.REACTIVE_CENTER) && bondi.getOrder() == IBond.Order.DOUBLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi); // Atom pos 2
+                        IAtom atomj = bondi.getOther(atomi); // Atom pos 2
                         if (atomj.getFlag(CDKConstants.REACTIVE_CENTER)
                                 && (atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
@@ -146,7 +146,7 @@ public class TautomerizationReaction extends ReactionEngine implements IReaction
                                 if (bondj.equals(bondi)) continue;
                                 if (bondj.getFlag(CDKConstants.REACTIVE_CENTER)
                                         && bondj.getOrder() == IBond.Order.SINGLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj); // Atom pos 3
+                                    IAtom atomk = bondj.getOther(atomj); // Atom pos 3
                                     if (atomk.getFlag(CDKConstants.REACTIVE_CENTER)
                                             && (atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk
                                                     .getFormalCharge()) == 0
@@ -157,7 +157,7 @@ public class TautomerizationReaction extends ReactionEngine implements IReaction
                                             if (bondk.equals(bondj)) continue;
                                             if (bondk.getFlag(CDKConstants.REACTIVE_CENTER)
                                                     && bondk.getOrder() == IBond.Order.SINGLE) {
-                                                IAtom atoml = bondk.getConnectedAtom(atomk); // Atom pos 4
+                                                IAtom atoml = bondk.getOther(atomk); // Atom pos 4
                                                 if (atoml.getFlag(CDKConstants.REACTIVE_CENTER)
                                                         && atoml.getSymbol().equals("H")) {
 
@@ -226,7 +226,7 @@ public class TautomerizationReaction extends ReactionEngine implements IReaction
                 while (bondis.hasNext()) {
                     IBond bondi = bondis.next();
                     if (bondi.getOrder() == IBond.Order.DOUBLE) {
-                        IAtom atomj = bondi.getConnectedAtom(atomi); // Atom pos 2
+                        IAtom atomj = bondi.getOther(atomi); // Atom pos 2
                         if ((atomj.getFormalCharge() == CDKConstants.UNSET ? 0 : atomj.getFormalCharge()) == 0
                                 && reactant.getConnectedSingleElectronsCount(atomj) == 0) {
                             Iterator<IBond> bondjs = reactant.getConnectedBondsList(atomj).iterator();
@@ -234,7 +234,7 @@ public class TautomerizationReaction extends ReactionEngine implements IReaction
                                 IBond bondj = bondjs.next();
                                 if (bondj.equals(bondi)) continue;
                                 if (bondj.getOrder() == IBond.Order.SINGLE) {
-                                    IAtom atomk = bondj.getConnectedAtom(atomj); // Atom pos 3
+                                    IAtom atomk = bondj.getOther(atomj); // Atom pos 3
                                     if ((atomk.getFormalCharge() == CDKConstants.UNSET ? 0 : atomk.getFormalCharge()) == 0
                                             && reactant.getConnectedSingleElectronsCount(atomk) == 0) {
                                         Iterator<IBond> bondks = reactant.getConnectedBondsList(atomk).iterator();
@@ -242,7 +242,7 @@ public class TautomerizationReaction extends ReactionEngine implements IReaction
                                             IBond bondk = bondks.next();
                                             if (bondk.equals(bondj)) continue;
                                             if (bondk.getOrder() == IBond.Order.SINGLE) {
-                                                IAtom atoml = bondk.getConnectedAtom(atomk); // Atom pos 4
+                                                IAtom atoml = bondk.getOther(atomk); // Atom pos 4
                                                 if (atoml.getSymbol().equals("H")) {
                                                     atomi.setFlag(CDKConstants.REACTIVE_CENTER, true);
                                                     atomj.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/main/java/org/openscience/cdk/tools/StructureResonanceGenerator.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/tools/StructureResonanceGenerator.java
@@ -335,8 +335,8 @@ public class StructureResonanceGenerator {
             for (int j = 0; j < bondList.size(); j++) {
                 if (flagBelonging[j] != i + 1) continue;
                 IBond bond = bondList.get(j);
-                IAtom atomA1 = bond.getAtom(0);
-                IAtom atomA2 = bond.getAtom(1);
+                IAtom atomA1 = bond.getBeg();
+                IAtom atomA2 = bond.getEnd();
                 if (!container.contains(atomA1)) container.addAtom(atomA1);
                 if (!container.contains(atomA2)) container.addAtom(atomA2);
                 container.addBond(bond);

--- a/base/reaction/src/main/java/org/openscience/cdk/tools/StructureResonanceGenerator.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/tools/StructureResonanceGenerator.java
@@ -335,7 +335,7 @@ public class StructureResonanceGenerator {
             for (int j = 0; j < bondList.size(); j++) {
                 if (flagBelonging[j] != i + 1) continue;
                 IBond bond = bondList.get(j);
-                IAtom atomA1 = bond.getBeg();
+                IAtom atomA1 = bond.getBegin();
                 IAtom atomA2 = bond.getEnd();
                 if (!container.contains(atomA1)) container.addAtom(atomA1);
                 if (!container.contains(atomA2)) container.addAtom(atomA2);

--- a/base/reaction/src/test/java/org/openscience/cdk/reaction/type/ElectronImpactPDBReactionTest.java
+++ b/base/reaction/src/test/java/org/openscience/cdk/reaction/type/ElectronImpactPDBReactionTest.java
@@ -100,7 +100,7 @@ public class ElectronImpactPDBReactionTest extends ReactionProcessTest {
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = (IBond) bonds.next();
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (bond.getOrder() == IBond.Order.DOUBLE && atom1.getSymbol().equals("C") && atom2.getSymbol().equals("C")) {
                 bond.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/test/java/org/openscience/cdk/reaction/type/ElectronImpactPDBReactionTest.java
+++ b/base/reaction/src/test/java/org/openscience/cdk/reaction/type/ElectronImpactPDBReactionTest.java
@@ -100,8 +100,8 @@ public class ElectronImpactPDBReactionTest extends ReactionProcessTest {
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = (IBond) bonds.next();
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (bond.getOrder() == IBond.Order.DOUBLE && atom1.getSymbol().equals("C") && atom2.getSymbol().equals("C")) {
                 bond.setFlag(CDKConstants.REACTIVE_CENTER, true);
                 atom1.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/test/java/org/openscience/cdk/reaction/type/ElectronImpactSDBReactionTest.java
+++ b/base/reaction/src/test/java/org/openscience/cdk/reaction/type/ElectronImpactSDBReactionTest.java
@@ -84,7 +84,7 @@ public class ElectronImpactSDBReactionTest extends ReactionProcessTest {
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = (IBond) bonds.next();
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (bond.getOrder() == IBond.Order.SINGLE && atom1.getSymbol().equals("C") && atom2.getSymbol().equals("C")) {
                 bond.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/reaction/src/test/java/org/openscience/cdk/reaction/type/ElectronImpactSDBReactionTest.java
+++ b/base/reaction/src/test/java/org/openscience/cdk/reaction/type/ElectronImpactSDBReactionTest.java
@@ -84,8 +84,8 @@ public class ElectronImpactSDBReactionTest extends ReactionProcessTest {
         Iterator<IBond> bonds = reactant.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = (IBond) bonds.next();
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (bond.getOrder() == IBond.Order.SINGLE && atom1.getSymbol().equals("C") && atom2.getSymbol().equals("C")) {
                 bond.setFlag(CDKConstants.REACTIVE_CENTER, true);
                 atom1.setFlag(CDKConstants.REACTIVE_CENTER, true);

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
@@ -33,7 +33,6 @@ import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IChemObjectChangeEvent;
 import org.openscience.cdk.interfaces.IChemObjectListener;
 import org.openscience.cdk.interfaces.IElectronContainer;
@@ -722,7 +721,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public IBond getBond(IAtom atom1, IAtom atom2) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bonds[i].contains(atom1) && bonds[i].getConnectedAtom(atom1) == atom2) {
+            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1) == atom2) {
                 return bonds[i];
             }
         }
@@ -789,7 +788,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     public List<IAtom> getConnectedAtomsList(IAtom atom) {
         List<IAtom> atomsList = new ArrayList<IAtom>();
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i].contains(atom)) atomsList.add(bonds[i].getConnectedAtom(atom));
+            if (bonds[i].contains(atom)) atomsList.add(bonds[i].getOther(atom));
         }
         return atomsList;
     }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -233,7 +233,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     /**
      * {@inheritDoc}
      */
-    public IAtom getBeg() {
+    public IAtom getBegin() {
         return atoms[0];
     }
 

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -247,28 +247,26 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     }
 
     /**
-     * Returns the atom connected to the given atom.
-     * 
-     * This method is only strictly relevant for 2-center bonds
-     * since in multi-center bonds, a given atom will be connected
-     * to multiple atoms.
-     * 
-     * If called for a multi-center bond, then the next atom in the
-     * atom list is returned. This is probably not what is expected and
-     * hence the user should instead call
-     * {@link #getConnectedAtoms(org.openscience.cdk.interfaces.IAtom)}
-     *
-     * @param atom The atom the bond partner is searched of
-     * @return the connected atom or null  if the atom is not part of the bond
-     * @see #getConnectedAtoms(org.openscience.cdk.interfaces.IAtom)
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom getOther(IAtom atom) {
+        if (atoms[0] == atom)
+            return atoms[1];
+        else if (atoms[1] == atom)
+            return atoms[0];
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public IAtom getConnectedAtom(IAtom atom) {
-        if (atoms[0] == atom) {
+        if (atoms[0] == atom)
             return atoms[1];
-        } else if (atoms[1] == atom) {
+        else if (atoms[1] == atom)
             return atoms[0];
-        }
         return null;
     }
 
@@ -281,7 +279,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      *
      * @param atom The atom whose partners are to be searched for
      * @return An array of the connected atoms, null if the atom is not part of the bond
-     * @see #getConnectedAtom(org.openscience.cdk.interfaces.IAtom)
+     * @see #getOther(org.openscience.cdk.interfaces.IAtom)
      */
     @Override
     public IAtom[] getConnectedAtoms(IAtom atom) {

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -271,32 +271,21 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     }
 
     /**
-     * Returns all the atoms in the bond connected to the specified atom.
-     * 
-     * Though this can be used for traditional 2-center bonds, it is oriented
-     * towards multi-center bonds, where a single atom is connected to multiple
-     * atoms.
-     *
-     * @param atom The atom whose partners are to be searched for
-     * @return An array of the connected atoms, null if the atom is not part of the bond
-     * @see #getOther(org.openscience.cdk.interfaces.IAtom)
+     * {@inheritDoc}
      */
     @Override
     public IAtom[] getConnectedAtoms(IAtom atom) {
-        boolean atomIsInBond = false;
-        for (IAtom localAtom : atoms) {
-            if (localAtom == atom) {
-                atomIsInBond = true;
-                break;
+        if (atomCount < 1) return null;
+        IAtom[] connected = new IAtom[atomCount-1];
+        int j = 0;
+        for (int i = 0; i < atomCount; i++) {
+            if (this.atoms[i] != atom) {
+                if (j >= connected.length)
+                    return null;
+                connected[j++] = this.atoms[i];
             }
         }
-        if (!atomIsInBond) return null;
-
-        List<IAtom> conAtoms = new ArrayList<IAtom>();
-        for (IAtom localAtom : atoms) {
-            if (localAtom != atom) conAtoms.add(localAtom);
-        }
-        return conAtoms.toArray(new IAtom[]{});
+        return connected;
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -77,7 +77,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     /**
      * A list of atoms participating in this bond.
      */
-    protected IAtom[]         atoms            = null;
+    protected IAtom[]         atoms            = new IAtom[2];
 
     /**
      * A descriptor the stereochemical orientation of this bond.
@@ -141,15 +141,14 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      * Constructs a bond with a given order and stereo orientation from an array
      * of atoms.
      *
-     * @param atom1  the first Atom in the bond
-     * @param atom2  the second Atom in the bond
+     * @param beg  the first Atom in the bond
+     * @param end  the second Atom in the bond
      * @param order  the bond order
      * @param stereo a descriptor the stereochemical orientation of this bond
      */
-    public Bond(IAtom atom1, IAtom atom2, Order order, IBond.Stereo stereo) {
-        atoms = new IAtom[2];
-        atoms[0] = atom1;
-        atoms[1] = atom2;
+    public Bond(IAtom beg, IAtom end, Order order, IBond.Stereo stereo) {
+        atoms[0] = beg;
+        atoms[1] = end;
         setOrder(order);
         this.stereo = stereo;
         this.atomCount = 2;
@@ -231,6 +230,20 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
             return null;
         else
             return atoms[position];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IAtom getBeg() {
+        return atoms[0];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IAtom getEnd() {
+        return atoms[1];
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -20,9 +20,7 @@
 package org.openscience.cdk.silent;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;

--- a/base/silent/src/test/java/org/openscience/cdk/silent/BondTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/BondTest.java
@@ -67,8 +67,8 @@ public class BondTest extends AbstractBondTest {
 
         IBond bond1 = new Bond(new IAtom[]{atom1, atom2, atom3, atom4, atom5});
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getAtom(0));
-        Assert.assertEquals(atom2, bond1.getAtom(1));
+        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom2, bond1.getEnd());
     }
 
     @Test
@@ -82,8 +82,8 @@ public class BondTest extends AbstractBondTest {
 
         IBond bond1 = new Bond(new IAtom[]{atom1, atom2, atom3, atom4, atom5}, IBond.Order.SINGLE);
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getAtom(0));
-        Assert.assertEquals(atom2, bond1.getAtom(1));
+        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom2, bond1.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond1.getOrder());
     }
 

--- a/base/silent/src/test/java/org/openscience/cdk/silent/BondTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/BondTest.java
@@ -50,8 +50,8 @@ public class BondTest extends AbstractBondTest {
     public void testBond() {
         IBond bond = new Bond();
         Assert.assertEquals(0, bond.getAtomCount());
-        Assert.assertNull(bond.getAtom(0));
-        Assert.assertNull(bond.getAtom(1));
+        Assert.assertNull(bond.getBeg());
+        Assert.assertNull(bond.getEnd());
         Assert.assertNull(bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -95,8 +95,8 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -109,8 +109,8 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o, IBond.Order.DOUBLE);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.DOUBLE);
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
     }
@@ -123,8 +123,8 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o, IBond.Order.SINGLE, IBond.Stereo.UP);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getAtom(0));
-        Assert.assertEquals(o, bond.getAtom(1));
+        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.SINGLE);
         Assert.assertEquals(IBond.Stereo.UP, bond.getStereo());
     }

--- a/base/silent/src/test/java/org/openscience/cdk/silent/BondTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/BondTest.java
@@ -50,7 +50,7 @@ public class BondTest extends AbstractBondTest {
     public void testBond() {
         IBond bond = new Bond();
         Assert.assertEquals(0, bond.getAtomCount());
-        Assert.assertNull(bond.getBeg());
+        Assert.assertNull(bond.getBegin());
         Assert.assertNull(bond.getEnd());
         Assert.assertNull(bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -67,7 +67,7 @@ public class BondTest extends AbstractBondTest {
 
         IBond bond1 = new Bond(new IAtom[]{atom1, atom2, atom3, atom4, atom5});
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom1, bond1.getBegin());
         Assert.assertEquals(atom2, bond1.getEnd());
     }
 
@@ -82,7 +82,7 @@ public class BondTest extends AbstractBondTest {
 
         IBond bond1 = new Bond(new IAtom[]{atom1, atom2, atom3, atom4, atom5}, IBond.Order.SINGLE);
         Assert.assertEquals(5, bond1.getAtomCount());
-        Assert.assertEquals(atom1, bond1.getBeg());
+        Assert.assertEquals(atom1, bond1.getBegin());
         Assert.assertEquals(atom2, bond1.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond1.getOrder());
     }
@@ -95,7 +95,7 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, bond.getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -109,7 +109,7 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o, IBond.Order.DOUBLE);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.DOUBLE);
         Assert.assertEquals(IBond.Stereo.NONE, bond.getStereo());
@@ -123,7 +123,7 @@ public class BondTest extends AbstractBondTest {
         IBond bond = new Bond(c, o, IBond.Order.SINGLE, IBond.Stereo.UP);
 
         Assert.assertEquals(2, bond.getAtomCount());
-        Assert.assertEquals(c, bond.getBeg());
+        Assert.assertEquals(c, bond.getBegin());
         Assert.assertEquals(o, bond.getEnd());
         Assert.assertTrue(bond.getOrder() == IBond.Order.SINGLE);
         Assert.assertEquals(IBond.Stereo.UP, bond.getStereo());

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
@@ -245,7 +245,7 @@ public final class Aromaticity {
         // set the new flags
         for (final IBond bond : bonds) {
             bond.setIsAromatic(true);
-            bond.getBeg().setIsAromatic(true);
+            bond.getBegin().setIsAromatic(true);
             bond.getEnd().setIsAromatic(true);
         }
 

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
@@ -245,8 +245,8 @@ public final class Aromaticity {
         // set the new flags
         for (final IBond bond : bonds) {
             bond.setIsAromatic(true);
-            bond.getAtom(0).setIsAromatic(true);
-            bond.getAtom(1).setIsAromatic(true);
+            bond.getBeg().setIsAromatic(true);
+            bond.getEnd().setIsAromatic(true);
         }
 
         molecule.setFlag(ISAROMATIC, !bonds.isEmpty());

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
@@ -122,7 +122,7 @@ final class AtomTypeModel extends ElectronDonation {
         for (IBond bond : container.bonds()) {
             if (bond.getOrder() == IBond.Order.DOUBLE || bond.getOrder() == IBond.Order.TRIPLE) {
 
-                IAtom a1 = bond.getBeg();
+                IAtom a1 = bond.getBegin();
                 IAtom a2 = bond.getEnd();
 
                 String a1Type = a1.getAtomTypeName();

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
@@ -122,8 +122,8 @@ final class AtomTypeModel extends ElectronDonation {
         for (IBond bond : container.bonds()) {
             if (bond.getOrder() == IBond.Order.DOUBLE || bond.getOrder() == IBond.Order.TRIPLE) {
 
-                IAtom a1 = bond.getAtom(0);
-                IAtom a2 = bond.getAtom(1);
+                IAtom a1 = bond.getBeg();
+                IAtom a2 = bond.getEnd();
 
                 String a1Type = a1.getAtomTypeName();
                 String a2Type = a2.getAtomTypeName();

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
@@ -106,8 +106,8 @@ final class DaylightModel extends ElectronDonation {
         // if there is an exocyclic pi bond we store the adjacent atom for
         // lookup later.
         for (IBond bond : container.bonds()) {
-            int u = atomIndex.get(bond.getAtom(0));
-            int v = atomIndex.get(bond.getAtom(1));
+            int u = atomIndex.get(bond.getBeg());
+            int v = atomIndex.get(bond.getEnd());
             degree[u]++;
             degree[v]++;
 

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
@@ -106,7 +106,7 @@ final class DaylightModel extends ElectronDonation {
         // if there is an exocyclic pi bond we store the adjacent atom for
         // lookup later.
         for (IBond bond : container.bonds()) {
-            int u = atomIndex.get(bond.getBeg());
+            int u = atomIndex.get(bond.getBegin());
             int v = atomIndex.get(bond.getEnd());
             degree[u]++;
             degree[v]++;

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/PiBondModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/PiBondModel.java
@@ -51,8 +51,8 @@ final class PiBondModel extends ElectronDonation {
 
         // count number of cyclic pi bonds
         for (IBond bond : container.bonds()) {
-            int u = container.indexOf(bond.getAtom(0));
-            int v = container.indexOf(bond.getAtom(1));
+            int u = container.indexOf(bond.getBeg());
+            int v = container.indexOf(bond.getEnd());
 
             if (bond.getOrder() == DOUBLE && ringSearch.cyclic(u, v)) {
                 piBonds[u]++;

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/PiBondModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/PiBondModel.java
@@ -51,7 +51,7 @@ final class PiBondModel extends ElectronDonation {
 
         // count number of cyclic pi bonds
         for (IBond bond : container.bonds()) {
-            int u = container.indexOf(bond.getBeg());
+            int u = container.indexOf(bond.getBegin());
             int v = container.indexOf(bond.getEnd());
 
             if (bond.getOrder() == DOUBLE && ringSearch.cyclic(u, v)) {

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -22,14 +22,12 @@
  */
 package org.openscience.cdk.fingerprint;
 
-import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.graph.PathTools;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.ringsearch.AllRingsFinder;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
@@ -342,7 +340,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
             for (IBond bond : state.getBonds(beg)) {
                 if (bond == prev)
                     continue;
-                final IAtom nbr = bond.getConnectedAtom(beg);
+                final IAtom nbr = bond.getOther(beg);
                 if (state.visit(nbr)) {
                     traversePaths(state, nbr, bond);
                     state.unvisit(nbr); // traverse all paths

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/HybridizationFingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/HybridizationFingerprinter.java
@@ -116,7 +116,7 @@ public class HybridizationFingerprinter extends Fingerprinter implements IFinger
      * Returns true if the bond binds two atoms, and both atoms are SP2.
      */
     private boolean isSP2Bond(IBond bond) {
-        return bond.getAtomCount() == 2 && bond.getAtom(0).getHybridization() == Hybridization.SP2
-               && bond.getAtom(1).getHybridization() == Hybridization.SP2;
+        return bond.getAtomCount() == 2 && bond.getBeg().getHybridization() == Hybridization.SP2
+               && bond.getEnd().getHybridization() == Hybridization.SP2;
     }
 }

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/HybridizationFingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/HybridizationFingerprinter.java
@@ -116,7 +116,7 @@ public class HybridizationFingerprinter extends Fingerprinter implements IFinger
      * Returns true if the bond binds two atoms, and both atoms are SP2.
      */
     private boolean isSP2Bond(IBond bond) {
-        return bond.getAtomCount() == 2 && bond.getBeg().getHybridization() == Hybridization.SP2
+        return bond.getAtomCount() == 2 && bond.getBegin().getHybridization() == Hybridization.SP2
                && bond.getEnd().getHybridization() == Hybridization.SP2;
     }
 }

--- a/base/standard/src/main/java/org/openscience/cdk/geometry/BondTools.java
+++ b/base/standard/src/main/java/org/openscience/cdk/geometry/BondTools.java
@@ -59,10 +59,10 @@ public class BondTools {
      */
     public static boolean isValidDoubleBondConfiguration(IAtomContainer container, IBond bond) {
         //org.openscience.cdk.interfaces.IAtom[] atoms = bond.getAtoms();
-        List<IAtom> connectedAtoms = container.getConnectedAtomsList(bond.getAtom(0));
+        List<IAtom> connectedAtoms = container.getConnectedAtomsList(bond.getBeg());
         IAtom from = null;
         for (IAtom connectedAtom : connectedAtoms) {
-            if (connectedAtom != bond.getAtom(1)) {
+            if (connectedAtom != bond.getEnd()) {
                 from = connectedAtom;
             }
         }
@@ -70,8 +70,8 @@ public class BondTools {
         for (int i = 0; i < array.length; i++) {
             array[i] = true;
         }
-        if (isStartOfDoubleBond(container, bond.getAtom(0), from, array)
-                && isEndOfDoubleBond(container, bond.getAtom(1), bond.getAtom(0), array)
+        if (isStartOfDoubleBond(container, bond.getBeg(), from, array)
+                && isEndOfDoubleBond(container, bond.getEnd(), bond.getBeg(), array)
                 && !bond.getFlag(CDKConstants.ISAROMATIC)) {
             return (true);
         } else {

--- a/base/standard/src/main/java/org/openscience/cdk/geometry/BondTools.java
+++ b/base/standard/src/main/java/org/openscience/cdk/geometry/BondTools.java
@@ -59,7 +59,7 @@ public class BondTools {
      */
     public static boolean isValidDoubleBondConfiguration(IAtomContainer container, IBond bond) {
         //org.openscience.cdk.interfaces.IAtom[] atoms = bond.getAtoms();
-        List<IAtom> connectedAtoms = container.getConnectedAtomsList(bond.getBeg());
+        List<IAtom> connectedAtoms = container.getConnectedAtomsList(bond.getBegin());
         IAtom from = null;
         for (IAtom connectedAtom : connectedAtoms) {
             if (connectedAtom != bond.getEnd()) {
@@ -70,8 +70,8 @@ public class BondTools {
         for (int i = 0; i < array.length; i++) {
             array[i] = true;
         }
-        if (isStartOfDoubleBond(container, bond.getBeg(), from, array)
-                && isEndOfDoubleBond(container, bond.getEnd(), bond.getBeg(), array)
+        if (isStartOfDoubleBond(container, bond.getBegin(), from, array)
+                && isEndOfDoubleBond(container, bond.getEnd(), bond.getBegin(), array)
                 && !bond.getFlag(CDKConstants.ISAROMATIC)) {
             return (true);
         } else {

--- a/base/standard/src/main/java/org/openscience/cdk/geometry/GeometryUtil.java
+++ b/base/standard/src/main/java/org/openscience/cdk/geometry/GeometryUtil.java
@@ -660,13 +660,13 @@ public final class GeometryUtil {
      * @return The array with the coordinates
      */
     public static int[] getBondCoordinates(IBond bond) {
-        if (bond.getBeg().getPoint2d() == null || bond.getEnd().getPoint2d() == null) {
+        if (bond.getBegin().getPoint2d() == null || bond.getEnd().getPoint2d() == null) {
             logger.error("getBondCoordinates() called on Bond without 2D coordinates!");
             return new int[0];
         }
-        int beginX = (int) bond.getBeg().getPoint2d().x;
+        int beginX = (int) bond.getBegin().getPoint2d().x;
         int endX = (int) bond.getEnd().getPoint2d().x;
-        int beginY = (int) bond.getBeg().getPoint2d().y;
+        int beginY = (int) bond.getBegin().getPoint2d().y;
         int endY = (int) bond.getEnd().getPoint2d().y;
         return new int[]{beginX, beginY, endX, endY};
     }
@@ -906,7 +906,7 @@ public final class GeometryUtil {
         int bondCounter = 0;
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (atom1.getPoint2d() != null && atom2.getPoint2d() != null) {
                 bondCounter++;
@@ -924,10 +924,10 @@ public final class GeometryUtil {
      * @return The geometric length of this bond
      */
     public static double getLength2D(IBond bond) {
-        if (bond.getBeg() == null || bond.getEnd() == null) {
+        if (bond.getBegin() == null || bond.getEnd() == null) {
             return 0.0;
         }
-        Point2d point1 = bond.getBeg().getPoint2d();
+        Point2d point1 = bond.getBegin().getPoint2d();
         Point2d point2 = bond.getEnd().getPoint2d();
         if (point1 == null || point2 == null) {
             return 0.0;
@@ -1143,7 +1143,7 @@ public final class GeometryUtil {
             // only consider two atom bonds into account
             if (bond.getAtomCount() == 2) {
                 counter++;
-                IAtom atom1 = bond.getBeg();
+                IAtom atom1 = bond.getBegin();
                 IAtom atom2 = bond.getEnd();
                 bondlength += Math.sqrt(Math.pow(atom1.getPoint2d().x - atom2.getPoint2d().x, 2)
                         + Math.pow(atom1.getPoint2d().y - atom2.getPoint2d().y, 2));
@@ -1565,7 +1565,7 @@ public final class GeometryUtil {
         double bondLengthSum = 0;
         int bondCounter = 0;
         for (IBond bond : container.bonds()) {
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (atom1.getPoint3d() != null && atom2.getPoint3d() != null) {
                 bondCounter++;
@@ -1644,7 +1644,7 @@ public final class GeometryUtil {
         double[] lengths = new double[container.getBondCount()];
         for (int i = 0; i < container.getBondCount(); i++) {
             final IBond bond = container.getBond(i);
-            final IAtom atom1 = bond.getBeg();
+            final IAtom atom1 = bond.getBegin();
             final IAtom atom2 = bond.getEnd();
             Point2d p1 = atom1.getPoint2d();
             Point2d p2 = atom2.getPoint2d();

--- a/base/standard/src/main/java/org/openscience/cdk/geometry/GeometryUtil.java
+++ b/base/standard/src/main/java/org/openscience/cdk/geometry/GeometryUtil.java
@@ -660,14 +660,14 @@ public final class GeometryUtil {
      * @return The array with the coordinates
      */
     public static int[] getBondCoordinates(IBond bond) {
-        if (bond.getAtom(0).getPoint2d() == null || bond.getAtom(1).getPoint2d() == null) {
+        if (bond.getBeg().getPoint2d() == null || bond.getEnd().getPoint2d() == null) {
             logger.error("getBondCoordinates() called on Bond without 2D coordinates!");
             return new int[0];
         }
-        int beginX = (int) bond.getAtom(0).getPoint2d().x;
-        int endX = (int) bond.getAtom(1).getPoint2d().x;
-        int beginY = (int) bond.getAtom(0).getPoint2d().y;
-        int endY = (int) bond.getAtom(1).getPoint2d().y;
+        int beginX = (int) bond.getBeg().getPoint2d().x;
+        int endX = (int) bond.getEnd().getPoint2d().x;
+        int beginY = (int) bond.getBeg().getPoint2d().y;
+        int endY = (int) bond.getEnd().getPoint2d().y;
         return new int[]{beginX, beginY, endX, endY};
     }
 
@@ -906,8 +906,8 @@ public final class GeometryUtil {
         int bondCounter = 0;
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (atom1.getPoint2d() != null && atom2.getPoint2d() != null) {
                 bondCounter++;
                 bondLengthSum += getLength2D(bond);
@@ -924,11 +924,11 @@ public final class GeometryUtil {
      * @return The geometric length of this bond
      */
     public static double getLength2D(IBond bond) {
-        if (bond.getAtom(0) == null || bond.getAtom(1) == null) {
+        if (bond.getBeg() == null || bond.getEnd() == null) {
             return 0.0;
         }
-        Point2d point1 = bond.getAtom(0).getPoint2d();
-        Point2d point2 = bond.getAtom(1).getPoint2d();
+        Point2d point1 = bond.getBeg().getPoint2d();
+        Point2d point2 = bond.getEnd().getPoint2d();
         if (point1 == null || point2 == null) {
             return 0.0;
         }
@@ -1143,8 +1143,8 @@ public final class GeometryUtil {
             // only consider two atom bonds into account
             if (bond.getAtomCount() == 2) {
                 counter++;
-                IAtom atom1 = bond.getAtom(0);
-                IAtom atom2 = bond.getAtom(1);
+                IAtom atom1 = bond.getBeg();
+                IAtom atom2 = bond.getEnd();
                 bondlength += Math.sqrt(Math.pow(atom1.getPoint2d().x - atom2.getPoint2d().x, 2)
                         + Math.pow(atom1.getPoint2d().y - atom2.getPoint2d().y, 2));
             }
@@ -1565,8 +1565,8 @@ public final class GeometryUtil {
         double bondLengthSum = 0;
         int bondCounter = 0;
         for (IBond bond : container.bonds()) {
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (atom1.getPoint3d() != null && atom2.getPoint3d() != null) {
                 bondCounter++;
                 bondLengthSum += atom1.getPoint3d().distance(atom2.getPoint3d());
@@ -1644,8 +1644,8 @@ public final class GeometryUtil {
         double[] lengths = new double[container.getBondCount()];
         for (int i = 0; i < container.getBondCount(); i++) {
             final IBond bond = container.getBond(i);
-            final IAtom atom1 = bond.getAtom(0);
-            final IAtom atom2 = bond.getAtom(1);
+            final IAtom atom1 = bond.getBeg();
+            final IAtom atom2 = bond.getEnd();
             Point2d p1 = atom1.getPoint2d();
             Point2d p2 = atom2.getPoint2d();
             if (p1 == null || p2 == null)

--- a/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
@@ -105,7 +105,7 @@ public class ConnectivityChecker {
         }
 
         for (IBond bond : container.bonds()) {
-            IAtomContainer begComp = componentsMap.get(bond.getBeg());
+            IAtomContainer begComp = componentsMap.get(bond.getBegin());
             IAtomContainer endComp = componentsMap.get(bond.getEnd());
             if (begComp == endComp)
                 begComp.addBond(bond);
@@ -123,8 +123,8 @@ public class ConnectivityChecker {
                 if (componentsMap.containsKey(a)) componentsMap.get(a).addStereoElement(stereo);
             } else if (stereo instanceof IDoubleBondStereochemistry) {
                 IBond bond = ((IDoubleBondStereochemistry) stereo).getStereoBond();
-                if (componentsMap.containsKey(bond.getBeg()) && componentsMap.containsKey(bond.getEnd()))
-                    componentsMap.get(bond.getBeg()).addStereoElement(stereo);
+                if (componentsMap.containsKey(bond.getBegin()) && componentsMap.containsKey(bond.getEnd()))
+                    componentsMap.get(bond.getBegin()).addStereoElement(stereo);
             } else if (stereo instanceof ExtendedTetrahedral) {
                 IAtom atom = ((ExtendedTetrahedral) stereo).focus();
                 if (componentsMap.containsKey(atom)) componentsMap.get(atom).addStereoElement(stereo);

--- a/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
@@ -105,8 +105,8 @@ public class ConnectivityChecker {
         }
 
         for (IBond bond : container.bonds()) {
-            IAtomContainer begComp = componentsMap.get(bond.getAtom(0));
-            IAtomContainer endComp = componentsMap.get(bond.getAtom(1));
+            IAtomContainer begComp = componentsMap.get(bond.getBeg());
+            IAtomContainer endComp = componentsMap.get(bond.getEnd());
             if (begComp == endComp)
                 begComp.addBond(bond);
         }
@@ -123,8 +123,8 @@ public class ConnectivityChecker {
                 if (componentsMap.containsKey(a)) componentsMap.get(a).addStereoElement(stereo);
             } else if (stereo instanceof IDoubleBondStereochemistry) {
                 IBond bond = ((IDoubleBondStereochemistry) stereo).getStereoBond();
-                if (componentsMap.containsKey(bond.getAtom(0)) && componentsMap.containsKey(bond.getAtom(1)))
-                    componentsMap.get(bond.getAtom(0)).addStereoElement(stereo);
+                if (componentsMap.containsKey(bond.getBeg()) && componentsMap.containsKey(bond.getEnd()))
+                    componentsMap.get(bond.getBeg()).addStereoElement(stereo);
             } else if (stereo instanceof ExtendedTetrahedral) {
                 IAtom atom = ((ExtendedTetrahedral) stereo).focus();
                 if (componentsMap.containsKey(atom)) componentsMap.get(atom).addStereoElement(stereo);

--- a/base/standard/src/main/java/org/openscience/cdk/graph/invariant/MorganNumbersTools.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/invariant/MorganNumbersTools.java
@@ -73,7 +73,7 @@ public class MorganNumbersTools {
         // build the graph and initialise the current connectivity
         // value to the number of connected non-hydrogens
         for (IBond bond : molecule.bonds()) {
-            int u = molecule.indexOf(bond.getBeg());
+            int u = molecule.indexOf(bond.getBegin());
             int v = molecule.indexOf(bond.getEnd());
             graph[u] = Ints.ensureCapacity(graph[u], degree[u] + 1, INITIAL_DEGREE);
             graph[v] = Ints.ensureCapacity(graph[v], degree[v] + 1, INITIAL_DEGREE);

--- a/base/standard/src/main/java/org/openscience/cdk/graph/invariant/MorganNumbersTools.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/invariant/MorganNumbersTools.java
@@ -73,8 +73,8 @@ public class MorganNumbersTools {
         // build the graph and initialise the current connectivity
         // value to the number of connected non-hydrogens
         for (IBond bond : molecule.bonds()) {
-            int u = molecule.indexOf(bond.getAtom(0));
-            int v = molecule.indexOf(bond.getAtom(1));
+            int u = molecule.indexOf(bond.getBeg());
+            int v = molecule.indexOf(bond.getEnd());
             graph[u] = Ints.ensureCapacity(graph[u], degree[u] + 1, INITIAL_DEGREE);
             graph[v] = Ints.ensureCapacity(graph[v], degree[v] + 1, INITIAL_DEGREE);
             graph[u][degree[u]++] = v;

--- a/base/standard/src/main/java/org/openscience/cdk/graph/matrix/ConnectionMatrix.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/matrix/ConnectionMatrix.java
@@ -52,7 +52,7 @@ public class ConnectionMatrix implements IGraphMatrix {
         double[][] conMat = new double[container.getAtomCount()][container.getAtomCount()];
         for (int f = 0; f < container.getBondCount(); f++) {
             bond = container.getBond(f);
-            indexAtom1 = container.indexOf(bond.getBeg());
+            indexAtom1 = container.indexOf(bond.getBegin());
             indexAtom2 = container.indexOf(bond.getEnd());
             conMat[indexAtom1][indexAtom2] = BondManipulator.destroyBondOrder(bond.getOrder());
             conMat[indexAtom2][indexAtom1] = BondManipulator.destroyBondOrder(bond.getOrder());

--- a/base/standard/src/main/java/org/openscience/cdk/graph/matrix/ConnectionMatrix.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/matrix/ConnectionMatrix.java
@@ -52,8 +52,8 @@ public class ConnectionMatrix implements IGraphMatrix {
         double[][] conMat = new double[container.getAtomCount()][container.getAtomCount()];
         for (int f = 0; f < container.getBondCount(); f++) {
             bond = container.getBond(f);
-            indexAtom1 = container.indexOf(bond.getAtom(0));
-            indexAtom2 = container.indexOf(bond.getAtom(1));
+            indexAtom1 = container.indexOf(bond.getBeg());
+            indexAtom2 = container.indexOf(bond.getEnd());
             conMat[indexAtom1][indexAtom2] = BondManipulator.destroyBondOrder(bond.getOrder());
             conMat[indexAtom2][indexAtom1] = BondManipulator.destroyBondOrder(bond.getOrder());
         }

--- a/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
+++ b/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
@@ -934,10 +934,10 @@ public class UniversalIsomorphismTester {
         }
 
         if (centralAtom != null && centralQueryAtom != null && ((IQueryAtom) centralQueryAtom).matches(centralAtom)) {
-            IQueryAtom queryAtom1 = (IQueryAtom) queryBond1.getConnectedAtom(centralQueryAtom);
-            IQueryAtom queryAtom2 = (IQueryAtom) queryBond2.getConnectedAtom(centralQueryAtom);
-            IAtom atom1 = bond1.getConnectedAtom(centralAtom);
-            IAtom atom2 = bond2.getConnectedAtom(centralAtom);
+            IQueryAtom queryAtom1 = (IQueryAtom) queryBond1.getOther(centralQueryAtom);
+            IQueryAtom queryAtom2 = (IQueryAtom) queryBond2.getOther(centralQueryAtom);
+            IAtom atom1 = bond1.getOther(centralAtom);
+            IAtom atom2 = bond2.getOther(centralAtom);
             if (queryAtom1.matches(atom1) && queryAtom2.matches(atom2) || queryAtom1.matches(atom2)
                     && queryAtom2.matches(atom1)) {
                 return true;

--- a/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
+++ b/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
@@ -520,7 +520,7 @@ public class UniversalIsomorphismTester {
                 bond = g.getBond(rMap.getId2());
             }
 
-            a = bond.getBeg();
+            a = bond.getBegin();
             a1 = (IAtom) table.get(a);
 
             if (a1 == null) {
@@ -746,13 +746,13 @@ public class UniversalIsomorphismTester {
                 IBond bondA2 = ac2.getBond(j);
                 if (bondA2 instanceof IQueryBond) {
                     IQueryBond queryBond = (IQueryBond) bondA2;
-                    IQueryAtom atom1 = (IQueryAtom) (bondA2.getBeg());
+                    IQueryAtom atom1 = (IQueryAtom) (bondA2.getBegin());
                     IQueryAtom atom2 = (IQueryAtom) (bondA2.getEnd());
                     IBond bond = ac1.getBond(i);
                     if (queryBond.matches(bond)) {
                         // ok, bonds match
-                        if (atom1.matches(bond.getBeg()) && atom2.matches(bond.getEnd())
-                                || atom1.matches(bond.getEnd()) && atom2.matches(bond.getBeg())) {
+                        if (atom1.matches(bond.getBegin()) && atom2.matches(bond.getEnd())
+                                || atom1.matches(bond.getEnd()) && atom2.matches(bond.getBegin())) {
                             // ok, atoms match in either order
                             gr.addNode(new RNode(i, j));
                         }
@@ -768,10 +768,10 @@ public class UniversalIsomorphismTester {
                                     CDKConstants.ISAROMATIC)))
                             && ( // atom type conditions
                             ( // a1 = a2 && b1 = b2
-                            ac1.getBond(i).getBeg().getSymbol().equals(ac2.getBond(j).getBeg().getSymbol()) && ac1
+                              ac1.getBond(i).getBegin().getSymbol().equals(ac2.getBond(j).getBegin().getSymbol()) && ac1
                                     .getBond(i).getEnd().getSymbol().equals(ac2.getBond(j).getEnd().getSymbol())) || ( // a1 = b2 && b1 = a2
-                            ac1.getBond(i).getBeg().getSymbol().equals(ac2.getBond(j).getEnd().getSymbol()) && ac1
-                                    .getBond(i).getEnd().getSymbol().equals(ac2.getBond(j).getBeg().getSymbol())))) {
+                                                                                                                       ac1.getBond(i).getBegin().getSymbol().equals(ac2.getBond(j).getEnd().getSymbol()) && ac1
+                                    .getBond(i).getEnd().getSymbol().equals(ac2.getBond(j).getBegin().getSymbol())))) {
                         gr.addNode(new RNode(i, j));
                     }
                 }
@@ -850,7 +850,7 @@ public class UniversalIsomorphismTester {
      *            the 2 bonds have no common atom
      */
     private static boolean hasCommonAtom(IBond a, IBond b) {
-        return a.contains(b.getBeg()) || a.contains(b.getEnd());
+        return a.contains(b.getBegin()) || a.contains(b.getEnd());
     }
 
     /**
@@ -864,8 +864,8 @@ public class UniversalIsomorphismTester {
     private static String getCommonSymbol(IBond a, IBond b) {
         String symbol = "";
 
-        if (a.contains(b.getBeg())) {
-            symbol = b.getBeg().getSymbol();
+        if (a.contains(b.getBegin())) {
+            symbol = b.getBegin().getSymbol();
         } else if (a.contains(b.getEnd())) {
             symbol = b.getEnd().getSymbol();
         }
@@ -886,14 +886,14 @@ public class UniversalIsomorphismTester {
         IAtom atom1 = null;
         IAtom atom2 = null;
 
-        if (a1.contains(b1.getBeg())) {
-            atom1 = b1.getBeg();
+        if (a1.contains(b1.getBegin())) {
+            atom1 = b1.getBegin();
         } else if (a1.contains(b1.getEnd())) {
             atom1 = b1.getEnd();
         }
 
-        if (a2.contains(b2.getBeg())) {
-            atom2 = b2.getBeg();
+        if (a2.contains(b2.getBegin())) {
+            atom2 = b2.getBegin();
         } else if (a2.contains(b2.getEnd())) {
             atom2 = b2.getEnd();
         }
@@ -921,14 +921,14 @@ public class UniversalIsomorphismTester {
         IAtom centralAtom = null;
         IAtom centralQueryAtom = null;
 
-        if (bond1.contains(bond2.getBeg())) {
-            centralAtom = bond2.getBeg();
+        if (bond1.contains(bond2.getBegin())) {
+            centralAtom = bond2.getBegin();
         } else if (bond1.contains(bond2.getEnd())) {
             centralAtom = bond2.getEnd();
         }
 
-        if (queryBond1.contains(queryBond2.getBeg())) {
-            centralQueryAtom = queryBond2.getBeg();
+        if (queryBond1.contains(queryBond2.getBegin())) {
+            centralQueryAtom = queryBond2.getBegin();
         } else if (queryBond1.contains(queryBond2.getEnd())) {
             centralQueryAtom = queryBond2.getEnd();
         }

--- a/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
+++ b/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
@@ -520,7 +520,7 @@ public class UniversalIsomorphismTester {
                 bond = g.getBond(rMap.getId2());
             }
 
-            a = bond.getAtom(0);
+            a = bond.getBeg();
             a1 = (IAtom) table.get(a);
 
             if (a1 == null) {
@@ -533,7 +533,7 @@ public class UniversalIsomorphismTester {
                 table.put(a, a1);
             }
 
-            a = bond.getAtom(1);
+            a = bond.getEnd();
             a2 = table.get(a);
 
             if (a2 == null) {
@@ -751,8 +751,8 @@ public class UniversalIsomorphismTester {
                     IBond bond = ac1.getBond(i);
                     if (queryBond.matches(bond)) {
                         // ok, bonds match
-                        if (atom1.matches(bond.getAtom(0)) && atom2.matches(bond.getAtom(1))
-                                || atom1.matches(bond.getAtom(1)) && atom2.matches(bond.getAtom(0))) {
+                        if (atom1.matches(bond.getBeg()) && atom2.matches(bond.getEnd())
+                                || atom1.matches(bond.getEnd()) && atom2.matches(bond.getBeg())) {
                             // ok, atoms match in either order
                             gr.addNode(new RNode(i, j));
                         }

--- a/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
+++ b/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
@@ -746,8 +746,8 @@ public class UniversalIsomorphismTester {
                 IBond bondA2 = ac2.getBond(j);
                 if (bondA2 instanceof IQueryBond) {
                     IQueryBond queryBond = (IQueryBond) bondA2;
-                    IQueryAtom atom1 = (IQueryAtom) (bondA2.getAtom(0));
-                    IQueryAtom atom2 = (IQueryAtom) (bondA2.getAtom(1));
+                    IQueryAtom atom1 = (IQueryAtom) (bondA2.getBeg());
+                    IQueryAtom atom2 = (IQueryAtom) (bondA2.getEnd());
                     IBond bond = ac1.getBond(i);
                     if (queryBond.matches(bond)) {
                         // ok, bonds match
@@ -768,10 +768,10 @@ public class UniversalIsomorphismTester {
                                     CDKConstants.ISAROMATIC)))
                             && ( // atom type conditions
                             ( // a1 = a2 && b1 = b2
-                            ac1.getBond(i).getAtom(0).getSymbol().equals(ac2.getBond(j).getAtom(0).getSymbol()) && ac1
-                                    .getBond(i).getAtom(1).getSymbol().equals(ac2.getBond(j).getAtom(1).getSymbol())) || ( // a1 = b2 && b1 = a2
-                            ac1.getBond(i).getAtom(0).getSymbol().equals(ac2.getBond(j).getAtom(1).getSymbol()) && ac1
-                                    .getBond(i).getAtom(1).getSymbol().equals(ac2.getBond(j).getAtom(0).getSymbol())))) {
+                            ac1.getBond(i).getBeg().getSymbol().equals(ac2.getBond(j).getBeg().getSymbol()) && ac1
+                                    .getBond(i).getEnd().getSymbol().equals(ac2.getBond(j).getEnd().getSymbol())) || ( // a1 = b2 && b1 = a2
+                            ac1.getBond(i).getBeg().getSymbol().equals(ac2.getBond(j).getEnd().getSymbol()) && ac1
+                                    .getBond(i).getEnd().getSymbol().equals(ac2.getBond(j).getBeg().getSymbol())))) {
                         gr.addNode(new RNode(i, j));
                     }
                 }
@@ -850,7 +850,7 @@ public class UniversalIsomorphismTester {
      *            the 2 bonds have no common atom
      */
     private static boolean hasCommonAtom(IBond a, IBond b) {
-        return a.contains(b.getAtom(0)) || a.contains(b.getAtom(1));
+        return a.contains(b.getBeg()) || a.contains(b.getEnd());
     }
 
     /**
@@ -864,10 +864,10 @@ public class UniversalIsomorphismTester {
     private static String getCommonSymbol(IBond a, IBond b) {
         String symbol = "";
 
-        if (a.contains(b.getAtom(0))) {
-            symbol = b.getAtom(0).getSymbol();
-        } else if (a.contains(b.getAtom(1))) {
-            symbol = b.getAtom(1).getSymbol();
+        if (a.contains(b.getBeg())) {
+            symbol = b.getBeg().getSymbol();
+        } else if (a.contains(b.getEnd())) {
+            symbol = b.getEnd().getSymbol();
         }
 
         return symbol;
@@ -886,16 +886,16 @@ public class UniversalIsomorphismTester {
         IAtom atom1 = null;
         IAtom atom2 = null;
 
-        if (a1.contains(b1.getAtom(0))) {
-            atom1 = b1.getAtom(0);
-        } else if (a1.contains(b1.getAtom(1))) {
-            atom1 = b1.getAtom(1);
+        if (a1.contains(b1.getBeg())) {
+            atom1 = b1.getBeg();
+        } else if (a1.contains(b1.getEnd())) {
+            atom1 = b1.getEnd();
         }
 
-        if (a2.contains(b2.getAtom(0))) {
-            atom2 = b2.getAtom(0);
-        } else if (a2.contains(b2.getAtom(1))) {
-            atom2 = b2.getAtom(1);
+        if (a2.contains(b2.getBeg())) {
+            atom2 = b2.getBeg();
+        } else if (a2.contains(b2.getEnd())) {
+            atom2 = b2.getEnd();
         }
 
         if (atom1 != null && atom2 != null) {
@@ -921,16 +921,16 @@ public class UniversalIsomorphismTester {
         IAtom centralAtom = null;
         IAtom centralQueryAtom = null;
 
-        if (bond1.contains(bond2.getAtom(0))) {
-            centralAtom = bond2.getAtom(0);
-        } else if (bond1.contains(bond2.getAtom(1))) {
-            centralAtom = bond2.getAtom(1);
+        if (bond1.contains(bond2.getBeg())) {
+            centralAtom = bond2.getBeg();
+        } else if (bond1.contains(bond2.getEnd())) {
+            centralAtom = bond2.getEnd();
         }
 
-        if (queryBond1.contains(queryBond2.getAtom(0))) {
-            centralQueryAtom = queryBond2.getAtom(0);
-        } else if (queryBond1.contains(queryBond2.getAtom(1))) {
-            centralQueryAtom = queryBond2.getAtom(1);
+        if (queryBond1.contains(queryBond2.getBeg())) {
+            centralQueryAtom = queryBond2.getBeg();
+        } else if (queryBond1.contains(queryBond2.getEnd())) {
+            centralQueryAtom = queryBond2.getEnd();
         }
 
         if (centralAtom != null && centralQueryAtom != null && ((IQueryAtom) centralQueryAtom).matches(centralAtom)) {

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/FischerRecognition.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/FischerRecognition.java
@@ -204,9 +204,9 @@ final class FischerRecognition {
 
         // the neighbors of our tetrahedral centre, the EAST or WEST may
         // be missing so we initialise these with the implicit (focus)
-        IAtom[] neighbors = new IAtom[]{cardinalBonds[NORTH].getConnectedAtom(focus),
+        IAtom[] neighbors = new IAtom[]{cardinalBonds[NORTH].getOther(focus),
                                         focus,
-                                        cardinalBonds[SOUTH].getConnectedAtom(focus),
+                                        cardinalBonds[SOUTH].getOther(focus),
                                         focus};
 
 
@@ -214,14 +214,14 @@ final class FischerRecognition {
         // connected atom. else if bond is defined (but not single or planar) or we
         // have 4 neighbours something is wrong and we skip this atom                
         if (isPlanarSigmaBond(cardinalBonds[EAST])) {
-            neighbors[EAST] = cardinalBonds[EAST].getConnectedAtom(focus);
+            neighbors[EAST] = cardinalBonds[EAST].getOther(focus);
         }
         else if (cardinalBonds[EAST] != null || bonds.length == 4) {
             return null;
         }
 
         if (isPlanarSigmaBond(cardinalBonds[WEST])) {
-            neighbors[WEST] = cardinalBonds[WEST].getConnectedAtom(focus);
+            neighbors[WEST] = cardinalBonds[WEST].getOther(focus);
         }
         else if (cardinalBonds[WEST] != null || bonds.length == 4) {
             return null;
@@ -247,7 +247,7 @@ final class FischerRecognition {
 
         for (final IBond bond : bonds) {
 
-            IAtom   other   = bond.getConnectedAtom(focus);
+            IAtom   other   = bond.getOther(focus);
             Point2d otherXy = other.getPoint2d();
 
             double deltaX = otherXy.x - centerXy.x;

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
@@ -356,7 +356,7 @@ public abstract class StereoElementFactory {
         /**{@inheritDoc} */
         @Override
         IDoubleBondStereochemistry createGeometric(IBond bond, Stereocenters stereocenters) {
-            return createGeometric(container.indexOf(bond.getAtom(0)), container.indexOf(bond.getAtom(1)),
+            return createGeometric(container.indexOf(bond.getBeg()), container.indexOf(bond.getEnd()),
                     stereocenters);
         }
 
@@ -665,13 +665,13 @@ public abstract class StereoElementFactory {
         private int elevationOf(IAtom focus, IBond bond) {
             switch (bond.getStereo()) {
                 case UP:
-                    return bond.getAtom(0) == focus ? +1 : 0;
+                    return bond.getBeg() == focus ? +1 : 0;
                 case UP_INVERTED:
-                    return bond.getAtom(1) == focus ? +1 : 0;
+                    return bond.getEnd() == focus ? +1 : 0;
                 case DOWN:
-                    return bond.getAtom(0) == focus ? -1 : 0;
+                    return bond.getBeg() == focus ? -1 : 0;
                 case DOWN_INVERTED:
-                    return bond.getAtom(1) == focus ? -1 : 0;
+                    return bond.getEnd() == focus ? -1 : 0;
             }
             return 0;
         }
@@ -700,7 +700,7 @@ public abstract class StereoElementFactory {
         /**{@inheritDoc} */
         @Override
         IDoubleBondStereochemistry createGeometric(IBond bond, Stereocenters stereocenters) {
-            return createGeometric(container.indexOf(bond.getAtom(0)), container.indexOf(bond.getAtom(1)),
+            return createGeometric(container.indexOf(bond.getBeg()), container.indexOf(bond.getEnd()),
                     stereocenters);
         }
 

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
@@ -356,8 +356,8 @@ public abstract class StereoElementFactory {
         /**{@inheritDoc} */
         @Override
         IDoubleBondStereochemistry createGeometric(IBond bond, Stereocenters stereocenters) {
-            return createGeometric(container.indexOf(bond.getBeg()), container.indexOf(bond.getEnd()),
-                    stereocenters);
+            return createGeometric(container.indexOf(bond.getBegin()), container.indexOf(bond.getEnd()),
+                                   stereocenters);
         }
 
         /**{@inheritDoc} */
@@ -665,11 +665,11 @@ public abstract class StereoElementFactory {
         private int elevationOf(IAtom focus, IBond bond) {
             switch (bond.getStereo()) {
                 case UP:
-                    return bond.getBeg() == focus ? +1 : 0;
+                    return bond.getBegin() == focus ? +1 : 0;
                 case UP_INVERTED:
                     return bond.getEnd() == focus ? +1 : 0;
                 case DOWN:
-                    return bond.getBeg() == focus ? -1 : 0;
+                    return bond.getBegin() == focus ? -1 : 0;
                 case DOWN_INVERTED:
                     return bond.getEnd() == focus ? -1 : 0;
             }
@@ -700,8 +700,8 @@ public abstract class StereoElementFactory {
         /**{@inheritDoc} */
         @Override
         IDoubleBondStereochemistry createGeometric(IBond bond, Stereocenters stereocenters) {
-            return createGeometric(container.indexOf(bond.getBeg()), container.indexOf(bond.getEnd()),
-                    stereocenters);
+            return createGeometric(container.indexOf(bond.getBegin()), container.indexOf(bond.getEnd()),
+                                   stereocenters);
         }
 
         /**{@inheritDoc} */

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AminoAcidManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AminoAcidManipulator.java
@@ -22,7 +22,6 @@
  *  */
 package org.openscience.cdk.tools.manipulator;
 
-import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAminoAcid;
 import org.openscience.cdk.interfaces.IAtom;

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -593,10 +593,10 @@ public class AtomContainerManipulator {
             } else if (stereoElement instanceof IDoubleBondStereochemistry) {
                 IDoubleBondStereochemistry dbs = (IDoubleBondStereochemistry) stereoElement;
                 IBond stereoBond = dbs.getStereoBond();
-                for (IAtom neighbor : org.getConnectedAtomsList(stereoBond.getAtom(0))) {
+                for (IAtom neighbor : org.getConnectedAtomsList(stereoBond.getBeg())) {
                     if (remove.remove(neighbor)) addClone(neighbor, cpy, map);
                 }
-                for (IAtom neighbor : org.getConnectedAtomsList(stereoBond.getAtom(1))) {
+                for (IAtom neighbor : org.getConnectedAtomsList(stereoBond.getEnd())) {
                     if (remove.remove(neighbor)) addClone(neighbor, cpy, map);
                 }
             }
@@ -788,8 +788,8 @@ public class AtomContainerManipulator {
                 //  \     /
                 //   u = v
 
-                IAtom u = orgStereo.getAtom(0);
-                IAtom v = orgStereo.getAtom(1);
+                IAtom u = orgStereo.getBeg();
+                IAtom v = orgStereo.getEnd();
                 IAtom x = orgLeft.getConnectedAtom(u);
                 IAtom y = orgRight.getConnectedAtom(v);
 
@@ -1322,12 +1322,12 @@ public class AtomContainerManipulator {
             query.getBond(i).setOrder(IBond.Order.SINGLE);
             query.getBond(i).setFlag(CDKConstants.ISAROMATIC, false);
             query.getBond(i).setFlag(CDKConstants.SINGLE_OR_DOUBLE, false);
-            query.getBond(i).getAtom(0).setSymbol("C");
-            query.getBond(i).getAtom(0).setHybridization(null);
-            query.getBond(i).getAtom(1).setSymbol("C");
-            query.getBond(i).getAtom(1).setHybridization(null);
-            query.getBond(i).getAtom(0).setFlag(CDKConstants.ISAROMATIC, false);
-            query.getBond(i).getAtom(1).setFlag(CDKConstants.ISAROMATIC, false);
+            query.getBond(i).getBeg().setSymbol("C");
+            query.getBond(i).getBeg().setHybridization(null);
+            query.getBond(i).getEnd().setSymbol("C");
+            query.getBond(i).getEnd().setHybridization(null);
+            query.getBond(i).getBeg().setFlag(CDKConstants.ISAROMATIC, false);
+            query.getBond(i).getEnd().setFlag(CDKConstants.ISAROMATIC, false);
         }
         return query;
     }

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -592,7 +592,7 @@ public class AtomContainerManipulator {
             } else if (stereoElement instanceof IDoubleBondStereochemistry) {
                 IDoubleBondStereochemistry dbs = (IDoubleBondStereochemistry) stereoElement;
                 IBond stereoBond = dbs.getStereoBond();
-                for (IAtom neighbor : org.getConnectedAtomsList(stereoBond.getBeg())) {
+                for (IAtom neighbor : org.getConnectedAtomsList(stereoBond.getBegin())) {
                     if (remove.remove(neighbor)) addClone(neighbor, cpy, map);
                 }
                 for (IAtom neighbor : org.getConnectedAtomsList(stereoBond.getEnd())) {
@@ -624,7 +624,7 @@ public class AtomContainerManipulator {
                     e.printStackTrace();
                 }
                 assert clone != null;
-                clone.setAtoms(new IAtom[]{map.get(bond.getBeg()), map.get(bond.getEnd())});
+                clone.setAtoms(new IAtom[]{map.get(bond.getBegin()), map.get(bond.getEnd())});
                 cpy.addBond(clone);
             }
         }
@@ -738,7 +738,7 @@ public class AtomContainerManipulator {
         int remaining = hydrogens.size();
 
         for (final IBond bond : org.bonds()) {
-            if (remaining > 0 && (hydrogens.contains(bond.getBeg()) || hydrogens.contains(bond.getEnd()))) {
+            if (remaining > 0 && (hydrogens.contains(bond.getBegin()) || hydrogens.contains(bond.getEnd()))) {
                 remaining--;
                 continue;
             }
@@ -787,7 +787,7 @@ public class AtomContainerManipulator {
                 //  \     /
                 //   u = v
 
-                IAtom u = orgStereo.getBeg();
+                IAtom u = orgStereo.getBegin();
                 IAtom v = orgStereo.getEnd();
                 IAtom x = orgLeft.getOther(u);
                 IAtom y = orgRight.getOther(v);
@@ -1024,7 +1024,7 @@ public class AtomContainerManipulator {
         for (int i = 0; i < count; i++) {
             // Check bond.
             final IBond bond = ac.getBond(i);
-            IAtom atom0 = bond.getBeg();
+            IAtom atom0 = bond.getBegin();
             IAtom atom1 = bond.getEnd();
             boolean remove_bond = false;
             for (IAtom atom : bond.atoms()) {
@@ -1321,11 +1321,11 @@ public class AtomContainerManipulator {
             query.getBond(i).setOrder(IBond.Order.SINGLE);
             query.getBond(i).setFlag(CDKConstants.ISAROMATIC, false);
             query.getBond(i).setFlag(CDKConstants.SINGLE_OR_DOUBLE, false);
-            query.getBond(i).getBeg().setSymbol("C");
-            query.getBond(i).getBeg().setHybridization(null);
+            query.getBond(i).getBegin().setSymbol("C");
+            query.getBond(i).getBegin().setHybridization(null);
             query.getBond(i).getEnd().setSymbol("C");
             query.getBond(i).getEnd().setHybridization(null);
-            query.getBond(i).getBeg().setFlag(CDKConstants.ISAROMATIC, false);
+            query.getBond(i).getBegin().setFlag(CDKConstants.ISAROMATIC, false);
             query.getBond(i).getEnd().setFlag(CDKConstants.ISAROMATIC, false);
         }
         return query;
@@ -1351,7 +1351,7 @@ public class AtomContainerManipulator {
         }
         for (int i = 0; i < bonds.length; i++) {
             IBond bond = src.getBond(i);
-            int u = src.indexOf(bond.getBeg());
+            int u = src.indexOf(bond.getBegin());
             int v = src.indexOf(bond.getEnd());
             bonds[i] = builder.newInstance(IBond.class, atoms[u], atoms[v]);
         }
@@ -1384,7 +1384,7 @@ public class AtomContainerManipulator {
         }
         for (int i = 0; i < bonds.length; i++) {
             IBond bond = src.getBond(i);
-            int u = src.indexOf(bond.getBeg());
+            int u = src.indexOf(bond.getBegin());
             int v = src.indexOf(bond.getEnd());
             bonds[i] = builder.newInstance(IBond.class, atoms[u], atoms[v]);
         }
@@ -1442,7 +1442,7 @@ public class AtomContainerManipulator {
         for (IBond bond : rs.ringFragments().bonds()) {
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 bond.setFlag(SINGLE_OR_DOUBLE, true);
-                bond.getBeg().setFlag(SINGLE_OR_DOUBLE, true);
+                bond.getBegin().setFlag(SINGLE_OR_DOUBLE, true);
                 bond.getEnd().setFlag(SINGLE_OR_DOUBLE, true);
                 singleOrDouble = singleOrDouble | true;
             }

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -63,7 +63,6 @@ import org.openscience.cdk.ringsearch.RingSearch;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
-import org.openscience.cdk.stereo.ExtendedTetrahedral;
 import org.openscience.cdk.stereo.TetrahedralChirality;
 
 /**
@@ -562,7 +561,7 @@ public class AtomContainerManipulator {
                         for (IBond bond : org.getConnectedBondsList(neighbour)) {
                             IBond.Stereo bondStereo = bond.getStereo();
                             if (bondStereo != null && bondStereo != IBond.Stereo.NONE) addToRemove = false;
-                            IAtom neighboursNeighbour = bond.getConnectedAtom(neighbour);
+                            IAtom neighboursNeighbour = bond.getOther(neighbour);
                             // remove in any case if the hetero atom is connected to more than one hydrogen
                             if (neighboursNeighbour.getSymbol().equals("H") && neighboursNeighbour != atom) {
                                 addToRemove = true;
@@ -790,8 +789,8 @@ public class AtomContainerManipulator {
 
                 IAtom u = orgStereo.getBeg();
                 IAtom v = orgStereo.getEnd();
-                IAtom x = orgLeft.getConnectedAtom(u);
-                IAtom y = orgRight.getConnectedAtom(v);
+                IAtom x = orgLeft.getOther(u);
+                IAtom y = orgRight.getOther(v);
 
                 // if xNew == x and yNew == y we don't need to find the
                 // connecting bonds

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -625,7 +625,7 @@ public class AtomContainerManipulator {
                     e.printStackTrace();
                 }
                 assert clone != null;
-                clone.setAtoms(new IAtom[]{map.get(bond.getAtom(0)), map.get(bond.getAtom(1))});
+                clone.setAtoms(new IAtom[]{map.get(bond.getBeg()), map.get(bond.getEnd())});
                 cpy.addBond(clone);
             }
         }
@@ -739,7 +739,7 @@ public class AtomContainerManipulator {
         int remaining = hydrogens.size();
 
         for (final IBond bond : org.bonds()) {
-            if (remaining > 0 && (hydrogens.contains(bond.getAtom(0)) || hydrogens.contains(bond.getAtom(1)))) {
+            if (remaining > 0 && (hydrogens.contains(bond.getBeg()) || hydrogens.contains(bond.getEnd()))) {
                 remaining--;
                 continue;
             }
@@ -1025,8 +1025,8 @@ public class AtomContainerManipulator {
         for (int i = 0; i < count; i++) {
             // Check bond.
             final IBond bond = ac.getBond(i);
-            IAtom atom0 = bond.getAtom(0);
-            IAtom atom1 = bond.getAtom(1);
+            IAtom atom0 = bond.getBeg();
+            IAtom atom1 = bond.getEnd();
             boolean remove_bond = false;
             for (IAtom atom : bond.atoms()) {
                 if (remove.contains(atom)) {
@@ -1352,8 +1352,8 @@ public class AtomContainerManipulator {
         }
         for (int i = 0; i < bonds.length; i++) {
             IBond bond = src.getBond(i);
-            int u = src.indexOf(bond.getAtom(0));
-            int v = src.indexOf(bond.getAtom(1));
+            int u = src.indexOf(bond.getBeg());
+            int v = src.indexOf(bond.getEnd());
             bonds[i] = builder.newInstance(IBond.class, atoms[u], atoms[v]);
         }
 
@@ -1385,8 +1385,8 @@ public class AtomContainerManipulator {
         }
         for (int i = 0; i < bonds.length; i++) {
             IBond bond = src.getBond(i);
-            int u = src.indexOf(bond.getAtom(0));
-            int v = src.indexOf(bond.getAtom(1));
+            int u = src.indexOf(bond.getBeg());
+            int v = src.indexOf(bond.getEnd());
             bonds[i] = builder.newInstance(IBond.class, atoms[u], atoms[v]);
         }
 
@@ -1443,8 +1443,8 @@ public class AtomContainerManipulator {
         for (IBond bond : rs.ringFragments().bonds()) {
             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                 bond.setFlag(SINGLE_OR_DOUBLE, true);
-                bond.getAtom(0).setFlag(SINGLE_OR_DOUBLE, true);
-                bond.getAtom(1).setFlag(SINGLE_OR_DOUBLE, true);
+                bond.getBeg().setFlag(SINGLE_OR_DOUBLE, true);
+                bond.getEnd().setFlag(SINGLE_OR_DOUBLE, true);
                 singleOrDouble = singleOrDouble | true;
             }
         }

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
@@ -420,7 +420,7 @@ public class ReactionManipulator {
             if (se instanceof ITetrahedralChirality) {
                 focus = ((ITetrahedralChirality) se).getChiralAtom();
             } else if (se instanceof IDoubleBondStereochemistry) {
-                focus = ((IDoubleBondStereochemistry) se).getStereoBond().getAtom(0);
+                focus = ((IDoubleBondStereochemistry) se).getStereoBond().getBeg();
             } else if (se instanceof ExtendedTetrahedral) {
                 focus = ((ExtendedTetrahedral) se).focus();
             }

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
@@ -403,7 +403,7 @@ public class ReactionManipulator {
 
         // split bonds
         for (IBond bond : mol.bonds()) {
-            IAtom beg = bond.getBeg();
+            IAtom beg = bond.getBegin();
             IAtom end = bond.getEnd();
             Integer begIdx = beg.getProperty(CDKConstants.REACTION_GROUP);
             Integer endIdx = end.getProperty(CDKConstants.REACTION_GROUP);
@@ -420,7 +420,7 @@ public class ReactionManipulator {
             if (se instanceof ITetrahedralChirality) {
                 focus = ((ITetrahedralChirality) se).getChiralAtom();
             } else if (se instanceof IDoubleBondStereochemistry) {
-                focus = ((IDoubleBondStereochemistry) se).getStereoBond().getBeg();
+                focus = ((IDoubleBondStereochemistry) se).getStereoBond().getBegin();
             } else if (se instanceof ExtendedTetrahedral) {
                 focus = ((ExtendedTetrahedral) se).focus();
             }
@@ -474,7 +474,7 @@ public class ReactionManipulator {
         Set<IntTuple> mappedProductBonds  = new HashSet<>();
         for (IAtomContainer reactant : reaction.getReactants().atomContainers()) {
             for (IBond bond : reactant.bonds()) {
-                Integer begidx = bond.getBeg().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer begidx = bond.getBegin().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 if (begidx != null && endidx != null)
                     mappedReactantBonds.add(new IntTuple(begidx, endidx));
@@ -486,7 +486,7 @@ public class ReactionManipulator {
 
         for (IAtomContainer product : reaction.getProducts().atomContainers()) {
             for (IBond bond : product.bonds()) {
-                Integer begidx = bond.getBeg().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer begidx = bond.getBegin().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 if (begidx != null && endidx != null)
                     mappedProductBonds.add(new IntTuple(begidx, endidx));
@@ -499,7 +499,7 @@ public class ReactionManipulator {
         // repeat above but now store any that are different or unmapped as being mapped
         for (IAtomContainer reactant : reaction.getReactants().atomContainers()) {
             for (IBond bond : reactant.bonds()) {
-                Integer begidx = bond.getBeg().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer begidx = bond.getBegin().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 if (begidx != null && endidx != null && mappedProductBonds.contains(new IntTuple(begidx, endidx)))
                     mapped.add(bond);
@@ -507,7 +507,7 @@ public class ReactionManipulator {
         }
         for (IAtomContainer product : reaction.getProducts().atomContainers()) {
             for (IBond bond : product.bonds()) {
-                Integer begidx = bond.getBeg().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer begidx = bond.getBegin().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 if (begidx != null && endidx != null && mappedReactantBonds.contains(new IntTuple(begidx, endidx)))
                     mapped.add(bond);

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
@@ -403,8 +403,8 @@ public class ReactionManipulator {
 
         // split bonds
         for (IBond bond : mol.bonds()) {
-            IAtom beg = bond.getAtom(0);
-            IAtom end = bond.getAtom(1);
+            IAtom beg = bond.getBeg();
+            IAtom end = bond.getEnd();
             Integer begIdx = beg.getProperty(CDKConstants.REACTION_GROUP);
             Integer endIdx = end.getProperty(CDKConstants.REACTION_GROUP);
             if (begIdx == null || endIdx == null)
@@ -474,8 +474,8 @@ public class ReactionManipulator {
         Set<IntTuple> mappedProductBonds  = new HashSet<>();
         for (IAtomContainer reactant : reaction.getReactants().atomContainers()) {
             for (IBond bond : reactant.bonds()) {
-                Integer begidx = bond.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                Integer endidx = bond.getAtom(1).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer begidx = bond.getBeg().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 if (begidx != null && endidx != null)
                     mappedReactantBonds.add(new IntTuple(begidx, endidx));
             }
@@ -486,8 +486,8 @@ public class ReactionManipulator {
 
         for (IAtomContainer product : reaction.getProducts().atomContainers()) {
             for (IBond bond : product.bonds()) {
-                Integer begidx = bond.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                Integer endidx = bond.getAtom(1).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer begidx = bond.getBeg().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 if (begidx != null && endidx != null)
                     mappedProductBonds.add(new IntTuple(begidx, endidx));
             }
@@ -499,16 +499,16 @@ public class ReactionManipulator {
         // repeat above but now store any that are different or unmapped as being mapped
         for (IAtomContainer reactant : reaction.getReactants().atomContainers()) {
             for (IBond bond : reactant.bonds()) {
-                Integer begidx = bond.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                Integer endidx = bond.getAtom(1).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer begidx = bond.getBeg().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 if (begidx != null && endidx != null && mappedProductBonds.contains(new IntTuple(begidx, endidx)))
                     mapped.add(bond);
             }
         }
         for (IAtomContainer product : reaction.getProducts().atomContainers()) {
             for (IBond bond : product.bonds()) {
-                Integer begidx = bond.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                Integer endidx = bond.getAtom(1).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer begidx = bond.getBeg().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                 if (begidx != null && endidx != null && mappedReactantBonds.contains(new IntTuple(begidx, endidx)))
                     mapped.add(bond);
             }

--- a/base/test-core/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest.java
@@ -154,8 +154,8 @@ public class RingSearchTest {
 
         when(container.indexOf(a1)).thenReturn(42);
         when(container.indexOf(a2)).thenReturn(43);
-        when(bond.getAtom(0)).thenReturn(a1);
-        when(bond.getAtom(1)).thenReturn(a2);
+        when(bond.getBeg()).thenReturn(a1);
+        when(bond.getEnd()).thenReturn(a2);
 
         RingSearch ringSearch = new RingSearch(container, cyclicSearch);
         ringSearch.cyclic(bond);

--- a/base/test-core/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest.java
@@ -154,7 +154,7 @@ public class RingSearchTest {
 
         when(container.indexOf(a1)).thenReturn(42);
         when(container.indexOf(a2)).thenReturn(43);
-        when(bond.getBeg()).thenReturn(a1);
+        when(bond.getBegin()).thenReturn(a1);
         when(bond.getEnd()).thenReturn(a2);
 
         RingSearch ringSearch = new RingSearch(container, cyclicSearch);

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
@@ -219,7 +219,7 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         // test cloning of atoms in bonds
         IAtomContainer clonedMol = (IAtomContainer) molecule.clone();
         Assert.assertNotNull(clonedMol);
-        Assert.assertNotSame(atom1, clonedMol.getBond(0).getBeg());
+        Assert.assertNotSame(atom1, clonedMol.getBond(0).getBegin());
         Assert.assertNotSame(atom2, clonedMol.getBond(0).getEnd());
     }
 
@@ -235,7 +235,7 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         // test that cloned bonds contain atoms from cloned atomcontainer
         IAtomContainer clonedMol = (IAtomContainer) molecule.clone();
         Assert.assertNotNull(clonedMol);
-        Assert.assertTrue(clonedMol.contains(clonedMol.getBond(0).getBeg()));
+        Assert.assertTrue(clonedMol.contains(clonedMol.getBond(0).getBegin()));
         Assert.assertTrue(clonedMol.contains(clonedMol.getBond(0).getEnd()));
     }
 
@@ -1707,13 +1707,13 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         while (bonds.hasNext())
             Assert.assertNotNull(bonds.next());
 
-        Assert.assertEquals(c1, acetone.getBond(0).getBeg());
+        Assert.assertEquals(c1, acetone.getBond(0).getBegin());
         Assert.assertEquals(c2, acetone.getBond(0).getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, acetone.getBond(0).getOrder());
-        Assert.assertEquals(c2, acetone.getBond(1).getBeg());
+        Assert.assertEquals(c2, acetone.getBond(1).getBegin());
         Assert.assertEquals(o, acetone.getBond(1).getEnd());
         Assert.assertEquals(IBond.Order.DOUBLE, acetone.getBond(1).getOrder());
-        Assert.assertEquals(c2, acetone.getBond(2).getBeg());
+        Assert.assertEquals(c2, acetone.getBond(2).getBegin());
         Assert.assertEquals(c3, acetone.getBond(2).getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, acetone.getBond(2).getOrder());
     }
@@ -1739,15 +1739,15 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         while (bonds.hasNext())
             Assert.assertNotNull(bonds.next());
 
-        Assert.assertEquals(c1, acetone.getBond(0).getBeg());
+        Assert.assertEquals(c1, acetone.getBond(0).getBegin());
         Assert.assertEquals(c2, acetone.getBond(0).getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, acetone.getBond(0).getOrder());
         Assert.assertEquals(IBond.Stereo.UP, acetone.getBond(0).getStereo());
-        Assert.assertEquals(c2, acetone.getBond(1).getBeg());
+        Assert.assertEquals(c2, acetone.getBond(1).getBegin());
         Assert.assertEquals(o, acetone.getBond(1).getEnd());
         Assert.assertEquals(IBond.Order.DOUBLE, acetone.getBond(1).getOrder());
         Assert.assertEquals(IBond.Stereo.DOWN, acetone.getBond(1).getStereo());
-        Assert.assertEquals(c2, acetone.getBond(2).getBeg());
+        Assert.assertEquals(c2, acetone.getBond(2).getBegin());
         Assert.assertEquals(c3, acetone.getBond(2).getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, acetone.getBond(2).getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, acetone.getBond(2).getStereo());

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
@@ -219,8 +219,8 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         // test cloning of atoms in bonds
         IAtomContainer clonedMol = (IAtomContainer) molecule.clone();
         Assert.assertNotNull(clonedMol);
-        Assert.assertNotSame(atom1, clonedMol.getBond(0).getAtom(0));
-        Assert.assertNotSame(atom2, clonedMol.getBond(0).getAtom(1));
+        Assert.assertNotSame(atom1, clonedMol.getBond(0).getBeg());
+        Assert.assertNotSame(atom2, clonedMol.getBond(0).getEnd());
     }
 
     @Test
@@ -235,8 +235,8 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         // test that cloned bonds contain atoms from cloned atomcontainer
         IAtomContainer clonedMol = (IAtomContainer) molecule.clone();
         Assert.assertNotNull(clonedMol);
-        Assert.assertTrue(clonedMol.contains(clonedMol.getBond(0).getAtom(0)));
-        Assert.assertTrue(clonedMol.contains(clonedMol.getBond(0).getAtom(1)));
+        Assert.assertTrue(clonedMol.contains(clonedMol.getBond(0).getBeg()));
+        Assert.assertTrue(clonedMol.contains(clonedMol.getBond(0).getEnd()));
     }
 
     @Test
@@ -1707,14 +1707,14 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         while (bonds.hasNext())
             Assert.assertNotNull(bonds.next());
 
-        Assert.assertEquals(c1, acetone.getBond(0).getAtom(0));
-        Assert.assertEquals(c2, acetone.getBond(0).getAtom(1));
+        Assert.assertEquals(c1, acetone.getBond(0).getBeg());
+        Assert.assertEquals(c2, acetone.getBond(0).getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, acetone.getBond(0).getOrder());
-        Assert.assertEquals(c2, acetone.getBond(1).getAtom(0));
-        Assert.assertEquals(o, acetone.getBond(1).getAtom(1));
+        Assert.assertEquals(c2, acetone.getBond(1).getBeg());
+        Assert.assertEquals(o, acetone.getBond(1).getEnd());
         Assert.assertEquals(IBond.Order.DOUBLE, acetone.getBond(1).getOrder());
-        Assert.assertEquals(c2, acetone.getBond(2).getAtom(0));
-        Assert.assertEquals(c3, acetone.getBond(2).getAtom(1));
+        Assert.assertEquals(c2, acetone.getBond(2).getBeg());
+        Assert.assertEquals(c3, acetone.getBond(2).getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, acetone.getBond(2).getOrder());
     }
 
@@ -1739,16 +1739,16 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         while (bonds.hasNext())
             Assert.assertNotNull(bonds.next());
 
-        Assert.assertEquals(c1, acetone.getBond(0).getAtom(0));
-        Assert.assertEquals(c2, acetone.getBond(0).getAtom(1));
+        Assert.assertEquals(c1, acetone.getBond(0).getBeg());
+        Assert.assertEquals(c2, acetone.getBond(0).getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, acetone.getBond(0).getOrder());
         Assert.assertEquals(IBond.Stereo.UP, acetone.getBond(0).getStereo());
-        Assert.assertEquals(c2, acetone.getBond(1).getAtom(0));
-        Assert.assertEquals(o, acetone.getBond(1).getAtom(1));
+        Assert.assertEquals(c2, acetone.getBond(1).getBeg());
+        Assert.assertEquals(o, acetone.getBond(1).getEnd());
         Assert.assertEquals(IBond.Order.DOUBLE, acetone.getBond(1).getOrder());
         Assert.assertEquals(IBond.Stereo.DOWN, acetone.getBond(1).getStereo());
-        Assert.assertEquals(c2, acetone.getBond(2).getAtom(0));
-        Assert.assertEquals(c3, acetone.getBond(2).getAtom(1));
+        Assert.assertEquals(c2, acetone.getBond(2).getBeg());
+        Assert.assertEquals(c3, acetone.getBond(2).getEnd());
         Assert.assertEquals(IBond.Order.SINGLE, acetone.getBond(2).getOrder());
         Assert.assertEquals(IBond.Stereo.NONE, acetone.getBond(2).getStereo());
     }

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         b.setAtoms(atomsToAdd);
 
         Assert.assertEquals(2, b.getAtomCount());
-        Assert.assertEquals(atomsToAdd[0], b.getBeg());
+        Assert.assertEquals(atomsToAdd[0], b.getBegin());
         Assert.assertEquals(atomsToAdd[1], b.getEnd());
     }
 
@@ -155,7 +155,7 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         b.setAtom(o, 1);
         b.setOrder(Order.SINGLE);
 
-        Assert.assertEquals(c, b.getBeg());
+        Assert.assertEquals(c, b.getBegin());
         Assert.assertEquals(o, b.getEnd());
     }
 
@@ -168,7 +168,7 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         b.setAtom(c, 0);
         b.setAtom(o, 1);
 
-        Assert.assertEquals(c, b.getBeg());
+        Assert.assertEquals(c, b.getBegin());
         Assert.assertEquals(o, b.getEnd());
     }
 
@@ -368,7 +368,7 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         IBond clone = (IBond) bond.clone();
 
         // test cloning of atoms
-        Assert.assertNotSame(atom1, clone.getBeg());
+        Assert.assertNotSame(atom1, clone.getBegin());
         Assert.assertNotSame(atom2, clone.getEnd());
     }
 
@@ -421,7 +421,7 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
 
         IBond bond = object.getBuilder().newInstance(IBond.class, new IAtom[]{atom1, atom2, atom3});
         Assert.assertEquals(3, bond.getAtomCount());
-        Assert.assertEquals(atom1, bond.getBeg());
+        Assert.assertEquals(atom1, bond.getBegin());
         Assert.assertEquals(atom2, bond.getEnd());
         Assert.assertEquals(atom3, bond.getAtom(2));
 

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
@@ -421,8 +421,8 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
 
         IBond bond = object.getBuilder().newInstance(IBond.class, new IAtom[]{atom1, atom2, atom3});
         Assert.assertEquals(3, bond.getAtomCount());
-        Assert.assertEquals(atom1, bond.getAtom(0));
-        Assert.assertEquals(atom2, bond.getAtom(1));
+        Assert.assertEquals(atom1, bond.getBeg());
+        Assert.assertEquals(atom2, bond.getEnd());
         Assert.assertEquals(atom3, bond.getAtom(2));
 
         Assert.assertEquals(bond.getOrder(), CDKConstants.UNSET);

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
@@ -368,8 +368,8 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         IBond clone = (IBond) bond.clone();
 
         // test cloning of atoms
-        Assert.assertNotSame(atom1, clone.getAtom(0));
-        Assert.assertNotSame(atom2, clone.getAtom(1));
+        Assert.assertNotSame(atom1, clone.getBeg());
+        Assert.assertNotSame(atom2, clone.getEnd());
     }
 
     @Test

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
@@ -181,11 +181,11 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         b.setAtom(o, 1);
         b.setOrder(Order.SINGLE);
 
-        Assert.assertEquals(c, b.getConnectedAtom(o));
-        Assert.assertEquals(o, b.getConnectedAtom(c));
+        Assert.assertEquals(c, b.getOther(o));
+        Assert.assertEquals(o, b.getOther(c));
 
         // test default return value
-        Assert.assertNull(b.getConnectedAtom(b.getBuilder().newInstance(IAtom.class)));
+        Assert.assertNull(b.getOther(b.getBuilder().newInstance(IAtom.class)));
     }
 
     @Test
@@ -488,8 +488,8 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         IAtom atom4 = object.getBuilder().newInstance(IAtom.class, "C");
 
         IBond bond1 = object.getBuilder().newInstance(IBond.class, new IAtom[]{atom1, atom2, atom3, atom4});
-        Assert.assertEquals(atom2, bond1.getConnectedAtom(atom1));
-        Assert.assertNull(bond1.getConnectedAtom(object.getBuilder().newInstance(IAtom.class)));
+        Assert.assertEquals(atom2, bond1.getOther(atom1));
+        Assert.assertNull(bond1.getOther(object.getBuilder().newInstance(IAtom.class)));
 
         IAtom[] conAtoms = bond1.getConnectedAtoms(atom1);
         boolean correct = true;

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
@@ -89,8 +89,8 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         b.setAtoms(atomsToAdd);
 
         Assert.assertEquals(2, b.getAtomCount());
-        Assert.assertEquals(atomsToAdd[0], b.getAtom(0));
-        Assert.assertEquals(atomsToAdd[1], b.getAtom(1));
+        Assert.assertEquals(atomsToAdd[0], b.getBeg());
+        Assert.assertEquals(atomsToAdd[1], b.getEnd());
     }
 
     @Test
@@ -155,8 +155,8 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         b.setAtom(o, 1);
         b.setOrder(Order.SINGLE);
 
-        Assert.assertEquals(c, b.getAtom(0));
-        Assert.assertEquals(o, b.getAtom(1));
+        Assert.assertEquals(c, b.getBeg());
+        Assert.assertEquals(o, b.getEnd());
     }
 
     @Test
@@ -168,8 +168,8 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         b.setAtom(c, 0);
         b.setAtom(o, 1);
 
-        Assert.assertEquals(c, b.getAtom(0));
-        Assert.assertEquals(o, b.getAtom(1));
+        Assert.assertEquals(c, b.getBeg());
+        Assert.assertEquals(o, b.getEnd());
     }
 
     @Test

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/AllRingsFinderTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/AllRingsFinderTest.java
@@ -95,7 +95,7 @@ public class AllRingsFinderTest extends CDKTestCase {
             for (int j = 0; j < ring.getBondCount(); j++) {
                 IBond ec = ring.getBond(j);
 
-                IAtom atom1 = ec.getBeg();
+                IAtom atom1 = ec.getBegin();
                 IAtom atom2 = ec.getEnd();
                 Assert.assertTrue(ring.contains(atom1));
                 Assert.assertTrue(ring.contains(atom2));

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/AllRingsFinderTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/AllRingsFinderTest.java
@@ -95,8 +95,8 @@ public class AllRingsFinderTest extends CDKTestCase {
             for (int j = 0; j < ring.getBondCount(); j++) {
                 IBond ec = ring.getBond(j);
 
-                IAtom atom1 = ec.getAtom(0);
-                IAtom atom2 = ec.getAtom(1);
+                IAtom atom1 = ec.getBeg();
+                IAtom atom2 = ec.getEnd();
                 Assert.assertTrue(ring.contains(atom1));
                 Assert.assertTrue(ring.contains(atom2));
             }

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/ATASaturationCheckerTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/ATASaturationCheckerTest.java
@@ -153,38 +153,38 @@ public class ATASaturationCheckerTest extends org.openscience.cdk.CDKTestCase {
         Assert.assertTrue(mol.getAtom(1).getHybridization() == IAtomType.Hybridization.SP2);
 
         Assert.assertTrue(mol.getBond(0).getEnd().getSymbol().equals("C"));
-        Assert.assertTrue(mol.getBond(0).getBeg().getSymbol().equals("O"));
+        Assert.assertTrue(mol.getBond(0).getBegin().getSymbol().equals("O"));
         Assert.assertEquals(mol.getBond(0).getOrder(), IBond.Order.DOUBLE);
 
-        Assert.assertTrue(mol.getBond(1).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(1).getBegin().getSymbol().equals("C"));
         Assert.assertTrue(mol.getBond(1).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(1).getOrder(), IBond.Order.SINGLE);
 
-        Assert.assertTrue(mol.getBond(2).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(2).getBegin().getSymbol().equals("C"));
         Assert.assertTrue(mol.getBond(2).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(2).getOrder(), IBond.Order.DOUBLE);
 
-        Assert.assertTrue(mol.getBond(3).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(3).getBegin().getSymbol().equals("C"));
         Assert.assertTrue(mol.getBond(3).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(3).getOrder(), IBond.Order.SINGLE);
 
         Assert.assertTrue(mol.getBond(4).getEnd().getSymbol().equals("O"));
-        Assert.assertTrue(mol.getBond(4).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(4).getBegin().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(4).getOrder(), IBond.Order.DOUBLE);
 
-        Assert.assertTrue(mol.getBond(5).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(5).getBegin().getSymbol().equals("C"));
         Assert.assertTrue(mol.getBond(5).getEnd().getSymbol().equals("C"));
         Assert.assertTrue(mol.getBond(5).getOrder() == IBond.Order.SINGLE);
 
-        Assert.assertTrue(mol.getBond(6).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(6).getBegin().getSymbol().equals("C"));
         Assert.assertTrue(mol.getBond(6).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(6).getOrder(), IBond.Order.DOUBLE);
 
-        Assert.assertTrue(mol.getBond(7).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(7).getBegin().getSymbol().equals("C"));
         Assert.assertTrue(mol.getBond(7).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(7).getOrder(), IBond.Order.SINGLE);
 
-        Assert.assertEquals(mol.getBond(0).getEnd(), mol.getBond(7).getBeg());
+        Assert.assertEquals(mol.getBond(0).getEnd(), mol.getBond(7).getBegin());
     }
 
     /**

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/ATASaturationCheckerTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/ATASaturationCheckerTest.java
@@ -152,39 +152,39 @@ public class ATASaturationCheckerTest extends org.openscience.cdk.CDKTestCase {
 
         Assert.assertTrue(mol.getAtom(1).getHybridization() == IAtomType.Hybridization.SP2);
 
-        Assert.assertTrue(mol.getBond(0).getAtom(1).getSymbol().equals("C"));
-        Assert.assertTrue(mol.getBond(0).getAtom(0).getSymbol().equals("O"));
+        Assert.assertTrue(mol.getBond(0).getEnd().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(0).getBeg().getSymbol().equals("O"));
         Assert.assertEquals(mol.getBond(0).getOrder(), IBond.Order.DOUBLE);
 
-        Assert.assertTrue(mol.getBond(1).getAtom(0).getSymbol().equals("C"));
-        Assert.assertTrue(mol.getBond(1).getAtom(1).getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(1).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(1).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(1).getOrder(), IBond.Order.SINGLE);
 
-        Assert.assertTrue(mol.getBond(2).getAtom(0).getSymbol().equals("C"));
-        Assert.assertTrue(mol.getBond(2).getAtom(1).getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(2).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(2).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(2).getOrder(), IBond.Order.DOUBLE);
 
-        Assert.assertTrue(mol.getBond(3).getAtom(0).getSymbol().equals("C"));
-        Assert.assertTrue(mol.getBond(3).getAtom(1).getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(3).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(3).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(3).getOrder(), IBond.Order.SINGLE);
 
-        Assert.assertTrue(mol.getBond(4).getAtom(1).getSymbol().equals("O"));
-        Assert.assertTrue(mol.getBond(4).getAtom(0).getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(4).getEnd().getSymbol().equals("O"));
+        Assert.assertTrue(mol.getBond(4).getBeg().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(4).getOrder(), IBond.Order.DOUBLE);
 
-        Assert.assertTrue(mol.getBond(5).getAtom(0).getSymbol().equals("C"));
-        Assert.assertTrue(mol.getBond(5).getAtom(1).getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(5).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(5).getEnd().getSymbol().equals("C"));
         Assert.assertTrue(mol.getBond(5).getOrder() == IBond.Order.SINGLE);
 
-        Assert.assertTrue(mol.getBond(6).getAtom(0).getSymbol().equals("C"));
-        Assert.assertTrue(mol.getBond(6).getAtom(1).getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(6).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(6).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(6).getOrder(), IBond.Order.DOUBLE);
 
-        Assert.assertTrue(mol.getBond(7).getAtom(0).getSymbol().equals("C"));
-        Assert.assertTrue(mol.getBond(7).getAtom(1).getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(7).getBeg().getSymbol().equals("C"));
+        Assert.assertTrue(mol.getBond(7).getEnd().getSymbol().equals("C"));
         Assert.assertEquals(mol.getBond(7).getOrder(), IBond.Order.SINGLE);
 
-        Assert.assertEquals(mol.getBond(0).getAtom(1), mol.getBond(7).getAtom(0));
+        Assert.assertEquals(mol.getBond(0).getEnd(), mol.getBond(7).getBeg());
     }
 
     /**

--- a/base/valencycheck/src/main/java/org/openscience/cdk/tools/AtomTypeAwareSaturationChecker.java
+++ b/base/valencycheck/src/main/java/org/openscience/cdk/tools/AtomTypeAwareSaturationChecker.java
@@ -205,17 +205,17 @@ public class AtomTypeAwareSaturationChecker implements IValencyChecker, IDeduceB
     public boolean bondOrderCanBeIncreased(IBond bond, IAtomContainer atomContainer) throws CDKException {
         boolean atom0isUnsaturated = false, atom1isUnsaturated = false;
         double sum;
-        if (bond.getAtom(0).getBondOrderSum() == null) {
-            sum = getAtomBondordersum(bond.getAtom(1), atomContainer);
+        if (bond.getBeg().getBondOrderSum() == null) {
+            sum = getAtomBondordersum(bond.getEnd(), atomContainer);
         } else
-            sum = bond.getAtom(0).getBondOrderSum();
-        if (bondsUsed(bond.getAtom(0), atomContainer) < sum) atom0isUnsaturated = true;
+            sum = bond.getBeg().getBondOrderSum();
+        if (bondsUsed(bond.getBeg(), atomContainer) < sum) atom0isUnsaturated = true;
 
-        if (bond.getAtom(1).getBondOrderSum() == null) {
-            sum = getAtomBondordersum(bond.getAtom(1), atomContainer);
+        if (bond.getEnd().getBondOrderSum() == null) {
+            sum = getAtomBondordersum(bond.getEnd(), atomContainer);
         } else
-            sum = bond.getAtom(1).getBondOrderSum();
-        if (bondsUsed(bond.getAtom(1), atomContainer) < sum) atom1isUnsaturated = true;
+            sum = bond.getEnd().getBondOrderSum();
+        if (bondsUsed(bond.getEnd(), atomContainer) < sum) atom1isUnsaturated = true;
 
         if (atom0isUnsaturated == atom1isUnsaturated)
             return atom0isUnsaturated;

--- a/base/valencycheck/src/main/java/org/openscience/cdk/tools/AtomTypeAwareSaturationChecker.java
+++ b/base/valencycheck/src/main/java/org/openscience/cdk/tools/AtomTypeAwareSaturationChecker.java
@@ -205,11 +205,11 @@ public class AtomTypeAwareSaturationChecker implements IValencyChecker, IDeduceB
     public boolean bondOrderCanBeIncreased(IBond bond, IAtomContainer atomContainer) throws CDKException {
         boolean atom0isUnsaturated = false, atom1isUnsaturated = false;
         double sum;
-        if (bond.getBeg().getBondOrderSum() == null) {
+        if (bond.getBegin().getBondOrderSum() == null) {
             sum = getAtomBondordersum(bond.getEnd(), atomContainer);
         } else
-            sum = bond.getBeg().getBondOrderSum();
-        if (bondsUsed(bond.getBeg(), atomContainer) < sum) atom0isUnsaturated = true;
+            sum = bond.getBegin().getBondOrderSum();
+        if (bondsUsed(bond.getBegin(), atomContainer) < sum) atom0isUnsaturated = true;
 
         if (bond.getEnd().getBondOrderSum() == null) {
             sum = getAtomBondordersum(bond.getEnd(), atomContainer);

--- a/base/valencycheck/src/main/java/org/openscience/cdk/tools/SaturationChecker.java
+++ b/base/valencycheck/src/main/java/org/openscience/cdk/tools/SaturationChecker.java
@@ -273,9 +273,9 @@ public class SaturationChecker implements IValencyChecker, IDeduceBondOrderTool 
             boolean succeeded = newSaturate(bonds, atomContainer);
             for (int i = 0; i < bonds.length; i++) {
                 if (bonds[i].getOrder() == IBond.Order.DOUBLE && bonds[i].getFlag(CDKConstants.ISAROMATIC)
-                        && (bonds[i].getBeg().getSymbol().equals("N") && bonds[i].getEnd().getSymbol().equals("N"))) {
+                        && (bonds[i].getBegin().getSymbol().equals("N") && bonds[i].getEnd().getSymbol().equals("N"))) {
                     int atomtohandle = 0;
-                    if (bonds[i].getBeg().getSymbol().equals("N")) atomtohandle = 1;
+                    if (bonds[i].getBegin().getSymbol().equals("N")) atomtohandle = 1;
                     List<IBond> bondstohandle = atomContainer.getConnectedBondsList(bonds[i].getAtom(atomtohandle));
                     for (int k = 0; k < bondstohandle.size(); k++) {
                         IBond bond = bondstohandle.get(k);

--- a/base/valencycheck/src/main/java/org/openscience/cdk/tools/SaturationChecker.java
+++ b/base/valencycheck/src/main/java/org/openscience/cdk/tools/SaturationChecker.java
@@ -273,9 +273,9 @@ public class SaturationChecker implements IValencyChecker, IDeduceBondOrderTool 
             boolean succeeded = newSaturate(bonds, atomContainer);
             for (int i = 0; i < bonds.length; i++) {
                 if (bonds[i].getOrder() == IBond.Order.DOUBLE && bonds[i].getFlag(CDKConstants.ISAROMATIC)
-                        && (bonds[i].getAtom(0).getSymbol().equals("N") && bonds[i].getAtom(1).getSymbol().equals("N"))) {
+                        && (bonds[i].getBeg().getSymbol().equals("N") && bonds[i].getEnd().getSymbol().equals("N"))) {
                     int atomtohandle = 0;
-                    if (bonds[i].getAtom(0).getSymbol().equals("N")) atomtohandle = 1;
+                    if (bonds[i].getBeg().getSymbol().equals("N")) atomtohandle = 1;
                     List<IBond> bondstohandle = atomContainer.getConnectedBondsList(bonds[i].getAtom(atomtohandle));
                     for (int k = 0; k < bondstohandle.size(); k++) {
                         IBond bond = bondstohandle.get(k);

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/CIPTool.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/CIPTool.java
@@ -168,8 +168,8 @@ public class CIPTool {
         //
         IAtom u = stereoBond.getBeg();
         IAtom v = stereoBond.getEnd();
-        IAtom x = leftBond.getConnectedAtom(u);
-        IAtom y = rightBond.getConnectedAtom(v);
+        IAtom x = leftBond.getOther(u);
+        IAtom y = rightBond.getOther(v);
 
         Conformation conformation = stereoCenter.getStereo();
 
@@ -355,7 +355,7 @@ public class CIPTool {
                 }
             } else {
                 int duplication = getDuplication(bond.getOrder());
-                IAtom connectedAtom = bond.getConnectedAtom(ligandAtom);
+                IAtom connectedAtom = bond.getOther(ligandAtom);
                 if (visitedAtoms.isVisited(connectedAtom)) {
                     ligands.add(new TerminalLigand(container, visitedAtoms, ligandAtom, connectedAtom));
                 } else {

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/CIPTool.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/CIPTool.java
@@ -166,8 +166,8 @@ public class CIPTool {
         //                        \
         //                         y
         //
-        IAtom u = stereoBond.getAtom(0);
-        IAtom v = stereoBond.getAtom(1);
+        IAtom u = stereoBond.getBeg();
+        IAtom v = stereoBond.getEnd();
         IAtom x = leftBond.getConnectedAtom(u);
         IAtom y = rightBond.getConnectedAtom(v);
 

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/CIPTool.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/CIPTool.java
@@ -166,7 +166,7 @@ public class CIPTool {
         //                        \
         //                         y
         //
-        IAtom u = stereoBond.getBeg();
+        IAtom u = stereoBond.getBegin();
         IAtom v = stereoBond.getEnd();
         IAtom x = leftBond.getOther(u);
         IAtom y = rightBond.getOther(v);

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -548,7 +548,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         for (int n = 0; n < mol.getBondCount(); n++) {
             IBond bond = mol.getBond(n);
             if (bond.getAtomCount() != 2) continue;
-            int a1 = mol.indexOf(bond.getAtom(0)), a2 = mol.indexOf(bond.getAtom(1));
+            int a1 = mol.indexOf(bond.getBeg()), a2 = mol.indexOf(bond.getEnd());
             if (amask[a1] && amask[a2]) {
                 atomAdj[a1] = appendInteger(atomAdj[a1], a2);
                 bondAdj[a1] = appendInteger(bondAdj[a1], n);
@@ -783,8 +783,8 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         for (int n = 0; n < nb; n++)
             if (bondOrder[n] == 2) {
                 IBond bond = mol.getBond(n);
-                piAtom[mol.indexOf(bond.getAtom(0))] = true;
-                piAtom[mol.indexOf(bond.getAtom(1))] = true;
+                piAtom[mol.indexOf(bond.getBeg())] = true;
+                piAtom[mol.indexOf(bond.getEnd())] = true;
             }
 
         ArrayList<int[]> maybe = new ArrayList<int[]>(); // rings which may yet be aromatic
@@ -901,7 +901,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
                 IBond.Stereo stereo = bond.getStereo();
                 xp[n] = (float) (o2d.x - x0);
                 yp[n] = (float) (o2d.y - y0);
-                zp[n] = other == bond.getAtom(0) ? 0 : stereo == IBond.Stereo.UP ? 1 : stereo == IBond.Stereo.DOWN ? -1
+                zp[n] = other == bond.getBeg() ? 0 : stereo == IBond.Stereo.UP ? 1 : stereo == IBond.Stereo.DOWN ? -1
                         : 0;
             } else {
                 return null; // no 2D coordinates on some atom
@@ -995,7 +995,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         for (int n = 0; n < nb; n++) {
             IBond bond = mol.getBond(n);
             if (bond.getAtomCount() != 2) continue;
-            int a1 = mol.indexOf(bond.getAtom(0)), a2 = mol.indexOf(bond.getAtom(1)), o = bondOrder[n];
+            int a1 = mol.indexOf(bond.getBeg()), a2 = mol.indexOf(bond.getEnd()), o = bondOrder[n];
             if (!amask[a1] || !amask[a2]) continue;
             bondSum[a1] += o;
             bondSum[a2] += o;
@@ -1248,7 +1248,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
     private int bondOrderBioType(int bidx) {
         IBond bond = mol.getBond(bidx);
         if (bond.getAtomCount() != 2) return 0;
-        final int a1 = mol.indexOf(bond.getAtom(0)), a2 = mol.indexOf(bond.getAtom(1));
+        final int a1 = mol.indexOf(bond.getBeg()), a2 = mol.indexOf(bond.getEnd());
         if (maskAro[a1] && maskAro[a2]) return -1;
         return bondOrder[bidx];
     }

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -30,10 +30,8 @@ package org.openscience.cdk.fingerprint;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -42,7 +40,6 @@ import java.util.zip.CRC32;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
-import com.google.common.primitives.Ints;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -548,7 +545,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         for (int n = 0; n < mol.getBondCount(); n++) {
             IBond bond = mol.getBond(n);
             if (bond.getAtomCount() != 2) continue;
-            int a1 = mol.indexOf(bond.getBeg()), a2 = mol.indexOf(bond.getEnd());
+            int a1 = mol.indexOf(bond.getBegin()), a2 = mol.indexOf(bond.getEnd());
             if (amask[a1] && amask[a2]) {
                 atomAdj[a1] = appendInteger(atomAdj[a1], a2);
                 bondAdj[a1] = appendInteger(bondAdj[a1], n);
@@ -783,7 +780,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         for (int n = 0; n < nb; n++)
             if (bondOrder[n] == 2) {
                 IBond bond = mol.getBond(n);
-                piAtom[mol.indexOf(bond.getBeg())] = true;
+                piAtom[mol.indexOf(bond.getBegin())] = true;
                 piAtom[mol.indexOf(bond.getEnd())] = true;
             }
 
@@ -901,8 +898,8 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
                 IBond.Stereo stereo = bond.getStereo();
                 xp[n] = (float) (o2d.x - x0);
                 yp[n] = (float) (o2d.y - y0);
-                zp[n] = other == bond.getBeg() ? 0 : stereo == IBond.Stereo.UP ? 1 : stereo == IBond.Stereo.DOWN ? -1
-                        : 0;
+                zp[n] = other == bond.getBegin() ? 0 : stereo == IBond.Stereo.UP ? 1 : stereo == IBond.Stereo.DOWN ? -1
+                                                                                                                   : 0;
             } else {
                 return null; // no 2D coordinates on some atom
             }
@@ -995,7 +992,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         for (int n = 0; n < nb; n++) {
             IBond bond = mol.getBond(n);
             if (bond.getAtomCount() != 2) continue;
-            int a1 = mol.indexOf(bond.getBeg()), a2 = mol.indexOf(bond.getEnd()), o = bondOrder[n];
+            int a1 = mol.indexOf(bond.getBegin()), a2 = mol.indexOf(bond.getEnd()), o = bondOrder[n];
             if (!amask[a1] || !amask[a2]) continue;
             bondSum[a1] += o;
             bondSum[a2] += o;
@@ -1248,7 +1245,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
     private int bondOrderBioType(int bidx) {
         IBond bond = mol.getBond(bidx);
         if (bond.getAtomCount() != 2) return 0;
-        final int a1 = mol.indexOf(bond.getBeg()), a2 = mol.indexOf(bond.getEnd());
+        final int a1 = mol.indexOf(bond.getBegin()), a2 = mol.indexOf(bond.getEnd());
         if (maskAro[a1] && maskAro[a2]) return -1;
         return bondOrder[bidx];
     }

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3R.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3R.java
@@ -436,7 +436,7 @@ public class RDFProtonDescriptor_G3R extends AbstractAtomicDescriptor implements
                     partial = 0;
                     position = aBondsInCycloex;
                     theInCycloexBond = mol.getBond(position);
-                    cycloexBondAtom0 = theInCycloexBond.getBeg();
+                    cycloexBondAtom0 = theInCycloexBond.getBegin();
                     cycloexBondAtom1 = theInCycloexBond.getEnd();
 
                     connAtoms = mol.getConnectedAtomsList(cycloexBondAtom0);
@@ -483,7 +483,7 @@ public class RDFProtonDescriptor_G3R extends AbstractAtomicDescriptor implements
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
@@ -571,7 +571,7 @@ public class RDFProtonDescriptor_G3R extends AbstractAtomicDescriptor implements
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3R.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3R.java
@@ -436,8 +436,8 @@ public class RDFProtonDescriptor_G3R extends AbstractAtomicDescriptor implements
                     partial = 0;
                     position = aBondsInCycloex;
                     theInCycloexBond = mol.getBond(position);
-                    cycloexBondAtom0 = theInCycloexBond.getAtom(0);
-                    cycloexBondAtom1 = theInCycloexBond.getAtom(1);
+                    cycloexBondAtom0 = theInCycloexBond.getBeg();
+                    cycloexBondAtom1 = theInCycloexBond.getEnd();
 
                     connAtoms = mol.getConnectedAtomsList(cycloexBondAtom0);
                     for (IAtom connAtom : connAtoms) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3R.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3R.java
@@ -483,8 +483,8 @@ public class RDFProtonDescriptor_G3R extends AbstractAtomicDescriptor implements
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getAtom(0);
-        IAtom atom1 = bond.getAtom(1);
+        IAtom atom0 = bond.getBeg();
+        IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
         }
@@ -571,7 +571,7 @@ public class RDFProtonDescriptor_G3R extends AbstractAtomicDescriptor implements
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getAtom(0);
+        IAtom atom0 = bond.getBeg();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDR.java
@@ -457,8 +457,8 @@ public class RDFProtonDescriptor_GDR extends AbstractAtomicDescriptor implements
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getAtom(0);
-        IAtom atom1 = bond.getAtom(1);
+        IAtom atom0 = bond.getBeg();
+        IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
         }
@@ -544,7 +544,7 @@ public class RDFProtonDescriptor_GDR extends AbstractAtomicDescriptor implements
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getAtom(0);
+        IAtom atom0 = bond.getBeg();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDR.java
@@ -419,8 +419,8 @@ public class RDFProtonDescriptor_GDR extends AbstractAtomicDescriptor implements
                     theDoubleBond = mol.getBond(position);
                     goodPosition = getNearestBondtoAGivenAtom(mol, atom, theDoubleBond);
                     goodBond = mol.getBond(goodPosition);
-                    goodAtom0 = goodBond.getAtom(0);
-                    goodAtom1 = goodBond.getAtom(1);
+                    goodAtom0 = goodBond.getBeg();
+                    goodAtom1 = goodBond.getEnd();
 
                     //System.out.println("GOOD POS IS "+mol.indexOf(goodAtoms[0])+" "+mol.indexOf(goodAtoms[1]));
 

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDR.java
@@ -419,7 +419,7 @@ public class RDFProtonDescriptor_GDR extends AbstractAtomicDescriptor implements
                     theDoubleBond = mol.getBond(position);
                     goodPosition = getNearestBondtoAGivenAtom(mol, atom, theDoubleBond);
                     goodBond = mol.getBond(goodPosition);
-                    goodAtom0 = goodBond.getBeg();
+                    goodAtom0 = goodBond.getBegin();
                     goodAtom1 = goodBond.getEnd();
 
                     //System.out.println("GOOD POS IS "+mol.indexOf(goodAtoms[0])+" "+mol.indexOf(goodAtoms[1]));
@@ -457,7 +457,7 @@ public class RDFProtonDescriptor_GDR extends AbstractAtomicDescriptor implements
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
@@ -544,7 +544,7 @@ public class RDFProtonDescriptor_GDR extends AbstractAtomicDescriptor implements
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR.java
@@ -425,8 +425,8 @@ public class RDFProtonDescriptor_GHR extends AbstractAtomicDescriptor implements
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getAtom(0);
-        IAtom atom1 = bond.getAtom(1);
+        IAtom atom0 = bond.getBeg();
+        IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
         }
@@ -513,7 +513,7 @@ public class RDFProtonDescriptor_GHR extends AbstractAtomicDescriptor implements
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getAtom(0);
+        IAtom atom0 = bond.getBeg();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR.java
@@ -425,7 +425,7 @@ public class RDFProtonDescriptor_GHR extends AbstractAtomicDescriptor implements
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
@@ -513,7 +513,7 @@ public class RDFProtonDescriptor_GHR extends AbstractAtomicDescriptor implements
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topol.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topol.java
@@ -437,8 +437,8 @@ public class RDFProtonDescriptor_GHR_topol extends AbstractAtomicDescriptor impl
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getAtom(0);
-        IAtom atom1 = bond.getAtom(1);
+        IAtom atom0 = bond.getBeg();
+        IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
         }
@@ -525,7 +525,7 @@ public class RDFProtonDescriptor_GHR_topol extends AbstractAtomicDescriptor impl
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getAtom(0);
+        IAtom atom0 = bond.getBeg();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topol.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topol.java
@@ -437,7 +437,7 @@ public class RDFProtonDescriptor_GHR_topol extends AbstractAtomicDescriptor impl
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
@@ -525,7 +525,7 @@ public class RDFProtonDescriptor_GHR_topol extends AbstractAtomicDescriptor impl
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSR.java
@@ -415,8 +415,8 @@ public class RDFProtonDescriptor_GSR extends AbstractAtomicDescriptor implements
                     position = thisSingleBond;
                     theSingleBond = mol.getBond(position);
                     middlePoint = theSingleBond.get3DCenter();
-                    singleBondAtom0 = theSingleBond.getAtom(0);
-                    singleBondAtom1 = theSingleBond.getAtom(1);
+                    singleBondAtom0 = theSingleBond.getBeg();
+                    singleBondAtom1 = theSingleBond.getEnd();
                     dist0 = calculateDistanceBetweenTwoAtoms(singleBondAtom0, atom);
                     dist1 = calculateDistanceBetweenTwoAtoms(singleBondAtom1, atom);
 

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSR.java
@@ -454,8 +454,8 @@ public class RDFProtonDescriptor_GSR extends AbstractAtomicDescriptor implements
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getAtom(0);
-        IAtom atom1 = bond.getAtom(1);
+        IAtom atom0 = bond.getBeg();
+        IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
         }
@@ -542,7 +542,7 @@ public class RDFProtonDescriptor_GSR extends AbstractAtomicDescriptor implements
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getAtom(0);
+        IAtom atom0 = bond.getBeg();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSR.java
@@ -415,7 +415,7 @@ public class RDFProtonDescriptor_GSR extends AbstractAtomicDescriptor implements
                     position = thisSingleBond;
                     theSingleBond = mol.getBond(position);
                     middlePoint = theSingleBond.get3DCenter();
-                    singleBondAtom0 = theSingleBond.getBeg();
+                    singleBondAtom0 = theSingleBond.getBegin();
                     singleBondAtom1 = theSingleBond.getEnd();
                     dist0 = calculateDistanceBetweenTwoAtoms(singleBondAtom0, atom);
                     dist1 = calculateDistanceBetweenTwoAtoms(singleBondAtom1, atom);
@@ -454,7 +454,7 @@ public class RDFProtonDescriptor_GSR extends AbstractAtomicDescriptor implements
     private boolean getIfBondIsNotRotatable(IAtomContainer mol, IBond bond, IAtomContainer detected) {
         boolean isBondNotRotatable = false;
         int counter = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         IAtom atom1 = bond.getEnd();
         if (detected != null) {
             if (detected.contains(bond)) counter += 1;
@@ -542,7 +542,7 @@ public class RDFProtonDescriptor_GSR extends AbstractAtomicDescriptor implements
         int nearestBond = 0;
         double[] values;
         double distance = 0;
-        IAtom atom0 = bond.getBeg();
+        IAtom atom0 = bond.getBegin();
         List<IBond> bondsAtLeft = mol.getConnectedBondsList(atom0);
         int partial;
         for (int i = 0; i < bondsAtLeft.size(); i++) {

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialPiChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialPiChargeDescriptor.java
@@ -152,20 +152,20 @@ public class BondPartialPiChargeDescriptor extends AbstractBondDescriptor {
     @Override
     public DescriptorValue calculate(IBond bond, IAtomContainer ac) {
         // FIXME: for now I'll cache a few modified atomic properties, and restore them at the end of this method
-        Double originalCharge1 = bond.getAtom(0).getCharge();
-        String originalAtomtypeName1 = bond.getAtom(0).getAtomTypeName();
-        Integer originalNeighborCount1 = bond.getAtom(0).getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization1 = bond.getAtom(0).getHybridization();
-        Integer originalValency1 = bond.getAtom(0).getValency();
-        Double originalCharge2 = bond.getAtom(1).getCharge();
-        String originalAtomtypeName2 = bond.getAtom(1).getAtomTypeName();
-        Integer originalNeighborCount2 = bond.getAtom(1).getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization2 = bond.getAtom(1).getHybridization();
-        Integer originalValency2 = bond.getAtom(1).getValency();
-        Double originalBondOrderSum1 = bond.getAtom(0).getBondOrderSum();
-        Order originalMaxBondOrder1 = bond.getAtom(0).getMaxBondOrder();
-        Double originalBondOrderSum2 = bond.getAtom(1).getBondOrderSum();
-        Order originalMaxBondOrder2 = bond.getAtom(1).getMaxBondOrder();
+        Double originalCharge1 = bond.getBeg().getCharge();
+        String originalAtomtypeName1 = bond.getBeg().getAtomTypeName();
+        Integer originalNeighborCount1 = bond.getBeg().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization1 = bond.getBeg().getHybridization();
+        Integer originalValency1 = bond.getBeg().getValency();
+        Double originalCharge2 = bond.getEnd().getCharge();
+        String originalAtomtypeName2 = bond.getEnd().getAtomTypeName();
+        Integer originalNeighborCount2 = bond.getEnd().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization2 = bond.getEnd().getHybridization();
+        Integer originalValency2 = bond.getEnd().getValency();
+        Double originalBondOrderSum1 = bond.getBeg().getBondOrderSum();
+        Order originalMaxBondOrder1 = bond.getBeg().getMaxBondOrder();
+        Double originalBondOrderSum2 = bond.getEnd().getBondOrderSum();
+        Order originalMaxBondOrder2 = bond.getEnd().getMaxBondOrder();
         if (!isCachedAtomContainer(ac)) {
             try {
                 AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(ac);
@@ -193,20 +193,20 @@ public class BondPartialPiChargeDescriptor extends AbstractBondDescriptor {
                 return getDummyDescriptorValue(ex1);
             }
         }
-        bond.getAtom(0).setCharge(originalCharge1);
-        bond.getAtom(0).setAtomTypeName(originalAtomtypeName1);
-        bond.getAtom(0).setHybridization(originalHybridization1);
-        bond.getAtom(0).setValency(originalValency1);
-        bond.getAtom(0).setFormalNeighbourCount(originalNeighborCount1);
-        bond.getAtom(1).setCharge(originalCharge2);
-        bond.getAtom(1).setAtomTypeName(originalAtomtypeName2);
-        bond.getAtom(1).setHybridization(originalHybridization2);
-        bond.getAtom(1).setValency(originalValency2);
-        bond.getAtom(1).setFormalNeighbourCount(originalNeighborCount2);
-        bond.getAtom(0).setMaxBondOrder(originalMaxBondOrder1);
-        bond.getAtom(0).setBondOrderSum(originalBondOrderSum1);
-        bond.getAtom(1).setMaxBondOrder(originalMaxBondOrder2);
-        bond.getAtom(1).setBondOrderSum(originalBondOrderSum2);
+        bond.getBeg().setCharge(originalCharge1);
+        bond.getBeg().setAtomTypeName(originalAtomtypeName1);
+        bond.getBeg().setHybridization(originalHybridization1);
+        bond.getBeg().setValency(originalValency1);
+        bond.getBeg().setFormalNeighbourCount(originalNeighborCount1);
+        bond.getEnd().setCharge(originalCharge2);
+        bond.getEnd().setAtomTypeName(originalAtomtypeName2);
+        bond.getEnd().setHybridization(originalHybridization2);
+        bond.getEnd().setValency(originalValency2);
+        bond.getEnd().setFormalNeighbourCount(originalNeighborCount2);
+        bond.getBeg().setMaxBondOrder(originalMaxBondOrder1);
+        bond.getBeg().setBondOrderSum(originalBondOrderSum1);
+        bond.getEnd().setMaxBondOrder(originalMaxBondOrder2);
+        bond.getEnd().setBondOrderSum(originalBondOrderSum2);
 
         return getCachedDescriptorValue(bond) != null ? new DescriptorValue(getSpecification(), getParameterNames(),
                 getParameters(), getCachedDescriptorValue(bond), NAMES) : null;

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialPiChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialPiChargeDescriptor.java
@@ -152,18 +152,18 @@ public class BondPartialPiChargeDescriptor extends AbstractBondDescriptor {
     @Override
     public DescriptorValue calculate(IBond bond, IAtomContainer ac) {
         // FIXME: for now I'll cache a few modified atomic properties, and restore them at the end of this method
-        Double originalCharge1 = bond.getBeg().getCharge();
-        String originalAtomtypeName1 = bond.getBeg().getAtomTypeName();
-        Integer originalNeighborCount1 = bond.getBeg().getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization1 = bond.getBeg().getHybridization();
-        Integer originalValency1 = bond.getBeg().getValency();
+        Double originalCharge1 = bond.getBegin().getCharge();
+        String originalAtomtypeName1 = bond.getBegin().getAtomTypeName();
+        Integer originalNeighborCount1 = bond.getBegin().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization1 = bond.getBegin().getHybridization();
+        Integer originalValency1 = bond.getBegin().getValency();
         Double originalCharge2 = bond.getEnd().getCharge();
         String originalAtomtypeName2 = bond.getEnd().getAtomTypeName();
         Integer originalNeighborCount2 = bond.getEnd().getFormalNeighbourCount();
         IAtomType.Hybridization originalHybridization2 = bond.getEnd().getHybridization();
         Integer originalValency2 = bond.getEnd().getValency();
-        Double originalBondOrderSum1 = bond.getBeg().getBondOrderSum();
-        Order originalMaxBondOrder1 = bond.getBeg().getMaxBondOrder();
+        Double originalBondOrderSum1 = bond.getBegin().getBondOrderSum();
+        Order originalMaxBondOrder1 = bond.getBegin().getMaxBondOrder();
         Double originalBondOrderSum2 = bond.getEnd().getBondOrderSum();
         Order originalMaxBondOrder2 = bond.getEnd().getMaxBondOrder();
         if (!isCachedAtomContainer(ac)) {
@@ -186,25 +186,25 @@ public class BondPartialPiChargeDescriptor extends AbstractBondDescriptor {
                 pepe.assignGasteigerPiPartialCharges(ac, true);
                 for (Iterator<IBond> it = ac.bonds().iterator(); it.hasNext();) {
                     IBond bondi = it.next();
-                    double result = Math.abs(bondi.getBeg().getCharge() - bondi.getEnd().getCharge());
+                    double result = Math.abs(bondi.getBegin().getCharge() - bondi.getEnd().getCharge());
                     cacheDescriptorValue(bondi, ac, new DoubleResult(result));
                 }
             } catch (Exception ex1) {
                 return getDummyDescriptorValue(ex1);
             }
         }
-        bond.getBeg().setCharge(originalCharge1);
-        bond.getBeg().setAtomTypeName(originalAtomtypeName1);
-        bond.getBeg().setHybridization(originalHybridization1);
-        bond.getBeg().setValency(originalValency1);
-        bond.getBeg().setFormalNeighbourCount(originalNeighborCount1);
+        bond.getBegin().setCharge(originalCharge1);
+        bond.getBegin().setAtomTypeName(originalAtomtypeName1);
+        bond.getBegin().setHybridization(originalHybridization1);
+        bond.getBegin().setValency(originalValency1);
+        bond.getBegin().setFormalNeighbourCount(originalNeighborCount1);
         bond.getEnd().setCharge(originalCharge2);
         bond.getEnd().setAtomTypeName(originalAtomtypeName2);
         bond.getEnd().setHybridization(originalHybridization2);
         bond.getEnd().setValency(originalValency2);
         bond.getEnd().setFormalNeighbourCount(originalNeighborCount2);
-        bond.getBeg().setMaxBondOrder(originalMaxBondOrder1);
-        bond.getBeg().setBondOrderSum(originalBondOrderSum1);
+        bond.getBegin().setMaxBondOrder(originalMaxBondOrder1);
+        bond.getBegin().setBondOrderSum(originalBondOrderSum1);
         bond.getEnd().setMaxBondOrder(originalMaxBondOrder2);
         bond.getEnd().setBondOrderSum(originalBondOrderSum2);
 

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialPiChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialPiChargeDescriptor.java
@@ -186,7 +186,7 @@ public class BondPartialPiChargeDescriptor extends AbstractBondDescriptor {
                 pepe.assignGasteigerPiPartialCharges(ac, true);
                 for (Iterator<IBond> it = ac.bonds().iterator(); it.hasNext();) {
                     IBond bondi = it.next();
-                    double result = Math.abs(bondi.getAtom(0).getCharge() - bondi.getAtom(1).getCharge());
+                    double result = Math.abs(bondi.getBeg().getCharge() - bondi.getEnd().getCharge());
                     cacheDescriptorValue(bondi, ac, new DoubleResult(result));
                 }
             } catch (Exception ex1) {

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialSigmaChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialSigmaChargeDescriptor.java
@@ -131,8 +131,8 @@ public class BondPartialSigmaChargeDescriptor extends AbstractBondDescriptor {
     @Override
     public DescriptorValue calculate(IBond bond, IAtomContainer ac) {
         // FIXME: for now I'll cache a few modified atomic properties, and restore them at the end of this method
-        Double originalCharge1 = bond.getAtom(0).getCharge();
-        Double originalCharge2 = bond.getAtom(1).getCharge();
+        Double originalCharge1 = bond.getBeg().getCharge();
+        Double originalCharge2 = bond.getEnd().getCharge();
         if (!isCachedAtomContainer(ac)) {
             IAtomContainer mol = ac.getBuilder().newInstance(IAtomContainer.class, ac);
             if (maxIterations != 0) peoe.setMaxGasteigerIters(maxIterations);
@@ -147,8 +147,8 @@ public class BondPartialSigmaChargeDescriptor extends AbstractBondDescriptor {
                 return getDummyDescriptorValue(ex1);
             }
         }
-        bond.getAtom(0).setCharge(originalCharge1);
-        bond.getAtom(1).setCharge(originalCharge2);
+        bond.getBeg().setCharge(originalCharge1);
+        bond.getEnd().setCharge(originalCharge2);
         return getCachedDescriptorValue(bond) != null ? new DescriptorValue(getSpecification(), getParameterNames(),
                 getParameters(), getCachedDescriptorValue(bond), NAMES) : null;
     }

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialSigmaChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialSigmaChargeDescriptor.java
@@ -131,7 +131,7 @@ public class BondPartialSigmaChargeDescriptor extends AbstractBondDescriptor {
     @Override
     public DescriptorValue calculate(IBond bond, IAtomContainer ac) {
         // FIXME: for now I'll cache a few modified atomic properties, and restore them at the end of this method
-        Double originalCharge1 = bond.getBeg().getCharge();
+        Double originalCharge1 = bond.getBegin().getCharge();
         Double originalCharge2 = bond.getEnd().getCharge();
         if (!isCachedAtomContainer(ac)) {
             IAtomContainer mol = ac.getBuilder().newInstance(IAtomContainer.class, ac);
@@ -140,14 +140,14 @@ public class BondPartialSigmaChargeDescriptor extends AbstractBondDescriptor {
                 peoe.assignGasteigerMarsiliSigmaPartialCharges(mol, true);
                 for (Iterator<IBond> it = ac.bonds().iterator(); it.hasNext();) {
                     IBond bondi = it.next();
-                    double result = Math.abs(bondi.getBeg().getCharge() - bondi.getEnd().getCharge());
+                    double result = Math.abs(bondi.getBegin().getCharge() - bondi.getEnd().getCharge());
                     cacheDescriptorValue(bondi, ac, new DoubleResult(result));
                 }
             } catch (Exception ex1) {
                 return getDummyDescriptorValue(ex1);
             }
         }
-        bond.getBeg().setCharge(originalCharge1);
+        bond.getBegin().setCharge(originalCharge1);
         bond.getEnd().setCharge(originalCharge2);
         return getCachedDescriptorValue(bond) != null ? new DescriptorValue(getSpecification(), getParameterNames(),
                 getParameters(), getCachedDescriptorValue(bond), NAMES) : null;

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialSigmaChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialSigmaChargeDescriptor.java
@@ -140,7 +140,7 @@ public class BondPartialSigmaChargeDescriptor extends AbstractBondDescriptor {
                 peoe.assignGasteigerMarsiliSigmaPartialCharges(mol, true);
                 for (Iterator<IBond> it = ac.bonds().iterator(); it.hasNext();) {
                     IBond bondi = it.next();
-                    double result = Math.abs(bondi.getAtom(0).getCharge() - bondi.getAtom(1).getCharge());
+                    double result = Math.abs(bondi.getBeg().getCharge() - bondi.getEnd().getCharge());
                     cacheDescriptorValue(bondi, ac, new DoubleResult(result));
                 }
             } catch (Exception ex1) {

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialTChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialTChargeDescriptor.java
@@ -159,20 +159,20 @@ public class BondPartialTChargeDescriptor extends AbstractBondDescriptor {
     @Override
     public DescriptorValue calculate(IBond bond, IAtomContainer ac) {
         // FIXME: for now I'll cache a few modified atomic properties, and restore them at the end of this method
-        Double originalCharge1 = bond.getAtom(0).getCharge();
-        String originalAtomtypeName1 = bond.getAtom(0).getAtomTypeName();
-        Integer originalNeighborCount1 = bond.getAtom(0).getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization1 = bond.getAtom(0).getHybridization();
-        Integer originalValency1 = bond.getAtom(0).getValency();
-        Double originalCharge2 = bond.getAtom(1).getCharge();
-        String originalAtomtypeName2 = bond.getAtom(1).getAtomTypeName();
-        Integer originalNeighborCount2 = bond.getAtom(1).getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization2 = bond.getAtom(1).getHybridization();
-        Integer originalValency2 = bond.getAtom(1).getValency();
-        Double originalBondOrderSum1 = bond.getAtom(0).getBondOrderSum();
-        Order originalMaxBondOrder1 = bond.getAtom(0).getMaxBondOrder();
-        Double originalBondOrderSum2 = bond.getAtom(1).getBondOrderSum();
-        Order originalMaxBondOrder2 = bond.getAtom(1).getMaxBondOrder();
+        Double originalCharge1 = bond.getBeg().getCharge();
+        String originalAtomtypeName1 = bond.getBeg().getAtomTypeName();
+        Integer originalNeighborCount1 = bond.getBeg().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization1 = bond.getBeg().getHybridization();
+        Integer originalValency1 = bond.getBeg().getValency();
+        Double originalCharge2 = bond.getEnd().getCharge();
+        String originalAtomtypeName2 = bond.getEnd().getAtomTypeName();
+        Integer originalNeighborCount2 = bond.getEnd().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization2 = bond.getEnd().getHybridization();
+        Integer originalValency2 = bond.getEnd().getValency();
+        Double originalBondOrderSum1 = bond.getBeg().getBondOrderSum();
+        Order originalMaxBondOrder1 = bond.getBeg().getMaxBondOrder();
+        Double originalBondOrderSum2 = bond.getEnd().getBondOrderSum();
+        Order originalMaxBondOrder2 = bond.getEnd().getMaxBondOrder();
         if (!isCachedAtomContainer(ac)) {
             try {
                 AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(ac);
@@ -210,20 +210,20 @@ public class BondPartialTChargeDescriptor extends AbstractBondDescriptor {
                 return getDummyDescriptorValue(e);
             }
         }
-        bond.getAtom(0).setCharge(originalCharge1);
-        bond.getAtom(0).setAtomTypeName(originalAtomtypeName1);
-        bond.getAtom(0).setHybridization(originalHybridization1);
-        bond.getAtom(0).setValency(originalValency1);
-        bond.getAtom(0).setFormalNeighbourCount(originalNeighborCount1);
-        bond.getAtom(1).setCharge(originalCharge2);
-        bond.getAtom(1).setAtomTypeName(originalAtomtypeName2);
-        bond.getAtom(1).setHybridization(originalHybridization2);
-        bond.getAtom(1).setValency(originalValency2);
-        bond.getAtom(1).setFormalNeighbourCount(originalNeighborCount2);
-        bond.getAtom(0).setMaxBondOrder(originalMaxBondOrder1);
-        bond.getAtom(0).setBondOrderSum(originalBondOrderSum1);
-        bond.getAtom(1).setMaxBondOrder(originalMaxBondOrder2);
-        bond.getAtom(1).setBondOrderSum(originalBondOrderSum2);
+        bond.getBeg().setCharge(originalCharge1);
+        bond.getBeg().setAtomTypeName(originalAtomtypeName1);
+        bond.getBeg().setHybridization(originalHybridization1);
+        bond.getBeg().setValency(originalValency1);
+        bond.getBeg().setFormalNeighbourCount(originalNeighborCount1);
+        bond.getEnd().setCharge(originalCharge2);
+        bond.getEnd().setAtomTypeName(originalAtomtypeName2);
+        bond.getEnd().setHybridization(originalHybridization2);
+        bond.getEnd().setValency(originalValency2);
+        bond.getEnd().setFormalNeighbourCount(originalNeighborCount2);
+        bond.getBeg().setMaxBondOrder(originalMaxBondOrder1);
+        bond.getBeg().setBondOrderSum(originalBondOrderSum1);
+        bond.getEnd().setMaxBondOrder(originalMaxBondOrder2);
+        bond.getEnd().setBondOrderSum(originalBondOrderSum2);
 
         return getCachedDescriptorValue(bond) != null ? new DescriptorValue(getSpecification(), getParameterNames(),
                 getParameters(), getCachedDescriptorValue(bond), NAMES) : null;

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialTChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialTChargeDescriptor.java
@@ -193,7 +193,7 @@ public class BondPartialTChargeDescriptor extends AbstractBondDescriptor {
                 List<Double> peoeBond = new ArrayList<Double>();
                 for (Iterator<IBond> it = ac.bonds().iterator(); it.hasNext();) {
                     IBond bondi = it.next();
-                    double result = Math.abs(bondi.getAtom(0).getCharge() - bondi.getAtom(1).getCharge());
+                    double result = Math.abs(bondi.getBeg().getCharge() - bondi.getEnd().getCharge());
                     peoeBond.add(result);
                 }
 
@@ -203,7 +203,7 @@ public class BondPartialTChargeDescriptor extends AbstractBondDescriptor {
                 pepe.assignGasteigerPiPartialCharges(ac, true);
                 for (int i = 0; i < ac.getBondCount(); i++) {
                     IBond bondi = ac.getBond(i);
-                    double result = Math.abs(bondi.getAtom(0).getCharge() - bondi.getAtom(1).getCharge());
+                    double result = Math.abs(bondi.getBeg().getCharge() - bondi.getEnd().getCharge());
                     cacheDescriptorValue(bondi, ac, new DoubleResult(peoeBond.get(i) + result));
                 }
             } catch (Exception e) {

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialTChargeDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondPartialTChargeDescriptor.java
@@ -159,18 +159,18 @@ public class BondPartialTChargeDescriptor extends AbstractBondDescriptor {
     @Override
     public DescriptorValue calculate(IBond bond, IAtomContainer ac) {
         // FIXME: for now I'll cache a few modified atomic properties, and restore them at the end of this method
-        Double originalCharge1 = bond.getBeg().getCharge();
-        String originalAtomtypeName1 = bond.getBeg().getAtomTypeName();
-        Integer originalNeighborCount1 = bond.getBeg().getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization1 = bond.getBeg().getHybridization();
-        Integer originalValency1 = bond.getBeg().getValency();
+        Double originalCharge1 = bond.getBegin().getCharge();
+        String originalAtomtypeName1 = bond.getBegin().getAtomTypeName();
+        Integer originalNeighborCount1 = bond.getBegin().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization1 = bond.getBegin().getHybridization();
+        Integer originalValency1 = bond.getBegin().getValency();
         Double originalCharge2 = bond.getEnd().getCharge();
         String originalAtomtypeName2 = bond.getEnd().getAtomTypeName();
         Integer originalNeighborCount2 = bond.getEnd().getFormalNeighbourCount();
         IAtomType.Hybridization originalHybridization2 = bond.getEnd().getHybridization();
         Integer originalValency2 = bond.getEnd().getValency();
-        Double originalBondOrderSum1 = bond.getBeg().getBondOrderSum();
-        Order originalMaxBondOrder1 = bond.getBeg().getMaxBondOrder();
+        Double originalBondOrderSum1 = bond.getBegin().getBondOrderSum();
+        Order originalMaxBondOrder1 = bond.getBegin().getMaxBondOrder();
         Double originalBondOrderSum2 = bond.getEnd().getBondOrderSum();
         Order originalMaxBondOrder2 = bond.getEnd().getMaxBondOrder();
         if (!isCachedAtomContainer(ac)) {
@@ -193,7 +193,7 @@ public class BondPartialTChargeDescriptor extends AbstractBondDescriptor {
                 List<Double> peoeBond = new ArrayList<Double>();
                 for (Iterator<IBond> it = ac.bonds().iterator(); it.hasNext();) {
                     IBond bondi = it.next();
-                    double result = Math.abs(bondi.getBeg().getCharge() - bondi.getEnd().getCharge());
+                    double result = Math.abs(bondi.getBegin().getCharge() - bondi.getEnd().getCharge());
                     peoeBond.add(result);
                 }
 
@@ -203,25 +203,25 @@ public class BondPartialTChargeDescriptor extends AbstractBondDescriptor {
                 pepe.assignGasteigerPiPartialCharges(ac, true);
                 for (int i = 0; i < ac.getBondCount(); i++) {
                     IBond bondi = ac.getBond(i);
-                    double result = Math.abs(bondi.getBeg().getCharge() - bondi.getEnd().getCharge());
+                    double result = Math.abs(bondi.getBegin().getCharge() - bondi.getEnd().getCharge());
                     cacheDescriptorValue(bondi, ac, new DoubleResult(peoeBond.get(i) + result));
                 }
             } catch (Exception e) {
                 return getDummyDescriptorValue(e);
             }
         }
-        bond.getBeg().setCharge(originalCharge1);
-        bond.getBeg().setAtomTypeName(originalAtomtypeName1);
-        bond.getBeg().setHybridization(originalHybridization1);
-        bond.getBeg().setValency(originalValency1);
-        bond.getBeg().setFormalNeighbourCount(originalNeighborCount1);
+        bond.getBegin().setCharge(originalCharge1);
+        bond.getBegin().setAtomTypeName(originalAtomtypeName1);
+        bond.getBegin().setHybridization(originalHybridization1);
+        bond.getBegin().setValency(originalValency1);
+        bond.getBegin().setFormalNeighbourCount(originalNeighborCount1);
         bond.getEnd().setCharge(originalCharge2);
         bond.getEnd().setAtomTypeName(originalAtomtypeName2);
         bond.getEnd().setHybridization(originalHybridization2);
         bond.getEnd().setValency(originalValency2);
         bond.getEnd().setFormalNeighbourCount(originalNeighborCount2);
-        bond.getBeg().setMaxBondOrder(originalMaxBondOrder1);
-        bond.getBeg().setBondOrderSum(originalBondOrderSum1);
+        bond.getBegin().setMaxBondOrder(originalMaxBondOrder1);
+        bond.getBegin().setBondOrderSum(originalBondOrderSum1);
         bond.getEnd().setMaxBondOrder(originalMaxBondOrder2);
         bond.getEnd().setBondOrderSum(originalBondOrderSum2);
 

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondSigmaElectronegativityDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondSigmaElectronegativityDescriptor.java
@@ -146,8 +146,8 @@ public class BondSigmaElectronegativityDescriptor extends AbstractBondDescriptor
 
         if (maxIterations != -1 && maxIterations != 0) electronegativity.setMaxIterations(maxIterations);
 
-        double electroAtom1 = electronegativity.calculateSigmaElectronegativity(ac, bond.getAtom(0));
-        double electroAtom2 = electronegativity.calculateSigmaElectronegativity(ac, bond.getAtom(1));
+        double electroAtom1 = electronegativity.calculateSigmaElectronegativity(ac, bond.getBeg());
+        double electroAtom2 = electronegativity.calculateSigmaElectronegativity(ac, bond.getEnd());
 
         return new DescriptorValue(getSpecification(), getParameterNames(), getParameters(), new DoubleResult(
                 Math.abs(electroAtom1 - electroAtom2)), NAMES);

--- a/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondSigmaElectronegativityDescriptor.java
+++ b/descriptor/qsarbond/src/main/java/org/openscience/cdk/qsar/descriptors/bond/BondSigmaElectronegativityDescriptor.java
@@ -146,7 +146,7 @@ public class BondSigmaElectronegativityDescriptor extends AbstractBondDescriptor
 
         if (maxIterations != -1 && maxIterations != 0) electronegativity.setMaxIterations(maxIterations);
 
-        double electroAtom1 = electronegativity.calculateSigmaElectronegativity(ac, bond.getBeg());
+        double electroAtom1 = electronegativity.calculateSigmaElectronegativity(ac, bond.getBegin());
         double electroAtom2 = electronegativity.calculateSigmaElectronegativity(ac, bond.getEnd());
 
         return new DescriptorValue(getSpecification(), getParameterNames(), getParameters(), new DoubleResult(

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/BPolDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/BPolDescriptor.java
@@ -142,8 +142,8 @@ public class BPolDescriptor extends AbstractMolecularDescriptor implements IMole
             String symbol0;
             String symbol1;
             for (IBond bond : container.bonds()) {
-                IAtom atom0 = bond.getAtom(0);
-                IAtom atom1 = bond.getAtom(1);
+                IAtom atom0 = bond.getBeg();
+                IAtom atom1 = bond.getEnd();
 
                 symbol0 = atom0.getSymbol();
                 symbol1 = atom1.getSymbol();

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/BPolDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/BPolDescriptor.java
@@ -142,7 +142,7 @@ public class BPolDescriptor extends AbstractMolecularDescriptor implements IMole
             String symbol0;
             String symbol1;
             for (IBond bond : container.bonds()) {
-                IAtom atom0 = bond.getBeg();
+                IAtom atom0 = bond.getBegin();
                 IAtom atom1 = bond.getEnd();
 
                 symbol0 = atom0.getSymbol();

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathDescriptor.java
@@ -232,8 +232,8 @@ public class ChiPathDescriptor extends AbstractMolecularDescriptor implements IM
         for (IBond bond : atomContainer.bonds()) {
             if (bond.getAtomCount() != 2) throw new CDKException("We only consider 2 center bonds");
             List<Integer> tmp = new ArrayList<Integer>();
-            tmp.add(atomContainer.indexOf(bond.getAtom(0)));
-            tmp.add(atomContainer.indexOf(bond.getAtom(1)));
+            tmp.add(atomContainer.indexOf(bond.getBeg()));
+            tmp.add(atomContainer.indexOf(bond.getEnd()));
             fragments.add(tmp);
         }
         return fragments;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathDescriptor.java
@@ -232,7 +232,7 @@ public class ChiPathDescriptor extends AbstractMolecularDescriptor implements IM
         for (IBond bond : atomContainer.bonds()) {
             if (bond.getAtomCount() != 2) throw new CDKException("We only consider 2 center bonds");
             List<Integer> tmp = new ArrayList<Integer>();
-            tmp.add(atomContainer.indexOf(bond.getBeg()));
+            tmp.add(atomContainer.indexOf(bond.getBegin()));
             tmp.add(atomContainer.indexOf(bond.getEnd()));
             fragments.add(tmp);
         }

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/GravitationalIndexDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/GravitationalIndexDescriptor.java
@@ -194,11 +194,11 @@ public class GravitationalIndexDescriptor extends AbstractMolecularDescriptor im
                 return getDummyDescriptorValue(new CDKException("GravitationalIndex: Only handles 2 center bonds"));
             }
 
-            mass1 = factory.getMajorIsotope(bond.getAtom(0).getSymbol()).getMassNumber();
-            mass2 = factory.getMajorIsotope(bond.getAtom(1).getSymbol()).getMassNumber();
+            mass1 = factory.getMajorIsotope(bond.getBeg().getSymbol()).getMassNumber();
+            mass2 = factory.getMajorIsotope(bond.getEnd().getSymbol()).getMassNumber();
 
-            Point3d p1 = bond.getAtom(0).getPoint3d();
-            Point3d p2 = bond.getAtom(1).getPoint3d();
+            Point3d p1 = bond.getBeg().getPoint3d();
+            Point3d p2 = bond.getEnd().getPoint3d();
 
             double x1 = p1.x;
             double y1 = p1.y;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/GravitationalIndexDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/GravitationalIndexDescriptor.java
@@ -220,13 +220,13 @@ public class GravitationalIndexDescriptor extends AbstractMolecularDescriptor im
                 return getDummyDescriptorValue(new CDKException("GravitationalIndex: Only handles 2 center bonds"));
             }
 
-            if (b.getAtom(0).getSymbol().equals("H") || b.getAtom(1).getSymbol().equals("H")) continue;
+            if (b.getBeg().getSymbol().equals("H") || b.getEnd().getSymbol().equals("H")) continue;
 
-            mass1 = factory.getMajorIsotope(b.getAtom(0).getSymbol()).getMassNumber();
-            mass2 = factory.getMajorIsotope(b.getAtom(1).getSymbol()).getMassNumber();
+            mass1 = factory.getMajorIsotope(b.getBeg().getSymbol()).getMassNumber();
+            mass2 = factory.getMajorIsotope(b.getEnd().getSymbol()).getMassNumber();
 
-            Point3d point0 = b.getAtom(0).getPoint3d();
-            Point3d point1 = b.getAtom(1).getPoint3d();
+            Point3d point0 = b.getBeg().getPoint3d();
+            Point3d point1 = b.getEnd().getPoint3d();
 
             double x1 = point0.x;
             double y1 = point0.y;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/GravitationalIndexDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/GravitationalIndexDescriptor.java
@@ -194,10 +194,10 @@ public class GravitationalIndexDescriptor extends AbstractMolecularDescriptor im
                 return getDummyDescriptorValue(new CDKException("GravitationalIndex: Only handles 2 center bonds"));
             }
 
-            mass1 = factory.getMajorIsotope(bond.getBeg().getSymbol()).getMassNumber();
+            mass1 = factory.getMajorIsotope(bond.getBegin().getSymbol()).getMassNumber();
             mass2 = factory.getMajorIsotope(bond.getEnd().getSymbol()).getMassNumber();
 
-            Point3d p1 = bond.getBeg().getPoint3d();
+            Point3d p1 = bond.getBegin().getPoint3d();
             Point3d p2 = bond.getEnd().getPoint3d();
 
             double x1 = p1.x;
@@ -220,12 +220,12 @@ public class GravitationalIndexDescriptor extends AbstractMolecularDescriptor im
                 return getDummyDescriptorValue(new CDKException("GravitationalIndex: Only handles 2 center bonds"));
             }
 
-            if (b.getBeg().getSymbol().equals("H") || b.getEnd().getSymbol().equals("H")) continue;
+            if (b.getBegin().getSymbol().equals("H") || b.getEnd().getSymbol().equals("H")) continue;
 
-            mass1 = factory.getMajorIsotope(b.getBeg().getSymbol()).getMassNumber();
+            mass1 = factory.getMajorIsotope(b.getBegin().getSymbol()).getMassNumber();
             mass2 = factory.getMajorIsotope(b.getEnd().getSymbol()).getMassNumber();
 
-            Point3d point0 = b.getBeg().getPoint3d();
+            Point3d point0 = b.getBegin().getPoint3d();
             Point3d point1 = b.getEnd().getPoint3d();
 
             double x1 = point0.x;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/HBondAcceptorCountDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/HBondAcceptorCountDescriptor.java
@@ -179,7 +179,7 @@ public class HBondAcceptorCountDescriptor extends AbstractMolecularDescriptor im
                 List<IBond> bonds = ac.getConnectedBondsList(atom);
                 int nPiBonds = 0;
                 for (IBond bond : bonds) {
-                    if (bond.getConnectedAtom(atom).getSymbol().equals("O")) continue atomloop;
+                    if (bond.getOther(atom).getSymbol().equals("O")) continue atomloop;
                     if (IBond.Order.DOUBLE.equals(bond.getOrder())) nPiBonds++;
                 }
 

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LargestChainDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LargestChainDescriptor.java
@@ -230,7 +230,7 @@ public class LargestChainDescriptor extends AbstractMolecularDescriptor implemen
                 cpy.addAtom(atom);
         }
         for (IBond bond : mol.bonds()) {
-            if (include.contains(bond.getAtom(0)) && include.contains(bond.getAtom(1)))
+            if (include.contains(bond.getBeg()) && include.contains(bond.getEnd()))
                 cpy.addBond(bond);
         }
         return cpy;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LargestChainDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LargestChainDescriptor.java
@@ -230,7 +230,7 @@ public class LargestChainDescriptor extends AbstractMolecularDescriptor implemen
                 cpy.addAtom(atom);
         }
         for (IBond bond : mol.bonds()) {
-            if (include.contains(bond.getBeg()) && include.contains(bond.getEnd()))
+            if (include.contains(bond.getBegin()) && include.contains(bond.getEnd()))
                 cpy.addBond(bond);
         }
         return cpy;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LargestPiSystemDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LargestPiSystemDescriptor.java
@@ -242,7 +242,7 @@ public class LargestPiSystemDescriptor extends AbstractMolecularDescriptor imple
             //logger.debug("BreadthFirstSearch around atom " + (atomNr + 1));
             List bonds = container.getConnectedBondsList(atom);
             for (Object bond : bonds) {
-                nextAtom = ((IBond) bond).getConnectedAtom(atom);
+                nextAtom = ((IBond) bond).getOther(atom);
                 if ((container.getMaximumBondOrder(nextAtom) != IBond.Order.SINGLE
                         || Math.abs(nextAtom.getFormalCharge()) >= 1 || nextAtom.getFlag(CDKConstants.ISAROMATIC)
                         || nextAtom.getSymbol().equals("N") || nextAtom.getSymbol().equals("O"))

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LongestAliphaticChainDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/LongestAliphaticChainDescriptor.java
@@ -290,7 +290,7 @@ public class LongestAliphaticChainDescriptor extends AbstractMolecularDescriptor
         for (IAtom atom : sphere) {
             List<IBond> bonds = container.getConnectedBondsList(atom);
             for (IBond bond : bonds) {
-                nextAtom = bond.getConnectedAtom(atom);
+                nextAtom = bond.getOther(atom);
                 if ((!nextAtom.getFlag(CDKConstants.ISAROMATIC) && !nextAtom.getFlag(CDKConstants.ISINRING)
                         & nextAtom.getSymbol().equals("C"))
                         & !nextAtom.getFlag(CDKConstants.VISITED)) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptor.java
@@ -156,7 +156,7 @@ public class RotatableBondsCountDescriptor extends AbstractMolecularDescriptor i
             }
         }
         for (IBond bond : ac.bonds()) {
-            IAtom atom0 = bond.getBeg();
+            IAtom atom0 = bond.getBegin();
             IAtom atom1 = bond.getEnd();
             if (atom0.getSymbol().equals("H") || atom1.getSymbol().equals("H")) continue;
             if (bond.getOrder() == Order.SINGLE) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptor.java
@@ -156,8 +156,8 @@ public class RotatableBondsCountDescriptor extends AbstractMolecularDescriptor i
             }
         }
         for (IBond bond : ac.bonds()) {
-            IAtom atom0 = bond.getAtom(0);
-            IAtom atom1 = bond.getAtom(1);
+            IAtom atom0 = bond.getBeg();
+            IAtom atom1 = bond.getEnd();
             if (atom0.getSymbol().equals("H") || atom1.getSymbol().equals("H")) continue;
             if (bond.getOrder() == Order.SINGLE) {
                 if ((BondManipulator.isLowerOrder(ac.getMaximumBondOrder(atom0), IBond.Order.TRIPLE))

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/SmallRingDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/SmallRingDescriptor.java
@@ -210,7 +210,7 @@ public class SmallRingDescriptor implements IMolecularDescriptor {
         for (int n = 0; n < mol.getBondCount(); n++) {
             IBond bond = mol.getBond(n);
             if (bond.getAtomCount() != 2) continue; // biconnected bonds only
-            int a1 = mol.indexOf(bond.getBeg()), a2 = mol.indexOf(bond.getEnd());
+            int a1 = mol.indexOf(bond.getBegin()), a2 = mol.indexOf(bond.getEnd());
 
             atomAdj[a1] = appendInteger(atomAdj[a1], a2);
             bondAdj[a1] = appendInteger(bondAdj[a1], n);
@@ -428,7 +428,7 @@ public class SmallRingDescriptor implements IMolecularDescriptor {
         for (int n = 0; n < nb; n++)
             if (bondOrder[n] == 2) {
                 IBond bond = mol.getBond(n);
-                piAtom[mol.indexOf(bond.getBeg())] = true;
+                piAtom[mol.indexOf(bond.getBegin())] = true;
                 piAtom[mol.indexOf(bond.getEnd())] = true;
             }
 
@@ -504,7 +504,7 @@ public class SmallRingDescriptor implements IMolecularDescriptor {
         for (int n = 0; n < nb; n++)
             if (bondOrder[n] > 0) {
                 IBond bond = mol.getBond(n);
-                electrons[mol.indexOf(bond.getBeg())] -= bondOrder[n];
+                electrons[mol.indexOf(bond.getBegin())] -= bondOrder[n];
                 electrons[mol.indexOf(bond.getEnd())] -= bondOrder[n];
             }
 

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/SmallRingDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/SmallRingDescriptor.java
@@ -210,7 +210,7 @@ public class SmallRingDescriptor implements IMolecularDescriptor {
         for (int n = 0; n < mol.getBondCount(); n++) {
             IBond bond = mol.getBond(n);
             if (bond.getAtomCount() != 2) continue; // biconnected bonds only
-            int a1 = mol.indexOf(bond.getAtom(0)), a2 = mol.indexOf(bond.getAtom(1));
+            int a1 = mol.indexOf(bond.getBeg()), a2 = mol.indexOf(bond.getEnd());
 
             atomAdj[a1] = appendInteger(atomAdj[a1], a2);
             bondAdj[a1] = appendInteger(bondAdj[a1], n);
@@ -428,8 +428,8 @@ public class SmallRingDescriptor implements IMolecularDescriptor {
         for (int n = 0; n < nb; n++)
             if (bondOrder[n] == 2) {
                 IBond bond = mol.getBond(n);
-                piAtom[mol.indexOf(bond.getAtom(0))] = true;
-                piAtom[mol.indexOf(bond.getAtom(1))] = true;
+                piAtom[mol.indexOf(bond.getBeg())] = true;
+                piAtom[mol.indexOf(bond.getEnd())] = true;
             }
 
         ArrayList<int[]> maybe = new ArrayList<int[]>(); // rings which may yet be aromatic
@@ -504,8 +504,8 @@ public class SmallRingDescriptor implements IMolecularDescriptor {
         for (int n = 0; n < nb; n++)
             if (bondOrder[n] > 0) {
                 IBond bond = mol.getBond(n);
-                electrons[mol.indexOf(bond.getAtom(0))] -= bondOrder[n];
-                electrons[mol.indexOf(bond.getAtom(1))] -= bondOrder[n];
+                electrons[mol.indexOf(bond.getBeg())] -= bondOrder[n];
+                electrons[mol.indexOf(bond.getEnd())] -= bondOrder[n];
             }
 
         // pull out all of the small rings that could be upgraded to aromatic

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/VAdjMaDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/VAdjMaDescriptor.java
@@ -113,7 +113,7 @@ public class VAdjMaDescriptor extends AbstractMolecularDescriptor implements IMo
 
         int n = 0; // count all heavy atom - heavy atom bonds
         for (IBond bond : atomContainer.bonds()) {
-            if (bond.getBeg().getAtomicNumber() != 1 && bond.getEnd().getAtomicNumber() != 1) {
+            if (bond.getBegin().getAtomicNumber() != 1 && bond.getEnd().getAtomicNumber() != 1) {
                 n++;
             }
         }

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/VAdjMaDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/VAdjMaDescriptor.java
@@ -113,7 +113,7 @@ public class VAdjMaDescriptor extends AbstractMolecularDescriptor implements IMo
 
         int n = 0; // count all heavy atom - heavy atom bonds
         for (IBond bond : atomContainer.bonds()) {
-            if (bond.getAtom(0).getAtomicNumber() != 1 && bond.getAtom(1).getAtomicNumber() != 1) {
+            if (bond.getBeg().getAtomicNumber() != 1 && bond.getEnd().getAtomicNumber() != 1) {
                 n++;
             }
         }

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
@@ -884,8 +884,8 @@ public class XLogPDescriptor extends AbstractMolecularDescriptor implements IMol
             IAtom bondAtom1 = null;
             while (bonds.hasNext()) {
                 IBond bond = (IBond) bonds.next();
-                bondAtom0 = bond.getAtom(0);
-                bondAtom1 = bond.getAtom(1);
+                bondAtom0 = bond.getBeg();
+                bondAtom1 = bond.getEnd();
                 if ((bondAtom0.getSymbol().equals("C") && bondAtom1.getSymbol().equals("N"))
                         || (bondAtom0.getSymbol().equals("N") && bondAtom1.getSymbol().equals("C"))
                         && bond.getOrder() == IBond.Order.SINGLE) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
@@ -884,7 +884,7 @@ public class XLogPDescriptor extends AbstractMolecularDescriptor implements IMol
             IAtom bondAtom1 = null;
             while (bonds.hasNext()) {
                 IBond bond = (IBond) bonds.next();
-                bondAtom0 = bond.getBeg();
+                bondAtom0 = bond.getBegin();
                 bondAtom1 = bond.getEnd();
                 if ((bondAtom0.getSymbol().equals("C") && bondAtom1.getSymbol().equals("N"))
                         || (bondAtom0.getSymbol().equals("N") && bondAtom1.getSymbol().equals("C"))

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
@@ -1287,14 +1287,14 @@ public class XLogPDescriptor extends AbstractMolecularDescriptor implements IMol
             bonds = ac.getConnectedBondsList(neighbour);
             for (int j = 0; j < bonds.size(); j++) {
                 IBond bond = (IBond) bonds.get(j);
-                if (bond.getOrder() != IBond.Order.SINGLE && bond.getConnectedAtom(neighbour) != atom
+                if (bond.getOrder() != IBond.Order.SINGLE && bond.getOther(neighbour) != atom
                         && !neighbour.getSymbol().equals("P") && !neighbour.getSymbol().equals("S")) {
                     picounter += 1;
                 }/*
-                  * else if (bonds[j].getConnectedAtom(neighbours[i])!=atom &&
+                  * else if (bonds[j].getOther(neighbours[i])!=atom &&
                   * !neighbours[i].getSymbol().equals("P") &&
                   * !neighbours[i].getSymbol().equals("S") &&
-                  * bonds[j].getConnectedAtom
+                  * bonds[j].getOther
                   * (neighbours[i]).getFlag(CDKConstants.ISAROMATIC)){ picounter
                   * += 1; }
                   */

--- a/descriptor/signature/src/test/java/org/openscience/cdk/signature/AbstractSignatureTest.java
+++ b/descriptor/signature/src/test/java/org/openscience/cdk/signature/AbstractSignatureTest.java
@@ -45,8 +45,8 @@ public class AbstractSignatureTest {
         }
         System.out.println();
         for (IBond bond : mol.bonds()) {
-            IAtom aa = bond.getAtom(0);
-            IAtom ab = bond.getAtom(1);
+            IAtom aa = bond.getBeg();
+            IAtom ab = bond.getEnd();
             int o = bond.getOrder().numeric();
             int x = mol.indexOf(aa);
             int y = mol.indexOf(ab);

--- a/descriptor/signature/src/test/java/org/openscience/cdk/signature/AbstractSignatureTest.java
+++ b/descriptor/signature/src/test/java/org/openscience/cdk/signature/AbstractSignatureTest.java
@@ -45,7 +45,7 @@ public class AbstractSignatureTest {
         }
         System.out.println();
         for (IBond bond : mol.bonds()) {
-            IAtom aa = bond.getBeg();
+            IAtom aa = bond.getBegin();
             IAtom ab = bond.getEnd();
             int o = bond.getOrder().numeric();
             int x = mol.indexOf(aa);

--- a/display/render/src/main/java/org/openscience/cdk/renderer/SymbolVisibility.java
+++ b/display/render/src/main/java/org/openscience/cdk/renderer/SymbolVisibility.java
@@ -139,7 +139,7 @@ public abstract class SymbolVisibility {
             // special case ethane
             if (bonds.size() == 1) {
                 Integer begHcnt = atom.getImplicitHydrogenCount();
-                IAtom end = bonds.get(0).getConnectedAtom(atom);
+                IAtom end = bonds.get(0).getOther(atom);
                 Integer endHcnt = end.getImplicitHydrogenCount();
                 if (begHcnt != null && endHcnt != null && begHcnt == 3 && endHcnt == 3)
                     return true;
@@ -207,8 +207,8 @@ public abstract class SymbolVisibility {
          */
         private static double getAngle(IAtom atom, IBond bond1, IBond bond2) {
             final Point2d pA = atom.getPoint2d();
-            final Point2d pB = bond1.getConnectedAtom(atom).getPoint2d();
-            final Point2d pC = bond2.getConnectedAtom(atom).getPoint2d();
+            final Point2d pB = bond1.getOther(atom).getPoint2d();
+            final Point2d pC = bond2.getOther(atom).getPoint2d();
             final Vector2d u = new Vector2d(pB.x - pA.x, pB.y - pA.y);
             final Vector2d v = new Vector2d(pC.x - pA.x, pC.y - pA.y);
             return u.angle(v);

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/BasicBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/BasicBondGenerator.java
@@ -311,7 +311,7 @@ public class BasicBondGenerator implements IGenerator<IAtomContainer> {
         if (bond.getAtomCount() > 2) return null;
 
         // is object right? if not replace with a good one
-        Point2d point1 = bond.getBeg().getPoint2d();
+        Point2d point1 = bond.getBegin().getPoint2d();
         Point2d point2 = bond.getEnd().getPoint2d();
         Color color = this.getColorForBond(bond, model);
         double bondWidth = this.getWidthForBond(bond, model);
@@ -398,7 +398,7 @@ public class BasicBondGenerator implements IGenerator<IAtomContainer> {
      */
     public LineElement generateInnerElement(IBond bond, IRing ring, RendererModel model) {
         Point2d center = GeometryUtil.get2DCenter(ring);
-        Point2d a = bond.getBeg().getPoint2d();
+        Point2d a = bond.getBegin().getPoint2d();
         Point2d b = bond.getEnd().getPoint2d();
 
         // the proportion to move in towards the ring center

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/BasicBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/BasicBondGenerator.java
@@ -311,8 +311,8 @@ public class BasicBondGenerator implements IGenerator<IAtomContainer> {
         if (bond.getAtomCount() > 2) return null;
 
         // is object right? if not replace with a good one
-        Point2d point1 = bond.getAtom(0).getPoint2d();
-        Point2d point2 = bond.getAtom(1).getPoint2d();
+        Point2d point1 = bond.getBeg().getPoint2d();
+        Point2d point2 = bond.getEnd().getPoint2d();
         Color color = this.getColorForBond(bond, model);
         double bondWidth = this.getWidthForBond(bond, model);
         double bondDistance = (Double) model.get(BondDistance.class) / model.getParameter(Scale.class).getValue();
@@ -398,8 +398,8 @@ public class BasicBondGenerator implements IGenerator<IAtomContainer> {
      */
     public LineElement generateInnerElement(IBond bond, IRing ring, RendererModel model) {
         Point2d center = GeometryUtil.get2DCenter(ring);
-        Point2d a = bond.getAtom(0).getPoint2d();
-        Point2d b = bond.getAtom(1).getPoint2d();
+        Point2d a = bond.getBeg().getPoint2d();
+        Point2d b = bond.getEnd().getPoint2d();
 
         // the proportion to move in towards the ring center
         double distanceFactor = model.getParameter(TowardsRingCenterProportion.class).getValue();

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -201,7 +201,7 @@ final class StandardBondGenerator {
      * @return rendering element
      */
     IRenderingElement generate(IBond bond) {
-        final IAtom atom1 = bond.getBeg();
+        final IAtom atom1 = bond.getBegin();
         final IAtom atom2 = bond.getEnd();
 
         IBond.Order order = bond.getOrder();
@@ -609,7 +609,7 @@ final class StandardBondGenerator {
         final IAtomContainer refContainer = cyclic ? ringMap.get(bond) : container;
 
         final int length = refContainer.getAtomCount();
-        final int index1 = refContainer.indexOf(bond.getBeg());
+        final int index1 = refContainer.indexOf(bond.getBegin());
         final int index2 = refContainer.indexOf(bond.getEnd());
 
         // if the bond is in a cycle we are using ring bonds to determine offset, since rings
@@ -617,8 +617,8 @@ final class StandardBondGenerator {
         // in the order they are in the ring.
         final boolean outOfOrder = cyclic && index1 == (index2 + 1) % length;
 
-        final IAtom atom1 = outOfOrder ? bond.getEnd() : bond.getBeg();
-        final IAtom atom2 = outOfOrder ? bond.getBeg() : bond.getEnd();
+        final IAtom atom1 = outOfOrder ? bond.getEnd() : bond.getBegin();
+        final IAtom atom2 = outOfOrder ? bond.getBegin() : bond.getEnd();
 
         if (IBond.Stereo.E_OR_Z.equals(bond.getStereo())) return generateCrossedDoubleBond(atom1, atom2);
 
@@ -712,11 +712,11 @@ final class StandardBondGenerator {
             case UP:
                 return bond.getEnd() == atom;
             case UP_INVERTED:
-                return bond.getBeg() == atom;
+                return bond.getBegin() == atom;
             case DOWN:
                 return bond.getEnd() == atom;
             case DOWN_INVERTED:
-                return bond.getBeg() == atom;
+                return bond.getBegin() == atom;
             default:
                 return false;
         }
@@ -1221,7 +1221,7 @@ final class StandardBondGenerator {
      * @throws java.lang.IllegalArgumentException bonds share no atoms
      */
     static int winding(IBond bond1, IBond bond2) {
-        final IAtom atom1 = bond1.getBeg();
+        final IAtom atom1 = bond1.getBegin();
         final IAtom atom2 = bond1.getEnd();
         if (bond2.contains(atom1)) {
             return winding(atom2.getPoint2d(), atom1.getPoint2d(), bond2.getOther(atom1).getPoint2d());

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -203,8 +203,8 @@ final class StandardBondGenerator {
      * @return rendering element
      */
     IRenderingElement generate(IBond bond) {
-        final IAtom atom1 = bond.getAtom(0);
-        final IAtom atom2 = bond.getAtom(1);
+        final IAtom atom1 = bond.getBeg();
+        final IAtom atom2 = bond.getEnd();
 
         IBond.Order order = bond.getOrder();
 
@@ -611,8 +611,8 @@ final class StandardBondGenerator {
         final IAtomContainer refContainer = cyclic ? ringMap.get(bond) : container;
 
         final int length = refContainer.getAtomCount();
-        final int index1 = refContainer.indexOf(bond.getAtom(0));
-        final int index2 = refContainer.indexOf(bond.getAtom(1));
+        final int index1 = refContainer.indexOf(bond.getBeg());
+        final int index2 = refContainer.indexOf(bond.getEnd());
 
         // if the bond is in a cycle we are using ring bonds to determine offset, since rings
         // have been normalised and ordered to wind anti-clockwise we want to get the atoms
@@ -712,13 +712,13 @@ final class StandardBondGenerator {
         if (bond.getStereo() == null) return false;
         switch (bond.getStereo()) {
             case UP:
-                return bond.getAtom(1) == atom;
+                return bond.getEnd() == atom;
             case UP_INVERTED:
-                return bond.getAtom(0) == atom;
+                return bond.getBeg() == atom;
             case DOWN:
-                return bond.getAtom(1) == atom;
+                return bond.getEnd() == atom;
             case DOWN_INVERTED:
-                return bond.getAtom(0) == atom;
+                return bond.getBeg() == atom;
             default:
                 return false;
         }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -65,11 +65,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.openscience.cdk.interfaces.IBond.Order.SINGLE;
-import static org.openscience.cdk.interfaces.IBond.Order.UNSET;
 import static org.openscience.cdk.interfaces.IBond.Stereo.NONE;
 import static org.openscience.cdk.renderer.generators.BasicSceneGenerator.BondLength;
 import static org.openscience.cdk.renderer.generators.standard.StandardGenerator.BondSeparation;
-import static org.openscience.cdk.renderer.generators.standard.StandardGenerator.HIDDEN;
 import static org.openscience.cdk.renderer.generators.standard.StandardGenerator.HashSpacing;
 import static org.openscience.cdk.renderer.generators.standard.StandardGenerator.WaveSpacing;
 import static org.openscience.cdk.renderer.generators.standard.VecmathUtil.adjacentLength;
@@ -345,7 +343,7 @@ final class StandardBondGenerator {
             if (toBonds.size() == 1) {
 
                 final IBond toBondNeighbor = toBonds.get(0);
-                final IAtom toNeighbor = toBondNeighbor.getConnectedAtom(to);
+                final IAtom toNeighbor = toBondNeighbor.getOther(to);
 
                 Vector2d refVector = newUnitVector(toPoint, toNeighbor.getPoint2d());
                 boolean wideToWide = false;
@@ -432,7 +430,7 @@ final class StandardBondGenerator {
         // fancy hashed wedges with slanted hatch sections aligned with neighboring bonds
         if (canDrawFancyHashedWedge(to, toBonds, adjacent)) {
             final IBond toBondNeighbor = toBonds.get(0);
-            final IAtom toNeighbor = toBondNeighbor.getConnectedAtom(to);
+            final IAtom toNeighbor = toBondNeighbor.getOther(to);
 
             Vector2d refVector = newUnitVector(toPoint, toNeighbor.getPoint2d());
 
@@ -768,7 +766,7 @@ final class StandardBondGenerator {
         final Vector2d unit = newUnitVector(atom1Point, atom2Point);
         Vector2d perpendicular = newPerpendicularVector(unit);
 
-        final Vector2d reference = newUnitVector(atom1.getPoint2d(), atom1Bond.getConnectedAtom(atom1).getPoint2d());
+        final Vector2d reference = newUnitVector(atom1.getPoint2d(), atom1Bond.getOther(atom1).getPoint2d());
 
         // there are two perpendicular vectors, this check ensures we have one on the same side as
         // the reference
@@ -979,7 +977,7 @@ final class StandardBondGenerator {
         final Vector2d bndVec  = VecmathUtil.newUnitVector(atom, bond);
         final Vector2d bndXVec = VecmathUtil.newPerpendicularVector(bndVec);
 
-        final double length = atom.getPoint2d().distance(bond.getConnectedAtom(atom).getPoint2d());
+        final double length = atom.getPoint2d().distance(bond.getOther(atom).getPoint2d());
         bndXVec.scale(length /2);
         final Tuple2d beg = VecmathUtil.sum(atom.getPoint2d(), bndXVec);
         bndXVec.scale(-1);
@@ -1226,9 +1224,9 @@ final class StandardBondGenerator {
         final IAtom atom1 = bond1.getBeg();
         final IAtom atom2 = bond1.getEnd();
         if (bond2.contains(atom1)) {
-            return winding(atom2.getPoint2d(), atom1.getPoint2d(), bond2.getConnectedAtom(atom1).getPoint2d());
+            return winding(atom2.getPoint2d(), atom1.getPoint2d(), bond2.getOther(atom1).getPoint2d());
         } else if (bond2.contains(atom2)) {
-            return winding(atom1.getPoint2d(), atom2.getPoint2d(), bond2.getConnectedAtom(atom2).getPoint2d());
+            return winding(atom1.getPoint2d(), atom2.getPoint2d(), bond2.getOther(atom2).getPoint2d());
         } else {
             throw new IllegalArgumentException("Bonds do not share any atoms");
         }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -619,8 +619,8 @@ final class StandardBondGenerator {
         // in the order they are in the ring.
         final boolean outOfOrder = cyclic && index1 == (index2 + 1) % length;
 
-        final IAtom atom1 = bond.getAtom(outOfOrder ? 1 : 0);
-        final IAtom atom2 = bond.getAtom(outOfOrder ? 0 : 1);
+        final IAtom atom1 = outOfOrder ? bond.getEnd() : bond.getBeg();
+        final IAtom atom2 = outOfOrder ? bond.getBeg() : bond.getEnd();
 
         if (IBond.Stereo.E_OR_Z.equals(bond.getStereo())) return generateCrossedDoubleBond(atom1, atom2);
 
@@ -1223,8 +1223,8 @@ final class StandardBondGenerator {
      * @throws java.lang.IllegalArgumentException bonds share no atoms
      */
     static int winding(IBond bond1, IBond bond2) {
-        final IAtom atom1 = bond1.getAtom(0);
-        final IAtom atom2 = bond1.getAtom(1);
+        final IAtom atom1 = bond1.getBeg();
+        final IAtom atom2 = bond1.getEnd();
         if (bond2.contains(atom1)) {
             return winding(atom2.getPoint2d(), atom1.getPoint2d(), bond2.getConnectedAtom(atom1).getPoint2d());
         } else if (bond2.contains(atom2)) {

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
@@ -128,7 +128,7 @@ final class StandardSgroupGenerator {
                 Set<IAtom> atoms = sgroup.getAtoms();
                 // should only be one bond
                 for (IBond bond : sgroup.getBonds()) {
-                    IAtom beg = bond.getBeg();
+                    IAtom beg = bond.getBegin();
                     IAtom end = bond.getEnd();
                     if (atoms.contains(beg)) {
                         StandardGenerator.hideFully(beg);
@@ -173,7 +173,7 @@ final class StandardSgroupGenerator {
             }
         }
         for (IBond bond : container.bonds()) {
-            IAtom beg = bond.getBeg();
+            IAtom beg = bond.getBegin();
             IAtom end = bond.getEnd();
             if (sgroupAtoms.contains(beg) && sgroupAtoms.contains(end)) {
                 numSgroupBonds++;
@@ -208,9 +208,9 @@ final class StandardSgroupGenerator {
         final Set<IAtom> parentAtoms = sgroup.getValue(SgroupKey.CtabParentAtomList);
 
         for (IBond bond : container.bonds()) {
-            if (parentAtoms.contains(bond.getBeg()) && parentAtoms.contains(bond.getEnd()))
+            if (parentAtoms.contains(bond.getBegin()) && parentAtoms.contains(bond.getEnd()))
                 continue;
-            if (atoms.contains(bond.getBeg()) || atoms.contains(bond.getEnd()))
+            if (atoms.contains(bond.getBegin()) || atoms.contains(bond.getEnd()))
                 StandardGenerator.hide(bond);
         }
         for (IAtom atom : atoms) {
@@ -240,7 +240,7 @@ final class StandardSgroupGenerator {
         if (crossing.size() > 1) {
             IAtom internal = null;
             for (IBond bond : crossing) {
-                IAtom beg = bond.getBeg();
+                IAtom beg = bond.getBegin();
                 IAtom end = bond.getEnd();
                 if (atoms.contains(beg)) {
                     if (internal != null && internal != beg) return; // can't do it
@@ -256,13 +256,13 @@ final class StandardSgroupGenerator {
             StandardGenerator.hide(atom);
         }
         for (IBond bond : container.bonds()) {
-            if (atoms.contains(bond.getBeg()) ||
+            if (atoms.contains(bond.getBegin()) ||
                 atoms.contains(bond.getEnd()))
                 StandardGenerator.hide(bond);
         }
         for (IBond bond : crossing) {
             StandardGenerator.unhide(bond);
-            IAtom a1 = bond.getBeg();
+            IAtom a1 = bond.getBegin();
             IAtom a2 = bond.getEnd();
             StandardGenerator.unhide(a1);
             if (atoms.contains(a1))
@@ -619,7 +619,7 @@ final class StandardSgroupGenerator {
 
                 final SgroupBracket bracket = e.getKey();
                 final IBond bond = e.getValue();
-                final IAtom inGroupAtom = atoms.contains(bond.getBeg()) ? bond.getBeg() : bond.getEnd();
+                final IAtom inGroupAtom = atoms.contains(bond.getBegin()) ? bond.getBegin() : bond.getEnd();
 
                 final Point2d p1 = bracket.getFirstPoint();
                 final Point2d p2 = bracket.getSecondPoint();
@@ -826,7 +826,7 @@ final class StandardSgroupGenerator {
         for (SgroupBracket bracket : brackets) {
             IBond crossingBond = null;
             for (IBond bond : bonds) {
-                IAtom a1 = bond.getBeg();
+                IAtom a1 = bond.getBegin();
                 IAtom a2 = bond.getEnd();
                 if (Line2D.linesIntersect(bracket.getFirstPoint().x, bracket.getFirstPoint().y,
                                           bracket.getSecondPoint().x, bracket.getSecondPoint().y,

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
@@ -128,8 +128,8 @@ final class StandardSgroupGenerator {
                 Set<IAtom> atoms = sgroup.getAtoms();
                 // should only be one bond
                 for (IBond bond : sgroup.getBonds()) {
-                    IAtom beg = bond.getAtom(0);
-                    IAtom end = bond.getAtom(1);
+                    IAtom beg = bond.getBeg();
+                    IAtom end = bond.getEnd();
                     if (atoms.contains(beg)) {
                         StandardGenerator.hideFully(beg);
                     } else {
@@ -173,8 +173,8 @@ final class StandardSgroupGenerator {
             }
         }
         for (IBond bond : container.bonds()) {
-            IAtom beg = bond.getAtom(0);
-            IAtom end = bond.getAtom(1);
+            IAtom beg = bond.getBeg();
+            IAtom end = bond.getEnd();
             if (sgroupAtoms.contains(beg) && sgroupAtoms.contains(end)) {
                 numSgroupBonds++;
                 if ((color = bond.getProperty(StandardGenerator.HIGHLIGHT_COLOR)) != null) {
@@ -208,9 +208,9 @@ final class StandardSgroupGenerator {
         final Set<IAtom> parentAtoms = sgroup.getValue(SgroupKey.CtabParentAtomList);
 
         for (IBond bond : container.bonds()) {
-            if (parentAtoms.contains(bond.getAtom(0)) && parentAtoms.contains(bond.getAtom(1)))
+            if (parentAtoms.contains(bond.getBeg()) && parentAtoms.contains(bond.getEnd()))
                 continue;
-            if (atoms.contains(bond.getAtom(0)) || atoms.contains(bond.getAtom(1)))
+            if (atoms.contains(bond.getBeg()) || atoms.contains(bond.getEnd()))
                 StandardGenerator.hide(bond);
         }
         for (IAtom atom : atoms) {
@@ -240,8 +240,8 @@ final class StandardSgroupGenerator {
         if (crossing.size() > 1) {
             IAtom internal = null;
             for (IBond bond : crossing) {
-                IAtom beg = bond.getAtom(0);
-                IAtom end = bond.getAtom(1);
+                IAtom beg = bond.getBeg();
+                IAtom end = bond.getEnd();
                 if (atoms.contains(beg)) {
                     if (internal != null && internal != beg) return; // can't do it
                     internal = beg;
@@ -256,14 +256,14 @@ final class StandardSgroupGenerator {
             StandardGenerator.hide(atom);
         }
         for (IBond bond : container.bonds()) {
-            if (atoms.contains(bond.getAtom(0)) ||
-                atoms.contains(bond.getAtom(1)))
+            if (atoms.contains(bond.getBeg()) ||
+                atoms.contains(bond.getEnd()))
                 StandardGenerator.hide(bond);
         }
         for (IBond bond : crossing) {
             StandardGenerator.unhide(bond);
-            IAtom a1 = bond.getAtom(0);
-            IAtom a2 = bond.getAtom(1);
+            IAtom a1 = bond.getBeg();
+            IAtom a2 = bond.getEnd();
             StandardGenerator.unhide(a1);
             if (atoms.contains(a1))
                 symbolRemap.put(a1, sgroup.getSubscript());
@@ -619,7 +619,7 @@ final class StandardSgroupGenerator {
 
                 final SgroupBracket bracket = e.getKey();
                 final IBond bond = e.getValue();
-                final IAtom inGroupAtom = atoms.contains(bond.getAtom(0)) ? bond.getAtom(0) : bond.getAtom(1);
+                final IAtom inGroupAtom = atoms.contains(bond.getBeg()) ? bond.getBeg() : bond.getEnd();
 
                 final Point2d p1 = bracket.getFirstPoint();
                 final Point2d p2 = bracket.getSecondPoint();
@@ -826,8 +826,8 @@ final class StandardSgroupGenerator {
         for (SgroupBracket bracket : brackets) {
             IBond crossingBond = null;
             for (IBond bond : bonds) {
-                IAtom a1 = bond.getAtom(0);
-                IAtom a2 = bond.getAtom(1);
+                IAtom a1 = bond.getBeg();
+                IAtom a2 = bond.getEnd();
                 if (Line2D.linesIntersect(bracket.getFirstPoint().x, bracket.getFirstPoint().y,
                                           bracket.getSecondPoint().x, bracket.getSecondPoint().y,
                                           a1.getPoint2d().x, a1.getPoint2d().y,

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/VecmathUtil.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/VecmathUtil.java
@@ -91,7 +91,7 @@ final class VecmathUtil {
      * @return unit vector
      */
     static Vector2d newUnitVector(final IAtom atom, final IBond bond) {
-        return newUnitVector(atom.getPoint2d(), bond.getConnectedAtom(atom).getPoint2d());
+        return newUnitVector(atom.getPoint2d(), bond.getOther(atom).getPoint2d());
     }
 
     /**
@@ -279,7 +279,7 @@ final class VecmathUtil {
 
         final List<IAtom> toAtoms = new ArrayList<IAtom>();
         for (IBond bond : bonds) {
-            toAtoms.add(bond.getConnectedAtom(fromAtom));
+            toAtoms.add(bond.getOther(fromAtom));
         }
 
         return getNearestVector(reference, newUnitVectors(fromAtom, toAtoms));

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/VecmathUtilTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/VecmathUtilTest.java
@@ -74,8 +74,8 @@ public class VecmathUtilTest {
         when(a1.getPoint2d()).thenReturn(new Point2d(0, 1));
         when(a2.getPoint2d()).thenReturn(new Point2d(1, 0));
         IBond bond = mock(IBond.class);
-        when(bond.getConnectedAtom(a1)).thenReturn(a2);
-        when(bond.getConnectedAtom(a2)).thenReturn(a1);
+        when(bond.getOther(a1)).thenReturn(a2);
+        when(bond.getOther(a2)).thenReturn(a1);
         Vector2d unit = VecmathUtil.newUnitVector(a1, bond);
         assertThat(unit.x, closeTo(0.707d, 0.01));
         assertThat(unit.y, closeTo(-0.707d, 0.01));
@@ -177,9 +177,9 @@ public class VecmathUtilTest {
         IBond b1 = mock(IBond.class);
         IBond b2 = mock(IBond.class);
         IBond b3 = mock(IBond.class);
-        when(b1.getConnectedAtom(a1)).thenReturn(a2);
-        when(b2.getConnectedAtom(a1)).thenReturn(a3);
-        when(b3.getConnectedAtom(a1)).thenReturn(a4);
+        when(b1.getOther(a1)).thenReturn(a2);
+        when(b2.getOther(a1)).thenReturn(a3);
+        when(b3.getOther(a1)).thenReturn(a4);
         when(a1.getPoint2d()).thenReturn(new Point2d(0, 0));
         when(a2.getPoint2d()).thenReturn(new Point2d(0, 1));
         when(a3.getPoint2d()).thenReturn(new Point2d(1, 0));

--- a/display/renderextra/src/main/java/org/openscience/cdk/renderer/generators/HighlightGenerator.java
+++ b/display/renderextra/src/main/java/org/openscience/cdk/renderer/generators/HighlightGenerator.java
@@ -164,7 +164,7 @@ public final class HighlightGenerator implements IGenerator<IAtomContainer> {
             // punch out the area occupied by atoms highlighted with a
             // different color
 
-            IAtom a1 = bond.getAtom(0), a2 = bond.getAtom(1);
+            IAtom a1 = bond.getBeg(), a2 = bond.getEnd();
             Integer a1Id = highlight.get(a1), a2Id = highlight.get(a2);
 
             if (a1Id != null && !a1Id.equals(id)) area.subtract(shapes.get(a1Id));
@@ -203,10 +203,10 @@ public final class HighlightGenerator implements IGenerator<IAtomContainer> {
      */
     private static Shape createBondHighlight(IBond bond, double radius) {
 
-        double x1 = bond.getAtom(0).getPoint2d().x;
-        double x2 = bond.getAtom(1).getPoint2d().x;
-        double y1 = bond.getAtom(0).getPoint2d().y;
-        double y2 = bond.getAtom(1).getPoint2d().y;
+        double x1 = bond.getBeg().getPoint2d().x;
+        double x2 = bond.getEnd().getPoint2d().x;
+        double y1 = bond.getBeg().getPoint2d().y;
+        double y2 = bond.getEnd().getPoint2d().y;
 
         double dx = x2 - x1;
         double dy = y2 - y1;

--- a/display/renderextra/src/main/java/org/openscience/cdk/renderer/generators/HighlightGenerator.java
+++ b/display/renderextra/src/main/java/org/openscience/cdk/renderer/generators/HighlightGenerator.java
@@ -164,7 +164,7 @@ public final class HighlightGenerator implements IGenerator<IAtomContainer> {
             // punch out the area occupied by atoms highlighted with a
             // different color
 
-            IAtom a1 = bond.getBeg(), a2 = bond.getEnd();
+            IAtom   a1   = bond.getBegin(), a2 = bond.getEnd();
             Integer a1Id = highlight.get(a1), a2Id = highlight.get(a2);
 
             if (a1Id != null && !a1Id.equals(id)) area.subtract(shapes.get(a1Id));
@@ -203,9 +203,9 @@ public final class HighlightGenerator implements IGenerator<IAtomContainer> {
      */
     private static Shape createBondHighlight(IBond bond, double radius) {
 
-        double x1 = bond.getBeg().getPoint2d().x;
+        double x1 = bond.getBegin().getPoint2d().x;
         double x2 = bond.getEnd().getPoint2d().x;
-        double y1 = bond.getBeg().getPoint2d().y;
+        double y1 = bond.getBegin().getPoint2d().y;
         double y2 = bond.getEnd().getPoint2d().y;
 
         double dx = x2 - x1;

--- a/legacy/src/main/java/org/openscience/cdk/aromaticity/CDKHueckelAromaticityDetector.java
+++ b/legacy/src/main/java/org/openscience/cdk/aromaticity/CDKHueckelAromaticityDetector.java
@@ -216,7 +216,7 @@ public class CDKHueckelAromaticityDetector {
                         && neighborBond.getOrder() == Order.DOUBLE
                         || neighborBond.getOrder() == Order.TRIPLE) {
                     if (!("N.sp2.3".equals(atom.getAtomTypeName()) && "O.sp2".equals(neighborBond
-                            .getConnectedAtom(atom).getAtomTypeName()))) return true;
+                                                                                         .getOther(atom).getAtomTypeName()))) return true;
                 }
             }
         }

--- a/legacy/src/main/java/org/openscience/cdk/geometry/GeometryTools.java
+++ b/legacy/src/main/java/org/openscience/cdk/geometry/GeometryTools.java
@@ -652,13 +652,13 @@ public class GeometryTools {
      *@return       The array with the coordinates
      */
     public static int[] getBondCoordinates(IBond bond) {
-        if (bond.getBeg().getPoint2d() == null || bond.getEnd().getPoint2d() == null) {
+        if (bond.getBegin().getPoint2d() == null || bond.getEnd().getPoint2d() == null) {
             logger.error("getBondCoordinates() called on Bond without 2D coordinates!");
             return new int[0];
         }
-        int beginX = (int) bond.getBeg().getPoint2d().x;
+        int beginX = (int) bond.getBegin().getPoint2d().x;
         int endX = (int) bond.getEnd().getPoint2d().x;
-        int beginY = (int) bond.getBeg().getPoint2d().y;
+        int beginY = (int) bond.getBegin().getPoint2d().y;
         int endY = (int) bond.getEnd().getPoint2d().y;
         return new int[]{beginX, beginY, endX, endY};
     }
@@ -905,7 +905,7 @@ public class GeometryTools {
         int bondCounter = 0;
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (atom1.getPoint2d() != null && atom2.getPoint2d() != null) {
                 bondCounter++;
@@ -927,7 +927,7 @@ public class GeometryTools {
         double[] lengths = new double[container.getBondCount()];
         for (int i = 0; i < container.getBondCount(); i++) {
             final IBond bond = container.getBond(i);
-            final IAtom atom1 = bond.getBeg();
+            final IAtom atom1 = bond.getBegin();
             final IAtom atom2 = bond.getEnd();
             if (atom1.getPoint2d() == null || atom2.getPoint2d() == null)
                 throw new IllegalArgumentException("An atom has no 2D coordinates.");
@@ -945,10 +945,10 @@ public class GeometryTools {
      *@return       The geometric length of this bond
      */
     public static double getLength2D(IBond bond) {
-        if (bond.getBeg() == null || bond.getEnd() == null) {
+        if (bond.getBegin() == null || bond.getEnd() == null) {
             return 0.0;
         }
-        Point2d point1 = bond.getBeg().getPoint2d();
+        Point2d point1 = bond.getBegin().getPoint2d();
         Point2d point2 = bond.getEnd().getPoint2d();
         if (point1 == null || point2 == null) {
             return 0.0;
@@ -1170,7 +1170,7 @@ public class GeometryTools {
             // only consider two atom bonds into account
             if (bond.getAtomCount() == 2) {
                 counter++;
-                IAtom atom1 = bond.getBeg();
+                IAtom atom1 = bond.getBegin();
                 IAtom atom2 = bond.getEnd();
                 bondlength += Math.sqrt(Math.pow(atom1.getPoint2d().x - atom2.getPoint2d().x, 2)
                         + Math.pow(atom1.getPoint2d().y - atom2.getPoint2d().y, 2));
@@ -1621,7 +1621,7 @@ public class GeometryTools {
         double bondLengthSum = 0;
         int bondCounter = 0;
         for (IBond bond : container.bonds()) {
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (atom1.getPoint3d() != null && atom2.getPoint3d() != null) {
                 bondCounter++;

--- a/legacy/src/main/java/org/openscience/cdk/geometry/GeometryTools.java
+++ b/legacy/src/main/java/org/openscience/cdk/geometry/GeometryTools.java
@@ -652,14 +652,14 @@ public class GeometryTools {
      *@return       The array with the coordinates
      */
     public static int[] getBondCoordinates(IBond bond) {
-        if (bond.getAtom(0).getPoint2d() == null || bond.getAtom(1).getPoint2d() == null) {
+        if (bond.getBeg().getPoint2d() == null || bond.getEnd().getPoint2d() == null) {
             logger.error("getBondCoordinates() called on Bond without 2D coordinates!");
             return new int[0];
         }
-        int beginX = (int) bond.getAtom(0).getPoint2d().x;
-        int endX = (int) bond.getAtom(1).getPoint2d().x;
-        int beginY = (int) bond.getAtom(0).getPoint2d().y;
-        int endY = (int) bond.getAtom(1).getPoint2d().y;
+        int beginX = (int) bond.getBeg().getPoint2d().x;
+        int endX = (int) bond.getEnd().getPoint2d().x;
+        int beginY = (int) bond.getBeg().getPoint2d().y;
+        int endY = (int) bond.getEnd().getPoint2d().y;
         return new int[]{beginX, beginY, endX, endY};
     }
 
@@ -905,8 +905,8 @@ public class GeometryTools {
         int bondCounter = 0;
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (atom1.getPoint2d() != null && atom2.getPoint2d() != null) {
                 bondCounter++;
                 bondLengthSum += getLength2D(bond);
@@ -927,8 +927,8 @@ public class GeometryTools {
         double[] lengths = new double[container.getBondCount()];
         for (int i = 0; i < container.getBondCount(); i++) {
             final IBond bond = container.getBond(i);
-            final IAtom atom1 = bond.getAtom(0);
-            final IAtom atom2 = bond.getAtom(1);
+            final IAtom atom1 = bond.getBeg();
+            final IAtom atom2 = bond.getEnd();
             if (atom1.getPoint2d() == null || atom2.getPoint2d() == null)
                 throw new IllegalArgumentException("An atom has no 2D coordinates.");
             lengths[i] = getLength2D(bond);
@@ -945,11 +945,11 @@ public class GeometryTools {
      *@return       The geometric length of this bond
      */
     public static double getLength2D(IBond bond) {
-        if (bond.getAtom(0) == null || bond.getAtom(1) == null) {
+        if (bond.getBeg() == null || bond.getEnd() == null) {
             return 0.0;
         }
-        Point2d point1 = bond.getAtom(0).getPoint2d();
-        Point2d point2 = bond.getAtom(1).getPoint2d();
+        Point2d point1 = bond.getBeg().getPoint2d();
+        Point2d point2 = bond.getEnd().getPoint2d();
         if (point1 == null || point2 == null) {
             return 0.0;
         }
@@ -1170,8 +1170,8 @@ public class GeometryTools {
             // only consider two atom bonds into account
             if (bond.getAtomCount() == 2) {
                 counter++;
-                IAtom atom1 = bond.getAtom(0);
-                IAtom atom2 = bond.getAtom(1);
+                IAtom atom1 = bond.getBeg();
+                IAtom atom2 = bond.getEnd();
                 bondlength += Math.sqrt(Math.pow(atom1.getPoint2d().x - atom2.getPoint2d().x, 2)
                         + Math.pow(atom1.getPoint2d().y - atom2.getPoint2d().y, 2));
             }
@@ -1621,8 +1621,8 @@ public class GeometryTools {
         double bondLengthSum = 0;
         int bondCounter = 0;
         for (IBond bond : container.bonds()) {
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (atom1.getPoint3d() != null && atom2.getPoint3d() != null) {
                 bondCounter++;
                 bondLengthSum += atom1.getPoint3d().distance(atom2.getPoint3d());

--- a/legacy/src/main/java/org/openscience/cdk/graph/MoleculeGraphs.java
+++ b/legacy/src/main/java/org/openscience/cdk/graph/MoleculeGraphs.java
@@ -65,7 +65,7 @@ public class MoleculeGraphs {
              * int order = (int) bond.getOrder(); for (int j=0; j<order; j++) {
              * graph.addEdge(bond.getAtoms()[0], bond.getAtoms()[1]); }
              */
-            graph.addEdge(bond.getBeg(), bond.getEnd());
+            graph.addEdge(bond.getBegin(), bond.getEnd());
         }
         return graph;
     }

--- a/legacy/src/main/java/org/openscience/cdk/graph/MoleculeGraphs.java
+++ b/legacy/src/main/java/org/openscience/cdk/graph/MoleculeGraphs.java
@@ -65,7 +65,7 @@ public class MoleculeGraphs {
              * int order = (int) bond.getOrder(); for (int j=0; j<order; j++) {
              * graph.addEdge(bond.getAtoms()[0], bond.getAtoms()[1]); }
              */
-            graph.addEdge(bond.getAtom(0), bond.getAtom(1));
+            graph.addEdge(bond.getBeg(), bond.getEnd());
         }
         return graph;
     }

--- a/legacy/src/main/java/org/openscience/cdk/normalize/SMSDNormalizer.java
+++ b/legacy/src/main/java/org/openscience/cdk/normalize/SMSDNormalizer.java
@@ -357,7 +357,7 @@ public class SMSDNormalizer extends AtomContainerManipulator {
             bonds[index] = new Bond();
             int indexI = 999;
             for (int i = 0; i < container.getAtomCount(); i++) {
-                if (container.getBond(index).getBeg() == container.getAtom(i)) {
+                if (container.getBond(index).getBegin() == container.getAtom(i)) {
                     indexI = i;
                     break;
                 }
@@ -439,7 +439,7 @@ public class SMSDNormalizer extends AtomContainerManipulator {
                     e.printStackTrace();
                 }
                 assert clone != null;
-                clone.setAtoms(new IAtom[]{map.get(bond.getBeg()), map.get(bond.getEnd())});
+                clone.setAtoms(new IAtom[]{map.get(bond.getBegin()), map.get(bond.getEnd())});
                 clone.setOrder(atomContainer.getBond(i).getOrder());
                 clone.setStereo(atomContainer.getBond(i).getStereo());
                 mol.addBond(clone);

--- a/legacy/src/main/java/org/openscience/cdk/normalize/SMSDNormalizer.java
+++ b/legacy/src/main/java/org/openscience/cdk/normalize/SMSDNormalizer.java
@@ -439,7 +439,7 @@ public class SMSDNormalizer extends AtomContainerManipulator {
                     e.printStackTrace();
                 }
                 assert clone != null;
-                clone.setAtoms(new IAtom[]{map.get(bond.getAtom(0)), map.get(bond.getAtom(1))});
+                clone.setAtoms(new IAtom[]{map.get(bond.getBeg()), map.get(bond.getEnd())});
                 clone.setOrder(atomContainer.getBond(i).getOrder());
                 clone.setStereo(atomContainer.getBond(i).getStereo());
                 mol.addBond(clone);

--- a/legacy/src/main/java/org/openscience/cdk/normalize/SMSDNormalizer.java
+++ b/legacy/src/main/java/org/openscience/cdk/normalize/SMSDNormalizer.java
@@ -357,14 +357,14 @@ public class SMSDNormalizer extends AtomContainerManipulator {
             bonds[index] = new Bond();
             int indexI = 999;
             for (int i = 0; i < container.getAtomCount(); i++) {
-                if (container.getBond(index).getAtom(0) == container.getAtom(i)) {
+                if (container.getBond(index).getBeg() == container.getAtom(i)) {
                     indexI = i;
                     break;
                 }
             }
             int indexJ = 999;
             for (int j = 0; j < container.getAtomCount(); j++) {
-                if (container.getBond(index).getAtom(1) == container.getAtom(j)) {
+                if (container.getBond(index).getEnd() == container.getAtom(j)) {
                     indexJ = j;
                     break;
                 }

--- a/legacy/src/main/java/org/openscience/cdk/qsar/descriptors/bond/IPBondLearningDescriptor.java
+++ b/legacy/src/main/java/org/openscience/cdk/qsar/descriptors/bond/IPBondLearningDescriptor.java
@@ -115,16 +115,16 @@ public class IPBondLearningDescriptor extends AbstractBondDescriptor {
     public DescriptorValue calculate(IBond bond, IAtomContainer atomContainer) {
         double value = 0;
         // FIXME: for now I'll cache a few modified atomic properties, and restore them at the end of this method
-        String originalAtomtypeName1 = bond.getBeg().getAtomTypeName();
-        Integer originalNeighborCount1 = bond.getBeg().getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization1 = bond.getBeg().getHybridization();
-        Integer originalValency1 = bond.getBeg().getValency();
+        String originalAtomtypeName1 = bond.getBegin().getAtomTypeName();
+        Integer originalNeighborCount1 = bond.getBegin().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization1 = bond.getBegin().getHybridization();
+        Integer originalValency1 = bond.getBegin().getValency();
         String originalAtomtypeName2 = bond.getEnd().getAtomTypeName();
         Integer originalNeighborCount2 = bond.getEnd().getFormalNeighbourCount();
         IAtomType.Hybridization originalHybridization2 = bond.getEnd().getHybridization();
         Integer originalValency2 = bond.getEnd().getValency();
-        Double originalBondOrderSum1 = bond.getBeg().getBondOrderSum();
-        Order originalMaxBondOrder1 = bond.getBeg().getMaxBondOrder();
+        Double originalBondOrderSum1 = bond.getBegin().getBondOrderSum();
+        Order originalMaxBondOrder1 = bond.getBegin().getMaxBondOrder();
         Double originalBondOrderSum2 = bond.getEnd().getBondOrderSum();
         Order originalMaxBondOrder2 = bond.getEnd().getMaxBondOrder();
 
@@ -145,16 +145,16 @@ public class IPBondLearningDescriptor extends AbstractBondDescriptor {
                 return getDummyDescriptorValue(e);
             }
         }
-        bond.getBeg().setAtomTypeName(originalAtomtypeName1);
-        bond.getBeg().setHybridization(originalHybridization1);
-        bond.getBeg().setValency(originalValency1);
-        bond.getBeg().setFormalNeighbourCount(originalNeighborCount1);
+        bond.getBegin().setAtomTypeName(originalAtomtypeName1);
+        bond.getBegin().setHybridization(originalHybridization1);
+        bond.getBegin().setValency(originalValency1);
+        bond.getBegin().setFormalNeighbourCount(originalNeighborCount1);
         bond.getEnd().setAtomTypeName(originalAtomtypeName2);
         bond.getEnd().setHybridization(originalHybridization2);
         bond.getEnd().setValency(originalValency2);
         bond.getEnd().setFormalNeighbourCount(originalNeighborCount2);
-        bond.getBeg().setMaxBondOrder(originalMaxBondOrder1);
-        bond.getBeg().setBondOrderSum(originalBondOrderSum1);
+        bond.getBegin().setMaxBondOrder(originalMaxBondOrder1);
+        bond.getBegin().setBondOrderSum(originalBondOrderSum1);
         bond.getEnd().setMaxBondOrder(originalMaxBondOrder2);
         bond.getEnd().setBondOrderSum(originalBondOrderSum2);
 

--- a/legacy/src/main/java/org/openscience/cdk/qsar/descriptors/bond/IPBondLearningDescriptor.java
+++ b/legacy/src/main/java/org/openscience/cdk/qsar/descriptors/bond/IPBondLearningDescriptor.java
@@ -115,18 +115,18 @@ public class IPBondLearningDescriptor extends AbstractBondDescriptor {
     public DescriptorValue calculate(IBond bond, IAtomContainer atomContainer) {
         double value = 0;
         // FIXME: for now I'll cache a few modified atomic properties, and restore them at the end of this method
-        String originalAtomtypeName1 = bond.getAtom(0).getAtomTypeName();
-        Integer originalNeighborCount1 = bond.getAtom(0).getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization1 = bond.getAtom(0).getHybridization();
-        Integer originalValency1 = bond.getAtom(0).getValency();
-        String originalAtomtypeName2 = bond.getAtom(1).getAtomTypeName();
-        Integer originalNeighborCount2 = bond.getAtom(1).getFormalNeighbourCount();
-        IAtomType.Hybridization originalHybridization2 = bond.getAtom(1).getHybridization();
-        Integer originalValency2 = bond.getAtom(1).getValency();
-        Double originalBondOrderSum1 = bond.getAtom(0).getBondOrderSum();
-        Order originalMaxBondOrder1 = bond.getAtom(0).getMaxBondOrder();
-        Double originalBondOrderSum2 = bond.getAtom(1).getBondOrderSum();
-        Order originalMaxBondOrder2 = bond.getAtom(1).getMaxBondOrder();
+        String originalAtomtypeName1 = bond.getBeg().getAtomTypeName();
+        Integer originalNeighborCount1 = bond.getBeg().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization1 = bond.getBeg().getHybridization();
+        Integer originalValency1 = bond.getBeg().getValency();
+        String originalAtomtypeName2 = bond.getEnd().getAtomTypeName();
+        Integer originalNeighborCount2 = bond.getEnd().getFormalNeighbourCount();
+        IAtomType.Hybridization originalHybridization2 = bond.getEnd().getHybridization();
+        Integer originalValency2 = bond.getEnd().getValency();
+        Double originalBondOrderSum1 = bond.getBeg().getBondOrderSum();
+        Order originalMaxBondOrder1 = bond.getBeg().getMaxBondOrder();
+        Double originalBondOrderSum2 = bond.getEnd().getBondOrderSum();
+        Order originalMaxBondOrder2 = bond.getEnd().getMaxBondOrder();
 
         if (!isCachedAtomContainer(atomContainer)) {
             try {
@@ -145,18 +145,18 @@ public class IPBondLearningDescriptor extends AbstractBondDescriptor {
                 return getDummyDescriptorValue(e);
             }
         }
-        bond.getAtom(0).setAtomTypeName(originalAtomtypeName1);
-        bond.getAtom(0).setHybridization(originalHybridization1);
-        bond.getAtom(0).setValency(originalValency1);
-        bond.getAtom(0).setFormalNeighbourCount(originalNeighborCount1);
-        bond.getAtom(1).setAtomTypeName(originalAtomtypeName2);
-        bond.getAtom(1).setHybridization(originalHybridization2);
-        bond.getAtom(1).setValency(originalValency2);
-        bond.getAtom(1).setFormalNeighbourCount(originalNeighborCount2);
-        bond.getAtom(0).setMaxBondOrder(originalMaxBondOrder1);
-        bond.getAtom(0).setBondOrderSum(originalBondOrderSum1);
-        bond.getAtom(1).setMaxBondOrder(originalMaxBondOrder2);
-        bond.getAtom(1).setBondOrderSum(originalBondOrderSum2);
+        bond.getBeg().setAtomTypeName(originalAtomtypeName1);
+        bond.getBeg().setHybridization(originalHybridization1);
+        bond.getBeg().setValency(originalValency1);
+        bond.getBeg().setFormalNeighbourCount(originalNeighborCount1);
+        bond.getEnd().setAtomTypeName(originalAtomtypeName2);
+        bond.getEnd().setHybridization(originalHybridization2);
+        bond.getEnd().setValency(originalValency2);
+        bond.getEnd().setFormalNeighbourCount(originalNeighborCount2);
+        bond.getBeg().setMaxBondOrder(originalMaxBondOrder1);
+        bond.getBeg().setBondOrderSum(originalBondOrderSum1);
+        bond.getEnd().setMaxBondOrder(originalMaxBondOrder2);
+        bond.getEnd().setBondOrderSum(originalBondOrderSum2);
 
         return new DescriptorValue(getSpecification(), getParameterNames(), getParameters(), new DoubleResult(value),
                 DESCRIPTOR_NAMES);

--- a/legacy/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/IPMolecularLearningDescriptor.java
+++ b/legacy/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/IPMolecularLearningDescriptor.java
@@ -170,7 +170,7 @@ public class IPMolecularLearningDescriptor extends AbstractMolecularDescriptor i
         }
         for (Iterator<IBond> itB = container.bonds().iterator(); itB.hasNext();) {
             IBond bond = itB.next();
-            if (bond.getOrder() == IBond.Order.DOUBLE & bond.getBeg().getSymbol().equals("C")
+            if (bond.getOrder() == IBond.Order.DOUBLE & bond.getBegin().getSymbol().equals("C")
                     & bond.getEnd().getSymbol().equals("C")) {
                 double value = IonizationPotentialTool.predictIP(container, bond);
                 if (value != 0) dar.add(value);

--- a/legacy/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/IPMolecularLearningDescriptor.java
+++ b/legacy/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/IPMolecularLearningDescriptor.java
@@ -170,8 +170,8 @@ public class IPMolecularLearningDescriptor extends AbstractMolecularDescriptor i
         }
         for (Iterator<IBond> itB = container.bonds().iterator(); itB.hasNext();) {
             IBond bond = itB.next();
-            if (bond.getOrder() == IBond.Order.DOUBLE & bond.getAtom(0).getSymbol().equals("C")
-                    & bond.getAtom(1).getSymbol().equals("C")) {
+            if (bond.getOrder() == IBond.Order.DOUBLE & bond.getBeg().getSymbol().equals("C")
+                    & bond.getEnd().getSymbol().equals("C")) {
                 double value = IonizationPotentialTool.predictIP(container, bond);
                 if (value != 0) dar.add(value);
 

--- a/legacy/src/main/java/org/openscience/cdk/ringsearch/FiguerasSSSRFinder.java
+++ b/legacy/src/main/java/org/openscience/cdk/ringsearch/FiguerasSSSRFinder.java
@@ -382,8 +382,8 @@ public class FiguerasSSSRFinder {
         while (bonds.hasNext()) {
             bond = (IBond) bonds.next();
             molecule.removeElectronContainer(bond);
-            r1 = getRing(bond.getAtom(0), molecule);
-            r2 = getRing(bond.getAtom(1), molecule);
+            r1 = getRing(bond.getBeg(), molecule);
+            r2 = getRing(bond.getEnd(), molecule);
             logger.debug("checkEdges: " + bond);
             if (r1.getAtomCount() > r2.getAtomCount()) {
                 ringSet.addAtomContainer(r1);

--- a/legacy/src/main/java/org/openscience/cdk/ringsearch/FiguerasSSSRFinder.java
+++ b/legacy/src/main/java/org/openscience/cdk/ringsearch/FiguerasSSSRFinder.java
@@ -382,7 +382,7 @@ public class FiguerasSSSRFinder {
         while (bonds.hasNext()) {
             bond = (IBond) bonds.next();
             molecule.removeElectronContainer(bond);
-            r1 = getRing(bond.getBeg(), molecule);
+            r1 = getRing(bond.getBegin(), molecule);
             r2 = getRing(bond.getEnd(), molecule);
             logger.debug("checkEdges: " + bond);
             if (r1.getAtomCount() > r2.getAtomCount()) {

--- a/legacy/src/main/java/org/openscience/cdk/smiles/DeduceBondSystemTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/DeduceBondSystemTool.java
@@ -831,7 +831,7 @@ public class DeduceBondSystemTool {
             for (int bondNumber : bondNumbers) {
                 IBond bond = mol.getBond(bondNumber);
                 ring.addBond(bond);
-                if (!ring.contains(bond.getBeg())) ring.addAtom(bond.getBeg());
+                if (!ring.contains(bond.getBegin())) ring.addAtom(bond.getBegin());
                 if (!ring.contains(bond.getEnd())) ring.addAtom(bond.getEnd());
             }
             ringSet.addAtomContainer(ring);

--- a/legacy/src/main/java/org/openscience/cdk/smiles/DeduceBondSystemTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/DeduceBondSystemTool.java
@@ -831,8 +831,8 @@ public class DeduceBondSystemTool {
             for (int bondNumber : bondNumbers) {
                 IBond bond = mol.getBond(bondNumber);
                 ring.addBond(bond);
-                if (!ring.contains(bond.getAtom(0))) ring.addAtom(bond.getAtom(0));
-                if (!ring.contains(bond.getAtom(1))) ring.addAtom(bond.getAtom(1));
+                if (!ring.contains(bond.getBeg())) ring.addAtom(bond.getBeg());
+                if (!ring.contains(bond.getEnd())) ring.addAtom(bond.getEnd());
             }
             ringSet.addAtomContainer(ring);
         }

--- a/legacy/src/main/java/org/openscience/cdk/smiles/FixBondOrdersTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/FixBondOrdersTool.java
@@ -425,8 +425,8 @@ public class FixBondOrdersTool {
         List<Integer[]> aptc = new ArrayList<Integer[]>();
         for (Integer i : bondsToCheck) {
             Integer[] aps = new Integer[2];
-            aps[0] = molecule.indexOf(molecule.getBond(i).getAtom(0));
-            aps[1] = molecule.indexOf(molecule.getBond(i).getAtom(1));
+            aps[0] = molecule.indexOf(molecule.getBond(i).getBeg());
+            aps[1] = molecule.indexOf(molecule.getBond(i).getEnd());
             aptc.add(aps);
         }
         return aptc;

--- a/legacy/src/main/java/org/openscience/cdk/smiles/FixBondOrdersTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/FixBondOrdersTool.java
@@ -425,7 +425,7 @@ public class FixBondOrdersTool {
         List<Integer[]> aptc = new ArrayList<Integer[]>();
         for (Integer i : bondsToCheck) {
             Integer[] aps = new Integer[2];
-            aps[0] = molecule.indexOf(molecule.getBond(i).getBeg());
+            aps[0] = molecule.indexOf(molecule.getBond(i).getBegin());
             aps[1] = molecule.indexOf(molecule.getBond(i).getEnd());
             aptc.add(aps);
         }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultBondMatcher.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultBondMatcher.java
@@ -148,7 +148,7 @@ public class DefaultBondMatcher implements BondMatcher {
     }
 
     private int getUnsaturation(IAtomContainer container, IBond bond) {
-        return getUnsaturation(container, bond.getBeg()) + getUnsaturation(container, bond.getEnd());
+        return getUnsaturation(container, bond.getBegin()) + getUnsaturation(container, bond.getEnd());
     }
 
     private int getUnsaturation(IAtomContainer container, IAtom atom) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultBondMatcher.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultBondMatcher.java
@@ -148,7 +148,7 @@ public class DefaultBondMatcher implements BondMatcher {
     }
 
     private int getUnsaturation(IAtomContainer container, IBond bond) {
-        return getUnsaturation(container, bond.getAtom(0)) + getUnsaturation(container, bond.getAtom(1));
+        return getUnsaturation(container, bond.getBeg()) + getUnsaturation(container, bond.getEnd());
     }
 
     private int getUnsaturation(IAtomContainer container, IAtom atom) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultMatcher.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultMatcher.java
@@ -77,12 +77,12 @@ public class DefaultMatcher {
             IBond bondA2, boolean shouldMatchBonds) {
 
         // ok, atoms match
-        if (atomMatcher1.matches(ac2, bondA2.getBeg()) && atomMatcher2.matches(ac2, bondA2.getEnd())) {
+        if (atomMatcher1.matches(ac2, bondA2.getBegin()) && atomMatcher2.matches(ac2, bondA2.getEnd())) {
             //            System.out.println("Atom Matched");
             return true;
         }
         // ok, atoms match
-        if (atomMatcher1.matches(ac2, bondA2.getEnd()) && atomMatcher2.matches(ac2, bondA2.getBeg())) {
+        if (atomMatcher1.matches(ac2, bondA2.getEnd()) && atomMatcher2.matches(ac2, bondA2.getBegin())) {
             //            System.out.println("Atom Matched");
             return true;
         }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultMatcher.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultMatcher.java
@@ -77,12 +77,12 @@ public class DefaultMatcher {
             IBond bondA2, boolean shouldMatchBonds) {
 
         // ok, atoms match
-        if (atomMatcher1.matches(ac2, bondA2.getAtom(0)) && atomMatcher2.matches(ac2, bondA2.getAtom(1))) {
+        if (atomMatcher1.matches(ac2, bondA2.getBeg()) && atomMatcher2.matches(ac2, bondA2.getEnd())) {
             //            System.out.println("Atom Matched");
             return true;
         }
         // ok, atoms match
-        if (atomMatcher1.matches(ac2, bondA2.getAtom(1)) && atomMatcher2.matches(ac2, bondA2.getAtom(0))) {
+        if (atomMatcher1.matches(ac2, bondA2.getEnd()) && atomMatcher2.matches(ac2, bondA2.getBeg())) {
             //            System.out.println("Atom Matched");
             return true;
         }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultVFBondMatcher.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultVFBondMatcher.java
@@ -147,7 +147,7 @@ public class DefaultVFBondMatcher implements VFBondMatcher {
     }
 
     private int getUnsaturation(TargetProperties container, IBond bond) {
-        return getUnsaturation(container, bond.getBeg()) + getUnsaturation(container, bond.getEnd());
+        return getUnsaturation(container, bond.getBegin()) + getUnsaturation(container, bond.getEnd());
     }
 
     private int getUnsaturation(TargetProperties container, IAtom atom) {
@@ -159,7 +159,7 @@ public class DefaultVFBondMatcher implements VFBondMatcher {
     }
 
     private int getUnsaturation(IAtomContainer container, IBond bond) {
-        return getUnsaturation(container, bond.getBeg()) + getUnsaturation(container, bond.getEnd());
+        return getUnsaturation(container, bond.getBegin()) + getUnsaturation(container, bond.getEnd());
     }
 
     private int getUnsaturation(IAtomContainer container, IAtom atom) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultVFBondMatcher.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/matchers/DefaultVFBondMatcher.java
@@ -147,7 +147,7 @@ public class DefaultVFBondMatcher implements VFBondMatcher {
     }
 
     private int getUnsaturation(TargetProperties container, IBond bond) {
-        return getUnsaturation(container, bond.getAtom(0)) + getUnsaturation(container, bond.getAtom(1));
+        return getUnsaturation(container, bond.getBeg()) + getUnsaturation(container, bond.getEnd());
     }
 
     private int getUnsaturation(TargetProperties container, IAtom atom) {
@@ -159,7 +159,7 @@ public class DefaultVFBondMatcher implements VFBondMatcher {
     }
 
     private int getUnsaturation(IAtomContainer container, IBond bond) {
-        return getUnsaturation(container, bond.getAtom(0)) + getUnsaturation(container, bond.getAtom(1));
+        return getUnsaturation(container, bond.getBeg()) + getUnsaturation(container, bond.getEnd());
     }
 
     private int getUnsaturation(IAtomContainer container, IAtom atom) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/McGregorChecks.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/McGregorChecks.java
@@ -113,11 +113,11 @@ public class McGregorChecks {
 
         if (ac1 instanceof IQueryAtomContainer) {
             if (((IQueryBond) bondA1).matches(bondA2)) {
-                IQueryAtom atom1 = (IQueryAtom) (bondA1.getAtom(0));
-                IQueryAtom atom2 = (IQueryAtom) (bondA1.getAtom(1));
+                IQueryAtom atom1 = (IQueryAtom) (bondA1.getBeg());
+                IQueryAtom atom2 = (IQueryAtom) (bondA1.getEnd());
                 // ok, bonds match
-                if (atom1.matches(bondA2.getAtom(0)) && atom2.matches(bondA2.getAtom(1))
-                        || atom1.matches(bondA2.getAtom(1)) && atom2.matches(bondA2.getAtom(0))) {
+                if (atom1.matches(bondA2.getBeg()) && atom2.matches(bondA2.getEnd())
+                        || atom1.matches(bondA2.getEnd()) && atom2.matches(bondA2.getBeg())) {
                     // ok, atoms match in either order
                     return true;
                 }
@@ -129,9 +129,9 @@ public class McGregorChecks {
             //Bond Matcher
             BondMatcher bondMatcher = new DefaultBondMatcher(ac1, bondA1, shouldMatchBonds);
             //Atom Matcher
-            AtomMatcher atomMatcher1 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getAtom(0), shouldMatchBonds);
+            AtomMatcher atomMatcher1 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getBeg(), shouldMatchBonds);
             //Atom Matcher
-            AtomMatcher atomMatcher2 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getAtom(1), shouldMatchBonds);
+            AtomMatcher atomMatcher2 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getEnd(), shouldMatchBonds);
 
             if (DefaultMatcher.isBondMatch(bondMatcher, ac2, bondA2, shouldMatchBonds)
                     && DefaultMatcher.isAtomMatch(atomMatcher1, atomMatcher2, ac2, bondA2, shouldMatchBonds)) {
@@ -309,8 +309,8 @@ public class McGregorChecks {
     protected static List<String> generateCTabCopy(IAtomContainer atomContainer) throws IOException {
         List<String> cTabCopy = new ArrayList<String>();
         for (int a = 0; a < atomContainer.getBondCount(); a++) {
-            String atomI = atomContainer.getBond(a).getAtom(0).getSymbol();
-            String atomJ = atomContainer.getBond(a).getAtom(1).getSymbol();
+            String atomI = atomContainer.getBond(a).getBeg().getSymbol();
+            String atomJ = atomContainer.getBond(a).getEnd().getSymbol();
             cTabCopy.add(atomI);
             cTabCopy.add(atomJ);
             cTabCopy.add("X");

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/McGregorChecks.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/McGregorChecks.java
@@ -507,13 +507,13 @@ public class McGregorChecks {
             IAtomContainer atomContainer, List<String> cBondNeighbors) {
         for (int atomIndex = 0; atomIndex < neighborBondNum; atomIndex++) {
             IBond bond = atomContainer.getBond(atomIndex);
-            if ((atomContainer.indexOf(bond.getAtom(0)) == correspondingAtom)
+            if ((atomContainer.indexOf(bond.getBeg()) == correspondingAtom)
                     && (cBondNeighbors.get(atomIndex * 4 + 2).compareToIgnoreCase("X") == 0)) {
                 cBondNeighbors.set(atomIndex * 4 + 2, cBondNeighbors.get(atomIndex * 4 + 0));
                 cBondNeighbors.set(atomIndex * 4 + 0, newSymbol);
             }
 
-            if ((atomContainer.indexOf(bond.getAtom(1)) == correspondingAtom)
+            if ((atomContainer.indexOf(bond.getEnd()) == correspondingAtom)
                     && (cBondNeighbors.get(atomIndex * 4 + 3).compareToIgnoreCase("X") == 0)) {
                 cBondNeighbors.set(atomIndex * 4 + 3, cBondNeighbors.get(atomIndex * 4 + 1));
                 cBondNeighbors.set(atomIndex * 4 + 1, newSymbol);

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/McGregorChecks.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/McGregorChecks.java
@@ -113,11 +113,11 @@ public class McGregorChecks {
 
         if (ac1 instanceof IQueryAtomContainer) {
             if (((IQueryBond) bondA1).matches(bondA2)) {
-                IQueryAtom atom1 = (IQueryAtom) (bondA1.getBeg());
+                IQueryAtom atom1 = (IQueryAtom) (bondA1.getBegin());
                 IQueryAtom atom2 = (IQueryAtom) (bondA1.getEnd());
                 // ok, bonds match
-                if (atom1.matches(bondA2.getBeg()) && atom2.matches(bondA2.getEnd())
-                        || atom1.matches(bondA2.getEnd()) && atom2.matches(bondA2.getBeg())) {
+                if (atom1.matches(bondA2.getBegin()) && atom2.matches(bondA2.getEnd())
+                        || atom1.matches(bondA2.getEnd()) && atom2.matches(bondA2.getBegin())) {
                     // ok, atoms match in either order
                     return true;
                 }
@@ -129,7 +129,7 @@ public class McGregorChecks {
             //Bond Matcher
             BondMatcher bondMatcher = new DefaultBondMatcher(ac1, bondA1, shouldMatchBonds);
             //Atom Matcher
-            AtomMatcher atomMatcher1 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getBeg(), shouldMatchBonds);
+            AtomMatcher atomMatcher1 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getBegin(), shouldMatchBonds);
             //Atom Matcher
             AtomMatcher atomMatcher2 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getEnd(), shouldMatchBonds);
 
@@ -309,7 +309,7 @@ public class McGregorChecks {
     protected static List<String> generateCTabCopy(IAtomContainer atomContainer) throws IOException {
         List<String> cTabCopy = new ArrayList<String>();
         for (int a = 0; a < atomContainer.getBondCount(); a++) {
-            String atomI = atomContainer.getBond(a).getBeg().getSymbol();
+            String atomI = atomContainer.getBond(a).getBegin().getSymbol();
             String atomJ = atomContainer.getBond(a).getEnd().getSymbol();
             cTabCopy.add(atomI);
             cTabCopy.add(atomJ);
@@ -507,7 +507,7 @@ public class McGregorChecks {
             IAtomContainer atomContainer, List<String> cBondNeighbors) {
         for (int atomIndex = 0; atomIndex < neighborBondNum; atomIndex++) {
             IBond bond = atomContainer.getBond(atomIndex);
-            if ((atomContainer.indexOf(bond.getBeg()) == correspondingAtom)
+            if ((atomContainer.indexOf(bond.getBegin()) == correspondingAtom)
                     && (cBondNeighbors.get(atomIndex * 4 + 2).compareToIgnoreCase("X") == 0)) {
                 cBondNeighbors.set(atomIndex * 4 + 2, cBondNeighbors.get(atomIndex * 4 + 0));
                 cBondNeighbors.set(atomIndex * 4 + 0, newSymbol);

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/QueryProcessor.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/QueryProcessor.java
@@ -98,7 +98,7 @@ public class QueryProcessor {
 
         for (int atomIndex = 0; atomIndex < query.getBondCount(); atomIndex++) {
 
-            Integer indexI = query.indexOf(query.getBond(atomIndex).getBeg());
+            Integer indexI = query.indexOf(query.getBond(atomIndex).getBegin());
             Integer indexJ = query.indexOf(query.getBond(atomIndex).getEnd());
             Integer order = query.getBond(atomIndex).getOrder().numeric();
 
@@ -143,7 +143,7 @@ public class QueryProcessor {
         //        System.out.println("\n" + cTab1Copy + "\n");
 
         for (int atomIndex = 0; atomIndex < query.getBondCount(); atomIndex++) {
-            Integer indexI = query.indexOf(query.getBond(atomIndex).getBeg());
+            Integer indexI = query.indexOf(query.getBond(atomIndex).getBegin());
             Integer indexJ = query.indexOf(query.getBond(atomIndex).getEnd());
             Integer order = 0;
             if (query.getBond(atomIndex).getOrder() != null) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/QueryProcessor.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/QueryProcessor.java
@@ -98,8 +98,8 @@ public class QueryProcessor {
 
         for (int atomIndex = 0; atomIndex < query.getBondCount(); atomIndex++) {
 
-            Integer indexI = query.indexOf(query.getBond(atomIndex).getAtom(0));
-            Integer indexJ = query.indexOf(query.getBond(atomIndex).getAtom(1));
+            Integer indexI = query.indexOf(query.getBond(atomIndex).getBeg());
+            Integer indexJ = query.indexOf(query.getBond(atomIndex).getEnd());
             Integer order = query.getBond(atomIndex).getOrder().numeric();
 
             //            System.out.println(AtomI + "= , =" + AtomJ );
@@ -143,8 +143,8 @@ public class QueryProcessor {
         //        System.out.println("\n" + cTab1Copy + "\n");
 
         for (int atomIndex = 0; atomIndex < query.getBondCount(); atomIndex++) {
-            Integer indexI = query.indexOf(query.getBond(atomIndex).getAtom(0));
-            Integer indexJ = query.indexOf(query.getBond(atomIndex).getAtom(1));
+            Integer indexI = query.indexOf(query.getBond(atomIndex).getBeg());
+            Integer indexJ = query.indexOf(query.getBond(atomIndex).getEnd());
             Integer order = 0;
             if (query.getBond(atomIndex).getOrder() != null) {
                 order = query.getBond(atomIndex).getOrder().numeric();

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/TargetProcessor.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/TargetProcessor.java
@@ -90,7 +90,7 @@ public class TargetProcessor {
 
         for (int atomIndex = 0; atomIndex < target.getBondCount(); atomIndex++) {
 
-            Integer indexI = target.indexOf(target.getBond(atomIndex).getBeg());
+            Integer indexI = target.indexOf(target.getBond(atomIndex).getBegin());
             Integer indexJ = target.indexOf(target.getBond(atomIndex).getEnd());
             Integer order = target.getBond(atomIndex).getOrder().numeric();
 

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/TargetProcessor.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/TargetProcessor.java
@@ -90,8 +90,8 @@ public class TargetProcessor {
 
         for (int atomIndex = 0; atomIndex < target.getBondCount(); atomIndex++) {
 
-            Integer indexI = target.indexOf(target.getBond(atomIndex).getAtom(0));
-            Integer indexJ = target.indexOf(target.getBond(atomIndex).getAtom(1));
+            Integer indexI = target.indexOf(target.getBond(atomIndex).getBeg());
+            Integer indexJ = target.indexOf(target.getBond(atomIndex).getEnd());
             Integer order = target.getBond(atomIndex).getOrder().numeric();
 
             for (int b = 0; b < unmappedNumB; b++) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcsplus/GenerateCompatibilityGraph.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcsplus/GenerateCompatibilityGraph.java
@@ -348,9 +348,9 @@ public final class GenerateCompatibilityGraph {
         //Bond Matcher
         BondMatcher bondMatcher = new DefaultBondMatcher(ac1, bondA1, shouldMatchBonds);
         //Atom Matcher
-        AtomMatcher atomMatcher1 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getAtom(0), shouldMatchBonds);
+        AtomMatcher atomMatcher1 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getBeg(), shouldMatchBonds);
         //Atom Matcher
-        AtomMatcher atomMatcher2 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getAtom(1), shouldMatchBonds);
+        AtomMatcher atomMatcher2 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getEnd(), shouldMatchBonds);
 
         if (DefaultMatcher.isBondMatch(bondMatcher, ac2, bondA2, shouldMatchBonds)
                 && DefaultMatcher.isAtomMatch(atomMatcher1, atomMatcher2, ac2, bondA2, shouldMatchBonds)) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcsplus/GenerateCompatibilityGraph.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcsplus/GenerateCompatibilityGraph.java
@@ -348,7 +348,7 @@ public final class GenerateCompatibilityGraph {
         //Bond Matcher
         BondMatcher bondMatcher = new DefaultBondMatcher(ac1, bondA1, shouldMatchBonds);
         //Atom Matcher
-        AtomMatcher atomMatcher1 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getBeg(), shouldMatchBonds);
+        AtomMatcher atomMatcher1 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getBegin(), shouldMatchBonds);
         //Atom Matcher
         AtomMatcher atomMatcher2 = new DefaultMCSPlusAtomMatcher(ac1, bondA1.getEnd(), shouldMatchBonds);
 

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
@@ -991,10 +991,10 @@ public class CDKMCS {
         }
 
         if (centralAtom != null && centralQueryAtom != null && ((IQueryAtom) centralQueryAtom).matches(centralAtom)) {
-            IQueryAtom queryAtom1 = (IQueryAtom) queryBond1.getConnectedAtom(centralQueryAtom);
-            IQueryAtom queryAtom2 = (IQueryAtom) queryBond2.getConnectedAtom(centralQueryAtom);
-            IAtom atom1 = bond1.getConnectedAtom(centralAtom);
-            IAtom atom2 = bond2.getConnectedAtom(centralAtom);
+            IQueryAtom queryAtom1 = (IQueryAtom) queryBond1.getOther(centralQueryAtom);
+            IQueryAtom queryAtom2 = (IQueryAtom) queryBond2.getOther(centralQueryAtom);
+            IAtom atom1 = bond1.getOther(centralAtom);
+            IAtom atom2 = bond2.getOther(centralAtom);
             if (queryAtom1.matches(atom1) && queryAtom2.matches(atom2) || queryAtom1.matches(atom2)
                     && queryAtom2.matches(atom1)) {
                 return true;

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
@@ -795,12 +795,12 @@ public class CDKMCS {
                 IBond bondA2 = ac2.getBond(j);
                 if (bondA2 instanceof IQueryBond) {
                     IQueryBond queryBond = (IQueryBond) bondA2;
-                    IQueryAtom atom1 = (IQueryAtom) (bondA2.getAtom(0));
-                    IQueryAtom atom2 = (IQueryAtom) (bondA2.getAtom(1));
+                    IQueryAtom atom1 = (IQueryAtom) (bondA2.getBeg());
+                    IQueryAtom atom2 = (IQueryAtom) (bondA2.getEnd());
                     if (queryBond.matches(bondA1)) {
                         // ok, bonds match
-                        if (atom1.matches(bondA1.getAtom(0)) && atom2.matches(bondA1.getAtom(1))
-                                || atom1.matches(bondA1.getAtom(1)) && atom2.matches(bondA1.getAtom(0))) {
+                        if (atom1.matches(bondA1.getBeg()) && atom2.matches(bondA1.getEnd())
+                                || atom1.matches(bondA1.getEnd()) && atom2.matches(bondA1.getBeg())) {
                             // ok, atoms match in either order
                             graph.addNode(new CDKRNode(i, j));
                         }
@@ -823,9 +823,9 @@ public class CDKMCS {
         //Bond Matcher
         BondMatcher bondMatcher = new DefaultBondMatcher(ac1, bondA1, shouldMatchBonds);
         //Atom Matcher
-        AtomMatcher atomMatcher1 = new DefaultRGraphAtomMatcher(ac1, bondA1.getAtom(0), shouldMatchBonds);
+        AtomMatcher atomMatcher1 = new DefaultRGraphAtomMatcher(ac1, bondA1.getBeg(), shouldMatchBonds);
         //Atom Matcher
-        AtomMatcher atomMatcher2 = new DefaultRGraphAtomMatcher(ac1, bondA1.getAtom(1), shouldMatchBonds);
+        AtomMatcher atomMatcher2 = new DefaultRGraphAtomMatcher(ac1, bondA1.getEnd(), shouldMatchBonds);
 
         if (DefaultMatcher.isBondMatch(bondMatcher, ac2, bondA2, shouldMatchBonds)
                 && DefaultMatcher.isAtomMatch(atomMatcher1, atomMatcher2, ac2, bondA2, shouldMatchBonds)) {
@@ -906,7 +906,7 @@ public class CDKMCS {
      *            the 2 bonds have no common atom
      */
     private static boolean hasCommonAtom(IBond bondA, IBond bondB) {
-        return bondA.contains(bondB.getAtom(0)) || bondA.contains(bondB.getAtom(1));
+        return bondA.contains(bondB.getBeg()) || bondA.contains(bondB.getEnd());
     }
 
     /**
@@ -920,10 +920,10 @@ public class CDKMCS {
     private static String getCommonSymbol(IBond bondA, IBond bondB) {
         String symbol = "";
 
-        if (bondA.contains(bondB.getAtom(0))) {
-            symbol = bondB.getAtom(0).getSymbol();
-        } else if (bondA.contains(bondB.getAtom(1))) {
-            symbol = bondB.getAtom(1).getSymbol();
+        if (bondA.contains(bondB.getBeg())) {
+            symbol = bondB.getBeg().getSymbol();
+        } else if (bondA.contains(bondB.getEnd())) {
+            symbol = bondB.getEnd().getSymbol();
         }
 
         return symbol;
@@ -942,16 +942,16 @@ public class CDKMCS {
         IAtom atom1 = null;
         IAtom atom2 = null;
 
-        if (bondA1.contains(bondB1.getAtom(0))) {
-            atom1 = bondB1.getAtom(0);
-        } else if (bondA1.contains(bondB1.getAtom(1))) {
-            atom1 = bondB1.getAtom(1);
+        if (bondA1.contains(bondB1.getBeg())) {
+            atom1 = bondB1.getBeg();
+        } else if (bondA1.contains(bondB1.getEnd())) {
+            atom1 = bondB1.getEnd();
         }
 
-        if (bondA2.contains(bondB2.getAtom(0))) {
-            atom2 = bondB2.getAtom(0);
-        } else if (bondA2.contains(bondB2.getAtom(1))) {
-            atom2 = bondB2.getAtom(1);
+        if (bondA2.contains(bondB2.getBeg())) {
+            atom2 = bondB2.getBeg();
+        } else if (bondA2.contains(bondB2.getEnd())) {
+            atom2 = bondB2.getEnd();
         }
 
         if (atom1 != null && atom2 != null) {
@@ -978,10 +978,10 @@ public class CDKMCS {
         IAtom centralAtom = null;
         IAtom centralQueryAtom = null;
 
-        if (bond1.contains(bond2.getAtom(0))) {
-            centralAtom = bond2.getAtom(0);
-        } else if (bond1.contains(bond2.getAtom(1))) {
-            centralAtom = bond2.getAtom(1);
+        if (bond1.contains(bond2.getBeg())) {
+            centralAtom = bond2.getBeg();
+        } else if (bond1.contains(bond2.getEnd())) {
+            centralAtom = bond2.getEnd();
         }
 
         if (queryBond1.contains(queryBond2.getAtom(0))) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
@@ -984,10 +984,10 @@ public class CDKMCS {
             centralAtom = bond2.getEnd();
         }
 
-        if (queryBond1.contains(queryBond2.getAtom(0))) {
-            centralQueryAtom = queryBond2.getAtom(0);
-        } else if (queryBond1.contains(queryBond2.getAtom(1))) {
-            centralQueryAtom = queryBond2.getAtom(1);
+        if (queryBond1.contains(queryBond2.getBeg())) {
+            centralQueryAtom = queryBond2.getBeg();
+        } else if (queryBond1.contains(queryBond2.getEnd())) {
+            centralQueryAtom = queryBond2.getEnd();
         }
 
         if (centralAtom != null && centralQueryAtom != null && ((IQueryAtom) centralQueryAtom).matches(centralAtom)) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
@@ -547,7 +547,7 @@ public class CDKMCS {
                 bond = graph.getBond(rMap.getId2());
             }
 
-            atom = bond.getBeg();
+            atom = bond.getBegin();
             atom1 = table.get(atom);
 
             if (atom1 == null) {
@@ -795,12 +795,12 @@ public class CDKMCS {
                 IBond bondA2 = ac2.getBond(j);
                 if (bondA2 instanceof IQueryBond) {
                     IQueryBond queryBond = (IQueryBond) bondA2;
-                    IQueryAtom atom1 = (IQueryAtom) (bondA2.getBeg());
+                    IQueryAtom atom1 = (IQueryAtom) (bondA2.getBegin());
                     IQueryAtom atom2 = (IQueryAtom) (bondA2.getEnd());
                     if (queryBond.matches(bondA1)) {
                         // ok, bonds match
-                        if (atom1.matches(bondA1.getBeg()) && atom2.matches(bondA1.getEnd())
-                                || atom1.matches(bondA1.getEnd()) && atom2.matches(bondA1.getBeg())) {
+                        if (atom1.matches(bondA1.getBegin()) && atom2.matches(bondA1.getEnd())
+                                || atom1.matches(bondA1.getEnd()) && atom2.matches(bondA1.getBegin())) {
                             // ok, atoms match in either order
                             graph.addNode(new CDKRNode(i, j));
                         }
@@ -823,7 +823,7 @@ public class CDKMCS {
         //Bond Matcher
         BondMatcher bondMatcher = new DefaultBondMatcher(ac1, bondA1, shouldMatchBonds);
         //Atom Matcher
-        AtomMatcher atomMatcher1 = new DefaultRGraphAtomMatcher(ac1, bondA1.getBeg(), shouldMatchBonds);
+        AtomMatcher atomMatcher1 = new DefaultRGraphAtomMatcher(ac1, bondA1.getBegin(), shouldMatchBonds);
         //Atom Matcher
         AtomMatcher atomMatcher2 = new DefaultRGraphAtomMatcher(ac1, bondA1.getEnd(), shouldMatchBonds);
 
@@ -906,7 +906,7 @@ public class CDKMCS {
      *            the 2 bonds have no common atom
      */
     private static boolean hasCommonAtom(IBond bondA, IBond bondB) {
-        return bondA.contains(bondB.getBeg()) || bondA.contains(bondB.getEnd());
+        return bondA.contains(bondB.getBegin()) || bondA.contains(bondB.getEnd());
     }
 
     /**
@@ -920,8 +920,8 @@ public class CDKMCS {
     private static String getCommonSymbol(IBond bondA, IBond bondB) {
         String symbol = "";
 
-        if (bondA.contains(bondB.getBeg())) {
-            symbol = bondB.getBeg().getSymbol();
+        if (bondA.contains(bondB.getBegin())) {
+            symbol = bondB.getBegin().getSymbol();
         } else if (bondA.contains(bondB.getEnd())) {
             symbol = bondB.getEnd().getSymbol();
         }
@@ -942,14 +942,14 @@ public class CDKMCS {
         IAtom atom1 = null;
         IAtom atom2 = null;
 
-        if (bondA1.contains(bondB1.getBeg())) {
-            atom1 = bondB1.getBeg();
+        if (bondA1.contains(bondB1.getBegin())) {
+            atom1 = bondB1.getBegin();
         } else if (bondA1.contains(bondB1.getEnd())) {
             atom1 = bondB1.getEnd();
         }
 
-        if (bondA2.contains(bondB2.getBeg())) {
-            atom2 = bondB2.getBeg();
+        if (bondA2.contains(bondB2.getBegin())) {
+            atom2 = bondB2.getBegin();
         } else if (bondA2.contains(bondB2.getEnd())) {
             atom2 = bondB2.getEnd();
         }
@@ -978,14 +978,14 @@ public class CDKMCS {
         IAtom centralAtom = null;
         IAtom centralQueryAtom = null;
 
-        if (bond1.contains(bond2.getBeg())) {
-            centralAtom = bond2.getBeg();
+        if (bond1.contains(bond2.getBegin())) {
+            centralAtom = bond2.getBegin();
         } else if (bond1.contains(bond2.getEnd())) {
             centralAtom = bond2.getEnd();
         }
 
-        if (queryBond1.contains(queryBond2.getBeg())) {
-            centralQueryAtom = queryBond2.getBeg();
+        if (queryBond1.contains(queryBond2.getBegin())) {
+            centralQueryAtom = queryBond2.getBegin();
         } else if (queryBond1.contains(queryBond2.getEnd())) {
             centralQueryAtom = queryBond2.getEnd();
         }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
@@ -547,7 +547,7 @@ public class CDKMCS {
                 bond = graph.getBond(rMap.getId2());
             }
 
-            atom = bond.getAtom(0);
+            atom = bond.getBeg();
             atom1 = table.get(atom);
 
             if (atom1 == null) {
@@ -560,7 +560,7 @@ public class CDKMCS {
                 table.put(atom, atom1);
             }
 
-            atom = bond.getAtom(1);
+            atom = bond.getEnd();
             atom2 = table.get(atom);
 
             if (atom2 == null) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
@@ -426,11 +426,11 @@ public class CDKRMapHandler {
                 CDKRMap map10 = null;
                 CDKRMap map11 = null;
 
-                if ((qbond.getAtom(0).getSymbol().equals(tbond.getAtom(0).getSymbol()))
-                        && (qbond.getAtom(1).getSymbol().equals(tbond.getAtom(1).getSymbol()))) {
-                    map00 = new CDKRMap(sourceGraph.indexOf(qbond.getAtom(0)), targetGraph.indexOf(tbond
+                if ((qbond.getBeg().getSymbol().equals(tbond.getBeg().getSymbol()))
+                        && (qbond.getEnd().getSymbol().equals(tbond.getEnd().getSymbol()))) {
+                    map00 = new CDKRMap(sourceGraph.indexOf(qbond.getBeg()), targetGraph.indexOf(tbond
                             .getAtom(0)));
-                    map11 = new CDKRMap(sourceGraph.indexOf(qbond.getAtom(1)), targetGraph.indexOf(tbond
+                    map11 = new CDKRMap(sourceGraph.indexOf(qbond.getEnd()), targetGraph.indexOf(tbond
                             .getAtom(1)));
                     if (!result1.contains(map00)) {
                         result1.add(map00);
@@ -439,11 +439,11 @@ public class CDKRMapHandler {
                         result1.add(map11);
                     }
                 }
-                if ((qbond.getAtom(0).getSymbol().equals(tbond.getAtom(1).getSymbol()))
-                        && (qbond.getAtom(1).getSymbol().equals(tbond.getAtom(0).getSymbol()))) {
-                    map01 = new CDKRMap(sourceGraph.indexOf(qbond.getAtom(0)), targetGraph.indexOf(tbond
+                if ((qbond.getBeg().getSymbol().equals(tbond.getEnd().getSymbol()))
+                        && (qbond.getEnd().getSymbol().equals(tbond.getBeg().getSymbol()))) {
+                    map01 = new CDKRMap(sourceGraph.indexOf(qbond.getBeg()), targetGraph.indexOf(tbond
                             .getAtom(1)));
-                    map10 = new CDKRMap(sourceGraph.indexOf(qbond.getAtom(1)), targetGraph.indexOf(tbond
+                    map10 = new CDKRMap(sourceGraph.indexOf(qbond.getEnd()), targetGraph.indexOf(tbond
                             .getAtom(0)));
                     if (!result2.contains(map01)) {
                         result2.add(map01);

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
@@ -426,10 +426,10 @@ public class CDKRMapHandler {
                 CDKRMap map10 = null;
                 CDKRMap map11 = null;
 
-                if ((qbond.getBeg().getSymbol().equals(tbond.getBeg().getSymbol()))
+                if ((qbond.getBegin().getSymbol().equals(tbond.getBegin().getSymbol()))
                         && (qbond.getEnd().getSymbol().equals(tbond.getEnd().getSymbol()))) {
-                    map00 = new CDKRMap(sourceGraph.indexOf(qbond.getBeg()), targetGraph.indexOf(tbond
-                            .getBeg()));
+                    map00 = new CDKRMap(sourceGraph.indexOf(qbond.getBegin()), targetGraph.indexOf(tbond
+                            .getBegin()));
                     map11 = new CDKRMap(sourceGraph.indexOf(qbond.getEnd()), targetGraph.indexOf(tbond
                             .getEnd()));
                     if (!result1.contains(map00)) {
@@ -439,12 +439,12 @@ public class CDKRMapHandler {
                         result1.add(map11);
                     }
                 }
-                if ((qbond.getBeg().getSymbol().equals(tbond.getEnd().getSymbol()))
-                        && (qbond.getEnd().getSymbol().equals(tbond.getBeg().getSymbol()))) {
-                    map01 = new CDKRMap(sourceGraph.indexOf(qbond.getBeg()), targetGraph.indexOf(tbond
+                if ((qbond.getBegin().getSymbol().equals(tbond.getEnd().getSymbol()))
+                        && (qbond.getEnd().getSymbol().equals(tbond.getBegin().getSymbol()))) {
+                    map01 = new CDKRMap(sourceGraph.indexOf(qbond.getBegin()), targetGraph.indexOf(tbond
                             .getEnd()));
                     map10 = new CDKRMap(sourceGraph.indexOf(qbond.getEnd()), targetGraph.indexOf(tbond
-                            .getBeg()));
+                            .getBegin()));
                     if (!result2.contains(map01)) {
                         result2.add(map01);
                     }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
@@ -429,9 +429,9 @@ public class CDKRMapHandler {
                 if ((qbond.getBeg().getSymbol().equals(tbond.getBeg().getSymbol()))
                         && (qbond.getEnd().getSymbol().equals(tbond.getEnd().getSymbol()))) {
                     map00 = new CDKRMap(sourceGraph.indexOf(qbond.getBeg()), targetGraph.indexOf(tbond
-                            .getAtom(0)));
+                            .getBeg()));
                     map11 = new CDKRMap(sourceGraph.indexOf(qbond.getEnd()), targetGraph.indexOf(tbond
-                            .getAtom(1)));
+                            .getEnd()));
                     if (!result1.contains(map00)) {
                         result1.add(map00);
                     }
@@ -442,9 +442,9 @@ public class CDKRMapHandler {
                 if ((qbond.getBeg().getSymbol().equals(tbond.getEnd().getSymbol()))
                         && (qbond.getEnd().getSymbol().equals(tbond.getBeg().getSymbol()))) {
                     map01 = new CDKRMap(sourceGraph.indexOf(qbond.getBeg()), targetGraph.indexOf(tbond
-                            .getAtom(1)));
+                            .getEnd()));
                     map10 = new CDKRMap(sourceGraph.indexOf(qbond.getEnd()), targetGraph.indexOf(tbond
-                            .getAtom(0)));
+                            .getBeg()));
                     if (!result2.contains(map01)) {
                         result2.add(map01);
                     }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/builder/TargetProperties.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/builder/TargetProperties.java
@@ -110,8 +110,8 @@ public class TargetProperties implements java.io.Serializable {
         }
 
         for (IBond bond : container.bonds()) {
-            map[atoms.get(bond.getAtom(0))][atoms.get(bond.getAtom(1))] = bond;
-            map[atoms.get(bond.getAtom(1))][atoms.get(bond.getAtom(0))] = bond;
+            map[atoms.get(bond.getBeg())][atoms.get(bond.getEnd())] = bond;
+            map[atoms.get(bond.getEnd())][atoms.get(bond.getBeg())] = bond;
         }
     }
 

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/builder/TargetProperties.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/builder/TargetProperties.java
@@ -110,8 +110,8 @@ public class TargetProperties implements java.io.Serializable {
         }
 
         for (IBond bond : container.bonds()) {
-            map[atoms.get(bond.getBeg())][atoms.get(bond.getEnd())] = bond;
-            map[atoms.get(bond.getEnd())][atoms.get(bond.getBeg())] = bond;
+            map[atoms.get(bond.getBegin())][atoms.get(bond.getEnd())] = bond;
+            map[atoms.get(bond.getEnd())][atoms.get(bond.getBegin())] = bond;
         }
     }
 

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/query/QueryCompiler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/query/QueryCompiler.java
@@ -133,8 +133,8 @@ public class QueryCompiler implements IQueryCompiler {
         }
         for (int i = 0; i < queryMolecule.getBondCount(); i++) {
             IBond bond = queryMolecule.getBond(i);
-            IAtom atomI = bond.getAtom(0);
-            IAtom atomJ = bond.getAtom(1);
+            IAtom atomI = bond.getBeg();
+            IAtom atomJ = bond.getEnd();
             result.connect(result.getNode(atomI), result.getNode(atomJ), createBondMatcher(queryMolecule, bond));
         }
         return result;
@@ -151,8 +151,8 @@ public class QueryCompiler implements IQueryCompiler {
         }
         for (int i = 0; i < queryMolecule.getBondCount(); i++) {
             IBond bond = queryMolecule.getBond(i);
-            IQueryAtom atomI = (IQueryAtom) bond.getAtom(0);
-            IQueryAtom atomJ = (IQueryAtom) bond.getAtom(1);
+            IQueryAtom atomI = (IQueryAtom) bond.getBeg();
+            IQueryAtom atomJ = (IQueryAtom) bond.getEnd();
             result.connect(result.getNode(atomI), result.getNode(atomJ), createBondMatcher((IQueryBond) bond));
         }
         return result;

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/query/QueryCompiler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/query/QueryCompiler.java
@@ -133,7 +133,7 @@ public class QueryCompiler implements IQueryCompiler {
         }
         for (int i = 0; i < queryMolecule.getBondCount(); i++) {
             IBond bond = queryMolecule.getBond(i);
-            IAtom atomI = bond.getBeg();
+            IAtom atomI = bond.getBegin();
             IAtom atomJ = bond.getEnd();
             result.connect(result.getNode(atomI), result.getNode(atomJ), createBondMatcher(queryMolecule, bond));
         }
@@ -151,7 +151,7 @@ public class QueryCompiler implements IQueryCompiler {
         }
         for (int i = 0; i < queryMolecule.getBondCount(); i++) {
             IBond bond = queryMolecule.getBond(i);
-            IQueryAtom atomI = (IQueryAtom) bond.getBeg();
+            IQueryAtom atomI = (IQueryAtom) bond.getBegin();
             IQueryAtom atomJ = (IQueryAtom) bond.getEnd();
             result.connect(result.getNode(atomI), result.getNode(atomJ), createBondMatcher((IQueryBond) bond));
         }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/filters/ChemicalFilters.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/filters/ChemicalFilters.java
@@ -597,9 +597,9 @@ public class ChemicalFilters {
     private double getBondFormalChargeMatches(IBond rBond, IBond pBond) {
         double score = 0.0;
         if (rBond != null && pBond != null) {
-            IAtom ratom1 = rBond.getBeg();
+            IAtom ratom1 = rBond.getBegin();
             IAtom ratom2 = rBond.getEnd();
-            IAtom patom1 = pBond.getBeg();
+            IAtom patom1 = pBond.getBegin();
             IAtom patom2 = pBond.getEnd();
 
             if (ratom1.getSymbol().equals(patom1.getSymbol()) && ratom1.getSymbol().equals(patom1.getSymbol())) {
@@ -643,12 +643,12 @@ public class ChemicalFilters {
 
         if (targetBond instanceof IQueryBond && queryBond instanceof IBond) {
             IQueryBond bond = (IQueryBond) targetBond;
-            IQueryAtom atom1 = (IQueryAtom) (targetBond.getBeg());
+            IQueryAtom atom1 = (IQueryAtom) (targetBond.getBegin());
             IQueryAtom atom2 = (IQueryAtom) (targetBond.getEnd());
             if (bond.matches(queryBond)) {
                 // ok, bonds match
-                if (atom1.matches(queryBond.getBeg()) && atom2.matches(queryBond.getEnd())
-                        || atom1.matches(queryBond.getEnd()) && atom2.matches(queryBond.getBeg())) {
+                if (atom1.matches(queryBond.getBegin()) && atom2.matches(queryBond.getEnd())
+                        || atom1.matches(queryBond.getEnd()) && atom2.matches(queryBond.getBegin())) {
                     // ok, atoms match in either order
                     score += 4;
                 }
@@ -657,12 +657,12 @@ public class ChemicalFilters {
             }
         } else if (queryBond instanceof IQueryBond && targetBond instanceof IBond) {
             IQueryBond bond = (IQueryBond) queryBond;
-            IQueryAtom atom1 = (IQueryAtom) (queryBond.getBeg());
+            IQueryAtom atom1 = (IQueryAtom) (queryBond.getBegin());
             IQueryAtom atom2 = (IQueryAtom) (queryBond.getEnd());
             if (bond.matches(targetBond)) {
                 // ok, bonds match
-                if (atom1.matches(targetBond.getBeg()) && atom2.matches(targetBond.getEnd())
-                        || atom1.matches(targetBond.getEnd()) && atom2.matches(targetBond.getBeg())) {
+                if (atom1.matches(targetBond.getBegin()) && atom2.matches(targetBond.getEnd())
+                        || atom1.matches(targetBond.getEnd()) && atom2.matches(targetBond.getBegin())) {
                     // ok, atoms match in either order
                     score += 4;
                 }
@@ -734,10 +734,10 @@ public class ChemicalFilters {
 
     private double getBondEnergy(IBond bond, BondEnergies bondEnergy) {
         double energy = 0.0;
-        if ((bond.getBeg().getFlag(CDKConstants.ISPLACED) == true && bond.getEnd().getFlag(CDKConstants.ISPLACED) == false)
-                || (bond.getBeg().getFlag(CDKConstants.ISPLACED) == false && bond.getEnd().getFlag(
+        if ((bond.getBegin().getFlag(CDKConstants.ISPLACED) == true && bond.getEnd().getFlag(CDKConstants.ISPLACED) == false)
+                || (bond.getBegin().getFlag(CDKConstants.ISPLACED) == false && bond.getEnd().getFlag(
                         CDKConstants.ISPLACED) == true)) {
-            Integer val = bondEnergy.getEnergies(bond.getBeg(), bond.getEnd(), bond.getOrder());
+            Integer val = bondEnergy.getEnergies(bond.getBegin(), bond.getEnd(), bond.getOrder());
             if (val != null) {
                 energy = val;
             }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/filters/ChemicalFilters.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/filters/ChemicalFilters.java
@@ -597,10 +597,10 @@ public class ChemicalFilters {
     private double getBondFormalChargeMatches(IBond rBond, IBond pBond) {
         double score = 0.0;
         if (rBond != null && pBond != null) {
-            IAtom ratom1 = rBond.getAtom(0);
-            IAtom ratom2 = rBond.getAtom(1);
-            IAtom patom1 = pBond.getAtom(0);
-            IAtom patom2 = pBond.getAtom(1);
+            IAtom ratom1 = rBond.getBeg();
+            IAtom ratom2 = rBond.getEnd();
+            IAtom patom1 = pBond.getBeg();
+            IAtom patom2 = pBond.getEnd();
 
             if (ratom1.getSymbol().equals(patom1.getSymbol()) && ratom1.getSymbol().equals(patom1.getSymbol())) {
                 if ((ratom1.getFormalCharge() != patom1.getFormalCharge())
@@ -643,12 +643,12 @@ public class ChemicalFilters {
 
         if (targetBond instanceof IQueryBond && queryBond instanceof IBond) {
             IQueryBond bond = (IQueryBond) targetBond;
-            IQueryAtom atom1 = (IQueryAtom) (targetBond.getAtom(0));
-            IQueryAtom atom2 = (IQueryAtom) (targetBond.getAtom(1));
+            IQueryAtom atom1 = (IQueryAtom) (targetBond.getBeg());
+            IQueryAtom atom2 = (IQueryAtom) (targetBond.getEnd());
             if (bond.matches(queryBond)) {
                 // ok, bonds match
-                if (atom1.matches(queryBond.getAtom(0)) && atom2.matches(queryBond.getAtom(1))
-                        || atom1.matches(queryBond.getAtom(1)) && atom2.matches(queryBond.getAtom(0))) {
+                if (atom1.matches(queryBond.getBeg()) && atom2.matches(queryBond.getEnd())
+                        || atom1.matches(queryBond.getEnd()) && atom2.matches(queryBond.getBeg())) {
                     // ok, atoms match in either order
                     score += 4;
                 }
@@ -657,12 +657,12 @@ public class ChemicalFilters {
             }
         } else if (queryBond instanceof IQueryBond && targetBond instanceof IBond) {
             IQueryBond bond = (IQueryBond) queryBond;
-            IQueryAtom atom1 = (IQueryAtom) (queryBond.getAtom(0));
-            IQueryAtom atom2 = (IQueryAtom) (queryBond.getAtom(1));
+            IQueryAtom atom1 = (IQueryAtom) (queryBond.getBeg());
+            IQueryAtom atom2 = (IQueryAtom) (queryBond.getEnd());
             if (bond.matches(targetBond)) {
                 // ok, bonds match
-                if (atom1.matches(targetBond.getAtom(0)) && atom2.matches(targetBond.getAtom(1))
-                        || atom1.matches(targetBond.getAtom(1)) && atom2.matches(targetBond.getAtom(0))) {
+                if (atom1.matches(targetBond.getBeg()) && atom2.matches(targetBond.getEnd())
+                        || atom1.matches(targetBond.getEnd()) && atom2.matches(targetBond.getBeg())) {
                     // ok, atoms match in either order
                     score += 4;
                 }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/filters/ChemicalFilters.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/filters/ChemicalFilters.java
@@ -734,10 +734,10 @@ public class ChemicalFilters {
 
     private double getBondEnergy(IBond bond, BondEnergies bondEnergy) {
         double energy = 0.0;
-        if ((bond.getAtom(0).getFlag(CDKConstants.ISPLACED) == true && bond.getAtom(1).getFlag(CDKConstants.ISPLACED) == false)
-                || (bond.getAtom(0).getFlag(CDKConstants.ISPLACED) == false && bond.getAtom(1).getFlag(
+        if ((bond.getBeg().getFlag(CDKConstants.ISPLACED) == true && bond.getEnd().getFlag(CDKConstants.ISPLACED) == false)
+                || (bond.getBeg().getFlag(CDKConstants.ISPLACED) == false && bond.getEnd().getFlag(
                         CDKConstants.ISPLACED) == true)) {
-            Integer val = bondEnergy.getEnergies(bond.getAtom(0), bond.getAtom(1), bond.getOrder());
+            Integer val = bondEnergy.getEnergies(bond.getBeg(), bond.getEnd(), bond.getOrder());
             if (val != null) {
                 energy = val;
             }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/helper/BondEnergy.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/helper/BondEnergy.java
@@ -97,7 +97,7 @@ public class BondEnergy {
     }
 
     public boolean matches(IBond bond) {
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
 
         if ((atom1.getSymbol().equalsIgnoreCase(symbol1) && atom2.getSymbol().equalsIgnoreCase(symbol2))

--- a/legacy/src/main/java/org/openscience/cdk/smsd/helper/BondEnergy.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/helper/BondEnergy.java
@@ -97,8 +97,8 @@ public class BondEnergy {
     }
 
     public boolean matches(IBond bond) {
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
 
         if ((atom1.getSymbol().equalsIgnoreCase(symbol1) && atom2.getSymbol().equalsIgnoreCase(symbol2))
                 || (atom1.getSymbol().equalsIgnoreCase(symbol2) && atom2.getSymbol().equalsIgnoreCase(symbol1))) {

--- a/legacy/src/main/java/org/openscience/cdk/smsd/labelling/AtomContainerPrinter.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/labelling/AtomContainerPrinter.java
@@ -60,7 +60,7 @@ public class AtomContainerPrinter {
         sb.append(' ');
         List<Edge> edges = new ArrayList<Edge>();
         for (IBond bond : atomContainer.bonds()) {
-            IAtom a0 = bond.getBeg();
+            IAtom a0 = bond.getBegin();
             IAtom a1 = bond.getEnd();
             int a0N = atomContainer.indexOf(a0);
             int a1N = atomContainer.indexOf(a1);

--- a/legacy/src/main/java/org/openscience/cdk/smsd/labelling/AtomContainerPrinter.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/labelling/AtomContainerPrinter.java
@@ -60,8 +60,8 @@ public class AtomContainerPrinter {
         sb.append(' ');
         List<Edge> edges = new ArrayList<Edge>();
         for (IBond bond : atomContainer.bonds()) {
-            IAtom a0 = bond.getAtom(0);
-            IAtom a1 = bond.getAtom(1);
+            IAtom a0 = bond.getBeg();
+            IAtom a1 = bond.getEnd();
             int a0N = atomContainer.indexOf(a0);
             int a1N = atomContainer.indexOf(a1);
             String a0S = a0.getSymbol();

--- a/legacy/src/main/java/org/openscience/cdk/smsd/ring/PathGraph.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/ring/PathGraph.java
@@ -154,7 +154,7 @@ public class PathGraph {
     private void loadEdges(IAtomContainer molecule) {
         for (int i = 0; i < molecule.getBondCount(); i++) {
             IBond bond = molecule.getBond(i);
-            edges.add(new PathEdge(Arrays.asList(bond.getAtom(0), bond.getAtom(1))));
+            edges.add(new PathEdge(Arrays.asList(bond.getBeg(), bond.getEnd())));
         }
     }
 

--- a/legacy/src/main/java/org/openscience/cdk/smsd/ring/PathGraph.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/ring/PathGraph.java
@@ -154,7 +154,7 @@ public class PathGraph {
     private void loadEdges(IAtomContainer molecule) {
         for (int i = 0; i < molecule.getBondCount(); i++) {
             IBond bond = molecule.getBond(i);
-            edges.add(new PathEdge(Arrays.asList(bond.getBeg(), bond.getEnd())));
+            edges.add(new PathEdge(Arrays.asList(bond.getBegin(), bond.getEnd())));
         }
     }
 

--- a/legacy/src/main/java/org/openscience/cdk/smsd/tools/ExtAtomContainerManipulator.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/tools/ExtAtomContainerManipulator.java
@@ -356,14 +356,14 @@ public class ExtAtomContainerManipulator extends AtomContainerManipulator {
             bonds[index] = new Bond();
             int indexI = 999;
             for (int i = 0; i < container.getAtomCount(); i++) {
-                if (container.getBond(index).getAtom(0) == container.getAtom(i)) {
+                if (container.getBond(index).getBeg() == container.getAtom(i)) {
                     indexI = i;
                     break;
                 }
             }
             int indexJ = 999;
             for (int j = 0; j < container.getAtomCount(); j++) {
-                if (container.getBond(index).getAtom(1) == container.getAtom(j)) {
+                if (container.getBond(index).getEnd() == container.getAtom(j)) {
                     indexJ = j;
                     break;
                 }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/tools/ExtAtomContainerManipulator.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/tools/ExtAtomContainerManipulator.java
@@ -356,7 +356,7 @@ public class ExtAtomContainerManipulator extends AtomContainerManipulator {
             bonds[index] = new Bond();
             int indexI = 999;
             for (int i = 0; i < container.getAtomCount(); i++) {
-                if (container.getBond(index).getBeg() == container.getAtom(i)) {
+                if (container.getBond(index).getBegin() == container.getAtom(i)) {
                     indexI = i;
                     break;
                 }
@@ -438,7 +438,7 @@ public class ExtAtomContainerManipulator extends AtomContainerManipulator {
                     e.printStackTrace();
                 }
                 assert clone != null;
-                clone.setAtoms(new IAtom[]{map.get(bond.getBeg()), map.get(bond.getEnd())});
+                clone.setAtoms(new IAtom[]{map.get(bond.getBegin()), map.get(bond.getEnd())});
                 clone.setOrder(atomContainer.getBond(i).getOrder());
                 clone.setStereo(atomContainer.getBond(i).getStereo());
                 mol.addBond(clone);

--- a/legacy/src/main/java/org/openscience/cdk/smsd/tools/ExtAtomContainerManipulator.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/tools/ExtAtomContainerManipulator.java
@@ -438,7 +438,7 @@ public class ExtAtomContainerManipulator extends AtomContainerManipulator {
                     e.printStackTrace();
                 }
                 assert clone != null;
-                clone.setAtoms(new IAtom[]{map.get(bond.getAtom(0)), map.get(bond.getAtom(1))});
+                clone.setAtoms(new IAtom[]{map.get(bond.getBeg()), map.get(bond.getEnd())});
                 clone.setOrder(atomContainer.getBond(i).getOrder());
                 clone.setStereo(atomContainer.getBond(i).getStereo());
                 mol.addBond(clone);

--- a/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
@@ -552,7 +552,7 @@ public class DeAromatizationTool {
                 curBond.setOrder(IBond.Order.DOUBLE);
                 nextIsSingle = true;
             }
-            curAtom = curBond.getConnectedAtom(curAtom);
+            curAtom = curBond.getOther(curAtom);
             List<IBond> bonds = ring.getConnectedBondsList(curAtom);
             for (IBond bond : bonds)
             {

--- a/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
@@ -106,10 +106,10 @@ public class DeAromatizationTool {
                 int count = 0;
                 while (done != 2) {
                     bond = getNextBond(atom, bond, ring);
-                    if (bond.getBeg() == atom)
+                    if (bond.getBegin() == atom)
                         atom = bond.getEnd();
                     else
-                        atom = bond.getBeg();
+                        atom = bond.getBegin();
                     count++;
                     if (count % 2 == 0) {
                         bond.setOrder(IBond.Order.DOUBLE);
@@ -526,7 +526,7 @@ public class DeAromatizationTool {
             if (bond.getOrder()!=IBond.Order.QUADRUPLE)
             {
                 curBond = bond;
-                curAtom = bond.getBeg();
+                curAtom = bond.getBegin();
                 if (bond.getOrder()==IBond.Order.SINGLE)
                 {
                     nextIsSingle = true;

--- a/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
@@ -106,10 +106,10 @@ public class DeAromatizationTool {
                 int count = 0;
                 while (done != 2) {
                     bond = getNextBond(atom, bond, ring);
-                    if (bond.getAtom(0) == atom)
-                        atom = bond.getAtom(1);
+                    if (bond.getBeg() == atom)
+                        atom = bond.getEnd();
                     else
-                        atom = bond.getAtom(0);
+                        atom = bond.getBeg();
                     count++;
                     if (count % 2 == 0) {
                         bond.setOrder(IBond.Order.DOUBLE);
@@ -526,7 +526,7 @@ public class DeAromatizationTool {
             if (bond.getOrder()!=IBond.Order.QUADRUPLE)
             {
                 curBond = bond;
-                curAtom = bond.getAtom(0);
+                curAtom = bond.getBeg();
                 if (bond.getOrder()==IBond.Order.SINGLE)
                 {
                     nextIsSingle = true;

--- a/misc/diff/src/main/java/org/openscience/cdk/tools/diff/BondDiff.java
+++ b/misc/diff/src/main/java/org/openscience/cdk/tools/diff/BondDiff.java
@@ -74,7 +74,7 @@ public class BondDiff {
         totalDiff.addChild(BondOrderDifference.construct("order", firstB.getOrder(), secondB.getOrder()));
         totalDiff.addChild(IntegerDifference.construct("atomCount", firstB.getAtomCount(), secondB.getAtomCount()));
         if (firstB.getAtomCount() == secondB.getAtomCount()) {
-            totalDiff.addChild(AtomDiff.difference(firstB.getBeg(), secondB.getBeg()));
+            totalDiff.addChild(AtomDiff.difference(firstB.getBegin(), secondB.getBegin()));
             totalDiff.addChild(AtomDiff.difference(firstB.getEnd(), secondB.getEnd()));
             for (int i = 2; i < firstB.getAtomCount(); i++) {
                 totalDiff.addChild(AtomDiff.difference(firstB.getAtom(i), secondB.getAtom(i)));

--- a/misc/diff/src/main/java/org/openscience/cdk/tools/diff/BondDiff.java
+++ b/misc/diff/src/main/java/org/openscience/cdk/tools/diff/BondDiff.java
@@ -74,7 +74,9 @@ public class BondDiff {
         totalDiff.addChild(BondOrderDifference.construct("order", firstB.getOrder(), secondB.getOrder()));
         totalDiff.addChild(IntegerDifference.construct("atomCount", firstB.getAtomCount(), secondB.getAtomCount()));
         if (firstB.getAtomCount() == secondB.getAtomCount()) {
-            for (int i = 0; i < firstB.getAtomCount(); i++) {
+            totalDiff.addChild(AtomDiff.difference(firstB.getBeg(), secondB.getBeg()));
+            totalDiff.addChild(AtomDiff.difference(firstB.getEnd(), secondB.getEnd()));
+            for (int i = 2; i < firstB.getAtomCount(); i++) {
                 totalDiff.addChild(AtomDiff.difference(firstB.getAtom(i), secondB.getAtom(i)));
             }
         }

--- a/misc/diff/src/test/java/org/openscience/cdk/tools/diff/AtomContainerDiffTest.java
+++ b/misc/diff/src/test/java/org/openscience/cdk/tools/diff/AtomContainerDiffTest.java
@@ -64,10 +64,10 @@ public class AtomContainerDiffTest extends CDKTestCase {
         when(b1.getAtomCount()).thenReturn(2);
         when(b2.getAtomCount()).thenReturn(2);
 
-        when(b1.getAtom(0)).thenReturn(carbon);
-        when(b1.getAtom(1)).thenReturn(carbon);
-        when(b2.getAtom(0)).thenReturn(carbon);
-        when(b2.getAtom(1)).thenReturn(oxygen);
+        when(b1.getBeg()).thenReturn(carbon);
+        when(b1.getEnd()).thenReturn(carbon);
+        when(b2.getBeg()).thenReturn(carbon);
+        when(b2.getEnd()).thenReturn(oxygen);
 
         IAtomContainer container1 = mock(IAtomContainer.class);
         IAtomContainer container2 = mock(IAtomContainer.class);
@@ -103,10 +103,10 @@ public class AtomContainerDiffTest extends CDKTestCase {
         when(b1.getAtomCount()).thenReturn(2);
         when(b2.getAtomCount()).thenReturn(2);
 
-        when(b1.getAtom(0)).thenReturn(carbon);
-        when(b1.getAtom(1)).thenReturn(carbon);
-        when(b2.getAtom(0)).thenReturn(carbon);
-        when(b2.getAtom(1)).thenReturn(oxygen);
+        when(b1.getBeg()).thenReturn(carbon);
+        when(b1.getEnd()).thenReturn(carbon);
+        when(b2.getBeg()).thenReturn(carbon);
+        when(b2.getEnd()).thenReturn(oxygen);
 
         IAtomContainer container1 = mock(IAtomContainer.class);
         IAtomContainer container2 = mock(IAtomContainer.class);

--- a/misc/diff/src/test/java/org/openscience/cdk/tools/diff/AtomContainerDiffTest.java
+++ b/misc/diff/src/test/java/org/openscience/cdk/tools/diff/AtomContainerDiffTest.java
@@ -64,9 +64,9 @@ public class AtomContainerDiffTest extends CDKTestCase {
         when(b1.getAtomCount()).thenReturn(2);
         when(b2.getAtomCount()).thenReturn(2);
 
-        when(b1.getBeg()).thenReturn(carbon);
+        when(b1.getBegin()).thenReturn(carbon);
         when(b1.getEnd()).thenReturn(carbon);
-        when(b2.getBeg()).thenReturn(carbon);
+        when(b2.getBegin()).thenReturn(carbon);
         when(b2.getEnd()).thenReturn(oxygen);
 
         IAtomContainer container1 = mock(IAtomContainer.class);
@@ -103,9 +103,9 @@ public class AtomContainerDiffTest extends CDKTestCase {
         when(b1.getAtomCount()).thenReturn(2);
         when(b2.getAtomCount()).thenReturn(2);
 
-        when(b1.getBeg()).thenReturn(carbon);
+        when(b1.getBegin()).thenReturn(carbon);
         when(b1.getEnd()).thenReturn(carbon);
-        when(b2.getBeg()).thenReturn(carbon);
+        when(b2.getBegin()).thenReturn(carbon);
         when(b2.getEnd()).thenReturn(oxygen);
 
         IAtomContainer container1 = mock(IAtomContainer.class);

--- a/misc/diff/src/test/java/org/openscience/cdk/tools/diff/BondDiffTest.java
+++ b/misc/diff/src/test/java/org/openscience/cdk/tools/diff/BondDiffTest.java
@@ -58,10 +58,10 @@ public class BondDiffTest extends CDKTestCase {
         when(bond1.getAtomCount()).thenReturn(2);
         when(bond2.getAtomCount()).thenReturn(2);
 
-        when(bond1.getAtom(0)).thenReturn(carbon);
-        when(bond1.getAtom(1)).thenReturn(carbon);
-        when(bond2.getAtom(0)).thenReturn(carbon);
-        when(bond2.getAtom(1)).thenReturn(oxygen);
+        when(bond1.getBeg()).thenReturn(carbon);
+        when(bond1.getEnd()).thenReturn(carbon);
+        when(bond2.getBeg()).thenReturn(carbon);
+        when(bond2.getEnd()).thenReturn(oxygen);
 
         bond1.setOrder(IBond.Order.SINGLE);
         bond2.setOrder(IBond.Order.DOUBLE);
@@ -92,10 +92,10 @@ public class BondDiffTest extends CDKTestCase {
         when(bond1.getAtomCount()).thenReturn(2);
         when(bond2.getAtomCount()).thenReturn(2);
 
-        when(bond1.getAtom(0)).thenReturn(carbon);
-        when(bond1.getAtom(1)).thenReturn(carbon);
-        when(bond2.getAtom(0)).thenReturn(carbon);
-        when(bond2.getAtom(1)).thenReturn(oxygen);
+        when(bond1.getBeg()).thenReturn(carbon);
+        when(bond1.getEnd()).thenReturn(carbon);
+        when(bond2.getBeg()).thenReturn(carbon);
+        when(bond2.getEnd()).thenReturn(oxygen);
 
         bond1.setOrder(IBond.Order.SINGLE);
         bond2.setOrder(IBond.Order.DOUBLE);

--- a/misc/diff/src/test/java/org/openscience/cdk/tools/diff/BondDiffTest.java
+++ b/misc/diff/src/test/java/org/openscience/cdk/tools/diff/BondDiffTest.java
@@ -58,9 +58,9 @@ public class BondDiffTest extends CDKTestCase {
         when(bond1.getAtomCount()).thenReturn(2);
         when(bond2.getAtomCount()).thenReturn(2);
 
-        when(bond1.getBeg()).thenReturn(carbon);
+        when(bond1.getBegin()).thenReturn(carbon);
         when(bond1.getEnd()).thenReturn(carbon);
-        when(bond2.getBeg()).thenReturn(carbon);
+        when(bond2.getBegin()).thenReturn(carbon);
         when(bond2.getEnd()).thenReturn(oxygen);
 
         bond1.setOrder(IBond.Order.SINGLE);
@@ -92,9 +92,9 @@ public class BondDiffTest extends CDKTestCase {
         when(bond1.getAtomCount()).thenReturn(2);
         when(bond2.getAtomCount()).thenReturn(2);
 
-        when(bond1.getBeg()).thenReturn(carbon);
+        when(bond1.getBegin()).thenReturn(carbon);
         when(bond1.getEnd()).thenReturn(carbon);
-        when(bond2.getBeg()).thenReturn(carbon);
+        when(bond2.getBegin()).thenReturn(carbon);
         when(bond2.getEnd()).thenReturn(oxygen);
 
         bond1.setOrder(IBond.Order.SINGLE);

--- a/misc/diff/src/test/java/org/openscience/cdk/tools/diff/SingleElectronDiffTest.java
+++ b/misc/diff/src/test/java/org/openscience/cdk/tools/diff/SingleElectronDiffTest.java
@@ -80,9 +80,9 @@ public class SingleElectronDiffTest extends CDKTestCase {
         when(bond1.getAtomCount()).thenReturn(2);
         when(bond2.getAtomCount()).thenReturn(2);
 
-        when(bond1.getBeg()).thenReturn(carbon);
+        when(bond1.getBegin()).thenReturn(carbon);
         when(bond1.getEnd()).thenReturn(carbon);
-        when(bond2.getBeg()).thenReturn(carbon);
+        when(bond2.getBegin()).thenReturn(carbon);
         when(bond2.getEnd()).thenReturn(oxygen);
 
         bond1.setOrder(IBond.Order.SINGLE);

--- a/misc/diff/src/test/java/org/openscience/cdk/tools/diff/SingleElectronDiffTest.java
+++ b/misc/diff/src/test/java/org/openscience/cdk/tools/diff/SingleElectronDiffTest.java
@@ -80,10 +80,10 @@ public class SingleElectronDiffTest extends CDKTestCase {
         when(bond1.getAtomCount()).thenReturn(2);
         when(bond2.getAtomCount()).thenReturn(2);
 
-        when(bond1.getAtom(0)).thenReturn(carbon);
-        when(bond1.getAtom(1)).thenReturn(carbon);
-        when(bond2.getAtom(0)).thenReturn(carbon);
-        when(bond2.getAtom(1)).thenReturn(oxygen);
+        when(bond1.getBeg()).thenReturn(carbon);
+        when(bond1.getEnd()).thenReturn(carbon);
+        when(bond2.getBeg()).thenReturn(carbon);
+        when(bond2.getEnd()).thenReturn(oxygen);
 
         bond1.setOrder(IBond.Order.SINGLE);
         bond2.setOrder(IBond.Order.DOUBLE);

--- a/misc/extra/src/main/java/org/openscience/cdk/graph/invariant/HuLuIndexTool.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/graph/invariant/HuLuIndexTool.java
@@ -154,7 +154,7 @@ public class HuLuIndexTool {
             while (bonds.hasNext()) {
                 IBond bond = bonds.next();
 
-                headAtom = bond.getBeg();
+                headAtom = bond.getBegin();
                 endAtom = bond.getEnd();
 
                 headAtomPosition = atomContainer.indexOf(headAtom);

--- a/misc/extra/src/main/java/org/openscience/cdk/graph/invariant/HuLuIndexTool.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/graph/invariant/HuLuIndexTool.java
@@ -154,8 +154,8 @@ public class HuLuIndexTool {
             while (bonds.hasNext()) {
                 IBond bond = bonds.next();
 
-                headAtom = bond.getAtom(0);
-                endAtom = bond.getAtom(1);
+                headAtom = bond.getBeg();
+                endAtom = bond.getEnd();
 
                 headAtomPosition = atomContainer.indexOf(headAtom);
                 endAtomPosition = atomContainer.indexOf(endAtom);

--- a/misc/extra/src/main/java/org/openscience/cdk/validate/Geometry3DValidator.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/validate/Geometry3DValidator.java
@@ -39,7 +39,7 @@ public class Geometry3DValidator extends AbstractValidator {
         ValidationReport report = new ValidationReport();
         // only consider two atom bonds
         if (subject.getAtomCount() == 2) {
-            double distance = subject.getBeg().getPoint3d().distance(subject.getEnd().getPoint3d());
+            double distance = subject.getBegin().getPoint3d().distance(subject.getEnd().getPoint3d());
             if (distance > 3.0) { // should really depend on the elements
                 ValidationTest badBondLengthError = new ValidationTest(subject,
                         "Bond length cannot exceed 3 Angstroms.",

--- a/misc/extra/src/main/java/org/openscience/cdk/validate/Geometry3DValidator.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/validate/Geometry3DValidator.java
@@ -39,7 +39,7 @@ public class Geometry3DValidator extends AbstractValidator {
         ValidationReport report = new ValidationReport();
         // only consider two atom bonds
         if (subject.getAtomCount() == 2) {
-            double distance = subject.getAtom(0).getPoint3d().distance(subject.getAtom(1).getPoint3d());
+            double distance = subject.getBeg().getPoint3d().distance(subject.getEnd().getPoint3d());
             if (distance > 3.0) { // should really depend on the elements
                 ValidationTest badBondLengthError = new ValidationTest(subject,
                         "Bond length cannot exceed 3 Angstroms.",

--- a/storage/inchi/src/main/java/org/openscience/cdk/graph/invariant/InChINumbersTools.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/graph/invariant/InChINumbersTools.java
@@ -215,7 +215,7 @@ public class InChINumbersTools {
     private static IAtom findPiBondedOxygen(IAtomContainer container, IAtom atom) {
         for (IBond bond : container.getConnectedBondsList(atom)) {
             if (bond.getOrder() == IBond.Order.DOUBLE) {
-                IAtom neighbor = bond.getConnectedAtom(atom);
+                IAtom neighbor = bond.getOther(atom);
                 int charge = neighbor.getFormalCharge() == null ? 0 : neighbor.getFormalCharge();
                 if (neighbor.getAtomicNumber() == 8 && charge == 0) return neighbor;
             }

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
@@ -391,23 +391,23 @@ public class InChIGenerator {
                 JniInchiAtom at3 = null;
                 // TODO: I should check for two atom bonds... or maybe that should happen when you
                 //    create a double bond stereochemistry
-                if (stereoBond.contains(surroundingBonds[0].getAtom(0))) {
+                if (stereoBond.contains(surroundingBonds[0].getBeg())) {
                     // first atom is A
-                    at1 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getAtom(0));
-                    at0 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getAtom(1));
+                    at1 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getBeg());
+                    at0 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getEnd());
                 } else {
                     // first atom is X
-                    at0 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getAtom(0));
-                    at1 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getAtom(1));
+                    at0 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getBeg());
+                    at1 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getEnd());
                 }
-                if (stereoBond.contains(surroundingBonds[1].getAtom(0))) {
+                if (stereoBond.contains(surroundingBonds[1].getBeg())) {
                     // first atom is B
-                    at2 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getAtom(0));
-                    at3 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getAtom(1));
+                    at2 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getBeg());
+                    at3 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getEnd());
                 } else {
                     // first atom is Y
-                    at2 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getAtom(1));
-                    at3 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getAtom(0));
+                    at2 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getEnd());
+                    at3 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getBeg());
                 }
                 INCHI_PARITY p = INCHI_PARITY.UNKNOWN;
                 if (stereoType == org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.TOGETHER) {

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
@@ -291,7 +291,7 @@ public class InChIGenerator {
             IBond bond = bonds.next();
 
             // Assumes 2 centre bond
-            JniInchiAtom at0 = (JniInchiAtom) atomMap.get(bond.getBeg());
+            JniInchiAtom at0 = (JniInchiAtom) atomMap.get(bond.getBegin());
             JniInchiAtom at1 = (JniInchiAtom) atomMap.get(bond.getEnd());
 
             // Get bond order
@@ -391,23 +391,23 @@ public class InChIGenerator {
                 JniInchiAtom at3 = null;
                 // TODO: I should check for two atom bonds... or maybe that should happen when you
                 //    create a double bond stereochemistry
-                if (stereoBond.contains(surroundingBonds[0].getBeg())) {
+                if (stereoBond.contains(surroundingBonds[0].getBegin())) {
                     // first atom is A
-                    at1 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getBeg());
+                    at1 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getBegin());
                     at0 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getEnd());
                 } else {
                     // first atom is X
-                    at0 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getBeg());
+                    at0 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getBegin());
                     at1 = (JniInchiAtom) atomMap.get(surroundingBonds[0].getEnd());
                 }
-                if (stereoBond.contains(surroundingBonds[1].getBeg())) {
+                if (stereoBond.contains(surroundingBonds[1].getBegin())) {
                     // first atom is B
-                    at2 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getBeg());
+                    at2 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getBegin());
                     at3 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getEnd());
                 } else {
                     // first atom is Y
                     at2 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getEnd());
-                    at3 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getBeg());
+                    at3 = (JniInchiAtom) atomMap.get(surroundingBonds[1].getBegin());
                 }
                 INCHI_PARITY p = INCHI_PARITY.UNKNOWN;
                 if (stereoType == org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.TOGETHER) {

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
@@ -450,21 +450,21 @@ public class InChIGenerator {
                 // first if there are two explicit atoms we need to replace one
                 // with the terminal atom - the configuration does not change
                 if (t0Bonds.size() == 2) {
-                    IAtom replace = t0Bonds.remove(0).getConnectedAtom(terminals[0]);
+                    IAtom replace = t0Bonds.remove(0).getOther(terminals[0]);
                     for (int i = 0; i < peripherals.length; i++)
                         if (replace == peripherals[i]) peripherals[i] = terminals[0];
                 }
 
                 if (t1Bonds.size() == 2) {
-                    IAtom replace = t1Bonds.remove(0).getConnectedAtom(terminals[1]);
+                    IAtom replace = t1Bonds.remove(0).getOther(terminals[1]);
                     for (int i = 0; i < peripherals.length; i++)
                         if (replace == peripherals[i]) peripherals[i] = terminals[1];
                 }
 
                 // the neighbor attached to each terminal atom that we will
                 // define the configuration of
-                IAtom t0Neighbor = t0Bonds.get(0).getConnectedAtom(terminals[0]);
-                IAtom t1Neighbor = t1Bonds.get(0).getConnectedAtom(terminals[1]);
+                IAtom t0Neighbor = t0Bonds.get(0).getOther(terminals[0]);
+                IAtom t1Neighbor = t1Bonds.get(0).getOther(terminals[1]);
 
                 // we now need to move all the atoms into the correct positions
                 // everytime we exchange atoms the configuration inverts

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
@@ -291,8 +291,8 @@ public class InChIGenerator {
             IBond bond = bonds.next();
 
             // Assumes 2 centre bond
-            JniInchiAtom at0 = (JniInchiAtom) atomMap.get(bond.getAtom(0));
-            JniInchiAtom at1 = (JniInchiAtom) atomMap.get(bond.getAtom(1));
+            JniInchiAtom at0 = (JniInchiAtom) atomMap.get(bond.getBeg());
+            JniInchiAtom at1 = (JniInchiAtom) atomMap.get(bond.getEnd());
 
             // Get bond order
             INCHI_BOND_TYPE order;

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
@@ -372,7 +372,7 @@ public class InChIToStructure {
     private static IAtom findOtherSinglyBonded(IAtomContainer container, IAtom atom, IAtom exclude) {
         for (final IBond bond : container.getConnectedBondsList(atom)) {
             if (!IBond.Order.SINGLE.equals(bond.getOrder()) || bond.contains(exclude)) continue;
-            return bond.getConnectedAtom(atom);
+            return bond.getOther(atom);
         }
         return atom;
     }

--- a/storage/io/src/main/java/org/openscience/cdk/io/CDKSourceCodeWriter.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/CDKSourceCodeWriter.java
@@ -220,8 +220,8 @@ public class CDKSourceCodeWriter extends DefaultChemObjectWriter {
     }
 
     private void writeBond(IBond bond) throws Exception {
-        writer.write("  IBond " + bond.getID() + " = builder.newInstance(IBond.class," + bond.getBeg().getID() + ", "
-                + bond.getEnd().getID() + ", IBond.Order." + bond.getOrder() + ");");
+        writer.write("  IBond " + bond.getID() + " = builder.newInstance(IBond.class," + bond.getBegin().getID() + ", "
+                     + bond.getEnd().getID() + ", IBond.Order." + bond.getOrder() + ");");
         writer.newLine();
     }
 

--- a/storage/io/src/main/java/org/openscience/cdk/io/CDKSourceCodeWriter.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/CDKSourceCodeWriter.java
@@ -220,8 +220,8 @@ public class CDKSourceCodeWriter extends DefaultChemObjectWriter {
     }
 
     private void writeBond(IBond bond) throws Exception {
-        writer.write("  IBond " + bond.getID() + " = builder.newInstance(IBond.class," + bond.getAtom(0).getID() + ", "
-                + bond.getAtom(1).getID() + ", IBond.Order." + bond.getOrder() + ");");
+        writer.write("  IBond " + bond.getID() + " = builder.newInstance(IBond.class," + bond.getBeg().getID() + ", "
+                + bond.getEnd().getID() + ", IBond.Order." + bond.getOrder() + ");");
         writer.newLine();
     }
 

--- a/storage/io/src/main/java/org/openscience/cdk/io/HINWriter.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/HINWriter.java
@@ -183,7 +183,7 @@ public class HINWriter extends DefaultChemObjectWriter {
                         IBond bond = bonds.next();
                         if (bond.contains(atom)) {
                             // current atom is in the bond so lets get the connected atom
-                            IAtom connectedAtom = bond.getConnectedAtom(atom);
+                            IAtom connectedAtom = bond.getOther(atom);
                             IBond.Order bondOrder = bond.getOrder();
                             int serial;
                             String bondType = "";

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
@@ -584,9 +584,9 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
                     || bond.getStereo() == IBond.Stereo.UP_OR_DOWN_INVERTED) {
                     // turn around atom coding to correct for inv stereo
                     line = formatMDLInt(atomindex.get(bond.getEnd()) + 1, 3);
-                    line += formatMDLInt(atomindex.get(bond.getBeg()) + 1, 3);
+                    line += formatMDLInt(atomindex.get(bond.getBegin()) + 1, 3);
                 } else {
-                    line = formatMDLInt(atomindex.get(bond.getBeg()) + 1, 3);
+                    line = formatMDLInt(atomindex.get(bond.getBegin()) + 1, 3);
                     line += formatMDLInt(atomindex.get(bond.getEnd()) + 1, 3);
                 }
 

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
@@ -583,11 +583,11 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
                 if (bond.getStereo() == IBond.Stereo.UP_INVERTED || bond.getStereo() == IBond.Stereo.DOWN_INVERTED
                     || bond.getStereo() == IBond.Stereo.UP_OR_DOWN_INVERTED) {
                     // turn around atom coding to correct for inv stereo
-                    line = formatMDLInt(atomindex.get(bond.getAtom(1)) + 1, 3);
-                    line += formatMDLInt(atomindex.get(bond.getAtom(0)) + 1, 3);
+                    line = formatMDLInt(atomindex.get(bond.getEnd()) + 1, 3);
+                    line += formatMDLInt(atomindex.get(bond.getBeg()) + 1, 3);
                 } else {
-                    line = formatMDLInt(atomindex.get(bond.getAtom(0)) + 1, 3);
-                    line += formatMDLInt(atomindex.get(bond.getAtom(1)) + 1, 3);
+                    line = formatMDLInt(atomindex.get(bond.getBeg()) + 1, 3);
+                    line += formatMDLInt(atomindex.get(bond.getEnd()) + 1, 3);
                 }
 
                 int bondType = 0;

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -506,7 +506,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                 if ("ANY".equals(attach)) {
                     Sgroup sgroup = new Sgroup();
                     sgroup.setType(SgroupType.ExtMulticenter);
-                    sgroup.addAtom(bond.getAtom(0)); // could be other end?
+                    sgroup.addAtom(bond.getBeg()); // could be other end?
                     sgroup.addBond(bond);
                     for (IAtom endpt : endpts)
                         sgroup.addAtom(endpt);

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -25,7 +25,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
@@ -506,7 +505,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                 if ("ANY".equals(attach)) {
                     Sgroup sgroup = new Sgroup();
                     sgroup.setType(SgroupType.ExtMulticenter);
-                    sgroup.addAtom(bond.getBeg()); // could be other end?
+                    sgroup.addAtom(bond.getBegin()); // could be other end?
                     sgroup.addBond(bond);
                     for (IAtom endpt : endpts)
                         sgroup.addAtom(endpt);

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -367,8 +367,8 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
         writer.write("BEGIN BOND\n");
         int bondIdx = 0;
         for (IBond bond : mol.bonds()) {
-            IAtom beg = bond.getAtom(0);
-            IAtom end = bond.getAtom(1);
+            IAtom beg = bond.getBeg();
+            IAtom end = bond.getEnd();
             if (beg == null || end == null)
                 throw new IllegalStateException("Bond " + bondIdx + " had one or more atoms.");
             int begIdx = findIdx(idxs, beg);
@@ -424,8 +424,8 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
             Sgroup sgroup = multicenterSgroups.get(bond);
             if (sgroup != null) {
                 List<IAtom> atoms = new ArrayList<>(sgroup.getAtoms());
-                atoms.remove(bond.getAtom(0));
-                atoms.remove(bond.getAtom(1));
+                atoms.remove(bond.getBeg());
+                atoms.remove(bond.getEnd());
                 writer.write(" ATTACH=ANY ENDPTS=(").write(atoms, idxs).write(')');
             }
 

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -367,7 +367,7 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
         writer.write("BEGIN BOND\n");
         int bondIdx = 0;
         for (IBond bond : mol.bonds()) {
-            IAtom beg = bond.getBeg();
+            IAtom beg = bond.getBegin();
             IAtom end = bond.getEnd();
             if (beg == null || end == null)
                 throw new IllegalStateException("Bond " + bondIdx + " had one or more atoms.");
@@ -424,7 +424,7 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
             Sgroup sgroup = multicenterSgroups.get(bond);
             if (sgroup != null) {
                 List<IAtom> atoms = new ArrayList<>(sgroup.getAtoms());
-                atoms.remove(bond.getBeg());
+                atoms.remove(bond.getBegin());
                 atoms.remove(bond.getEnd());
                 writer.write(" ATTACH=ANY ENDPTS=(").write(atoms, idxs).write(')');
             }

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLValence.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLValence.java
@@ -69,7 +69,7 @@ final class MDLValence {
 
         // compute the bond order sums
         for (IBond bond : container.bonds()) {
-            int u = atomToIndex.get(bond.getBeg());
+            int u = atomToIndex.get(bond.getBegin());
             int v = atomToIndex.get(bond.getEnd());
 
             int bondOrder = bond.getOrder().numeric();

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLValence.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLValence.java
@@ -69,8 +69,8 @@ final class MDLValence {
 
         // compute the bond order sums
         for (IBond bond : container.bonds()) {
-            int u = atomToIndex.get(bond.getAtom(0));
-            int v = atomToIndex.get(bond.getAtom(1));
+            int u = atomToIndex.get(bond.getBeg());
+            int v = atomToIndex.get(bond.getEnd());
 
             int bondOrder = bond.getOrder().numeric();
 

--- a/storage/io/src/main/java/org/openscience/cdk/io/Mol2Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/Mol2Reader.java
@@ -381,8 +381,8 @@ public class Mol2Reader extends DefaultChemObjectReader {
                                 } else if ("am".equals(orderStr) || "ar".equals(orderStr)) {
                                     bond.setOrder(Order.SINGLE);
                                     bond.setFlag(CDKConstants.ISAROMATIC, true);
-                                    bond.getAtom(0).setFlag(CDKConstants.ISAROMATIC, true);
-                                    bond.getAtom(1).setFlag(CDKConstants.ISAROMATIC, true);
+                                    bond.getBeg().setFlag(CDKConstants.ISAROMATIC, true);
+                                    bond.getEnd().setFlag(CDKConstants.ISAROMATIC, true);
                                 } else if ("du".equals(orderStr)) {
                                     bond.setOrder(Order.SINGLE);
                                 } else if ("un".equals(orderStr)) {

--- a/storage/io/src/main/java/org/openscience/cdk/io/Mol2Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/Mol2Reader.java
@@ -381,7 +381,7 @@ public class Mol2Reader extends DefaultChemObjectReader {
                                 } else if ("am".equals(orderStr) || "ar".equals(orderStr)) {
                                     bond.setOrder(Order.SINGLE);
                                     bond.setFlag(CDKConstants.ISAROMATIC, true);
-                                    bond.getBeg().setFlag(CDKConstants.ISAROMATIC, true);
+                                    bond.getBegin().setFlag(CDKConstants.ISAROMATIC, true);
                                     bond.getEnd().setFlag(CDKConstants.ISAROMATIC, true);
                                 } else if ("du".equals(orderStr)) {
                                     bond.setOrder(Order.SINGLE);

--- a/storage/io/src/main/java/org/openscience/cdk/io/Mol2Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/Mol2Writer.java
@@ -233,7 +233,7 @@ public class Mol2Writer extends DefaultChemObjectWriter {
 
                 // we need to check the atom types to see if we have an amide bond
                 // and we're assuming a 2-centered bond
-                final IAtom bondAtom1 = bond.getBeg();
+                final IAtom bondAtom1 = bond.getBegin();
                 final IAtom bondAtom2 = bond.getEnd();
                 try {
                     final IAtomType bondAtom1Type = matcher.findMatchingAtomType(mol, bondAtom1);
@@ -247,8 +247,8 @@ public class Mol2Writer extends DefaultChemObjectWriter {
                     e.printStackTrace();
                 }
 
-                writer.write((counter + 1) + " " + (mol.indexOf(bond.getBeg()) + 1) + " "
-                        + (mol.indexOf(bond.getEnd()) + 1) + " " + sybylBondOrder);
+                writer.write((counter + 1) + " " + (mol.indexOf(bond.getBegin()) + 1) + " "
+                             + (mol.indexOf(bond.getEnd()) + 1) + " " + sybylBondOrder);
                 writer.newLine();
                 counter++;
             }

--- a/storage/io/src/main/java/org/openscience/cdk/io/Mol2Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/Mol2Writer.java
@@ -233,8 +233,8 @@ public class Mol2Writer extends DefaultChemObjectWriter {
 
                 // we need to check the atom types to see if we have an amide bond
                 // and we're assuming a 2-centered bond
-                final IAtom bondAtom1 = bond.getAtom(0);
-                final IAtom bondAtom2 = bond.getAtom(1);
+                final IAtom bondAtom1 = bond.getBeg();
+                final IAtom bondAtom2 = bond.getEnd();
                 try {
                     final IAtomType bondAtom1Type = matcher.findMatchingAtomType(mol, bondAtom1);
                     final IAtomType bondAtom2Type = matcher.findMatchingAtomType(mol, bondAtom2);
@@ -247,8 +247,8 @@ public class Mol2Writer extends DefaultChemObjectWriter {
                     e.printStackTrace();
                 }
 
-                writer.write((counter + 1) + " " + (mol.indexOf(bond.getAtom(0)) + 1) + " "
-                        + (mol.indexOf(bond.getAtom(1)) + 1) + " " + sybylBondOrder);
+                writer.write((counter + 1) + " " + (mol.indexOf(bond.getBeg()) + 1) + " "
+                        + (mol.indexOf(bond.getEnd()) + 1) + " " + sybylBondOrder);
                 writer.newLine();
                 counter++;
             }

--- a/storage/io/src/main/java/org/openscience/cdk/io/RGroupQueryWriter.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/RGroupQueryWriter.java
@@ -210,7 +210,7 @@ public class RGroupQueryWriter extends DefaultChemObjectWriter {
                     int apoIdx = 1;
                     boolean implicitlyOrdered = true;
                     while (rApo.get(apoIdx) != null && implicitlyOrdered) {
-                        IAtom partner = rApo.get(apoIdx).getConnectedAtom(rgroupAtom);
+                        IAtom partner = rApo.get(apoIdx).getOther(rgroupAtom);
                         for (int atIdx = 0; atIdx < rootAtc.getAtomCount(); atIdx++) {
                             if (rootAtc.getAtom(atIdx).equals(partner)) {
                                 if (atIdx < prevPos) implicitlyOrdered = false;
@@ -229,7 +229,7 @@ public class RGroupQueryWriter extends DefaultChemObjectWriter {
 
                                 apoIdx = 1;
                                 while (rApo.get(apoIdx) != null) {
-                                    IAtom partner = rApo.get(apoIdx).getConnectedAtom(rgroupAtom);
+                                    IAtom partner = rApo.get(apoIdx).getOther(rgroupAtom);
 
                                     for (int a = 0; a < rootAtc.getAtomCount(); a++) {
                                         if (rootAtc.getAtom(a).equals(partner)) {

--- a/storage/io/src/test/java/org/openscience/cdk/io/MDLV2000BondBlockTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/MDLV2000BondBlockTest.java
@@ -55,7 +55,7 @@ public class MDLV2000BondBlockTest {
     public void atomNumbers() throws Exception {
         String input = "  1  3  1  0  0  0  0";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getBegin(), is(atoms[0]));
         assertThat(bond.getEnd(), is(atoms[2]));
     }
 
@@ -219,7 +219,7 @@ public class MDLV2000BondBlockTest {
     public void longLine() throws Exception {
         String input = "  1  3  1  0  0  0  0  0  0";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getBegin(), is(atoms[0]));
         assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
@@ -231,7 +231,7 @@ public class MDLV2000BondBlockTest {
     public void longLineWithPadding() throws Exception {
         String input = "  1  3  1  0  0  0  0    ";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getBegin(), is(atoms[0]));
         assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
@@ -243,7 +243,7 @@ public class MDLV2000BondBlockTest {
     public void shortLine() throws Exception {
         String input = "  1  3  1  0";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getBegin(), is(atoms[0]));
         assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
@@ -255,7 +255,7 @@ public class MDLV2000BondBlockTest {
     public void shortLineWithPadding() throws Exception {
         String input = "  1  3  1  0       ";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getBegin(), is(atoms[0]));
         assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
@@ -267,7 +267,7 @@ public class MDLV2000BondBlockTest {
     public void shortLineNoStereo() throws Exception {
         String input = "  1  3  1";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getBegin(), is(atoms[0]));
         assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));

--- a/storage/io/src/test/java/org/openscience/cdk/io/MDLV2000BondBlockTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/MDLV2000BondBlockTest.java
@@ -55,8 +55,8 @@ public class MDLV2000BondBlockTest {
     public void atomNumbers() throws Exception {
         String input = "  1  3  1  0  0  0  0";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getAtom(0), is(atoms[0]));
-        assertThat(bond.getAtom(1), is(atoms[2]));
+        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getEnd(), is(atoms[2]));
     }
 
     @Test
@@ -219,8 +219,8 @@ public class MDLV2000BondBlockTest {
     public void longLine() throws Exception {
         String input = "  1  3  1  0  0  0  0  0  0";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getAtom(0), is(atoms[0]));
-        assertThat(bond.getAtom(1), is(atoms[2]));
+        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
         assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));
@@ -231,8 +231,8 @@ public class MDLV2000BondBlockTest {
     public void longLineWithPadding() throws Exception {
         String input = "  1  3  1  0  0  0  0    ";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getAtom(0), is(atoms[0]));
-        assertThat(bond.getAtom(1), is(atoms[2]));
+        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
         assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));
@@ -243,8 +243,8 @@ public class MDLV2000BondBlockTest {
     public void shortLine() throws Exception {
         String input = "  1  3  1  0";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getAtom(0), is(atoms[0]));
-        assertThat(bond.getAtom(1), is(atoms[2]));
+        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
         assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));
@@ -255,8 +255,8 @@ public class MDLV2000BondBlockTest {
     public void shortLineWithPadding() throws Exception {
         String input = "  1  3  1  0       ";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getAtom(0), is(atoms[0]));
-        assertThat(bond.getAtom(1), is(atoms[2]));
+        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
         assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));
@@ -267,8 +267,8 @@ public class MDLV2000BondBlockTest {
     public void shortLineNoStereo() throws Exception {
         String input = "  1  3  1";
         IBond bond = reader.readBondFast(input, builder, atoms, new int[atoms.length], 1);
-        assertThat(bond.getAtom(0), is(atoms[0]));
-        assertThat(bond.getAtom(1), is(atoms[2]));
+        assertThat(bond.getBeg(), is(atoms[0]));
+        assertThat(bond.getEnd(), is(atoms[2]));
         assertThat(bond.getOrder(), is(IBond.Order.SINGLE));
         assertThat(bond.getStereo(), is(IBond.Stereo.NONE));
         assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));

--- a/storage/io/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -746,11 +746,11 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         for (IBond bond : mol.bonds()) {
             IPseudoAtom rGroup = null;
             IAtom partner = null;
-            if (bond.getBeg() instanceof IPseudoAtom) {
-                rGroup = (IPseudoAtom) bond.getBeg();
+            if (bond.getBegin() instanceof IPseudoAtom) {
+                rGroup = (IPseudoAtom) bond.getBegin();
                 partner = bond.getEnd();
             } else {
-                partner = bond.getBeg();
+                partner = bond.getBegin();
                 rGroup = (IPseudoAtom) bond.getEnd();
             }
             if (partner.getSymbol().equals("N")) {
@@ -781,8 +781,8 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         reader.close();
         for (IBond bond : mol.bonds()) {
             IPseudoAtom rGroup;
-            if (bond.getBeg() instanceof IPseudoAtom)
-                rGroup = (IPseudoAtom) bond.getBeg();
+            if (bond.getBegin() instanceof IPseudoAtom)
+                rGroup = (IPseudoAtom) bond.getBegin();
             else
                 rGroup = (IPseudoAtom) bond.getEnd();
 

--- a/storage/io/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -746,12 +746,12 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         for (IBond bond : mol.bonds()) {
             IPseudoAtom rGroup = null;
             IAtom partner = null;
-            if (bond.getAtom(0) instanceof IPseudoAtom) {
-                rGroup = (IPseudoAtom) bond.getAtom(0);
-                partner = bond.getAtom(1);
+            if (bond.getBeg() instanceof IPseudoAtom) {
+                rGroup = (IPseudoAtom) bond.getBeg();
+                partner = bond.getEnd();
             } else {
-                partner = bond.getAtom(0);
-                rGroup = (IPseudoAtom) bond.getAtom(1);
+                partner = bond.getBeg();
+                rGroup = (IPseudoAtom) bond.getEnd();
             }
             if (partner.getSymbol().equals("N")) {
                 Assert.assertEquals(rGroup.getLabel(), "R4");
@@ -781,10 +781,10 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         reader.close();
         for (IBond bond : mol.bonds()) {
             IPseudoAtom rGroup;
-            if (bond.getAtom(0) instanceof IPseudoAtom)
-                rGroup = (IPseudoAtom) bond.getAtom(0);
+            if (bond.getBeg() instanceof IPseudoAtom)
+                rGroup = (IPseudoAtom) bond.getBeg();
             else
-                rGroup = (IPseudoAtom) bond.getAtom(1);
+                rGroup = (IPseudoAtom) bond.getEnd();
 
             if (bond.getOrder() == IBond.Order.DOUBLE) {
                 Assert.assertEquals(rGroup.getLabel(), "R32");

--- a/storage/io/src/test/java/org/openscience/cdk/io/PCCompoundASNReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/PCCompoundASNReaderTest.java
@@ -78,7 +78,7 @@ public class PCCompoundASNReaderTest extends SimpleChemObjectReaderTest {
         // check bond stuff
         Assert.assertEquals(30, molecule.getBondCount());
         Assert.assertNotNull(molecule.getBond(3));
-        Assert.assertEquals(molecule.getAtom(2), molecule.getBond(3).getBeg());
+        Assert.assertEquals(molecule.getAtom(2), molecule.getBond(3).getBegin());
         Assert.assertEquals(molecule.getAtom(11), molecule.getBond(3).getEnd());
 
         // some extracted props

--- a/storage/io/src/test/java/org/openscience/cdk/io/PCCompoundASNReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/PCCompoundASNReaderTest.java
@@ -78,8 +78,8 @@ public class PCCompoundASNReaderTest extends SimpleChemObjectReaderTest {
         // check bond stuff
         Assert.assertEquals(30, molecule.getBondCount());
         Assert.assertNotNull(molecule.getBond(3));
-        Assert.assertEquals(molecule.getAtom(2), molecule.getBond(3).getAtom(0));
-        Assert.assertEquals(molecule.getAtom(11), molecule.getBond(3).getAtom(1));
+        Assert.assertEquals(molecule.getAtom(2), molecule.getBond(3).getBeg());
+        Assert.assertEquals(molecule.getAtom(11), molecule.getBond(3).getEnd());
 
         // some extracted props
         Assert.assertEquals("InChI=1/C9H17NO4/c1-7(11)14-8(5-9(12)13)6-10(2,3)4/h8H,5-6H2,1-4H3",

--- a/storage/io/src/test/java/org/openscience/cdk/io/RGroupQueryReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/RGroupQueryReaderTest.java
@@ -203,8 +203,8 @@ public class RGroupQueryReaderTest extends SimpleChemObjectReaderTest {
                         Map<IAtom, Map<Integer, IBond>> rootApo = rGroupQuery.getRootAttachmentPoints();
                         Map<Integer, IBond> apoBonds = rootApo.get(at);
                         Assert.assertEquals(apoBonds.size(), 2);
-                        Assert.assertEquals(apoBonds.get(1).getConnectedAtom(at).getSymbol(), "N");
-                        Assert.assertTrue(apoBonds.get(2).getConnectedAtom(at).getSymbol().equals("C"));
+                        Assert.assertEquals(apoBonds.get(1).getOther(at).getSymbol(), "N");
+                        Assert.assertTrue(apoBonds.get(2).getOther(at).getSymbol().equals("C"));
                         //Test: Oxygens are the 2nd APO's for R1
                         RGroupList rList = rGroupQuery.getRGroupDefinitions().get(1);
                         Assert.assertEquals(rList.getRGroups().size(), 2);
@@ -284,10 +284,10 @@ public class RGroupQueryReaderTest extends SimpleChemObjectReaderTest {
                 Map<Integer, IBond> apoBonds = rGroupQuery.getRootAttachmentPoints().get(at);
                 Assert.assertEquals(apoBonds.size(), 2);
 
-                IAtom boundAtom1 = apoBonds.get(1).getConnectedAtom(at);
+                IAtom boundAtom1 = apoBonds.get(1).getOther(at);
                 Assert.assertTrue(boundAtom1.getSymbol().equals("Te") || boundAtom1.getSymbol().equals("S"));
 
-                IAtom boundAtom2 = apoBonds.get(2).getConnectedAtom(at);
+                IAtom boundAtom2 = apoBonds.get(2).getOther(at);
                 Assert.assertTrue(boundAtom2.getSymbol().equals("Po") || boundAtom2.getSymbol().equals("O"));
             }
         }

--- a/storage/io/src/test/java/org/openscience/cdk/io/cml/CML23FragmentsTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/cml/CML23FragmentsTest.java
@@ -167,8 +167,8 @@ public class CML23FragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
     }
@@ -184,8 +184,8 @@ public class CML23FragmentsTest extends CDKTestCase {
         Assert.assertEquals(2, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
         Assert.assertEquals("b2", mol.getBond(1).getID());

--- a/storage/io/src/test/java/org/openscience/cdk/io/cml/CML23FragmentsTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/cml/CML23FragmentsTest.java
@@ -167,7 +167,7 @@ public class CML23FragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
@@ -184,7 +184,7 @@ public class CML23FragmentsTest extends CDKTestCase {
         Assert.assertEquals(2, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());

--- a/storage/io/src/test/java/org/openscience/cdk/io/cml/CMLFragmentsTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/cml/CMLFragmentsTest.java
@@ -162,7 +162,7 @@ public class CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
@@ -179,7 +179,7 @@ public class CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
@@ -196,7 +196,7 @@ public class CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
@@ -213,7 +213,7 @@ public class CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(2, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());

--- a/storage/io/src/test/java/org/openscience/cdk/io/cml/CMLFragmentsTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/cml/CMLFragmentsTest.java
@@ -162,8 +162,8 @@ public class CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
     }
@@ -179,8 +179,8 @@ public class CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
     }
@@ -196,8 +196,8 @@ public class CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
     }
@@ -213,8 +213,8 @@ public class CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(2, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
         Assert.assertEquals("b2", mol.getBond(1).getID());

--- a/storage/io/src/test/java/org/openscience/cdk/io/cml/Jumbo46CMLFragmentsTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/cml/Jumbo46CMLFragmentsTest.java
@@ -96,8 +96,8 @@ public class Jumbo46CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
     }
@@ -113,8 +113,8 @@ public class Jumbo46CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(2, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getAtom(0);
-        IAtom atom2 = bond.getAtom(1);
+        IAtom atom1 = bond.getBeg();
+        IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
         Assert.assertEquals("b2", mol.getBond(1).getID());

--- a/storage/io/src/test/java/org/openscience/cdk/io/cml/Jumbo46CMLFragmentsTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/cml/Jumbo46CMLFragmentsTest.java
@@ -96,7 +96,7 @@ public class Jumbo46CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(1, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());
@@ -113,7 +113,7 @@ public class Jumbo46CMLFragmentsTest extends CDKTestCase {
         Assert.assertEquals(2, mol.getBondCount());
         org.openscience.cdk.interfaces.IBond bond = mol.getBond(0);
         Assert.assertEquals(2, bond.getAtomCount());
-        IAtom atom1 = bond.getBeg();
+        IAtom atom1 = bond.getBegin();
         IAtom atom2 = bond.getEnd();
         Assert.assertEquals("a1", atom1.getID());
         Assert.assertEquals("a2", atom2.getID());

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
@@ -367,7 +367,7 @@ public class CMLRoundTripTest extends CDKTestCase {
         Assert.assertEquals(1, roundTrippedMol.getBondCount());
         IBond roundTrippedBond = roundTrippedMol.getBond(0);
         Assert.assertEquals(2, roundTrippedBond.getAtomCount());
-        Assert.assertEquals("C", roundTrippedBond.getBeg().getSymbol()); // preserved direction?
+        Assert.assertEquals("C", roundTrippedBond.getBegin().getSymbol()); // preserved direction?
         Assert.assertEquals("O", roundTrippedBond.getEnd().getSymbol());
         Assert.assertEquals(bond.getOrder(), roundTrippedBond.getOrder());
     }

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
@@ -367,8 +367,8 @@ public class CMLRoundTripTest extends CDKTestCase {
         Assert.assertEquals(1, roundTrippedMol.getBondCount());
         IBond roundTrippedBond = roundTrippedMol.getBond(0);
         Assert.assertEquals(2, roundTrippedBond.getAtomCount());
-        Assert.assertEquals("C", roundTrippedBond.getAtom(0).getSymbol()); // preserved direction?
-        Assert.assertEquals("O", roundTrippedBond.getAtom(1).getSymbol());
+        Assert.assertEquals("C", roundTrippedBond.getBeg().getSymbol()); // preserved direction?
+        Assert.assertEquals("O", roundTrippedBond.getEnd().getSymbol());
         Assert.assertEquals(bond.getOrder(), roundTrippedBond.getOrder());
     }
 

--- a/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
+++ b/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
@@ -508,8 +508,8 @@ public class PDBReader extends DefaultChemObjectReader {
         IBond bond = firstAtom.getBuilder().newInstance(IBond.class, firstAtom, secondAtom, IBond.Order.SINGLE);
         for (int i = 0; i < bondsFromConnectRecords.size(); i++) {
             IBond existingBond = (IBond) bondsFromConnectRecords.get(i);
-            IAtom a = existingBond.getAtom(0);
-            IAtom b = existingBond.getAtom(1);
+            IAtom a = existingBond.getBeg();
+            IAtom b = existingBond.getEnd();
             if ((a == firstAtom && b == secondAtom) || (b == firstAtom && a == secondAtom)) {
                 // already stored
                 return;

--- a/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
+++ b/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
@@ -40,9 +40,7 @@ import javax.vecmath.Point3d;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.config.AtomTypeFactory;
-import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
-import org.openscience.cdk.exception.NoSuchAtomTypeException;
 import org.openscience.cdk.graph.rebond.RebondTool;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -508,7 +506,7 @@ public class PDBReader extends DefaultChemObjectReader {
         IBond bond = firstAtom.getBuilder().newInstance(IBond.class, firstAtom, secondAtom, IBond.Order.SINGLE);
         for (int i = 0; i < bondsFromConnectRecords.size(); i++) {
             IBond existingBond = (IBond) bondsFromConnectRecords.get(i);
-            IAtom a = existingBond.getBeg();
+            IAtom a = existingBond.getBegin();
             IAtom b = existingBond.getEnd();
             if ((a == firstAtom && b == secondAtom) || (b == firstAtom && a == secondAtom)) {
                 // already stored

--- a/storage/pdb/src/main/java/org/openscience/cdk/templates/AminoAcids.java
+++ b/storage/pdb/src/main/java/org/openscience/cdk/templates/AminoAcids.java
@@ -79,7 +79,7 @@ public class AminoAcids {
             while (bonds.hasNext()) {
                 IBond bond = (IBond) bonds.next();
                 info[counter][0] = counter;
-                info[counter][1] = acid.indexOf(bond.getBeg());
+                info[counter][1] = acid.indexOf(bond.getBegin());
                 info[counter][2] = acid.indexOf(bond.getEnd());
                 info[counter][3] = bond.getOrder().numeric();
                 counter++;

--- a/storage/pdb/src/main/java/org/openscience/cdk/templates/AminoAcids.java
+++ b/storage/pdb/src/main/java/org/openscience/cdk/templates/AminoAcids.java
@@ -79,8 +79,8 @@ public class AminoAcids {
             while (bonds.hasNext()) {
                 IBond bond = (IBond) bonds.next();
                 info[counter][0] = counter;
-                info[counter][1] = acid.indexOf(bond.getAtom(0));
-                info[counter][2] = acid.indexOf(bond.getAtom(1));
+                info[counter][1] = acid.indexOf(bond.getBeg());
+                info[counter][2] = acid.indexOf(bond.getEnd());
                 info[counter][3] = bond.getOrder().numeric();
                 counter++;
             }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
@@ -113,8 +113,8 @@ final class CDKToBeam {
 
         checkArgument(b.getAtomCount() == 2, "Invalid number of atoms on bond");
 
-        int u = indices.get(b.getAtom(0));
-        int v = indices.get(b.getAtom(1));
+        int u = indices.get(b.getBeg());
+        int v = indices.get(b.getEnd());
 
         return toBeamEdgeLabel(b, this.flavour).edge(u, v);
     }
@@ -253,8 +253,8 @@ final class CDKToBeam {
 
         checkArgument(b.getAtomCount() == 2, "Invalid number of atoms on bond");
 
-        int u = indices.get(b.getAtom(0));
-        int v = indices.get(b.getAtom(1));
+        int u = indices.get(b.getBeg());
+        int v = indices.get(b.getEnd());
 
         return toBeamEdgeLabel(b, flavour).edge(u, v);
     }
@@ -271,7 +271,7 @@ final class CDKToBeam {
     private static Bond toBeamEdgeLabel(IBond b, int flavour) throws CDKException {
 
         if (SmiFlavor.isSet(flavour, SmiFlavor.UseAromaticSymbols) && b.isAromatic()) {
-            if (!b.getAtom(0).isAromatic() || !b.getAtom(1).isAromatic())
+            if (!b.getBeg().isAromatic() || !b.getEnd().isAromatic())
                 throw new IllegalStateException("Aromatic bond connects non-aromatic atomic atoms");
             return Bond.AROMATIC;
         }
@@ -311,12 +311,12 @@ final class CDKToBeam {
         // don't try to set a configuration on aromatic bonds
         if (SmiFlavor.isSet(flavour, SmiFlavor.UseAromaticSymbols) && db.getFlag(CDKConstants.ISAROMATIC)) return;
 
-        int u = indices.get(db.getAtom(0));
-        int v = indices.get(db.getAtom(1));
+        int u = indices.get(db.getBeg());
+        int v = indices.get(db.getEnd());
 
         // is bs[0] always connected to db.atom(0)?
-        int x = indices.get(bs[0].getConnectedAtom(db.getAtom(0)));
-        int y = indices.get(bs[1].getConnectedAtom(db.getAtom(1)));
+        int x = indices.get(bs[0].getConnectedAtom(db.getBeg()));
+        int y = indices.get(bs[1].getConnectedAtom(db.getEnd()));
 
         if (dbs.getStereo() == TOGETHER) {
             gb.geometric(u, v).together(x, y);

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
@@ -113,7 +113,7 @@ final class CDKToBeam {
 
         checkArgument(b.getAtomCount() == 2, "Invalid number of atoms on bond");
 
-        int u = indices.get(b.getBeg());
+        int u = indices.get(b.getBegin());
         int v = indices.get(b.getEnd());
 
         return toBeamEdgeLabel(b, this.flavour).edge(u, v);
@@ -253,7 +253,7 @@ final class CDKToBeam {
 
         checkArgument(b.getAtomCount() == 2, "Invalid number of atoms on bond");
 
-        int u = indices.get(b.getBeg());
+        int u = indices.get(b.getBegin());
         int v = indices.get(b.getEnd());
 
         return toBeamEdgeLabel(b, flavour).edge(u, v);
@@ -271,7 +271,7 @@ final class CDKToBeam {
     private static Bond toBeamEdgeLabel(IBond b, int flavour) throws CDKException {
 
         if (SmiFlavor.isSet(flavour, SmiFlavor.UseAromaticSymbols) && b.isAromatic()) {
-            if (!b.getBeg().isAromatic() || !b.getEnd().isAromatic())
+            if (!b.getBegin().isAromatic() || !b.getEnd().isAromatic())
                 throw new IllegalStateException("Aromatic bond connects non-aromatic atomic atoms");
             return Bond.AROMATIC;
         }
@@ -311,11 +311,11 @@ final class CDKToBeam {
         // don't try to set a configuration on aromatic bonds
         if (SmiFlavor.isSet(flavour, SmiFlavor.UseAromaticSymbols) && db.getFlag(CDKConstants.ISAROMATIC)) return;
 
-        int u = indices.get(db.getBeg());
+        int u = indices.get(db.getBegin());
         int v = indices.get(db.getEnd());
 
         // is bs[0] always connected to db.atom(0)?
-        int x = indices.get(bs[0].getOther(db.getBeg()));
+        int x = indices.get(bs[0].getOther(db.getBegin()));
         int y = indices.get(bs[1].getOther(db.getEnd()));
 
         if (dbs.getStereo() == TOGETHER) {

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
@@ -315,8 +315,8 @@ final class CDKToBeam {
         int v = indices.get(db.getEnd());
 
         // is bs[0] always connected to db.atom(0)?
-        int x = indices.get(bs[0].getConnectedAtom(db.getBeg()));
-        int y = indices.get(bs[1].getConnectedAtom(db.getEnd()));
+        int x = indices.get(bs[0].getOther(db.getBeg()));
+        int y = indices.get(bs[1].getOther(db.getEnd()));
 
         if (dbs.getStereo() == TOGETHER) {
             gb.geometric(u, v).together(x, y);

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -578,7 +578,7 @@ public final class SmilesParser {
 
                 for (IAtom atom : atomset) {
                     for (IBond bond : mol.getConnectedBondsList(atom)) {
-                        if (!atomset.contains(bond.getConnectedAtom(atom)))
+                        if (!atomset.contains(bond.getOther(atom)))
                             sgroup.addBond(bond);
                     }
                     sgroup.addAtom(atom);

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -1260,8 +1260,8 @@ public class SmilesParserTest extends CDKTestCase {
         Assert.assertEquals(17, mol.getBondCount());
         for (int i = 0; i < 17; i++) {
             IBond bond = mol.getBond(i);
-            if (bond.getAtom(0).getSymbol().equals("H") || bond.getAtom(0).getSymbol().equals("Br")
-                    || bond.getAtom(1).getSymbol().equals("H") || bond.getAtom(1).getSymbol().equals("Br")) {
+            if (bond.getBeg().getSymbol().equals("H") || bond.getBeg().getSymbol().equals("Br")
+                    || bond.getEnd().getSymbol().equals("H") || bond.getEnd().getSymbol().equals("Br")) {
                 assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));
             } else {
                 assertTrue(bond.getFlag(CDKConstants.ISAROMATIC));
@@ -1311,7 +1311,7 @@ public class SmilesParserTest extends CDKTestCase {
         Assert.assertEquals(7, mol.getBondCount());
         for (int i = 0; i < 7; i++) {
             IBond bond = mol.getBond(i);
-            if (bond.getAtom(0).getSymbol().equals("O") || bond.getAtom(1).getSymbol().equals("O")) {
+            if (bond.getBeg().getSymbol().equals("O") || bond.getEnd().getSymbol().equals("O")) {
                 assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));
             } else {
                 assertTrue(bond.getFlag(CDKConstants.ISAROMATIC));

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -36,12 +36,10 @@ import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;
-import org.openscience.cdk.aromaticity.ElectronDonation;
 import org.openscience.cdk.atomtype.CDKAtomTypeMatcher;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.ConnectivityChecker;
-import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -1260,8 +1258,8 @@ public class SmilesParserTest extends CDKTestCase {
         Assert.assertEquals(17, mol.getBondCount());
         for (int i = 0; i < 17; i++) {
             IBond bond = mol.getBond(i);
-            if (bond.getBeg().getSymbol().equals("H") || bond.getBeg().getSymbol().equals("Br")
-                    || bond.getEnd().getSymbol().equals("H") || bond.getEnd().getSymbol().equals("Br")) {
+            if (bond.getBegin().getSymbol().equals("H") || bond.getBegin().getSymbol().equals("Br")
+                || bond.getEnd().getSymbol().equals("H") || bond.getEnd().getSymbol().equals("Br")) {
                 assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));
             } else {
                 assertTrue(bond.getFlag(CDKConstants.ISAROMATIC));
@@ -1311,7 +1309,7 @@ public class SmilesParserTest extends CDKTestCase {
         Assert.assertEquals(7, mol.getBondCount());
         for (int i = 0; i < 7; i++) {
             IBond bond = mol.getBond(i);
-            if (bond.getBeg().getSymbol().equals("O") || bond.getEnd().getSymbol().equals("O")) {
+            if (bond.getBegin().getSymbol().equals("O") || bond.getEnd().getSymbol().equals("O")) {
                 assertFalse(bond.getFlag(CDKConstants.ISAROMATIC));
             } else {
                 assertTrue(bond.getFlag(CDKConstants.ISAROMATIC));

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
@@ -487,7 +487,7 @@ public class AtomPlacer3D {
         List<IBond> bonds = molecule.getConnectedBondsList(atom);
         IAtom connectedAtom = null;
         for (IBond bond : bonds) {
-            connectedAtom = bond.getConnectedAtom(atom);
+            connectedAtom = bond.getOther(atom);
             if (isUnplacedHeavyAtom(connectedAtom) && connectedAtom.getFlag(CDKConstants.ISINRING)) {
                 return connectedAtom;
             }
@@ -517,7 +517,7 @@ public class AtomPlacer3D {
     public IAtom getPlacedHeavyAtom(IAtomContainer molecule, IAtom atom) {
         List<IBond> bonds = molecule.getConnectedBondsList(atom);
         for (IBond bond : bonds) {
-            IAtom connectedAtom = bond.getConnectedAtom(atom);
+            IAtom connectedAtom = bond.getOther(atom);
             if (isPlacedHeavyAtom(connectedAtom)) {
                 return connectedAtom;
             }
@@ -536,7 +536,7 @@ public class AtomPlacer3D {
     public IAtom getPlacedHeavyAtom(IAtomContainer molecule, IAtom atomA, IAtom atomB) {
         List<IBond> bonds = molecule.getConnectedBondsList(atomA);
         for (IBond bond : bonds) {
-            IAtom connectedAtom = bond.getConnectedAtom(atomA);
+            IAtom connectedAtom = bond.getOther(atomA);
             if (isPlacedHeavyAtom(connectedAtom) && connectedAtom != atomB) {
                 return connectedAtom;
             }
@@ -557,7 +557,7 @@ public class AtomPlacer3D {
         IAtomContainer connectedAtoms = molecule.getBuilder().newInstance(IAtomContainer.class);
         IAtom connectedAtom = null;
         for (IBond bond : bonds) {
-            connectedAtom = bond.getConnectedAtom(atom);
+            connectedAtom = bond.getOther(atom);
             if (isPlacedHeavyAtom(connectedAtom)) {
                 connectedAtoms.addAtom(connectedAtom);
             }

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
@@ -374,14 +374,14 @@ public class AtomPlacer3D {
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            if (bond.getAtom(0).getFlag(CDKConstants.ISPLACED) && !(bond.getAtom(1).getFlag(CDKConstants.ISPLACED))) {
-                if (isAliphaticHeavyAtom(bond.getAtom(1))) {
-                    return bond.getAtom(1);
+            if (bond.getBeg().getFlag(CDKConstants.ISPLACED) && !(bond.getEnd().getFlag(CDKConstants.ISPLACED))) {
+                if (isAliphaticHeavyAtom(bond.getEnd())) {
+                    return bond.getEnd();
                 }
             }
-            if (bond.getAtom(1).getFlag(CDKConstants.ISPLACED) && !(bond.getAtom(0).getFlag(CDKConstants.ISPLACED))) {
-                if (isAliphaticHeavyAtom(bond.getAtom(0))) {
-                    return bond.getAtom(0);
+            if (bond.getEnd().getFlag(CDKConstants.ISPLACED) && !(bond.getBeg().getFlag(CDKConstants.ISPLACED))) {
+                if (isAliphaticHeavyAtom(bond.getBeg())) {
+                    return bond.getBeg();
                 }
             }
         }
@@ -413,8 +413,8 @@ public class AtomPlacer3D {
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom0 = bond.getAtom(0);
-            IAtom atom1 = bond.getAtom(1);
+            IAtom atom0 = bond.getBeg();
+            IAtom atom1 = bond.getEnd();
             if (atom0.getFlag(CDKConstants.ISPLACED) && !(atom1.getFlag(CDKConstants.ISPLACED))) {
                 if (isAliphaticHeavyAtom(atom1) && isHeavyAtom(atom0)) {
                     return atom0;
@@ -439,8 +439,8 @@ public class AtomPlacer3D {
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom0 = bond.getAtom(0);
-            IAtom atom1 = bond.getAtom(1);
+            IAtom atom0 = bond.getBeg();
+            IAtom atom1 = bond.getEnd();
             if (atom0.getFlag(CDKConstants.ISPLACED) && !(atom1.getFlag(CDKConstants.ISPLACED))) {
                 if (isRingHeavyAtom(atom1) && isHeavyAtom(atom0)) {
                     return atom0;

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
@@ -374,14 +374,14 @@ public class AtomPlacer3D {
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            if (bond.getBeg().getFlag(CDKConstants.ISPLACED) && !(bond.getEnd().getFlag(CDKConstants.ISPLACED))) {
+            if (bond.getBegin().getFlag(CDKConstants.ISPLACED) && !(bond.getEnd().getFlag(CDKConstants.ISPLACED))) {
                 if (isAliphaticHeavyAtom(bond.getEnd())) {
                     return bond.getEnd();
                 }
             }
-            if (bond.getEnd().getFlag(CDKConstants.ISPLACED) && !(bond.getBeg().getFlag(CDKConstants.ISPLACED))) {
-                if (isAliphaticHeavyAtom(bond.getBeg())) {
-                    return bond.getBeg();
+            if (bond.getEnd().getFlag(CDKConstants.ISPLACED) && !(bond.getBegin().getFlag(CDKConstants.ISPLACED))) {
+                if (isAliphaticHeavyAtom(bond.getBegin())) {
+                    return bond.getBegin();
                 }
             }
         }
@@ -413,7 +413,7 @@ public class AtomPlacer3D {
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom0 = bond.getBeg();
+            IAtom atom0 = bond.getBegin();
             IAtom atom1 = bond.getEnd();
             if (atom0.getFlag(CDKConstants.ISPLACED) && !(atom1.getFlag(CDKConstants.ISPLACED))) {
                 if (isAliphaticHeavyAtom(atom1) && isHeavyAtom(atom0)) {
@@ -439,7 +439,7 @@ public class AtomPlacer3D {
         Iterator<IBond> bonds = molecule.bonds().iterator();
         while (bonds.hasNext()) {
             IBond bond = bonds.next();
-            IAtom atom0 = bond.getBeg();
+            IAtom atom0 = bond.getBegin();
             IAtom atom1 = bond.getEnd();
             if (atom0.getFlag(CDKConstants.ISPLACED) && !(atom1.getFlag(CDKConstants.ISPLACED))) {
                 if (isRingHeavyAtom(atom1) && isHeavyAtom(atom0)) {

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomTetrahedralLigandPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomTetrahedralLigandPlacer3D.java
@@ -818,7 +818,7 @@ public class AtomTetrahedralLigandPlacer3D {
         IAtomContainer connectedAtoms = atom.getBuilder().newInstance(IAtomContainer.class);
         IAtom connectedAtom = null;
         for (int i = 0; i < bonds.size(); i++) {
-            connectedAtom = ((IBond) bonds.get(i)).getConnectedAtom(atom);
+            connectedAtom = ((IBond) bonds.get(i)).getOther(atom);
             if (connectedAtom.getFlag(CDKConstants.ISPLACED)) {
                 connectedAtoms.addAtom(connectedAtom);
             }

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/FurtherAtomPlacer3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/FurtherAtomPlacer3DTest.java
@@ -163,9 +163,9 @@ public class FurtherAtomPlacer3DTest extends AtomPlacer3DTest {
         Assert.assertEquals(atom0.getFlag(CDKConstants.ISPLACED), true);
 
         for (IBond bond : molecule.bonds()) {
-            if (bond.getConnectedAtom(molecule.getAtom(4)) != null
-                    && !bond.getConnectedAtom(molecule.getAtom(4)).getFlag(CDKConstants.ISPLACED)) {
-                natompair = bond.getConnectedAtom(molecule.getAtom(4));
+            if (bond.getOther(molecule.getAtom(4)) != null
+                    && !bond.getOther(molecule.getAtom(4)).getFlag(CDKConstants.ISPLACED)) {
+                natompair = bond.getOther(molecule.getAtom(4));
             }
         }
         Assert.assertEquals(natompair, molecule.getAtom(3));

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
@@ -228,7 +228,7 @@ public class ModelBuilder3DTest extends CDKTestCase {
     public static void checkAverageBondLength(IAtomContainer ac) {
         double avlength = GeometryUtil.getBondLengthAverage3D(ac);
         for (int i = 0; i < ac.getBondCount(); i++) {
-            double distance = ac.getBond(i).getBeg().getPoint3d().distance(ac.getBond(i).getEnd().getPoint3d());
+            double distance = ac.getBond(i).getBegin().getPoint3d().distance(ac.getBond(i).getEnd().getPoint3d());
             Assert.assertTrue("Unreasonable bond length (" + distance + ") for bond " + i, distance >= avlength / 2
                     && distance <= avlength * 2);
         }

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
@@ -228,7 +228,7 @@ public class ModelBuilder3DTest extends CDKTestCase {
     public static void checkAverageBondLength(IAtomContainer ac) {
         double avlength = GeometryUtil.getBondLengthAverage3D(ac);
         for (int i = 0; i < ac.getBondCount(); i++) {
-            double distance = ac.getBond(i).getAtom(0).getPoint3d().distance(ac.getBond(i).getAtom(1).getPoint3d());
+            double distance = ac.getBond(i).getBeg().getPoint3d().distance(ac.getBond(i).getEnd().getPoint3d());
             Assert.assertTrue("Unreasonable bond length (" + distance + ") for bond " + i, distance >= avlength / 2
                     && distance <= avlength * 2);
         }

--- a/tool/builder3dtools/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateExtractor.java
+++ b/tool/builder3dtools/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateExtractor.java
@@ -477,7 +477,7 @@ public class TemplateExtractor {
     public IAtomContainer removeLoopBonds(IAtomContainer molecule, int position) {
         for (int i = 0; i < molecule.getBondCount(); i++) {
             IBond bond = molecule.getBond(i);
-            if (bond.getAtom(0) == bond.getAtom(1)) {
+            if (bond.getBeg() == bond.getEnd()) {
                 System.out.println("Loop found! Molecule:" + position);
                 molecule.removeBond(bond);
             }

--- a/tool/builder3dtools/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateExtractor.java
+++ b/tool/builder3dtools/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateExtractor.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.fingerprint.HybridizationFingerprinter;
-import org.openscience.cdk.fingerprint.IFingerprinter;
 import org.openscience.cdk.fingerprint.BitSetFingerprint;
 import org.openscience.cdk.fingerprint.IBitFingerprint;
 import org.openscience.cdk.graph.Cycles;
@@ -477,7 +476,7 @@ public class TemplateExtractor {
     public IAtomContainer removeLoopBonds(IAtomContainer molecule, int position) {
         for (int i = 0; i < molecule.getBondCount(); i++) {
             IBond bond = molecule.getBond(i);
-            if (bond.getBeg() == bond.getEnd()) {
+            if (bond.getBegin() == bond.getEnd()) {
                 System.out.println("Loop found! Molecule:" + position);
                 molecule.removeBond(bond);
             }

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerMarsiliPartialCharges.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerMarsiliPartialCharges.java
@@ -165,8 +165,8 @@ public class GasteigerMarsiliPartialCharges implements IChargeCalculator {
             while (bonds.hasNext()) {
                 IBond bond = (IBond) bonds.next();
 
-                atom1 = ac.indexOf(bond.getAtom(0));
-                atom2 = ac.indexOf(bond.getAtom(1));
+                atom1 = ac.indexOf(bond.getBeg());
+                atom2 = ac.indexOf(bond.getEnd());
 
                 if (gasteigerFactors[STEP_SIZE * atom1 + atom1 + 4] >= gasteigerFactors[STEP_SIZE * atom2 + atom2 + 4]) {
                     if (ac.getAtom(atom2).getSymbol().equals("H")) {

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerMarsiliPartialCharges.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerMarsiliPartialCharges.java
@@ -165,7 +165,7 @@ public class GasteigerMarsiliPartialCharges implements IChargeCalculator {
             while (bonds.hasNext()) {
                 IBond bond = (IBond) bonds.next();
 
-                atom1 = ac.indexOf(bond.getBeg());
+                atom1 = ac.indexOf(bond.getBegin());
                 atom2 = ac.indexOf(bond.getEnd());
 
                 if (gasteigerFactors[STEP_SIZE * atom1 + atom1 + 4] >= gasteigerFactors[STEP_SIZE * atom2 + atom2 + 4]) {

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerPEPEPartialCharges.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerPEPEPartialCharges.java
@@ -529,19 +529,19 @@ public class GasteigerPEPEPartialCharges implements IChargeCalculator {
                     IAtomContainer ati = iSet.getAtomContainer(j);
                     if (!ati.equals(ac))
                         for (int k = 0; k < ati.getBondCount(); k++) {
-                            IAtom a0 = ati.getBond(k).getAtom(0);
-                            IAtom a1 = ati.getBond(k).getAtom(1);
+                            IAtom a0 = ati.getBond(k).getBeg();
+                            IAtom a1 = ati.getBond(k).getEnd();
                             if (!a0.getSymbol().equals("H") || !a1.getSymbol().equals("H"))
-                                if ((a0.getID().equals(ac.getBond(i).getAtom(0).getID()) && a1.getID().equals(
-                                        ac.getBond(i).getAtom(1).getID()))
-                                        || (a1.getID().equals(ac.getBond(i).getAtom(0).getID()) && a0.getID().equals(
-                                                ac.getBond(i).getAtom(1).getID()))) {
+                                if ((a0.getID().equals(ac.getBond(i).getBeg().getID()) && a1.getID().equals(
+                                        ac.getBond(i).getEnd().getID()))
+                                        || (a1.getID().equals(ac.getBond(i).getBeg().getID()) && a0.getID().equals(
+                                                ac.getBond(i).getEnd().getID()))) {
                                     if (a0.getFormalCharge() != 0 || a1.getFormalCharge() != 0) continue out;
                                 }
                         }
                 }
-                ac.getBond(i).getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
-                ac.getBond(i).getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, true);
+                ac.getBond(i).getBeg().setFlag(CDKConstants.REACTIVE_CENTER, true);
+                ac.getBond(i).getEnd().setFlag(CDKConstants.REACTIVE_CENTER, true);
                 ac.getBond(i).setFlag(CDKConstants.REACTIVE_CENTER, true);
                 found = true;
             }
@@ -562,8 +562,8 @@ public class GasteigerPEPEPartialCharges implements IChargeCalculator {
             IAtomContainer mol = setOfReactions.getReaction(i).getProducts().getAtomContainer(0);
             for (int k = 0; k < mol.getBondCount(); k++) {
                 mol.getBond(k).setFlag(CDKConstants.REACTIVE_CENTER, false);
-                mol.getBond(k).getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, false);
-                mol.getBond(k).getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, false);
+                mol.getBond(k).getBeg().setFlag(CDKConstants.REACTIVE_CENTER, false);
+                mol.getBond(k).getEnd().setFlag(CDKConstants.REACTIVE_CENTER, false);
             }
             setOfM2.addAtomContainer(mol);
             List<IParameterReact> paramList2 = new ArrayList<IParameterReact>();

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerPEPEPartialCharges.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerPEPEPartialCharges.java
@@ -498,8 +498,8 @@ public class GasteigerPEPEPartialCharges implements IChargeCalculator {
         IBond bond = ac.getBond(number);
         if (!container.contains(bond)) {
             bond.setFlag(CDKConstants.REACTIVE_CENTER, b);
-            bond.getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, b);
-            bond.getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, b);
+            bond.getBeg().setFlag(CDKConstants.REACTIVE_CENTER, b);
+            bond.getEnd().setFlag(CDKConstants.REACTIVE_CENTER, b);
         } else
             return null;
         return ac;
@@ -637,7 +637,7 @@ public class GasteigerPEPEPartialCharges implements IChargeCalculator {
             fQ = 0.5;
             for (int i = 0; i < atomContainer.getBondCount(); i++) {
                 IBond bond = atomContainer.getBond(i);
-                if (bond.getAtom(0).getFormalCharge() != 0.0 && bond.getAtom(1).getFormalCharge() != 0.0) {
+                if (bond.getBeg().getFormalCharge() != 0.0 && bond.getEnd().getFormalCharge() != 0.0) {
                     fQ = 0.25;
                     break;
                 }

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerPEPEPartialCharges.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/GasteigerPEPEPartialCharges.java
@@ -498,7 +498,7 @@ public class GasteigerPEPEPartialCharges implements IChargeCalculator {
         IBond bond = ac.getBond(number);
         if (!container.contains(bond)) {
             bond.setFlag(CDKConstants.REACTIVE_CENTER, b);
-            bond.getBeg().setFlag(CDKConstants.REACTIVE_CENTER, b);
+            bond.getBegin().setFlag(CDKConstants.REACTIVE_CENTER, b);
             bond.getEnd().setFlag(CDKConstants.REACTIVE_CENTER, b);
         } else
             return null;
@@ -529,18 +529,18 @@ public class GasteigerPEPEPartialCharges implements IChargeCalculator {
                     IAtomContainer ati = iSet.getAtomContainer(j);
                     if (!ati.equals(ac))
                         for (int k = 0; k < ati.getBondCount(); k++) {
-                            IAtom a0 = ati.getBond(k).getBeg();
+                            IAtom a0 = ati.getBond(k).getBegin();
                             IAtom a1 = ati.getBond(k).getEnd();
                             if (!a0.getSymbol().equals("H") || !a1.getSymbol().equals("H"))
-                                if ((a0.getID().equals(ac.getBond(i).getBeg().getID()) && a1.getID().equals(
+                                if ((a0.getID().equals(ac.getBond(i).getBegin().getID()) && a1.getID().equals(
                                         ac.getBond(i).getEnd().getID()))
-                                        || (a1.getID().equals(ac.getBond(i).getBeg().getID()) && a0.getID().equals(
+                                        || (a1.getID().equals(ac.getBond(i).getBegin().getID()) && a0.getID().equals(
                                                 ac.getBond(i).getEnd().getID()))) {
                                     if (a0.getFormalCharge() != 0 || a1.getFormalCharge() != 0) continue out;
                                 }
                         }
                 }
-                ac.getBond(i).getBeg().setFlag(CDKConstants.REACTIVE_CENTER, true);
+                ac.getBond(i).getBegin().setFlag(CDKConstants.REACTIVE_CENTER, true);
                 ac.getBond(i).getEnd().setFlag(CDKConstants.REACTIVE_CENTER, true);
                 ac.getBond(i).setFlag(CDKConstants.REACTIVE_CENTER, true);
                 found = true;
@@ -562,7 +562,7 @@ public class GasteigerPEPEPartialCharges implements IChargeCalculator {
             IAtomContainer mol = setOfReactions.getReaction(i).getProducts().getAtomContainer(0);
             for (int k = 0; k < mol.getBondCount(); k++) {
                 mol.getBond(k).setFlag(CDKConstants.REACTIVE_CENTER, false);
-                mol.getBond(k).getBeg().setFlag(CDKConstants.REACTIVE_CENTER, false);
+                mol.getBond(k).getBegin().setFlag(CDKConstants.REACTIVE_CENTER, false);
                 mol.getBond(k).getEnd().setFlag(CDKConstants.REACTIVE_CENTER, false);
             }
             setOfM2.addAtomContainer(mol);
@@ -637,7 +637,7 @@ public class GasteigerPEPEPartialCharges implements IChargeCalculator {
             fQ = 0.5;
             for (int i = 0; i < atomContainer.getBondCount(); i++) {
                 IBond bond = atomContainer.getBond(i);
-                if (bond.getBeg().getFormalCharge() != 0.0 && bond.getEnd().getFormalCharge() != 0.0) {
+                if (bond.getBegin().getFormalCharge() != 0.0 && bond.getEnd().getFormalCharge() != 0.0) {
                     fQ = 0.25;
                     break;
                 }

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/Polarizability.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/Polarizability.java
@@ -295,7 +295,7 @@ public class Polarizability {
         IAtom connectedAtom;
         int hCounter = 0;
         for (IBond bond : bonds) {
-            connectedAtom = bond.getConnectedAtom(atom);
+            connectedAtom = bond.getOther(atom);
             if (connectedAtom.getSymbol().equals("H")) {
                 hCounter += 1;
             }

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/Polarizability.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/Polarizability.java
@@ -198,7 +198,7 @@ public class Polarizability {
         IAtomContainer acH = atomContainer.getBuilder().newInstance(IAtomContainer.class, atomContainer);
         addExplicitHydrogens(acH);
         if (bond.getAtomCount() == 2) {
-            polarizabilitiy += getKJPolarizabilityFactor(acH, bond.getBeg());
+            polarizabilitiy += getKJPolarizabilityFactor(acH, bond.getBegin());
             polarizabilitiy += getKJPolarizabilityFactor(acH, bond.getEnd());
         }
         return (polarizabilitiy / 2);

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/Polarizability.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/Polarizability.java
@@ -198,8 +198,8 @@ public class Polarizability {
         IAtomContainer acH = atomContainer.getBuilder().newInstance(IAtomContainer.class, atomContainer);
         addExplicitHydrogens(acH);
         if (bond.getAtomCount() == 2) {
-            polarizabilitiy += getKJPolarizabilityFactor(acH, bond.getAtom(0));
-            polarizabilitiy += getKJPolarizabilityFactor(acH, bond.getAtom(1));
+            polarizabilitiy += getKJPolarizabilityFactor(acH, bond.getBeg());
+            polarizabilitiy += getKJPolarizabilityFactor(acH, bond.getEnd());
         }
         return (polarizabilitiy / 2);
     }

--- a/tool/forcefield/src/main/java/org/openscience/cdk/modeling/builder3d/ForceFieldConfigurator.java
+++ b/tool/forcefield/src/main/java/org/openscience/cdk/modeling/builder3d/ForceFieldConfigurator.java
@@ -301,20 +301,20 @@ public class ForceFieldConfigurator {
             //logger.debug("bond[" + i + "] properties : " + molecule.getBond(i).getProperties());
             bondType = "0";
             if (bond.getOrder() == IBond.Order.SINGLE) {
-                if ((bond.getAtom(0).getAtomTypeName().equals("Csp2"))
-                        & ((bond.getAtom(1).getAtomTypeName().equals("Csp2")) | (bond.getAtom(1).getAtomTypeName()
+                if ((bond.getBeg().getAtomTypeName().equals("Csp2"))
+                        & ((bond.getEnd().getAtomTypeName().equals("Csp2")) | (bond.getEnd().getAtomTypeName()
                                 .equals("C=")))) {
                     bondType = "1";
                 }
 
-                if ((bond.getAtom(0).getAtomTypeName().equals("C="))
-                        & ((bond.getAtom(1).getAtomTypeName().equals("Csp2")) | (bond.getAtom(1).getAtomTypeName()
+                if ((bond.getBeg().getAtomTypeName().equals("C="))
+                        & ((bond.getEnd().getAtomTypeName().equals("Csp2")) | (bond.getEnd().getAtomTypeName()
                                 .equals("C=")))) {
                     bondType = "1";
                 }
 
-                if ((bond.getAtom(0).getAtomTypeName().equals("Csp"))
-                        & (bond.getAtom(1).getAtomTypeName().equals("Csp"))) {
+                if ((bond.getBeg().getAtomTypeName().equals("Csp"))
+                        & (bond.getEnd().getAtomTypeName().equals("Csp"))) {
                     bondType = "1";
                 }
             }

--- a/tool/forcefield/src/main/java/org/openscience/cdk/modeling/builder3d/ForceFieldConfigurator.java
+++ b/tool/forcefield/src/main/java/org/openscience/cdk/modeling/builder3d/ForceFieldConfigurator.java
@@ -301,19 +301,19 @@ public class ForceFieldConfigurator {
             //logger.debug("bond[" + i + "] properties : " + molecule.getBond(i).getProperties());
             bondType = "0";
             if (bond.getOrder() == IBond.Order.SINGLE) {
-                if ((bond.getBeg().getAtomTypeName().equals("Csp2"))
+                if ((bond.getBegin().getAtomTypeName().equals("Csp2"))
                         & ((bond.getEnd().getAtomTypeName().equals("Csp2")) | (bond.getEnd().getAtomTypeName()
                                 .equals("C=")))) {
                     bondType = "1";
                 }
 
-                if ((bond.getBeg().getAtomTypeName().equals("C="))
+                if ((bond.getBegin().getAtomTypeName().equals("C="))
                         & ((bond.getEnd().getAtomTypeName().equals("Csp2")) | (bond.getEnd().getAtomTypeName()
                                 .equals("C=")))) {
                     bondType = "1";
                 }
 
-                if ((bond.getBeg().getAtomTypeName().equals("Csp"))
+                if ((bond.getBegin().getAtomTypeName().equals("Csp"))
                         & (bond.getEnd().getAtomTypeName().equals("Csp"))) {
                     bondType = "1";
                 }

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FragmentUtils.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FragmentUtils.java
@@ -59,10 +59,10 @@ public class FragmentUtils {
             // later on we'll want to make sure that the fragment doesn't contain
             // the bond joining the current atom and the atom that is on the other side
             IAtom excludedAtom;
-            if (atom.equals(bond.getAtom(0)))
-                excludedAtom = bond.getAtom(1);
+            if (atom.equals(bond.getBeg()))
+                excludedAtom = bond.getEnd();
             else
-                excludedAtom = bond.getAtom(0);
+                excludedAtom = bond.getBeg();
 
             List<IBond> part = new ArrayList<IBond>();
             part.add(bond);

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FragmentUtils.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FragmentUtils.java
@@ -114,7 +114,7 @@ public class FragmentUtils {
         for (IBond aBond : connectedBonds) {
             if (bondList.contains(aBond)) continue;
             bondList.add(aBond);
-            IAtom nextAtom = aBond.getConnectedAtom(atom);
+            IAtom nextAtom = aBond.getOther(atom);
             if (atomContainer.getConnectedAtomsCount(nextAtom) == 1) continue;
             traverse(atomContainer, nextAtom, bondList);
         }

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FragmentUtils.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FragmentUtils.java
@@ -59,10 +59,10 @@ public class FragmentUtils {
             // later on we'll want to make sure that the fragment doesn't contain
             // the bond joining the current atom and the atom that is on the other side
             IAtom excludedAtom;
-            if (atom.equals(bond.getBeg()))
+            if (atom.equals(bond.getBegin()))
                 excludedAtom = bond.getEnd();
             else
-                excludedAtom = bond.getBeg();
+                excludedAtom = bond.getBegin();
 
             List<IBond> part = new ArrayList<IBond>();
             part.add(bond);

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/MurckoFragmenter.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/MurckoFragmenter.java
@@ -423,12 +423,12 @@ public class MurckoFragmenter implements IFragmenter {
     }
 
     private boolean islinker(IBond bond) {
-        return islinker(bond.getBeg()) || islinker(bond.getEnd());
+        return islinker(bond.getBegin()) || islinker(bond.getEnd());
     }
 
     private boolean isZeroAtomLinker(IBond bond) {
         boolean isRingBond = bond.getFlag(CDKConstants.ISINRING);
-        return isring(bond.getBeg()) && isring(bond.getEnd()) && !isRingBond;
+        return isring(bond.getBegin()) && isring(bond.getEnd()) && !isRingBond;
     }
 
     private boolean hasframework(IAtomContainer atomContainer) {

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/MurckoFragmenter.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/MurckoFragmenter.java
@@ -423,12 +423,12 @@ public class MurckoFragmenter implements IFragmenter {
     }
 
     private boolean islinker(IBond bond) {
-        return islinker(bond.getAtom(0)) || islinker(bond.getAtom(1));
+        return islinker(bond.getBeg()) || islinker(bond.getEnd());
     }
 
     private boolean isZeroAtomLinker(IBond bond) {
         boolean isRingBond = bond.getFlag(CDKConstants.ISINRING);
-        return isring(bond.getAtom(0)) && isring(bond.getAtom(1)) && !isRingBond;
+        return isring(bond.getBeg()) && isring(bond.getEnd()) && !isRingBond;
     }
 
     private boolean hasframework(IAtomContainer atomContainer) {

--- a/tool/group/src/test/java/org/openscience/cdk/group/AtomContainerPrinter.java
+++ b/tool/group/src/test/java/org/openscience/cdk/group/AtomContainerPrinter.java
@@ -50,7 +50,7 @@ public class AtomContainerPrinter {
             edgeStrings = new ArrayList<String>();
         }
         for (IBond bond : atomContainer.bonds()) {
-            int a0 = atomContainer.indexOf(bond.getBeg());
+            int a0 = atomContainer.indexOf(bond.getBegin());
             int a1 = atomContainer.indexOf(bond.getEnd());
             int pA0 = permutation.get(a0);
             int pA1 = permutation.get(a1);

--- a/tool/group/src/test/java/org/openscience/cdk/group/AtomContainerPrinter.java
+++ b/tool/group/src/test/java/org/openscience/cdk/group/AtomContainerPrinter.java
@@ -50,8 +50,8 @@ public class AtomContainerPrinter {
             edgeStrings = new ArrayList<String>();
         }
         for (IBond bond : atomContainer.bonds()) {
-            int a0 = atomContainer.indexOf(bond.getAtom(0));
-            int a1 = atomContainer.indexOf(bond.getAtom(1));
+            int a0 = atomContainer.indexOf(bond.getBeg());
+            int a1 = atomContainer.indexOf(bond.getEnd());
             int pA0 = permutation.get(a0);
             int pA1 = permutation.get(a1);
             char o = bondOrderToChar(bond.getOrder());

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/AbstractHashGenerator.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/AbstractHashGenerator.java
@@ -141,8 +141,8 @@ class AbstractHashGenerator {
 
         for (IBond bond : container.bonds()) {
 
-            int v = container.indexOf(bond.getAtom(0));
-            int w = container.indexOf(bond.getAtom(1));
+            int v = container.indexOf(bond.getBeg());
+            int w = container.indexOf(bond.getEnd());
 
             if (v < 0 || w < 0)
                 throw new IllegalArgumentException("bond at index " + container.indexOf(bond)

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/AbstractHashGenerator.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/AbstractHashGenerator.java
@@ -141,7 +141,7 @@ class AbstractHashGenerator {
 
         for (IBond bond : container.bonds()) {
 
-            int v = container.indexOf(bond.getBeg());
+            int v = container.indexOf(bond.getBegin());
             int w = container.indexOf(bond.getEnd());
 
             if (v < 0 || w < 0)

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactory.java
@@ -97,10 +97,10 @@ public final class DoubleBondElementEncoderFactory implements StereoEncoderFacto
         int[] us = new int[2];
         int[] vs = new int[2];
 
-        us[0] = atomToIndex.get(bs[0].getConnectedAtom(db.getBeg()));
+        us[0] = atomToIndex.get(bs[0].getOther(db.getBeg()));
         us[1] = graph[u].length == 2 ? u : findOther(graph[u], v, us[0]);
 
-        vs[0] = atomToIndex.get(bs[1].getConnectedAtom(db.getEnd()));
+        vs[0] = atomToIndex.get(bs[1].getOther(db.getEnd()));
         vs[1] = graph[v].length == 2 ? v : findOther(graph[v], u, vs[0]);
 
         int parity = dbs.getStereo() == OPPOSITE ? +1 : -1;

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactory.java
@@ -83,8 +83,8 @@ public final class DoubleBondElementEncoderFactory implements StereoEncoderFacto
             int[][] graph) {
 
         IBond db = dbs.getStereoBond();
-        int u = atomToIndex.get(db.getAtom(0));
-        int v = atomToIndex.get(db.getAtom(1));
+        int u = atomToIndex.get(db.getBeg());
+        int v = atomToIndex.get(db.getEnd());
 
         // we now need to expand our view of the environment - the vertex arrays
         // 'us' and 'vs' hold the neighbors of each end point of the double bond
@@ -97,10 +97,10 @@ public final class DoubleBondElementEncoderFactory implements StereoEncoderFacto
         int[] us = new int[2];
         int[] vs = new int[2];
 
-        us[0] = atomToIndex.get(bs[0].getConnectedAtom(db.getAtom(0)));
+        us[0] = atomToIndex.get(bs[0].getConnectedAtom(db.getBeg()));
         us[1] = graph[u].length == 2 ? u : findOther(graph[u], v, us[0]);
 
-        vs[0] = atomToIndex.get(bs[1].getConnectedAtom(db.getAtom(1)));
+        vs[0] = atomToIndex.get(bs[1].getConnectedAtom(db.getEnd()));
         vs[1] = graph[v].length == 2 ? v : findOther(graph[v], u, vs[0]);
 
         int parity = dbs.getStereo() == OPPOSITE ? +1 : -1;

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactory.java
@@ -83,7 +83,7 @@ public final class DoubleBondElementEncoderFactory implements StereoEncoderFacto
             int[][] graph) {
 
         IBond db = dbs.getStereoBond();
-        int u = atomToIndex.get(db.getBeg());
+        int u = atomToIndex.get(db.getBegin());
         int v = atomToIndex.get(db.getEnd());
 
         // we now need to expand our view of the environment - the vertex arrays
@@ -97,7 +97,7 @@ public final class DoubleBondElementEncoderFactory implements StereoEncoderFacto
         int[] us = new int[2];
         int[] vs = new int[2];
 
-        us[0] = atomToIndex.get(bs[0].getOther(db.getBeg()));
+        us[0] = atomToIndex.get(bs[0].getOther(db.getBegin()));
         us[1] = graph[u].length == 2 ? u : findOther(graph[u], v, us[0]);
 
         vs[0] = atomToIndex.get(bs[1].getOther(db.getEnd()));

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactory.java
@@ -298,7 +298,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
      */
     private static boolean has2DCoordinates(List<IBond> bonds) {
         for (IBond bond : bonds) {
-            if (bond.getAtom(0).getPoint2d() == null || bond.getAtom(1).getPoint2d() == null) return false;
+            if (bond.getBeg().getPoint2d() == null || bond.getEnd().getPoint2d() == null) return false;
         }
         return true;
     }
@@ -312,7 +312,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
      */
     private static boolean has3DCoordinates(List<IBond> bonds) {
         for (IBond bond : bonds) {
-            if (bond.getAtom(0).getPoint3d() == null || bond.getAtom(1).getPoint3d() == null) return false;
+            if (bond.getBeg().getPoint3d() == null || bond.getEnd().getPoint3d() == null) return false;
         }
         return true;
     }
@@ -328,7 +328,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
      * @return elevation of bond
      */
     static int elevation(IBond bond, IAtom a) {
-        return bond.getAtom(0).equals(a) ? elevation(bond) : elevation(bond) * -1;
+        return bond.getBeg().equals(a) ? elevation(bond) : elevation(bond) * -1;
     }
 
     /**
@@ -418,8 +418,8 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
          * @param bond the bond to add
          */
         public void add(IBond bond) {
-            add(bond.getAtom(0), bond);
-            add(bond.getAtom(1), bond);
+            add(bond.getBeg(), bond);
+            add(bond.getEnd(), bond);
         }
 
         /**

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactory.java
@@ -298,7 +298,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
      */
     private static boolean has2DCoordinates(List<IBond> bonds) {
         for (IBond bond : bonds) {
-            if (bond.getBeg().getPoint2d() == null || bond.getEnd().getPoint2d() == null) return false;
+            if (bond.getBegin().getPoint2d() == null || bond.getEnd().getPoint2d() == null) return false;
         }
         return true;
     }
@@ -312,7 +312,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
      */
     private static boolean has3DCoordinates(List<IBond> bonds) {
         for (IBond bond : bonds) {
-            if (bond.getBeg().getPoint3d() == null || bond.getEnd().getPoint3d() == null) return false;
+            if (bond.getBegin().getPoint3d() == null || bond.getEnd().getPoint3d() == null) return false;
         }
         return true;
     }
@@ -328,7 +328,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
      * @return elevation of bond
      */
     static int elevation(IBond bond, IAtom a) {
-        return bond.getBeg().equals(a) ? elevation(bond) : elevation(bond) * -1;
+        return bond.getBegin().equals(a) ? elevation(bond) : elevation(bond) * -1;
     }
 
     /**
@@ -418,7 +418,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
          * @param bond the bond to add
          */
         public void add(IBond bond) {
-            add(bond.getBeg(), bond);
+            add(bond.getBegin(), bond);
             add(bond.getEnd(), bond);
         }
 

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactory.java
@@ -74,8 +74,8 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
             if (bonds.size() == 2) {
 
                 // (s)tart/(e)nd of cumulated system: -s=a=e-
-                IAtom s = bonds.get(0).getConnectedAtom(a);
-                IAtom e = bonds.get(1).getConnectedAtom(a);
+                IAtom s = bonds.get(0).getOther(a);
+                IAtom e = bonds.get(1).getOther(a);
                 // need the parents to re-use the double bond encoder
                 IAtom sParent = a;
                 IAtom eParent = a;
@@ -88,8 +88,8 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
 
                 // expand out from 'l'
                 while (s != null && map.cumulated(s)) {
-                    IAtom p = map.bonds(s).get(0).getConnectedAtom(s);
-                    IAtom q = map.bonds(s).get(1).getConnectedAtom(s);
+                    IAtom p = map.bonds(s).get(0).getOther(s);
+                    IAtom q = map.bonds(s).get(1).getOther(s);
                     sParent = s;
                     s = visited.add(p) ? p : visited.add(q) ? q : null;
                     size++;
@@ -97,8 +97,8 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
 
                 // expand from 'r'
                 while (e != null && map.cumulated(e)) {
-                    IAtom p = map.bonds(e).get(0).getConnectedAtom(e);
-                    IAtom q = map.bonds(e).get(1).getConnectedAtom(e);
+                    IAtom p = map.bonds(e).get(0).getOther(e);
+                    IAtom q = map.bonds(e).get(1).getOther(e);
                     eParent = e;
                     e = visited.add(p) ? p : visited.add(q) ? q : null;
                     size++;
@@ -236,7 +236,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
 
         for (IBond bond : connected) {
             if (!isDoubleBond(bond)) {
-                IAtom other = bond.getConnectedAtom(a);
+                IAtom other = bond.getOther(a);
                 coordinates[i + offset] = other.getPoint2d();
                 elevations[i + offset] = elevation(bond, a);
                 indices[i] = container.indexOf(other);
@@ -273,7 +273,7 @@ public class GeometricCumulativeDoubleBondFactory implements StereoEncoderFactor
 
         for (IBond bond : connected) {
             if (!isDoubleBond(bond)) {
-                IAtom other = bond.getConnectedAtom(a);
+                IAtom other = bond.getOther(a);
                 coordinates[i + offset] = other.getPoint3d();
                 indices[i] = container.indexOf(other);
                 i++;

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricDoubleBondEncoderFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricDoubleBondEncoderFactory.java
@@ -73,8 +73,8 @@ public final class GeometricDoubleBondEncoderFactory implements StereoEncoderFac
             // if double bond and not E or Z query bond
             if (DOUBLE.equals(bond.getOrder()) && !E_OR_Z.equals(bond.getStereo())) {
 
-                IAtom left = bond.getAtom(0);
-                IAtom right = bond.getAtom(1);
+                IAtom left = bond.getBeg();
+                IAtom right = bond.getEnd();
 
                 // skip -N=N- double bonds which exhibit inversion
                 if (Integer.valueOf(7).equals(left.getAtomicNumber())

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricDoubleBondEncoderFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricDoubleBondEncoderFactory.java
@@ -73,7 +73,7 @@ public final class GeometricDoubleBondEncoderFactory implements StereoEncoderFac
             // if double bond and not E or Z query bond
             if (DOUBLE.equals(bond.getOrder()) && !E_OR_Z.equals(bond.getStereo())) {
 
-                IAtom left = bond.getBeg();
+                IAtom left = bond.getBegin();
                 IAtom right = bond.getEnd();
 
                 // skip -N=N- double bonds which exhibit inversion

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricTetrahedralEncoderFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricTetrahedralEncoderFactory.java
@@ -273,10 +273,10 @@ public class GeometricTetrahedralEncoderFactory implements StereoEncoderFactory 
 
             // change elevation depending on which end of the wedge/hatch
             // the atom is on
-            if (bond.getAtom(0).equals(atom)) {
-                map.put(bond.getAtom(1), elevation);
+            if (bond.getBeg().equals(atom)) {
+                map.put(bond.getEnd(), elevation);
             } else {
-                map.put(bond.getAtom(0), -1 * elevation);
+                map.put(bond.getBeg(), -1 * elevation);
             }
         }
     }

--- a/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricTetrahedralEncoderFactory.java
+++ b/tool/hash/src/main/java/org/openscience/cdk/hash/stereo/GeometricTetrahedralEncoderFactory.java
@@ -273,10 +273,10 @@ public class GeometricTetrahedralEncoderFactory implements StereoEncoderFactory 
 
             // change elevation depending on which end of the wedge/hatch
             // the atom is on
-            if (bond.getBeg().equals(atom)) {
+            if (bond.getBegin().equals(atom)) {
                 map.put(bond.getEnd(), elevation);
             } else {
-                map.put(bond.getBeg(), -1 * elevation);
+                map.put(bond.getBegin(), -1 * elevation);
             }
         }
     }

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactoryTest.java
@@ -72,7 +72,7 @@ public class DoubleBondElementEncoderFactoryTest {
         IBond left = mock(IBond.class);
         IBond right = mock(IBond.class);
 
-        when(stereoBond.getBeg()).thenReturn(c1);
+        when(stereoBond.getBegin()).thenReturn(c1);
         when(stereoBond.getEnd()).thenReturn(c2);
         when(left.getOther(c1)).thenReturn(cl3);
         when(right.getOther(c2)).thenReturn(cl4);
@@ -111,7 +111,7 @@ public class DoubleBondElementEncoderFactoryTest {
         IBond left = mock(IBond.class);
         IBond right = mock(IBond.class);
 
-        when(stereoBond.getBeg()).thenReturn(c1);
+        when(stereoBond.getBegin()).thenReturn(c1);
         when(stereoBond.getEnd()).thenReturn(c2);
         when(left.getOther(c1)).thenReturn(cl3);
         when(right.getOther(c2)).thenReturn(cl4);

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactoryTest.java
@@ -74,8 +74,8 @@ public class DoubleBondElementEncoderFactoryTest {
 
         when(stereoBond.getBeg()).thenReturn(c1);
         when(stereoBond.getEnd()).thenReturn(c2);
-        when(left.getConnectedAtom(c1)).thenReturn(cl3);
-        when(right.getConnectedAtom(c2)).thenReturn(cl4);
+        when(left.getOther(c1)).thenReturn(cl3);
+        when(right.getOther(c2)).thenReturn(cl4);
 
         IDoubleBondStereochemistry dbs = mock(IDoubleBondStereochemistry.class);
         when(dbs.getStereoBond()).thenReturn(stereoBond);
@@ -113,8 +113,8 @@ public class DoubleBondElementEncoderFactoryTest {
 
         when(stereoBond.getBeg()).thenReturn(c1);
         when(stereoBond.getEnd()).thenReturn(c2);
-        when(left.getConnectedAtom(c1)).thenReturn(cl3);
-        when(right.getConnectedAtom(c2)).thenReturn(cl4);
+        when(left.getOther(c1)).thenReturn(cl3);
+        when(right.getOther(c2)).thenReturn(cl4);
 
         IDoubleBondStereochemistry dbs = mock(IDoubleBondStereochemistry.class);
         when(dbs.getStereoBond()).thenReturn(stereoBond);

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/DoubleBondElementEncoderFactoryTest.java
@@ -72,8 +72,8 @@ public class DoubleBondElementEncoderFactoryTest {
         IBond left = mock(IBond.class);
         IBond right = mock(IBond.class);
 
-        when(stereoBond.getAtom(0)).thenReturn(c1);
-        when(stereoBond.getAtom(1)).thenReturn(c2);
+        when(stereoBond.getBeg()).thenReturn(c1);
+        when(stereoBond.getEnd()).thenReturn(c2);
         when(left.getConnectedAtom(c1)).thenReturn(cl3);
         when(right.getConnectedAtom(c2)).thenReturn(cl4);
 
@@ -111,8 +111,8 @@ public class DoubleBondElementEncoderFactoryTest {
         IBond left = mock(IBond.class);
         IBond right = mock(IBond.class);
 
-        when(stereoBond.getAtom(0)).thenReturn(c1);
-        when(stereoBond.getAtom(1)).thenReturn(c2);
+        when(stereoBond.getBeg()).thenReturn(c1);
+        when(stereoBond.getEnd()).thenReturn(c2);
         when(left.getConnectedAtom(c1)).thenReturn(cl3);
         when(right.getConnectedAtom(c2)).thenReturn(cl4);
 

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactoryTest.java
@@ -94,8 +94,8 @@ public class GeometricCumulativeDoubleBondFactoryTest {
         IAtom a2 = mock(IAtom.class);
         IBond bond = mock(IBond.class);
         when(bond.getStereo()).thenReturn(IBond.Stereo.UP);
-        when(bond.getAtom(0)).thenReturn(a1);
-        when(bond.getAtom(1)).thenReturn(a2);
+        when(bond.getBeg()).thenReturn(a1);
+        when(bond.getEnd()).thenReturn(a2);
         assertThat(GeometricCumulativeDoubleBondFactory.elevation(bond, a1), is(+1));
         assertThat(GeometricCumulativeDoubleBondFactory.elevation(bond, a2), is(-1));
     }
@@ -106,8 +106,8 @@ public class GeometricCumulativeDoubleBondFactoryTest {
         IAtom a2 = mock(IAtom.class);
         IBond bond = mock(IBond.class);
         when(bond.getStereo()).thenReturn(IBond.Stereo.DOWN);
-        when(bond.getAtom(0)).thenReturn(a1);
-        when(bond.getAtom(1)).thenReturn(a2);
+        when(bond.getBeg()).thenReturn(a1);
+        when(bond.getEnd()).thenReturn(a2);
         assertThat(GeometricCumulativeDoubleBondFactory.elevation(bond, a1), is(-1));
         assertThat(GeometricCumulativeDoubleBondFactory.elevation(bond, a2), is(+1));
     }

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactoryTest.java
@@ -94,7 +94,7 @@ public class GeometricCumulativeDoubleBondFactoryTest {
         IAtom a2 = mock(IAtom.class);
         IBond bond = mock(IBond.class);
         when(bond.getStereo()).thenReturn(IBond.Stereo.UP);
-        when(bond.getBeg()).thenReturn(a1);
+        when(bond.getBegin()).thenReturn(a1);
         when(bond.getEnd()).thenReturn(a2);
         assertThat(GeometricCumulativeDoubleBondFactory.elevation(bond, a1), is(+1));
         assertThat(GeometricCumulativeDoubleBondFactory.elevation(bond, a2), is(-1));
@@ -106,7 +106,7 @@ public class GeometricCumulativeDoubleBondFactoryTest {
         IAtom a2 = mock(IAtom.class);
         IBond bond = mock(IBond.class);
         when(bond.getStereo()).thenReturn(IBond.Stereo.DOWN);
-        when(bond.getBeg()).thenReturn(a1);
+        when(bond.getBegin()).thenReturn(a1);
         when(bond.getEnd()).thenReturn(a2);
         assertThat(GeometricCumulativeDoubleBondFactory.elevation(bond, a1), is(-1));
         assertThat(GeometricCumulativeDoubleBondFactory.elevation(bond, a2), is(+1));

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricDoubleBondEncoderFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricDoubleBondEncoderFactoryTest.java
@@ -100,16 +100,16 @@ public class GeometricDoubleBondEncoderFactoryTest {
         IBond cd = mock(IBond.class);
         IBond cf = mock(IBond.class);
 
-        when(ba.getAtom(0)).thenReturn(b);
-        when(ba.getAtom(1)).thenReturn(a);
-        when(be.getAtom(0)).thenReturn(b);
-        when(be.getAtom(1)).thenReturn(e);
-        when(bc.getAtom(0)).thenReturn(b);
-        when(bc.getAtom(1)).thenReturn(c);
-        when(cd.getAtom(0)).thenReturn(c);
-        when(cd.getAtom(1)).thenReturn(d);
-        when(cf.getAtom(0)).thenReturn(c);
-        when(cf.getAtom(1)).thenReturn(f);
+        when(ba.getBeg()).thenReturn(b);
+        when(ba.getEnd()).thenReturn(a);
+        when(be.getBeg()).thenReturn(b);
+        when(be.getEnd()).thenReturn(e);
+        when(bc.getBeg()).thenReturn(b);
+        when(bc.getEnd()).thenReturn(c);
+        when(cd.getBeg()).thenReturn(c);
+        when(cd.getEnd()).thenReturn(d);
+        when(cf.getBeg()).thenReturn(c);
+        when(cf.getEnd()).thenReturn(f);
 
         when(bc.getOrder()).thenReturn(IBond.Order.DOUBLE);
         when(mol.bonds()).thenReturn(Arrays.asList(ba, be, bc, cd, cf));
@@ -168,16 +168,16 @@ public class GeometricDoubleBondEncoderFactoryTest {
         IBond cd = mock(IBond.class);
         IBond cf = mock(IBond.class);
 
-        when(ba.getAtom(0)).thenReturn(b);
-        when(ba.getAtom(1)).thenReturn(a);
-        when(be.getAtom(0)).thenReturn(b);
-        when(be.getAtom(1)).thenReturn(e);
-        when(bc.getAtom(0)).thenReturn(b);
-        when(bc.getAtom(1)).thenReturn(c);
-        when(cd.getAtom(0)).thenReturn(c);
-        when(cd.getAtom(1)).thenReturn(d);
-        when(cf.getAtom(0)).thenReturn(c);
-        when(cf.getAtom(1)).thenReturn(f);
+        when(ba.getBeg()).thenReturn(b);
+        when(ba.getEnd()).thenReturn(a);
+        when(be.getBeg()).thenReturn(b);
+        when(be.getEnd()).thenReturn(e);
+        when(bc.getBeg()).thenReturn(b);
+        when(bc.getEnd()).thenReturn(c);
+        when(cd.getBeg()).thenReturn(c);
+        when(cd.getEnd()).thenReturn(d);
+        when(cf.getBeg()).thenReturn(c);
+        when(cf.getEnd()).thenReturn(f);
 
         when(bc.getOrder()).thenReturn(IBond.Order.DOUBLE);
         when(mol.bonds()).thenReturn(Arrays.asList(ba, be, bc, cd, cf));

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricDoubleBondEncoderFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricDoubleBondEncoderFactoryTest.java
@@ -100,15 +100,15 @@ public class GeometricDoubleBondEncoderFactoryTest {
         IBond cd = mock(IBond.class);
         IBond cf = mock(IBond.class);
 
-        when(ba.getBeg()).thenReturn(b);
+        when(ba.getBegin()).thenReturn(b);
         when(ba.getEnd()).thenReturn(a);
-        when(be.getBeg()).thenReturn(b);
+        when(be.getBegin()).thenReturn(b);
         when(be.getEnd()).thenReturn(e);
-        when(bc.getBeg()).thenReturn(b);
+        when(bc.getBegin()).thenReturn(b);
         when(bc.getEnd()).thenReturn(c);
-        when(cd.getBeg()).thenReturn(c);
+        when(cd.getBegin()).thenReturn(c);
         when(cd.getEnd()).thenReturn(d);
-        when(cf.getBeg()).thenReturn(c);
+        when(cf.getBegin()).thenReturn(c);
         when(cf.getEnd()).thenReturn(f);
 
         when(bc.getOrder()).thenReturn(IBond.Order.DOUBLE);
@@ -168,15 +168,15 @@ public class GeometricDoubleBondEncoderFactoryTest {
         IBond cd = mock(IBond.class);
         IBond cf = mock(IBond.class);
 
-        when(ba.getBeg()).thenReturn(b);
+        when(ba.getBegin()).thenReturn(b);
         when(ba.getEnd()).thenReturn(a);
-        when(be.getBeg()).thenReturn(b);
+        when(be.getBegin()).thenReturn(b);
         when(be.getEnd()).thenReturn(e);
-        when(bc.getBeg()).thenReturn(b);
+        when(bc.getBegin()).thenReturn(b);
         when(bc.getEnd()).thenReturn(c);
-        when(cd.getBeg()).thenReturn(c);
+        when(cd.getBegin()).thenReturn(c);
         when(cd.getEnd()).thenReturn(d);
-        when(cf.getBeg()).thenReturn(c);
+        when(cf.getBegin()).thenReturn(c);
         when(cf.getEnd()).thenReturn(f);
 
         when(bc.getOrder()).thenReturn(IBond.Order.DOUBLE);

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricTetrahedralEncoderFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricTetrahedralEncoderFactoryTest.java
@@ -95,17 +95,17 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(DOWN);
-        when(c1n3.getAtom(0)).thenReturn(c1);
-        when(c1n3.getAtom(1)).thenReturn(n3);
+        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getAtom(0)).thenReturn(c1);
-        when(c1o2.getAtom(1)).thenReturn(o2);
+        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getAtom(0)).thenReturn(c1);
-        when(c1c4.getAtom(1)).thenReturn(c4);
+        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getAtom(0)).thenReturn(c1);
-        when(c1h5.getAtom(1)).thenReturn(h5);
+        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
 
@@ -158,14 +158,14 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(DOWN);
-        when(c1n3.getAtom(0)).thenReturn(c1);
-        when(c1n3.getAtom(1)).thenReturn(n3);
+        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getAtom(0)).thenReturn(c1);
-        when(c1o2.getAtom(1)).thenReturn(o2);
+        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getAtom(0)).thenReturn(c1);
-        when(c1c4.getAtom(1)).thenReturn(c4);
+        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getEnd()).thenReturn(c4);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
 
@@ -223,17 +223,17 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(NONE);
-        when(c1n3.getAtom(0)).thenReturn(c1);
-        when(c1n3.getAtom(1)).thenReturn(n3);
+        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getAtom(0)).thenReturn(c1);
-        when(c1o2.getAtom(1)).thenReturn(o2);
+        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getAtom(0)).thenReturn(c1);
-        when(c1c4.getAtom(1)).thenReturn(c4);
+        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getAtom(0)).thenReturn(c1);
-        when(c1h5.getAtom(1)).thenReturn(h5);
+        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
 
@@ -285,14 +285,14 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(NONE);
-        when(c1n3.getAtom(0)).thenReturn(c1);
-        when(c1n3.getAtom(1)).thenReturn(n3);
+        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getAtom(0)).thenReturn(c1);
-        when(c1o2.getAtom(1)).thenReturn(o2);
+        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getAtom(0)).thenReturn(c1);
-        when(c1c4.getAtom(1)).thenReturn(c4);
+        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getEnd()).thenReturn(c4);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
 
@@ -344,17 +344,17 @@ public class GeometricTetrahedralEncoderFactoryTest {
         // when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(DOWN);
-        when(c1n3.getAtom(0)).thenReturn(c1);
-        when(c1n3.getAtom(1)).thenReturn(n3);
+        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getAtom(0)).thenReturn(c1);
-        when(c1o2.getAtom(1)).thenReturn(o2);
+        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getAtom(0)).thenReturn(c1);
-        when(c1c4.getAtom(1)).thenReturn(c4);
+        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getAtom(0)).thenReturn(c1);
-        when(c1h5.getAtom(1)).thenReturn(h5);
+        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
 
@@ -400,17 +400,17 @@ public class GeometricTetrahedralEncoderFactoryTest {
         // with a hatch bond from c1 to n3
         //when(c1n3.getStereo()).thenReturn(DOWN);
         when(c1n3.getStereo()).thenReturn(NONE);
-        when(c1n3.getAtom(0)).thenReturn(c1);
-        when(c1n3.getAtom(1)).thenReturn(n3);
+        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getAtom(0)).thenReturn(c1);
-        when(c1o2.getAtom(1)).thenReturn(o2);
+        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getAtom(0)).thenReturn(c1);
-        when(c1c4.getAtom(1)).thenReturn(c4);
+        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getAtom(0)).thenReturn(c1);
-        when(c1h5.getAtom(1)).thenReturn(h5);
+        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
 
@@ -456,17 +456,17 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(DOWN);
-        when(c1n3.getAtom(0)).thenReturn(c1);
-        when(c1n3.getAtom(1)).thenReturn(n3);
+        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getAtom(0)).thenReturn(c1);
-        when(c1o2.getAtom(1)).thenReturn(o2);
+        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getAtom(0)).thenReturn(c1);
-        when(c1c4.getAtom(1)).thenReturn(c4);
+        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getAtom(0)).thenReturn(c1);
-        when(c1h5.getAtom(1)).thenReturn(h5);
+        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
 

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricTetrahedralEncoderFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricTetrahedralEncoderFactoryTest.java
@@ -95,16 +95,16 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(DOWN);
-        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getBegin()).thenReturn(c1);
         when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getBegin()).thenReturn(c1);
         when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getBegin()).thenReturn(c1);
         when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getBegin()).thenReturn(c1);
         when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
@@ -158,13 +158,13 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(DOWN);
-        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getBegin()).thenReturn(c1);
         when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getBegin()).thenReturn(c1);
         when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getBegin()).thenReturn(c1);
         when(c1c4.getEnd()).thenReturn(c4);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
@@ -223,16 +223,16 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(NONE);
-        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getBegin()).thenReturn(c1);
         when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getBegin()).thenReturn(c1);
         when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getBegin()).thenReturn(c1);
         when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getBegin()).thenReturn(c1);
         when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
@@ -285,13 +285,13 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(NONE);
-        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getBegin()).thenReturn(c1);
         when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getBegin()).thenReturn(c1);
         when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getBegin()).thenReturn(c1);
         when(c1c4.getEnd()).thenReturn(c4);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
@@ -344,16 +344,16 @@ public class GeometricTetrahedralEncoderFactoryTest {
         // when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(DOWN);
-        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getBegin()).thenReturn(c1);
         when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getBegin()).thenReturn(c1);
         when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getBegin()).thenReturn(c1);
         when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getBegin()).thenReturn(c1);
         when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
@@ -400,16 +400,16 @@ public class GeometricTetrahedralEncoderFactoryTest {
         // with a hatch bond from c1 to n3
         //when(c1n3.getStereo()).thenReturn(DOWN);
         when(c1n3.getStereo()).thenReturn(NONE);
-        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getBegin()).thenReturn(c1);
         when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getBegin()).thenReturn(c1);
         when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getBegin()).thenReturn(c1);
         when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getBegin()).thenReturn(c1);
         when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);
@@ -456,16 +456,16 @@ public class GeometricTetrahedralEncoderFactoryTest {
         when(c1.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
         // with a hatch bond from c1 to n3
         when(c1n3.getStereo()).thenReturn(DOWN);
-        when(c1n3.getBeg()).thenReturn(c1);
+        when(c1n3.getBegin()).thenReturn(c1);
         when(c1n3.getEnd()).thenReturn(n3);
         when(c1o2.getStereo()).thenReturn(NONE);
-        when(c1o2.getBeg()).thenReturn(c1);
+        when(c1o2.getBegin()).thenReturn(c1);
         when(c1o2.getEnd()).thenReturn(o2);
         when(c1c4.getStereo()).thenReturn(NONE);
-        when(c1c4.getBeg()).thenReturn(c1);
+        when(c1c4.getBegin()).thenReturn(c1);
         when(c1c4.getEnd()).thenReturn(c4);
         when(c1h5.getStereo()).thenReturn(NONE);
-        when(c1h5.getBeg()).thenReturn(c1);
+        when(c1h5.getBegin()).thenReturn(c1);
         when(c1h5.getEnd()).thenReturn(h5);
 
         StereoEncoder encoder = new GeometricTetrahedralEncoderFactory().create(container, graph);

--- a/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
+++ b/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
@@ -426,8 +426,8 @@ public class PharmacophoreMatcher {
             for (IBond bond : pharmacophoreQuery.bonds()) {
                 if (!(bond instanceof PharmacophoreQueryAngleBond)) continue;
 
-                IAtom startQAtom = bond.getAtom(0);
-                IAtom middleQAtom = bond.getAtom(1);
+                IAtom startQAtom = bond.getBeg();
+                IAtom middleQAtom = bond.getEnd();
                 IAtom endQAtom = bond.getAtom(2);
 
                 // make a list of the patoms in the target that match

--- a/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
+++ b/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
@@ -426,7 +426,7 @@ public class PharmacophoreMatcher {
             for (IBond bond : pharmacophoreQuery.bonds()) {
                 if (!(bond instanceof PharmacophoreQueryAngleBond)) continue;
 
-                IAtom startQAtom = bond.getBeg();
+                IAtom startQAtom = bond.getBegin();
                 IAtom middleQAtom = bond.getEnd();
                 IAtom endQAtom = bond.getAtom(2);
 

--- a/tool/pcore/src/test/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcherTest.java
+++ b/tool/pcore/src/test/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcherTest.java
@@ -176,8 +176,8 @@ public class PharmacophoreMatcherTest {
         Assert.assertEquals(3, bMatches.get(0).size());
 
         PharmacophoreBond pbond = (PharmacophoreBond) bMatches.get(0).get(0);
-        PharmacophoreAtom patom1 = (PharmacophoreAtom) pbond.getAtom(0);
-        PharmacophoreAtom patom2 = (PharmacophoreAtom) pbond.getAtom(1);
+        PharmacophoreAtom patom1 = (PharmacophoreAtom) pbond.getBeg();
+        PharmacophoreAtom patom2 = (PharmacophoreAtom) pbond.getEnd();
         Assert.assertEquals("D", patom1.getSymbol());
         Assert.assertEquals("A", patom2.getSymbol());
 

--- a/tool/pcore/src/test/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcherTest.java
+++ b/tool/pcore/src/test/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcherTest.java
@@ -176,7 +176,7 @@ public class PharmacophoreMatcherTest {
         Assert.assertEquals(3, bMatches.get(0).size());
 
         PharmacophoreBond pbond = (PharmacophoreBond) bMatches.get(0).get(0);
-        PharmacophoreAtom patom1 = (PharmacophoreAtom) pbond.getBeg();
+        PharmacophoreAtom patom1 = (PharmacophoreAtom) pbond.getBegin();
         PharmacophoreAtom patom2 = (PharmacophoreAtom) pbond.getEnd();
         Assert.assertEquals("D", patom1.getSymbol());
         Assert.assertEquals("A", patom2.getSymbol());

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -807,8 +807,8 @@ public class AtomPlacer {
      */
     static void copyPlaced(IRing dest, IAtomContainer src) {
         for (IBond bond : src.bonds()) {
-            IAtom beg = bond.getAtom(0);
-            IAtom end = bond.getAtom(1);
+            IAtom beg = bond.getBeg();
+            IAtom end = bond.getEnd();
             if (beg.getFlag(CDKConstants.ISPLACED)) {
                 dest.addAtom(beg);
                 if (end.getFlag(CDKConstants.ISPLACED)) {

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -806,7 +806,7 @@ public class AtomPlacer {
      */
     static void copyPlaced(IRing dest, IAtomContainer src) {
         for (IBond bond : src.bonds()) {
-            IAtom beg = bond.getBeg();
+            IAtom beg = bond.getBegin();
             IAtom end = bond.getEnd();
             if (beg.getFlag(CDKConstants.ISPLACED)) {
                 dest.addAtom(beg);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -25,7 +25,6 @@ package org.openscience.cdk.layout;
 
 import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.CDKConstants;
-import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.BondTools;
 import org.openscience.cdk.geometry.GeometryUtil;
@@ -384,7 +383,7 @@ public class AtomPlacer {
                 int charge = atom.getFormalCharge();
 
                 // double length of the last bond to determing next placement
-                Point2d p = new Point2d(prevBond.getConnectedAtom(atom).getPoint2d());
+                Point2d p = new Point2d(prevBond.getOther(atom).getPoint2d());
                 p.interpolate(atom.getPoint2d(), 2);
                 nextAtom.setPoint2d(p);
             }
@@ -660,7 +659,7 @@ public class AtomPlacer {
                 List bonds = ac.getConnectedBondsList(atom);
                 for (int g = 0; g < bonds.size(); g++) {
                     IBond curBond = (IBond) bonds.get(g);
-                    nextAtom = curBond.getConnectedAtom(atom);
+                    nextAtom = curBond.getOther(atom);
                     if (!nextAtom.getFlag(CDKConstants.VISITED) && !nextAtom.getFlag(CDKConstants.ISPLACED)) {
                         nextAtomNr = ac.indexOf(nextAtom);
                         logger.debug("BreadthFirstSearch is meeting new atom " + (nextAtomNr + 1));

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
@@ -255,8 +255,8 @@ final class CorrectGeometricConfiguration {
      * @return the reflected point
      */
     private Point2d reflect(Point2d p, IBond bond) {
-        IAtom a = bond.getAtom(0);
-        IAtom b = bond.getAtom(1);
+        IAtom a = bond.getBeg();
+        IAtom b = bond.getEnd();
         return reflect(p, a.getPoint2d().x, a.getPoint2d().y, b.getPoint2d().x, b.getPoint2d().y);
     }
 

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
@@ -128,7 +128,7 @@ final class CorrectGeometricConfiguration {
         IBond db = dbs.getStereoBond();
         IBond[] bonds = dbs.getBonds();
 
-        IAtom left = db.getBeg();
+        IAtom left = db.getBegin();
         IAtom right = db.getEnd();
 
         int p = parity(dbs);
@@ -254,7 +254,7 @@ final class CorrectGeometricConfiguration {
      * @return the reflected point
      */
     private Point2d reflect(Point2d p, IBond bond) {
-        IAtom a = bond.getBeg();
+        IAtom a = bond.getBegin();
         IAtom b = bond.getEnd();
         return reflect(p, a.getPoint2d().x, a.getPoint2d().y, b.getPoint2d().x, b.getPoint2d().y);
     }

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
@@ -129,8 +129,8 @@ final class CorrectGeometricConfiguration {
         IBond db = dbs.getStereoBond();
         IBond[] bonds = dbs.getBonds();
 
-        IAtom left = db.getAtom(0);
-        IAtom right = db.getAtom(1);
+        IAtom left = db.getBeg();
+        IAtom right = db.getEnd();
 
         int p = parity(dbs);
         int q = parity(getAtoms(left, bonds[0].getConnectedAtom(left), right))

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
@@ -33,7 +33,6 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.ringsearch.RingSearch;
-import org.openscience.cdk.tools.LoggingToolFactory;
 
 import javax.vecmath.Point2d;
 import java.util.Arrays;
@@ -133,8 +132,8 @@ final class CorrectGeometricConfiguration {
         IAtom right = db.getEnd();
 
         int p = parity(dbs);
-        int q = parity(getAtoms(left, bonds[0].getConnectedAtom(left), right))
-                * parity(getAtoms(right, bonds[1].getConnectedAtom(right), left));
+        int q = parity(getAtoms(left, bonds[0].getOther(left), right))
+                * parity(getAtoms(right, bonds[1].getOther(right), left));
 
         // configuration is unspecified? then we add an unspecified bond.
         // note: IDoubleBondStereochemistry doesn't indicate this yet

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/IdentityTemplateLibrary.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/IdentityTemplateLibrary.java
@@ -129,8 +129,8 @@ final class IdentityTemplateLibrary {
         int[] bondedValence = new int[mol.getAtomCount()];
         for (int i = 0; i < mol.getBondCount(); i++) {
             IBond bond = mol.getBond(i);
-            bondedValence[idxs.get(bond.getAtom(0))] += bond.getOrder().numeric();
-            bondedValence[idxs.get(bond.getAtom(1))] += bond.getOrder().numeric();
+            bondedValence[idxs.get(bond.getBeg())] += bond.getOrder().numeric();
+            bondedValence[idxs.get(bond.getEnd())] += bond.getOrder().numeric();
         }
 
         // http://www.opensmiles.org/opensmiles.html#orgsbst

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/IdentityTemplateLibrary.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/IdentityTemplateLibrary.java
@@ -27,7 +27,6 @@ package org.openscience.cdk.layout;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import org.openscience.cdk.exception.CDKException;
-import org.openscience.cdk.graph.rebond.Point;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -50,7 +49,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -129,7 +127,7 @@ final class IdentityTemplateLibrary {
         int[] bondedValence = new int[mol.getAtomCount()];
         for (int i = 0; i < mol.getBondCount(); i++) {
             IBond bond = mol.getBond(i);
-            bondedValence[idxs.get(bond.getBeg())] += bond.getOrder().numeric();
+            bondedValence[idxs.get(bond.getBegin())] += bond.getOrder().numeric();
             bondedValence[idxs.get(bond.getEnd())] += bond.getOrder().numeric();
         }
 

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/LayoutRefiner.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/LayoutRefiner.java
@@ -348,7 +348,7 @@ final class LayoutRefiner {
                 if (bond.getOrder() != IBond.Order.SINGLE || bond.isInRing())
                     continue;
 
-                final IAtom beg = bond.getBeg();
+                final IAtom beg = bond.getBegin();
                 final IAtom end = bond.getEnd();
                 final int begIdx = idxs.get(beg);
                 final int endIdx = idxs.get(end);
@@ -428,7 +428,7 @@ final class LayoutRefiner {
             amoved.add(mol.getAtom(xs[i]));
         }
         for (IBond bond : bfix) {
-            if (amoved.contains(bond.getBeg()) && amoved.contains(bond.getEnd()))
+            if (amoved.contains(bond.getBegin()) && amoved.contains(bond.getEnd()))
                 cnt++;
         }
         return cnt;
@@ -525,7 +525,7 @@ final class LayoutRefiner {
         else
             stackBackup.push(pair.snd);
 
-        reflect(stackBackup, pair.bndAt[0].getBeg(), pair.bndAt[0].getEnd());
+        reflect(stackBackup, pair.bndAt[0].getBegin(), pair.bndAt[0].getEnd());
         congestion.update(stackBackup.xs, stackBackup.len);
         return true;
     }
@@ -616,7 +616,7 @@ final class LayoutRefiner {
                 if (first != pair)
                     continue;
 
-                final IAtom beg = bond.getBeg();
+                final IAtom beg = bond.getBegin();
                 final IAtom end = bond.getEnd();
                 final int begPriority = beg.getProperty(AtomPlacer.PRIORITY);
                 final int endPriority = end.getProperty(AtomPlacer.PRIORITY);
@@ -700,7 +700,7 @@ final class LayoutRefiner {
             if (first != pair)
                 continue;
 
-            final IAtom beg = bond.getBeg();
+            final IAtom beg = bond.getBegin();
             final IAtom end = bond.getEnd();
             final int begIdx = idxs.get(beg);
             final int endIdx = idxs.get(end);
@@ -1039,7 +1039,7 @@ final class LayoutRefiner {
      * @return common atom or null if non exists
      */
     private static IAtom getCommon(IBond bndA, IBond bndB) {
-        IAtom beg = bndA.getBeg();
+        IAtom beg = bndA.getBegin();
         IAtom end = bndA.getEnd();
         if (bndB.contains(beg))
             return beg;

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/LayoutRefiner.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/LayoutRefiner.java
@@ -348,8 +348,8 @@ final class LayoutRefiner {
                 if (bond.getOrder() != IBond.Order.SINGLE || bond.isInRing())
                     continue;
 
-                final IAtom beg = bond.getAtom(0);
-                final IAtom end = bond.getAtom(1);
+                final IAtom beg = bond.getBeg();
+                final IAtom end = bond.getEnd();
                 final int begIdx = idxs.get(beg);
                 final int endIdx = idxs.get(end);
 
@@ -428,7 +428,7 @@ final class LayoutRefiner {
             amoved.add(mol.getAtom(xs[i]));
         }
         for (IBond bond : bfix) {
-            if (amoved.contains(bond.getAtom(0)) && amoved.contains(bond.getAtom(1)))
+            if (amoved.contains(bond.getBeg()) && amoved.contains(bond.getEnd()))
                 cnt++;
         }
         return cnt;
@@ -616,8 +616,8 @@ final class LayoutRefiner {
                 if (first != pair)
                     continue;
 
-                final IAtom beg = bond.getAtom(0);
-                final IAtom end = bond.getAtom(1);
+                final IAtom beg = bond.getBeg();
+                final IAtom end = bond.getEnd();
                 final int begPriority = beg.getProperty(AtomPlacer.PRIORITY);
                 final int endPriority = end.getProperty(AtomPlacer.PRIORITY);
 
@@ -700,8 +700,8 @@ final class LayoutRefiner {
             if (first != pair)
                 continue;
 
-            final IAtom beg = bond.getAtom(0);
-            final IAtom end = bond.getAtom(1);
+            final IAtom beg = bond.getBeg();
+            final IAtom end = bond.getEnd();
             final int begIdx = idxs.get(beg);
             final int endIdx = idxs.get(end);
             int begPriority = beg.getProperty(AtomPlacer.PRIORITY);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/LayoutRefiner.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/LayoutRefiner.java
@@ -525,7 +525,7 @@ final class LayoutRefiner {
         else
             stackBackup.push(pair.snd);
 
-        reflect(stackBackup, pair.bndAt[0].getAtom(0), pair.bndAt[0].getAtom(1));
+        reflect(stackBackup, pair.bndAt[0].getBeg(), pair.bndAt[0].getEnd());
         congestion.update(stackBackup.xs, stackBackup.len);
         return true;
     }
@@ -1039,8 +1039,8 @@ final class LayoutRefiner {
      * @return common atom or null if non exists
      */
     private static IAtom getCommon(IBond bndA, IBond bndB) {
-        IAtom beg = bndA.getAtom(0);
-        IAtom end = bndA.getAtom(1);
+        IAtom beg = bndA.getBeg();
+        IAtom end = bndA.getEnd();
         if (bndB.contains(beg))
             return beg;
         else if (bndB.contains(end))

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/LayoutRefiner.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/LayoutRefiner.java
@@ -477,10 +477,10 @@ final class LayoutRefiner {
                 if (bfix.contains(bond))
                     continue;
                 Arrays.fill(visited, false);
-                stackBackup.len = visit(visited, stackBackup.xs, v, idxs.get(bond.getConnectedAtom(atom)), 0);
+                stackBackup.len = visit(visited, stackBackup.xs, v, idxs.get(bond.getOther(atom)), 0);
 
                 Point2d a = atom.getPoint2d();
-                Point2d b = bond.getConnectedAtom(atom).getPoint2d();
+                Point2d b = bond.getOther(atom).getPoint2d();
 
                 Vector2d perp = new Vector2d(b.x - a.x, b.y - a.y);
                 perp.normalize();
@@ -568,8 +568,8 @@ final class LayoutRefiner {
                 return Integer.MAX_VALUE;
 
             Arrays.fill(visited, false);
-            int split = visit(visited, stack.xs, idxs.get(pivotA), idxs.get(bndA.getConnectedAtom(pivotA)), 0);
-            stack.len = visit(visited, stack.xs, idxs.get(pivotB), idxs.get(bndB.getConnectedAtom(pivotB)), split);
+            int split = visit(visited, stack.xs, idxs.get(pivotA), idxs.get(bndA.getOther(pivotA)), 0);
+            stack.len = visit(visited, stack.xs, idxs.get(pivotB), idxs.get(bndB.getOther(pivotB)), split);
 
             // perform bend one way
             backupCoords(backup, stack);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/MacroCycleLayout.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/MacroCycleLayout.java
@@ -343,7 +343,7 @@ final class MacroCycleLayout {
             IBond bond = anon.removeBond(anon.getBondCount() - 1);
             IAtom dummy = bldr.newInstance(IAtom.class, "C");
             anon.addAtom(dummy);
-            anon.addBond(bldr.newInstance(IBond.class, bond.getBeg(), dummy, IBond.Order.SINGLE));
+            anon.addBond(bldr.newInstance(IBond.class, bond.getBegin(), dummy, IBond.Order.SINGLE));
             anon.addBond(bldr.newInstance(IBond.class, dummy, bond.getEnd(), IBond.Order.SINGLE));
         }
         return anon;

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/MacroCycleLayout.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/MacroCycleLayout.java
@@ -343,8 +343,8 @@ final class MacroCycleLayout {
             IBond bond = anon.removeBond(anon.getBondCount() - 1);
             IAtom dummy = bldr.newInstance(IAtom.class, "C");
             anon.addAtom(dummy);
-            anon.addBond(bldr.newInstance(IBond.class, bond.getAtom(0), dummy, IBond.Order.SINGLE));
-            anon.addBond(bldr.newInstance(IBond.class, dummy, bond.getAtom(1), IBond.Order.SINGLE));
+            anon.addBond(bldr.newInstance(IBond.class, bond.getBeg(), dummy, IBond.Order.SINGLE));
+            anon.addBond(bldr.newInstance(IBond.class, dummy, bond.getEnd(), IBond.Order.SINGLE));
         }
         return anon;
     }

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -154,7 +154,7 @@ final class NonplanarBonds {
             }
             else if (element instanceof IDoubleBondStereochemistry) {
                 IBond doubleBond = ((IDoubleBondStereochemistry) element).getStereoBond();
-                doubleBondElements[atomToIndex.get(doubleBond.getBeg())] =
+                doubleBondElements[atomToIndex.get(doubleBond.getBegin())] =
                         doubleBondElements[atomToIndex.get(doubleBond.getEnd())] = (IDoubleBondStereochemistry) element;
             }
         }
@@ -588,7 +588,7 @@ final class NonplanarBonds {
      */
     private void labelUnspecified(IBond doubleBond) {
 
-        final IAtom aBeg = doubleBond.getBeg();
+        final IAtom aBeg = doubleBond.getBegin();
         final IAtom aEnd = doubleBond.getEnd();
 
         final int beg = atomToIndex.get(aBeg);
@@ -708,7 +708,7 @@ final class NonplanarBonds {
             if (bond.getOrder() != DOUBLE)
                 continue;
 
-            final IAtom aBeg = bond.getBeg();
+            final IAtom aBeg = bond.getBegin();
             final IAtom aEnd = bond.getEnd();
 
             final int beg = atomToIndex.get(aBeg);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -154,8 +154,8 @@ final class NonplanarBonds {
             }
             else if (element instanceof IDoubleBondStereochemistry) {
                 IBond doubleBond = ((IDoubleBondStereochemistry) element).getStereoBond();
-                doubleBondElements[atomToIndex.get(doubleBond.getAtom(0))] =
-                        doubleBondElements[atomToIndex.get(doubleBond.getAtom(1))] = (IDoubleBondStereochemistry) element;
+                doubleBondElements[atomToIndex.get(doubleBond.getBeg())] =
+                        doubleBondElements[atomToIndex.get(doubleBond.getEnd())] = (IDoubleBondStereochemistry) element;
             }
         }
 
@@ -588,8 +588,8 @@ final class NonplanarBonds {
      */
     private void labelUnspecified(IBond doubleBond) {
 
-        final IAtom aBeg = doubleBond.getAtom(0);
-        final IAtom aEnd = doubleBond.getAtom(1);
+        final IAtom aBeg = doubleBond.getBeg();
+        final IAtom aEnd = doubleBond.getEnd();
 
         final int beg = atomToIndex.get(aBeg);
         final int end = atomToIndex.get(aEnd);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -708,8 +708,8 @@ final class NonplanarBonds {
             if (bond.getOrder() != DOUBLE)
                 continue;
 
-            final IAtom aBeg = bond.getAtom(0);
-            final IAtom aEnd = bond.getAtom(1);
+            final IAtom aBeg = bond.getBeg();
+            final IAtom aEnd = bond.getEnd();
 
             final int beg = atomToIndex.get(aBeg);
             final int end = atomToIndex.get(aEnd);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/OverlapResolver.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/OverlapResolver.java
@@ -247,14 +247,14 @@ public class OverlapResolver {
         double y1 = 0, y2 = 0, y3 = 0, y4 = 0;
         //Point2D.Double p1 = null, p2 = null, p3 = null, p4 = null;
 
-        x1 = bond1.getBeg().getPoint2d().x;
+        x1 = bond1.getBegin().getPoint2d().x;
         x2 = bond1.getEnd().getPoint2d().x;
-        x3 = bond2.getBeg().getPoint2d().x;
+        x3 = bond2.getBegin().getPoint2d().x;
         x4 = bond2.getEnd().getPoint2d().x;
 
-        y1 = bond1.getBeg().getPoint2d().y;
+        y1 = bond1.getBegin().getPoint2d().y;
         y2 = bond1.getEnd().getPoint2d().y;
-        y3 = bond2.getBeg().getPoint2d().y;
+        y3 = bond2.getBegin().getPoint2d().y;
         y4 = bond2.getEnd().getPoint2d().y;
 
         Line2D.Double line1 = new Line2D.Double(new Point2D.Double(x1, y1), new Point2D.Double(x2, y2));

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/OverlapResolver.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/OverlapResolver.java
@@ -247,15 +247,15 @@ public class OverlapResolver {
         double y1 = 0, y2 = 0, y3 = 0, y4 = 0;
         //Point2D.Double p1 = null, p2 = null, p3 = null, p4 = null;
 
-        x1 = bond1.getAtom(0).getPoint2d().x;
-        x2 = bond1.getAtom(1).getPoint2d().x;
-        x3 = bond2.getAtom(0).getPoint2d().x;
-        x4 = bond2.getAtom(1).getPoint2d().x;
+        x1 = bond1.getBeg().getPoint2d().x;
+        x2 = bond1.getEnd().getPoint2d().x;
+        x3 = bond2.getBeg().getPoint2d().x;
+        x4 = bond2.getEnd().getPoint2d().x;
 
-        y1 = bond1.getAtom(0).getPoint2d().y;
-        y2 = bond1.getAtom(1).getPoint2d().y;
-        y3 = bond2.getAtom(0).getPoint2d().y;
-        y4 = bond2.getAtom(1).getPoint2d().y;
+        y1 = bond1.getBeg().getPoint2d().y;
+        y2 = bond1.getEnd().getPoint2d().y;
+        y3 = bond2.getBeg().getPoint2d().y;
+        y4 = bond2.getEnd().getPoint2d().y;
 
         Line2D.Double line1 = new Line2D.Double(new Point2D.Double(x1, y1), new Point2D.Double(x2, y2));
         Line2D.Double line2 = new Line2D.Double(new Point2D.Double(x3, y3), new Point2D.Double(x4, y4));

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/RingPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/RingPlacer.java
@@ -40,7 +40,6 @@ import javax.vecmath.Point2d;
 import javax.vecmath.Tuple2d;
 import javax.vecmath.Vector2d;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -172,7 +171,7 @@ public class RingPlacer {
         IBond currentBond = (IBond) bonds.get(0);
         for (int i = 0; i < ring.getBondCount(); i++) {
             currentBond = ring.getNextBond(currentBond, currentAtom);
-            currentAtom = currentBond.getConnectedAtom(currentAtom);
+            currentAtom = currentBond.getOther(currentAtom);
             atomsToDraw.addElement(currentAtom);
         }
         atomPlacer.populatePolygonCorners(atomsToDraw, ringCenter, startAngle, addAngle, radius);
@@ -319,7 +318,7 @@ public class RingPlacer {
         List<IAtom> atoms = new ArrayList<>();
         for (int i = 0; i < ring.getBondCount(); i++) {
             currentBond = ring.getNextBond(currentBond, currentAtom);
-            currentAtom = currentBond.getConnectedAtom(currentAtom);
+            currentAtom = currentBond.getOther(currentAtom);
             if (!sharedAtoms.contains(currentAtom)) {
                 atoms.add(currentAtom);
             }
@@ -378,7 +377,7 @@ public class RingPlacer {
          */
         for (int i = 0; i < ring.getBondCount(); i++) {
             currentBond = ring.getNextBond(currentBond, currentAtom);
-            currentAtom = currentBond.getConnectedAtom(currentAtom);
+            currentAtom = currentBond.getOther(currentAtom);
             atomsToDraw.addElement(currentAtom);
         }
         logger.debug("currentAtom  " + currentAtom);
@@ -494,7 +493,7 @@ public class RingPlacer {
         Vector atomsToDraw = new Vector();
         for (int i = 0; i < ring.getBondCount() - 2; i++) {
             currentBond = ring.getNextBond(currentBond, currentAtom);
-            currentAtom = currentBond.getConnectedAtom(currentAtom);
+            currentAtom = currentBond.getOther(currentAtom);
             atomsToDraw.addElement(currentAtom);
         }
         addAngle = addAngle * direction;

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -249,10 +249,10 @@ public class StructureDiagramGenerator {
 
                 if (!afix.isEmpty()) {
                     for (IBond bond : mol.bonds()) {
-                        if (afix.containsKey(bond.getBeg()) && afix.containsKey(bond.getEnd())) {
+                        if (afix.containsKey(bond.getBegin()) && afix.containsKey(bond.getEnd())) {
                             // only fix acyclic bonds if the source atoms were also acyclic
                             if (!bond.isInRing()) {
-                                IAtom srcBeg = afix.get(bond.getBeg());
+                                IAtom srcBeg = afix.get(bond.getBegin());
                                 IAtom srcEnd = afix.get(bond.getEnd());
                                 for (IAtomContainer product : reaction.getProducts().atomContainers()) {
                                     IBond srcBond = product.getBond(srcBeg, srcEnd);
@@ -892,7 +892,7 @@ public class StructureDiagramGenerator {
         final double diff = Math.toRadians(1);
         int count = 0;
         for (IBond bond : mol.bonds()) {
-            Point2d beg = bond.getBeg().getPoint2d();
+            Point2d beg = bond.getBegin().getPoint2d();
             Point2d end = bond.getEnd().getPoint2d();
             if (beg.x > end.x) {
                 Point2d tmp = beg;
@@ -1095,13 +1095,13 @@ public class StructureDiagramGenerator {
             if (!ionicBonds.contains(bond)) {
                 newfrag.addBond(bond);
             } else {
-                Integer numBegIonic = bond.getBeg().getProperty("ionicDegree");
+                Integer numBegIonic = bond.getBegin().getProperty("ionicDegree");
                 Integer numEndIonic = bond.getEnd().getProperty("ionicDegree");
                 if (numBegIonic == null) numBegIonic = 0;
                 if (numEndIonic == null) numEndIonic = 0;
                 numBegIonic++;
                 numEndIonic++;
-                bond.getBeg().setProperty("ionicDegree", numBegIonic);
+                bond.getBegin().setProperty("ionicDegree", numBegIonic);
                 bond.getEnd().setProperty("ionicDegree", numEndIonic);
             }
         }
@@ -1118,11 +1118,11 @@ public class StructureDiagramGenerator {
                 atomToFrag.put(atom, subfragment);
 
         for (IBond bond : ionicBonds) {
-            IAtom beg = bond.getBeg();
+            IAtom beg = bond.getBegin();
             IAtom end = bond.getEnd();
 
             // select which bond to stretch from
-            Integer numBegIonic = bond.getBeg().getProperty("ionicDegree");
+            Integer numBegIonic = bond.getBegin().getProperty("ionicDegree");
             Integer numEndIonic = bond.getEnd().getProperty("ionicDegree");
             if (numBegIonic == null || numEndIonic == null)
                 continue;
@@ -1339,8 +1339,8 @@ public class StructureDiagramGenerator {
 
             boolean unique = true;
             for (IBond bond : ionicBonds)
-                if (bond.getBeg().equals(beg) && bond.getEnd().equals(end) ||
-                    bond.getEnd().equals(beg) && bond.getBeg().equals(end))
+                if (bond.getBegin().equals(beg) && bond.getEnd().equals(end) ||
+                    bond.getEnd().equals(beg) && bond.getBegin().equals(end))
                     unique = false;
 
             if (unique)
@@ -1414,7 +1414,7 @@ public class StructureDiagramGenerator {
         final IAtomContainer ringWithStubs = bldr.newInstance(IAtomContainer.class);
         ringWithStubs.add(ringSystem);
         for (IBond bond : molecule.bonds()) {
-            IAtom atom1 = bond.getBeg();
+            IAtom atom1 = bond.getBegin();
             IAtom atom2 = bond.getEnd();
             if (isHydrogen(atom1) || isHydrogen(atom2)) continue;
             if (ringAtoms.contains(atom1) ^ ringAtoms.contains(atom2)) {
@@ -1863,12 +1863,12 @@ public class StructureDiagramGenerator {
         for (int f = 0; f < molecule.getBondCount(); f++) {
             bond = molecule.getBond(f);
 
-            if (bond.getEnd().getFlag(CDKConstants.ISPLACED) && !bond.getBeg().getFlag(CDKConstants.ISPLACED)) {
+            if (bond.getEnd().getFlag(CDKConstants.ISPLACED) && !bond.getBegin().getFlag(CDKConstants.ISPLACED)) {
                 return bond.getEnd();
             }
 
-            if (bond.getBeg().getFlag(CDKConstants.ISPLACED) && !bond.getEnd().getFlag(CDKConstants.ISPLACED)) {
-                return bond.getBeg();
+            if (bond.getBegin().getFlag(CDKConstants.ISPLACED) && !bond.getEnd().getFlag(CDKConstants.ISPLACED)) {
+                return bond.getBegin();
             }
         }
         return null;
@@ -1881,7 +1881,7 @@ public class StructureDiagramGenerator {
      */
     private IBond getNextBondWithUnplacedRingAtom() {
         for (IBond bond : molecule.bonds()) {
-            IAtom beg = bond.getBeg();
+            IAtom beg = bond.getBegin();
             IAtom end = bond.getEnd();
             if (beg.getPoint2d() != null && end.getPoint2d() != null) {
                 if (end.getFlag(CDKConstants.ISPLACED) && !beg.getFlag(CDKConstants.ISPLACED) && beg.isInRing()) {
@@ -1913,7 +1913,7 @@ public class StructureDiagramGenerator {
             logger.debug("placeFirstBondOfFirstRing->bondVector.length() after scaling:" + bondVector.length());
             IAtom atom;
             Point2d point = new Point2d(0, 0);
-            atom = bond.getBeg();
+            atom = bond.getBegin();
             logger.debug("Atom 1 of first Bond: " + (molecule.indexOf(atom) + 1));
             atom.setPoint2d(point);
             atom.setFlag(CDKConstants.ISPLACED, true);
@@ -1932,7 +1932,7 @@ public class StructureDiagramGenerator {
              */
             sharedAtoms = atom.getBuilder().newInstance(IAtomContainer.class);
             sharedAtoms.addBond(bond);
-            sharedAtoms.addAtom(bond.getBeg());
+            sharedAtoms.addAtom(bond.getBegin());
             sharedAtoms.addAtom(bond.getEnd());
         } catch (Exception exc) {
             logger.debug(exc);
@@ -1963,8 +1963,8 @@ public class StructureDiagramGenerator {
      * @return the unplaced ring atom in this bond
      */
     private IAtom getRingAtom(IBond bond) {
-        if (bond.getBeg().getFlag(CDKConstants.ISINRING) && !bond.getBeg().getFlag(CDKConstants.ISPLACED)) {
-            return bond.getBeg();
+        if (bond.getBegin().getFlag(CDKConstants.ISINRING) && !bond.getBegin().getFlag(CDKConstants.ISPLACED)) {
+            return bond.getBegin();
         }
         if (bond.getEnd().getFlag(CDKConstants.ISINRING) && !bond.getEnd().getFlag(CDKConstants.ISPLACED)) {
             return bond.getEnd();
@@ -2042,10 +2042,10 @@ public class StructureDiagramGenerator {
      */
     public IAtom getOtherBondAtom(IAtom atom, IBond bond) {
         if (!bond.contains(atom)) return null;
-        if (bond.getBeg().equals(atom))
+        if (bond.getBegin().equals(atom))
             return bond.getEnd();
         else
-            return bond.getBeg();
+            return bond.getBegin();
     }
 
     /**
@@ -2088,7 +2088,7 @@ public class StructureDiagramGenerator {
                 visit.add(atom);
             }
             for (IBond bond : mol.bonds()) {
-                IAtom beg = bond.getBeg();
+                IAtom beg = bond.getBegin();
                 IAtom end = bond.getEnd();
                 if (visit.contains(beg) && visit.contains(end))
                     substructure.addBond(bond);
@@ -2132,7 +2132,7 @@ public class StructureDiagramGenerator {
             List<Map.Entry<IBond,Vector2d>>   xBondVec = new ArrayList<>();
             if (numCrossing == 2) {
                 for (IBond bond : mol.bonds()) {
-                    IAtom beg = bond.getBeg();
+                    IAtom beg = bond.getBegin();
                     IAtom end = bond.getEnd();
                     if (patoms.contains(beg) == patoms.contains(end))
                         continue;
@@ -2147,7 +2147,7 @@ public class StructureDiagramGenerator {
                     }
                 }
                 for (IBond bond : sgroup.getBonds()) {
-                    IAtom beg = bond.getBeg();
+                    IAtom beg = bond.getBegin();
                     IAtom end = bond.getEnd();
                     if (sgroupAtoms.contains(beg)) {
                         xBondVec.add(new SimpleImmutableEntry<>(bond,
@@ -2181,7 +2181,7 @@ public class StructureDiagramGenerator {
                 if (bond.isInRing())
                     continue;
 
-                IAtom beg  = sgroupAtoms.contains(bond.getBeg()) ? bond.getBeg() : bond.getEnd();
+                IAtom beg  = sgroupAtoms.contains(bond.getBegin()) ? bond.getBegin() : bond.getEnd();
                 Map.Entry<Point2d,Vector2d> best = null;
                 for (Map.Entry<Point2d,Vector2d> candidate : outgoing) {
                     if (best == null || candidate.getKey().distance(beg.getPoint2d()) < best.getKey().distance(beg.getPoint2d()))
@@ -2249,7 +2249,7 @@ public class StructureDiagramGenerator {
             Point2d center = GeometryUtil.get2DCenter(shared);
 
             for (IBond bond : mol.bonds()) {
-                if (e.getKey().contains(bond.getBeg()) && e.getKey().contains(bond.getEnd())) {
+                if (e.getKey().contains(bond.getBegin()) && e.getKey().contains(bond.getEnd())) {
                     bonds.add(bond);
                 }
             }
@@ -2264,10 +2264,10 @@ public class StructureDiagramGenerator {
                     final IBond bond = bndIter.next();
                     final IAtom atom = begIter.next();
 
-                    if (numRingBonds(mol, bond.getBeg()) > 2 && numRingBonds(mol, bond.getEnd()) > 2)
+                    if (numRingBonds(mol, bond.getBegin()) > 2 && numRingBonds(mol, bond.getEnd()) > 2)
                         continue;
 
-                    final Point2d newBegP = new Point2d(bond.getBeg().getPoint2d());
+                    final Point2d newBegP = new Point2d(bond.getBegin().getPoint2d());
                     final Point2d newEndP = new Point2d(bond.getEnd().getPoint2d());
 
                     final Vector2d bndVec  = new Vector2d(newEndP.x-newBegP.x, newEndP.y-newBegP.y);
@@ -2485,7 +2485,7 @@ public class StructureDiagramGenerator {
     }
 
     private static double angle(IBond bond) {
-        Point2d end = bond.getBeg().getPoint2d();
+        Point2d end = bond.getBegin().getPoint2d();
         Point2d beg = bond.getEnd().getPoint2d();
         return Math.atan2(end.y - beg.y, end.x - beg.x);
     }
@@ -2500,7 +2500,7 @@ public class StructureDiagramGenerator {
      * @return the new bracket
      */
     private SgroupBracket newCrossingBracket(IBond bond, Multimap<IBond,Sgroup> bonds, Map<IBond,Integer> counter, boolean vert) {
-        final IAtom beg = bond.getBeg();
+        final IAtom beg = bond.getBegin();
         final IAtom end = bond.getEnd();
         final Point2d begXy = beg.getPoint2d();
         final Point2d endXy = end.getPoint2d();

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -251,11 +251,11 @@ public class StructureDiagramGenerator {
 
                 if (!afix.isEmpty()) {
                     for (IBond bond : mol.bonds()) {
-                        if (afix.containsKey(bond.getAtom(0)) && afix.containsKey(bond.getAtom(1))) {
+                        if (afix.containsKey(bond.getBeg()) && afix.containsKey(bond.getEnd())) {
                             // only fix acyclic bonds if the source atoms were also acyclic
                             if (!bond.isInRing()) {
-                                IAtom srcBeg = afix.get(bond.getAtom(0));
-                                IAtom srcEnd = afix.get(bond.getAtom(1));
+                                IAtom srcBeg = afix.get(bond.getBeg());
+                                IAtom srcEnd = afix.get(bond.getEnd());
                                 for (IAtomContainer product : reaction.getProducts().atomContainers()) {
                                     IBond srcBond = product.getBond(srcBeg, srcEnd);
                                     if (srcBond != null) {
@@ -894,8 +894,8 @@ public class StructureDiagramGenerator {
         final double diff = Math.toRadians(1);
         int count = 0;
         for (IBond bond : mol.bonds()) {
-            Point2d beg = bond.getAtom(0).getPoint2d();
-            Point2d end = bond.getAtom(1).getPoint2d();
+            Point2d beg = bond.getBeg().getPoint2d();
+            Point2d end = bond.getEnd().getPoint2d();
             if (beg.x > end.x) {
                 Point2d tmp = beg;
                 beg = end;
@@ -1097,14 +1097,14 @@ public class StructureDiagramGenerator {
             if (!ionicBonds.contains(bond)) {
                 newfrag.addBond(bond);
             } else {
-                Integer numBegIonic = bond.getAtom(0).getProperty("ionicDegree");
-                Integer numEndIonic = bond.getAtom(1).getProperty("ionicDegree");
+                Integer numBegIonic = bond.getBeg().getProperty("ionicDegree");
+                Integer numEndIonic = bond.getEnd().getProperty("ionicDegree");
                 if (numBegIonic == null) numBegIonic = 0;
                 if (numEndIonic == null) numEndIonic = 0;
                 numBegIonic++;
                 numEndIonic++;
-                bond.getAtom(0).setProperty("ionicDegree", numBegIonic);
-                bond.getAtom(1).setProperty("ionicDegree", numEndIonic);
+                bond.getBeg().setProperty("ionicDegree", numBegIonic);
+                bond.getEnd().setProperty("ionicDegree", numEndIonic);
             }
         }
 
@@ -1120,12 +1120,12 @@ public class StructureDiagramGenerator {
                 atomToFrag.put(atom, subfragment);
 
         for (IBond bond : ionicBonds) {
-            IAtom beg = bond.getAtom(0);
-            IAtom end = bond.getAtom(1);
+            IAtom beg = bond.getBeg();
+            IAtom end = bond.getEnd();
 
             // select which bond to stretch from
-            Integer numBegIonic = bond.getAtom(0).getProperty("ionicDegree");
-            Integer numEndIonic = bond.getAtom(1).getProperty("ionicDegree");
+            Integer numBegIonic = bond.getBeg().getProperty("ionicDegree");
+            Integer numEndIonic = bond.getEnd().getProperty("ionicDegree");
             if (numBegIonic == null || numEndIonic == null)
                 continue;
             if (numBegIonic > numEndIonic) {
@@ -1341,8 +1341,8 @@ public class StructureDiagramGenerator {
 
             boolean unique = true;
             for (IBond bond : ionicBonds)
-                if (bond.getAtom(0).equals(beg) && bond.getAtom(1).equals(end) ||
-                    bond.getAtom(1).equals(beg) && bond.getAtom(0).equals(end))
+                if (bond.getBeg().equals(beg) && bond.getEnd().equals(end) ||
+                    bond.getEnd().equals(beg) && bond.getBeg().equals(end))
                     unique = false;
 
             if (unique)
@@ -1416,8 +1416,8 @@ public class StructureDiagramGenerator {
         final IAtomContainer ringWithStubs = bldr.newInstance(IAtomContainer.class);
         ringWithStubs.add(ringSystem);
         for (IBond bond : molecule.bonds()) {
-            IAtom atom1 = bond.getAtom(0);
-            IAtom atom2 = bond.getAtom(1);
+            IAtom atom1 = bond.getBeg();
+            IAtom atom2 = bond.getEnd();
             if (isHydrogen(atom1) || isHydrogen(atom2)) continue;
             if (ringAtoms.contains(atom1) ^ ringAtoms.contains(atom2)) {
                 ringWithStubs.addBond(bond);
@@ -1865,12 +1865,12 @@ public class StructureDiagramGenerator {
         for (int f = 0; f < molecule.getBondCount(); f++) {
             bond = molecule.getBond(f);
 
-            if (bond.getAtom(1).getFlag(CDKConstants.ISPLACED) && !bond.getAtom(0).getFlag(CDKConstants.ISPLACED)) {
-                return bond.getAtom(1);
+            if (bond.getEnd().getFlag(CDKConstants.ISPLACED) && !bond.getBeg().getFlag(CDKConstants.ISPLACED)) {
+                return bond.getEnd();
             }
 
-            if (bond.getAtom(0).getFlag(CDKConstants.ISPLACED) && !bond.getAtom(1).getFlag(CDKConstants.ISPLACED)) {
-                return bond.getAtom(0);
+            if (bond.getBeg().getFlag(CDKConstants.ISPLACED) && !bond.getEnd().getFlag(CDKConstants.ISPLACED)) {
+                return bond.getBeg();
             }
         }
         return null;
@@ -1883,8 +1883,8 @@ public class StructureDiagramGenerator {
      */
     private IBond getNextBondWithUnplacedRingAtom() {
         for (IBond bond : molecule.bonds()) {
-            IAtom beg = bond.getAtom(0);
-            IAtom end = bond.getAtom(1);
+            IAtom beg = bond.getBeg();
+            IAtom end = bond.getEnd();
             if (beg.getPoint2d() != null && end.getPoint2d() != null) {
                 if (end.getFlag(CDKConstants.ISPLACED) && !beg.getFlag(CDKConstants.ISPLACED) && beg.isInRing()) {
                     return bond;
@@ -1915,12 +1915,12 @@ public class StructureDiagramGenerator {
             logger.debug("placeFirstBondOfFirstRing->bondVector.length() after scaling:" + bondVector.length());
             IAtom atom;
             Point2d point = new Point2d(0, 0);
-            atom = bond.getAtom(0);
+            atom = bond.getBeg();
             logger.debug("Atom 1 of first Bond: " + (molecule.indexOf(atom) + 1));
             atom.setPoint2d(point);
             atom.setFlag(CDKConstants.ISPLACED, true);
             point = new Point2d(0, 0);
-            atom = bond.getAtom(1);
+            atom = bond.getEnd();
             logger.debug("Atom 2 of first Bond: " + (molecule.indexOf(atom) + 1));
             point.add(bondVector);
             atom.setPoint2d(point);
@@ -1934,8 +1934,8 @@ public class StructureDiagramGenerator {
              */
             sharedAtoms = atom.getBuilder().newInstance(IAtomContainer.class);
             sharedAtoms.addBond(bond);
-            sharedAtoms.addAtom(bond.getAtom(0));
-            sharedAtoms.addAtom(bond.getAtom(1));
+            sharedAtoms.addAtom(bond.getBeg());
+            sharedAtoms.addAtom(bond.getEnd());
         } catch (Exception exc) {
             logger.debug(exc);
         }
@@ -1965,11 +1965,11 @@ public class StructureDiagramGenerator {
      * @return the unplaced ring atom in this bond
      */
     private IAtom getRingAtom(IBond bond) {
-        if (bond.getAtom(0).getFlag(CDKConstants.ISINRING) && !bond.getAtom(0).getFlag(CDKConstants.ISPLACED)) {
-            return bond.getAtom(0);
+        if (bond.getBeg().getFlag(CDKConstants.ISINRING) && !bond.getBeg().getFlag(CDKConstants.ISPLACED)) {
+            return bond.getBeg();
         }
-        if (bond.getAtom(1).getFlag(CDKConstants.ISINRING) && !bond.getAtom(1).getFlag(CDKConstants.ISPLACED)) {
-            return bond.getAtom(1);
+        if (bond.getEnd().getFlag(CDKConstants.ISINRING) && !bond.getEnd().getFlag(CDKConstants.ISPLACED)) {
+            return bond.getEnd();
         }
         return null;
     }
@@ -2044,10 +2044,10 @@ public class StructureDiagramGenerator {
      */
     public IAtom getOtherBondAtom(IAtom atom, IBond bond) {
         if (!bond.contains(atom)) return null;
-        if (bond.getAtom(0).equals(atom))
-            return bond.getAtom(1);
+        if (bond.getBeg().equals(atom))
+            return bond.getEnd();
         else
-            return bond.getAtom(0);
+            return bond.getBeg();
     }
 
     /**
@@ -2090,8 +2090,8 @@ public class StructureDiagramGenerator {
                 visit.add(atom);
             }
             for (IBond bond : mol.bonds()) {
-                IAtom beg = bond.getAtom(0);
-                IAtom end = bond.getAtom(1);
+                IAtom beg = bond.getBeg();
+                IAtom end = bond.getEnd();
                 if (visit.contains(beg) && visit.contains(end))
                     substructure.addBond(bond);
             }
@@ -2134,8 +2134,8 @@ public class StructureDiagramGenerator {
             List<Map.Entry<IBond,Vector2d>>   xBondVec = new ArrayList<>();
             if (numCrossing == 2) {
                 for (IBond bond : mol.bonds()) {
-                    IAtom beg = bond.getAtom(0);
-                    IAtom end = bond.getAtom(1);
+                    IAtom beg = bond.getBeg();
+                    IAtom end = bond.getEnd();
                     if (patoms.contains(beg) == patoms.contains(end))
                         continue;
                     if (patoms.contains(beg)) {
@@ -2149,8 +2149,8 @@ public class StructureDiagramGenerator {
                     }
                 }
                 for (IBond bond : sgroup.getBonds()) {
-                    IAtom beg = bond.getAtom(0);
-                    IAtom end = bond.getAtom(1);
+                    IAtom beg = bond.getBeg();
+                    IAtom end = bond.getEnd();
                     if (sgroupAtoms.contains(beg)) {
                         xBondVec.add(new SimpleImmutableEntry<>(bond,
                                                                 new Vector2d(end.getPoint2d().x - beg.getPoint2d().x,
@@ -2183,7 +2183,7 @@ public class StructureDiagramGenerator {
                 if (bond.isInRing())
                     continue;
 
-                IAtom beg  = sgroupAtoms.contains(bond.getAtom(0)) ? bond.getAtom(0) : bond.getAtom(1);
+                IAtom beg  = sgroupAtoms.contains(bond.getBeg()) ? bond.getBeg() : bond.getEnd();
                 Map.Entry<Point2d,Vector2d> best = null;
                 for (Map.Entry<Point2d,Vector2d> candidate : outgoing) {
                     if (best == null || candidate.getKey().distance(beg.getPoint2d()) < best.getKey().distance(beg.getPoint2d()))
@@ -2251,7 +2251,7 @@ public class StructureDiagramGenerator {
             Point2d center = GeometryUtil.get2DCenter(shared);
 
             for (IBond bond : mol.bonds()) {
-                if (e.getKey().contains(bond.getAtom(0)) && e.getKey().contains(bond.getAtom(1))) {
+                if (e.getKey().contains(bond.getBeg()) && e.getKey().contains(bond.getEnd())) {
                     bonds.add(bond);
                 }
             }
@@ -2266,11 +2266,11 @@ public class StructureDiagramGenerator {
                     final IBond bond = bndIter.next();
                     final IAtom atom = begIter.next();
 
-                    if (numRingBonds(mol, bond.getAtom(0)) > 2 && numRingBonds(mol, bond.getAtom(1)) > 2)
+                    if (numRingBonds(mol, bond.getBeg()) > 2 && numRingBonds(mol, bond.getEnd()) > 2)
                         continue;
 
-                    final Point2d newBegP = new Point2d(bond.getAtom(0).getPoint2d());
-                    final Point2d newEndP = new Point2d(bond.getAtom(1).getPoint2d());
+                    final Point2d newBegP = new Point2d(bond.getBeg().getPoint2d());
+                    final Point2d newEndP = new Point2d(bond.getEnd().getPoint2d());
 
                     final Vector2d bndVec  = new Vector2d(newEndP.x-newBegP.x, newEndP.y-newBegP.y);
                     final Vector2d bndXVec = new Vector2d(-bndVec.y, bndVec.x);
@@ -2487,8 +2487,8 @@ public class StructureDiagramGenerator {
     }
 
     private static double angle(IBond bond) {
-        Point2d end = bond.getAtom(0).getPoint2d();
-        Point2d beg = bond.getAtom(1).getPoint2d();
+        Point2d end = bond.getBeg().getPoint2d();
+        Point2d beg = bond.getEnd().getPoint2d();
         return Math.atan2(end.y - beg.y, end.x - beg.x);
     }
 
@@ -2502,8 +2502,8 @@ public class StructureDiagramGenerator {
      * @return the new bracket
      */
     private SgroupBracket newCrossingBracket(IBond bond, Multimap<IBond,Sgroup> bonds, Map<IBond,Integer> counter, boolean vert) {
-        final IAtom beg = bond.getAtom(0);
-        final IAtom end = bond.getAtom(1);
+        final IAtom beg = bond.getBeg();
+        final IAtom end = bond.getEnd();
         final Point2d begXy = beg.getPoint2d();
         final Point2d endXy = end.getPoint2d();
         final Vector2d lenOffset = new Vector2d(endXy.x-begXy.x, endXy.y-begXy.y);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -52,13 +52,11 @@ import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupBracket;
 import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.sgroup.SgroupType;
-import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.ReactionManipulator;
 import org.openscience.cdk.tools.manipulator.RingSetManipulator;
-import uk.ac.ebi.beam.Element;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
@@ -778,7 +776,7 @@ public class StructureDiagramGenerator {
             else {
                 final List<IBond> attachBonds = molecule.getConnectedBondsList(begAttach);
                 if (attachBonds.size() == 1) {
-                    IAtom end = attachBonds.get(0).getConnectedAtom(begAttach);
+                    IAtom end = attachBonds.get(0).getOther(begAttach);
                     Point2d xyBeg = begAttach.getPoint2d();
                     Point2d xyEnd = end.getPoint2d();
 
@@ -939,7 +937,7 @@ public class StructureDiagramGenerator {
                     break;
             }
         } else if (bonds.size() == 1) {
-            IAtom  other  = bonds.get(0).getConnectedAtom(atom);
+            IAtom  other  = bonds.get(0).getOther(atom);
             double deltaX = atom.getPoint2d().x - other.getPoint2d().x;
             if (Math.abs(deltaX) > 0.05)
                 pos = (int) Math.signum(deltaX);
@@ -1224,7 +1222,7 @@ public class StructureDiagramGenerator {
 
                 // skip in first pass if charge separated
                 for (IBond bond : frag.getConnectedBondsList(atom)) {
-                    if (Integer.signum(nullAsZero(bond.getConnectedAtom(atom).getFormalCharge())) + sign == 0)
+                    if (Integer.signum(nullAsZero(bond.getOther(atom).getFormalCharge())) + sign == 0)
                         continue FIRST_PASS;
                 }
 
@@ -1826,7 +1824,7 @@ public class StructureDiagramGenerator {
         List bonds = molecule.getConnectedBondsList(atom);
         IAtom connectedAtom;
         for (int f = 0; f < bonds.size(); f++) {
-            connectedAtom = ((IBond) bonds.get(f)).getConnectedAtom(atom);
+            connectedAtom = ((IBond) bonds.get(f)).getOther(atom);
             if (!connectedAtom.getFlag(CDKConstants.ISPLACED)) {
                 unplacedAtoms.addAtom(connectedAtom);
             }
@@ -1847,7 +1845,7 @@ public class StructureDiagramGenerator {
         List bonds = molecule.getConnectedBondsList(atom);
         IAtom connectedAtom;
         for (int f = 0; f < bonds.size(); f++) {
-            connectedAtom = ((IBond) bonds.get(f)).getConnectedAtom(atom);
+            connectedAtom = ((IBond) bonds.get(f)).getOther(atom);
             if (connectedAtom.getFlag(CDKConstants.ISPLACED)) {
                 placedAtoms.addAtom(connectedAtom);
             }
@@ -2195,7 +2193,7 @@ public class StructureDiagramGenerator {
                 // visit rest of connected molecule
                 Set<Integer> iVisit = new HashSet<>();
                 iVisit.add(idxs.get(beg));
-                visit(iVisit, adjlist, idxs.get(bond.getConnectedAtom(beg)));
+                visit(iVisit, adjlist, idxs.get(bond.getOther(beg)));
                 iVisit.remove(idxs.get(beg));
                 IAtomContainer frag = mol.getBuilder().newInstance(IAtomContainer.class);
                 for (Integer idx : iVisit)
@@ -2204,7 +2202,7 @@ public class StructureDiagramGenerator {
                 Vector2d orgVec = e.getValue();
                 Vector2d newVec = best.getValue();
 
-                Point2d endP    = bond.getConnectedAtom(beg).getPoint2d();
+                Point2d endP    = bond.getOther(beg).getPoint2d();
                 Point2d newEndP = new Point2d(beg.getPoint2d());
                 newEndP.add(newVec);
 
@@ -2214,7 +2212,7 @@ public class StructureDiagramGenerator {
 
                 // position
                 GeometryUtil.translate2D(frag, newEndP.x - endP.x, newEndP.y - endP.y);
-                GeometryUtil.rotate(frag, new Point2d(bond.getConnectedAtom(beg).getPoint2d()), theta);
+                GeometryUtil.rotate(frag, new Point2d(bond.getOther(beg).getPoint2d()), theta);
             }
         }
 
@@ -2336,7 +2334,7 @@ public class StructureDiagramGenerator {
 
                     final IBond attachBond = bondMap.get(atomIdx, adjlist[atomIdx][0]);
                     final Point2d begP = atom.getPoint2d();
-                    final Point2d endP = attachBond.getConnectedAtom(atom).getPoint2d();
+                    final Point2d endP = attachBond.getOther(atom).getPoint2d();
 
                     Vector2d orgVec = new Vector2d(endP.x-begP.x, endP.y-begP.y);
                     Vector2d newVec = new Vector2d(newEndP.x-newBegP.x, newEndP.y-newBegP.y);

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
@@ -1147,10 +1147,10 @@ public class StructureDiagramGeneratorTest extends CDKTestCase {
     }
 
     boolean isCrossing(IBond a, IBond b) {
-        Point2d p1 = a.getAtom(0).getPoint2d();
-        Point2d p2 = a.getAtom(1).getPoint2d();
-        Point2d p3 = b.getAtom(0).getPoint2d();
-        Point2d p4 = b.getAtom(1).getPoint2d();
+        Point2d p1 = a.getBeg().getPoint2d();
+        Point2d p2 = a.getEnd().getPoint2d();
+        Point2d p3 = b.getBeg().getPoint2d();
+        Point2d p4 = b.getEnd().getPoint2d();
         return Line2D.linesIntersect(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, p4.x, p4.y);
     }
 

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
@@ -30,7 +30,6 @@ import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
-import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.geometry.GeometryUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -44,7 +43,6 @@ import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.io.ISimpleChemObjectReader;
 import org.openscience.cdk.io.MDLReader;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.io.MDLV2000Writer;
 import org.openscience.cdk.io.Mol2Reader;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupBracket;
@@ -1147,9 +1145,9 @@ public class StructureDiagramGeneratorTest extends CDKTestCase {
     }
 
     boolean isCrossing(IBond a, IBond b) {
-        Point2d p1 = a.getBeg().getPoint2d();
+        Point2d p1 = a.getBegin().getPoint2d();
         Point2d p2 = a.getEnd().getPoint2d();
-        Point2d p3 = b.getBeg().getPoint2d();
+        Point2d p3 = b.getBegin().getPoint2d();
         Point2d p4 = b.getEnd().getPoint2d();
         return Line2D.linesIntersect(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, p4.x, p4.y);
     }

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
@@ -216,7 +216,7 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
         // bond is undirected so we need to ensure v1 is the first atom in the bond
         // we also need to to swap the substituents later
         boolean swap = false;
-        if (targetElement.getStereoBond().getAtom(0) != target.getAtom(v1)) {
+        if (targetElement.getStereoBond().getBeg() != target.getAtom(v1)) {
             int tmp = v1;
             v1 = v2;
             v2 = tmp;
@@ -325,8 +325,8 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
                 indices[nElements++] = idx;
             } else if (element instanceof IDoubleBondStereochemistry) {
                 IDoubleBondStereochemistry dbs = (IDoubleBondStereochemistry) element;
-                int idx1 = map.get(dbs.getStereoBond().getAtom(0));
-                int idx2 = map.get(dbs.getStereoBond().getAtom(1));
+                int idx1 = map.get(dbs.getStereoBond().getBeg());
+                int idx2 = map.get(dbs.getStereoBond().getEnd());
                 elements[idx2] = elements[idx1] = element;
                 types[idx1] = types[idx2] = Type.Geometric;
                 indices[nElements++] = idx1; // only visit the first atom

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
@@ -228,11 +228,11 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
         int p = parity(queryElement.getStereo());
         int q = parity(targetElement.getStereo());
 
-        int uLeft = queryMap.get(queryBonds[0].getConnectedAtom(query.getAtom(u1)));
-        int uRight = queryMap.get(queryBonds[1].getConnectedAtom(query.getAtom(u2)));
+        int uLeft = queryMap.get(queryBonds[0].getOther(query.getAtom(u1)));
+        int uRight = queryMap.get(queryBonds[1].getOther(query.getAtom(u2)));
 
-        int vLeft = targetMap.get(targetBonds[0].getConnectedAtom(target.getAtom(v1)));
-        int vRight = targetMap.get(targetBonds[1].getConnectedAtom(target.getAtom(v2)));
+        int vLeft = targetMap.get(targetBonds[0].getOther(target.getAtom(v1)));
+        int vRight = targetMap.get(targetBonds[1].getOther(target.getAtom(v2)));
 
         if (swap) {
             int tmp = vLeft;
@@ -285,7 +285,7 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
      */
     private int otherIndex(int i) {
         IDoubleBondStereochemistry element = (IDoubleBondStereochemistry) queryElements[i];
-        return queryMap.get(element.getStereoBond().getConnectedAtom(query.getAtom(i)));
+        return queryMap.get(element.getStereoBond().getOther(query.getAtom(i)));
     }
 
     /**

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
@@ -216,7 +216,7 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
         // bond is undirected so we need to ensure v1 is the first atom in the bond
         // we also need to to swap the substituents later
         boolean swap = false;
-        if (targetElement.getStereoBond().getBeg() != target.getAtom(v1)) {
+        if (targetElement.getStereoBond().getBegin() != target.getAtom(v1)) {
             int tmp = v1;
             v1 = v2;
             v2 = tmp;
@@ -325,7 +325,7 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
                 indices[nElements++] = idx;
             } else if (element instanceof IDoubleBondStereochemistry) {
                 IDoubleBondStereochemistry dbs = (IDoubleBondStereochemistry) element;
-                int idx1 = map.get(dbs.getStereoBond().getBeg());
+                int idx1 = map.get(dbs.getStereoBond().getBegin());
                 int idx2 = map.get(dbs.getStereoBond().getEnd());
                 elements[idx2] = elements[idx1] = element;
                 types[idx1] = types[idx2] = Type.Geometric;

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/StereoBond.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/StereoBond.java
@@ -53,9 +53,9 @@ public class StereoBond extends SMARTSBond {
     }
 
     public Direction direction(IAtom atom) {
-        if (atom == getAtom(0))
+        if (atom == getBeg())
             return direction;
-        else if (atom == getAtom(1)) return inv(direction);
+        else if (atom == getEnd()) return inv(direction);
         throw new IllegalArgumentException("atom is not a memeber of this bond");
     }
 

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/StereoBond.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/StereoBond.java
@@ -53,7 +53,7 @@ public class StereoBond extends SMARTSBond {
     }
 
     public Direction direction(IAtom atom) {
-        if (atom == getBeg())
+        if (atom == getBegin())
             return direction;
         else if (atom == getEnd()) return inv(direction);
         throw new IllegalArgumentException("atom is not a memeber of this bond");

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsFragmentExtractor.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsFragmentExtractor.java
@@ -134,8 +134,8 @@ public final class SmartsFragmentExtractor {
         // reference and traversal
         for (int bondIdx = 0; bondIdx < numBonds; bondIdx++) {
             IBond bond = mol.getBond(bondIdx);
-            IAtom beg = bond.getAtom(0);
-            IAtom end = bond.getAtom(1);
+            IAtom beg = bond.getBeg();
+            IAtom end = bond.getEnd();
             int begIdx = mol.indexOf(beg);
             int endIdx = mol.indexOf(end);
             this.bexpr[bondIdx] = encodeBondExpr(bondIdx, begIdx, endIdx);

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsFragmentExtractor.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsFragmentExtractor.java
@@ -134,7 +134,7 @@ public final class SmartsFragmentExtractor {
         // reference and traversal
         for (int bondIdx = 0; bondIdx < numBonds; bondIdx++) {
             IBond bond = mol.getBond(bondIdx);
-            IAtom beg = bond.getBeg();
+            IAtom beg = bond.getBegin();
             IAtom end = bond.getEnd();
             int begIdx = mol.indexOf(beg);
             int endIdx = mol.indexOf(end);

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsFragmentExtractor.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsFragmentExtractor.java
@@ -390,7 +390,7 @@ public final class SmartsFragmentExtractor {
             int atmDeg = this.deg[atmIdx];
             for (int i = 0; i < atmDeg; i++) {
                 IBond bond = mol.getBond(bondAdj[atmIdx][i]);
-                IAtom nbr = bond.getConnectedAtom(atom);
+                IAtom nbr = bond.getOther(atom);
                 if (nbr.getAtomicNumber() != null && nbr.getAtomicNumber() == 1)
                     hcount++;
                 int bord = bond.getOrder() != null ? bond.getOrder().numeric() : 0;

--- a/tool/smarts/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
@@ -465,7 +465,7 @@ public class SMARTSQueryTool {
 
                 // get the atoms in this bond
                 IBond bond = atomContainer.getBond(bondID);
-                atom1 = bond.getBeg();
+                atom1 = bond.getBegin();
                 atom2 = bond.getEnd();
 
                 Integer idx1 = atomContainer.indexOf(atom1);

--- a/tool/smarts/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
@@ -465,8 +465,8 @@ public class SMARTSQueryTool {
 
                 // get the atoms in this bond
                 IBond bond = atomContainer.getBond(bondID);
-                atom1 = bond.getAtom(0);
-                atom2 = bond.getAtom(1);
+                atom1 = bond.getBeg();
+                atom2 = bond.getEnd();
 
                 Integer idx1 = atomContainer.indexOf(atom1);
                 Integer idx2 = atomContainer.indexOf(atom2);

--- a/tool/smarts/src/main/java/org/openscience/cdk/smiles/smarts/parser/SmartsQueryVisitor.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smiles/smarts/parser/SmartsQueryVisitor.java
@@ -323,8 +323,8 @@ public class SmartsQueryVisitor implements SMARTSParserVisitor {
         // for each double bond, find the stereo bonds. currently doesn't
         // handle logical bonds i.e. C/C-,=C/C
         for (IBond bond : doubleBonds) {
-            IAtom left = bond.getAtom(0);
-            IAtom right = bond.getAtom(1);
+            IAtom left = bond.getBeg();
+            IAtom right = bond.getEnd();
             StereoBond leftBond = findStereoBond(left);
             StereoBond rightBond = findStereoBond(right);
             if (leftBond == null || rightBond == null) continue;

--- a/tool/smarts/src/main/java/org/openscience/cdk/smiles/smarts/parser/SmartsQueryVisitor.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smiles/smarts/parser/SmartsQueryVisitor.java
@@ -17,8 +17,6 @@
  */
 package org.openscience.cdk.smiles.smarts.parser;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.ReactionRole;
 import org.openscience.cdk.interfaces.IAtom;
@@ -323,7 +321,7 @@ public class SmartsQueryVisitor implements SMARTSParserVisitor {
         // for each double bond, find the stereo bonds. currently doesn't
         // handle logical bonds i.e. C/C-,=C/C
         for (IBond bond : doubleBonds) {
-            IAtom left = bond.getBeg();
+            IAtom left = bond.getBegin();
             IAtom right = bond.getEnd();
             StereoBond leftBond = findStereoBond(left);
             StereoBond rightBond = findStereoBond(right);

--- a/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
+++ b/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
@@ -654,7 +654,7 @@ public final class InChITautomerGenerator {
 
         while (offSet < container.getBondCount() && dblBondPositions == null) {
             IBond bond = container.getBond(offSet);
-            if (atomsInNeedOfFix.contains(bond.getAtom(0)) && atomsInNeedOfFix.contains(bond.getAtom(1))) {
+            if (atomsInNeedOfFix.contains(bond.getBeg()) && atomsInNeedOfFix.contains(bond.getEnd())) {
                 bond.setOrder(IBond.Order.DOUBLE);
                 dblBondsAdded = dblBondsAdded + 1;
                 if (dblBondsAdded == doubleBondMax) {

--- a/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
+++ b/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
@@ -452,7 +452,7 @@ public final class InChITautomerGenerator {
                 bondRemoved = false;
                 for (IAtom removedAtom : removedAtoms) {
                     if (bond.contains(removedAtom)) {
-                        IAtom other = bond.getConnectedAtom(removedAtom);
+                        IAtom other = bond.getOther(removedAtom);
                         int decValence = 0;
                         switch (bond.getOrder()) {
                             case SINGLE:
@@ -538,7 +538,7 @@ public final class InChITautomerGenerator {
                             for (int bondIdx = 0; bondIdx < tautomerSkeleton.getBondCount(); bondIdx++) {
                                 IBond skBond = tautomerSkeleton.getBond(bondIdx);
                                 if (skBond.contains(skAtom1)) {
-                                    IAtom skAtom2 = skBond.getConnectedAtom(skAtom1);
+                                    IAtom skAtom2 = skBond.getOther(skAtom1);
                                     for (IAtom atom2 : tautomer.atoms()) {
                                         if (atom2.getID().equals(skAtom2.getID())) {
                                             IBond tautBond = tautomer.getBond(atom1, atom2);

--- a/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
+++ b/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
@@ -654,7 +654,7 @@ public final class InChITautomerGenerator {
 
         while (offSet < container.getBondCount() && dblBondPositions == null) {
             IBond bond = container.getBond(offSet);
-            if (atomsInNeedOfFix.contains(bond.getBeg()) && atomsInNeedOfFix.contains(bond.getEnd())) {
+            if (atomsInNeedOfFix.contains(bond.getBegin()) && atomsInNeedOfFix.contains(bond.getEnd())) {
                 bond.setOrder(IBond.Order.DOUBLE);
                 dblBondsAdded = dblBondsAdded + 1;
                 if (dblBondsAdded == doubleBondMax) {


### PR DESCRIPTION
Clean up two, I've left the n-centre bonds as they are (for now) but added utility methods for ```bond.getAtom(0)``` and ```bond.getAtom(1)```. These can now be called with ```bond.getBeg()``` and ```bond.getEnd()```. Also ```getConnectedAtom(IAtom)`` is now the shorter ``getOther(IAtom)``. The existing methods are still there so no API breakage.

The first one is shortened to line up nicely.

```
IAtom beg = bond.getBeg();
IAtom end = bond.getEnd();
IBond nbr = bond.getOther(beg); // nbr == end
```

The terms begin/first, and end/second are widely used, not only do they provide cleaner code but they should lower the barrier to entry from other toolkits. Here is a quick survey of other toolkits.

[OEChem](https://docs.eyesopen.com/toolkits/python/oechemtk/bondproperties.html): bond.GetBgn() and bond.GetEnd() bond.GetNbr()
[RDKit](http://www.rdkit.org/docs/cppapi/classRDKit_1_1Bond.html) getBeginAtom() getEndAtom() getOtherAtom()
[OpenBabel](http://openbabel.org/dev-api/classOpenBabel_1_1OBBond.shtml) bond.GetBeginAtom() bond.GetEndAtom() bond.GetNbrAtom()
[ChemAxon](https://www.chemaxon.com/jchem/doc/dev/java/api/index.html?chemaxon/struc/MolBond.html): bond.getAtom1() bond.getAtom2() bond.getOtherAtom()



