### PR TITLE
Direct allocation for "hot" objects

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/DefaultChemObjectBuilder.java
+++ b/base/data/src/main/java/org/openscience/cdk/DefaultChemObjectBuilder.java
@@ -206,4 +206,27 @@ public class DefaultChemObjectBuilder implements IChemObjectBuilder {
         return factory.ofClass(clazz, params);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom newAtom() {
+        return new Atom();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IBond newBond() {
+        return new Bond();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer newAtomContainer() {
+        return new AtomContainer();
+    }
 }

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugChemObjectBuilder.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugChemObjectBuilder.java
@@ -204,4 +204,27 @@ public class DebugChemObjectBuilder implements IChemObjectBuilder {
         return factory.ofClass(clazz, params);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom newAtom() {
+        return new DebugAtom();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IBond newBond() {
+        return new DebugBond();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer newAtomContainer() {
+        return new DebugAtomContainer();
+    }
 }

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IChemObjectBuilder.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IChemObjectBuilder.java
@@ -41,6 +41,32 @@ public interface IChemObjectBuilder {
      * @throws IllegalArgumentException Exception thrown when the {@link IChemObjectBuilder}
      *               builder cannot instantiate the <code>clazz</code> with the given parameters.
      */
-    public <T extends ICDKObject> T newInstance(Class<T> clazz, Object... params) throws IllegalArgumentException;
+    <T extends ICDKObject> T newInstance(Class<T> clazz, Object... params) throws IllegalArgumentException;
 
+    /**
+     * Create a new atom using the default constructor. This method is considerably faster
+     * than the dynamic dispatch of {@code newInstance(IAtom.class)} and should be used for
+     * high throughput applications (e.g. IO).
+     *
+     * @return new atom
+     */
+    IAtom newAtom();
+
+    /**
+     * Create a new bond using the default constructor. This method is considerably faster
+     * than the dynamic dispatch of {@code newInstance(IAtom.class)} and should be used for
+     * high throughput applications (e.g. IO).
+     *
+     * @return new bond
+     */
+    IBond newBond();
+
+    /**
+     * Create a new atom container using the default constructor. This method is considerably faster
+     * than the dynamic dispatch of {@code newInstance(IAtom.class)} and should be used for
+     * high throughput applications (e.g. IO).
+     *
+     * @return the new atom container
+     */
+    IAtomContainer newAtomContainer();
 }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
@@ -201,4 +201,27 @@ public class SilentChemObjectBuilder implements IChemObjectBuilder {
         return factory.ofClass(clazz, params);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom newAtom() {
+        return new Atom();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IBond newBond() {
+        return new Bond();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer newAtomContainer() {
+        return new AtomContainer(0,0,0,0);
+    }
 }

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -763,7 +763,8 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                 throw new CDKException("invalid line length: " + length + " " + line);
         }
 
-        IBond bond = builder.newInstance(IBond.class, atoms[u], atoms[v]);
+        IBond bond = builder.newBond();
+        bond.setAtoms(new IAtom[]{atoms[u], atoms[v]});
 
         switch (type) {
             case 1: // single
@@ -1279,8 +1280,11 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
      * @throws CDKException the symbol is not allowed
      */
     private IAtom createAtom(String symbol, IChemObjectBuilder builder, int lineNum) throws CDKException {
-        if (isPeriodicElement(symbol))
-            return builder.newInstance(IAtom.class, symbol);
+        if (isPeriodicElement(symbol)) {
+            IAtom atom = builder.newAtom();
+            atom.setSymbol(symbol);
+            return atom;
+        }
         if (symbol.equals("D") && interpretHydrogenIsotopes.isSet()) {
             if (mode == Mode.STRICT) throw new CDKException("invalid symbol: " + symbol);
             IAtom atom = builder.newInstance(IAtom.class, "H");

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -156,7 +156,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
 
 
         logger.info("Reading CTAB block");
-        IAtomContainer readData = builder.newInstance(IAtomContainer.class);
+        IAtomContainer readData = builder.newAtomContainer();
         boolean foundEND = false;
         String lastLine = readHeader(readData);
         while (isReady() && !foundEND) {
@@ -256,7 +256,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                 foundEND = true;
             } else {
                 logger.debug("Parsing atom from: " + command);
-                IAtom atom = readData.getBuilder().newInstance(IAtom.class);
+                IAtom atom = readData.getBuilder().newAtom();
                 StringTokenizer tokenizer = new StringTokenizer(command);
                 // parse the index
                 try {
@@ -270,7 +270,8 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                 // parse the element
                 String element = tokenizer.nextToken();
                 if (isotopeFactory.isElement(element)) {
-                    atom = isotopeFactory.configure(readData.getBuilder().newInstance(IAtom.class, element));
+                    atom.setSymbol(element);
+                    isotopeFactory.configure(atom); // ?
                 } else if ("A".equals(element)) {
                     atom = readData.getBuilder().newInstance(IPseudoAtom.class, element);
                 } else if ("Q".equals(element)) {
@@ -401,7 +402,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
             } else {
                 logger.debug("Parsing bond from: " + command);
                 StringTokenizer tokenizer = new StringTokenizer(command);
-                IBond bond = readData.getBuilder().newInstance(IBond.class);
+                IBond bond = readData.getBuilder().newBond();
                 // parse the index
                 try {
                     String indexString = tokenizer.nextToken();

--- a/storage/io/src/main/java/org/openscience/cdk/io/iterator/IteratingSDFReader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/iterator/IteratingSDFReader.java
@@ -248,7 +248,7 @@ public class IteratingSDFReader extends DefaultIteratingChemObjectReader<IAtomCo
                     try {
                         ISimpleChemObjectReader reader = getReader(currentFormat);
                         reader.setReader(new StringReader(buffer.toString()));
-                        molecule = reader.read(builder.newInstance(IAtomContainer.class, 0, 0, 0, 0));
+                        molecule = reader.read(builder.newAtomContainer());
                     } catch (Exception exception) {
                         logger.error("Error while reading next molecule: " + exception.getMessage());
                         logger.debug(exception);

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
@@ -490,11 +490,7 @@ final class BeamToCDK {
      * @return a new atom container instance
      */
     private IAtomContainer emptyContainer() {
-        try {
-            return (IAtomContainer) emptyContainer.clone();
-        } catch (CloneNotSupportedException e) {
-            return builder.newInstance(IAtomContainer.class, 0, 0, 0, 0);
-        }
+        return builder.newAtomContainer();
     }
 
     /**
@@ -506,15 +502,10 @@ final class BeamToCDK {
      * @return new atom with configured symbol and atomic number
      */
     private IAtom createAtom(Element element) {
-        try {
-            IAtom atom = (IAtom) templateAtom.clone();
-            atom.setSymbol(element.symbol());
-            atom.setAtomicNumber(element.atomicNumber());
-            return atom;
-        } catch (CloneNotSupportedException e) {
-            // clone is always supported if overridden but just in case :-)
-            return builder.newInstance(IAtom.class, element.symbol());
-        }
+        IAtom atom = builder.newAtom();
+        atom.setSymbol(element.symbol());
+        atom.setAtomicNumber(element.atomicNumber());
+        return atom;
     }
 
     /**
@@ -529,14 +520,9 @@ final class BeamToCDK {
      * @return new bond instance
      */
     private IBond createBond(IAtom either, IAtom other, IBond.Order order) {
-        try {
-            IBond bond = (IBond) templateBond.clone();
-            bond.setAtoms(new IAtom[]{either, other});
-            bond.setOrder(order);
-            return bond;
-        } catch (CloneNotSupportedException e) {
-            // clone is always supported if overridden but just in case  :-)
-            return builder.newInstance(IBond.class, either, other, order);
-        }
+        IBond bond = builder.newBond();
+        bond.setAtoms(new IAtom[]{either, other});
+        bond.setOrder(order);
+        return bond;
     }
 }


### PR DESCRIPTION
When the interfaces/factory (chemobjbuilder) were introduced the factory class had many methods for each and every type of chemobject and the constructor. This is clearly not maintainable and the classes were replaced with a complex if/else cascade for object creation. I later cleaned this up to make it more maintainable and used introspection to register constructors.

I am pleased with the end result as it's much cleaner but the factory (and interfaces) for domain objects is a bit of an anti-pattern... with the single ```newInstance``` method you lose all the type safety of the constructors and compiler optimisations. Previously circumvent this I have (in the SMILES parser) cached the objects and used clone, again this is nasty and non-optimal.

This patches proposes introducing direct methods back into the factory for default constructors of "hot" objects. High throughput methods (e.g. IO) can then leverage these. A quick analysis of the library shows the identifies the following candidates:

```
IAtom 4307
IBond 1576
IAtomContainer 1251
IIsotope 471 <- surprised by this!
IAtomContainerSet 236
IReaction 167
IMolecularFormula 139
ISingleElectron 91
IMonomer 85
IChemModel 76
IReactionSet 73
IRing 69
ILonePair 63
IPseudoAtom 57
IElement 56
IChemSequence 56
IPDBAtom 50
IStrand 48
IRingSet 34
IReactionScheme 34
IMolecularFormulaSet 26
IAdductFormula 26
IChemFile 24
IPDBStructure 18
ICrystal 18
IAtomType 13
IPDBMonomer 5
IAminoAcid 3
IPDBPolymer 2
IBioPolymer 2
ISubstance 1
IPolymer 1
IFragmentAtom 1
IElectronContainer 1
```

Note that the 1:n of Atoms/Bonds has a bigger impact than IAtomContainer so these are even "hotter" in terms of creation.

I've added default constructors for Atom/Bond/AtomContiainer here is how it affects read performance. It may be surprising how much it affects the speed:

### newInstance(IAtom.class, "C")+newInstance(IBond.class, beg, end)+newInstance(IAtomContainer.class) 
(Current)
```
/data/chembl_22_1.sdf	58.891s 
/data/chembl_22_1.sdf	57.766s
/data/chembl_22_1.sdf	57.881s
/data/chembl_22_1.sdf	58.289s
/data/chembl_22_1.sdf	57.701s
```
### newAtom(), newBond(), newAtomContainer()
(Patch)
```
/data/chembl_22_1.sdf	44.331s
/data/chembl_22_1.sdf	43.050s
/data/chembl_22_1.sdf	43.033s
/data/chembl_22_1.sdf	43.263s
/data/chembl_22_1.sdf	43.275s
```
### Atom.clone(), Bond.clone(), AtomContainer.clone()
(Current)
```
/data/chembl_22.smi 11.933s
/data/chembl_22.smi 11.323s
/data/chembl_22.smi 11.299s
/data/chembl_22.smi 11.331s
/data/chembl_22.smi 11.310s
```
### newInstance(IAtom.class) newInstance(IBond.class) newInstance(IAtomContainer.class)
```
/data/chembl_22.smi	13.161s
/data/chembl_22.smi	12.612s
/data/chembl_22.smi	12.585s
/data/chembl_22.smi	12.593s
/data/chembl_22.smi	12.599s
```
### newAtom(), newBond(), newAtomContainer()
(Patch)
```
/data/chembl_22.smi	11.063s
/data/chembl_22.smi	10.401s
/data/chembl_22.smi	10.385s
/data/chembl_22.smi	10.385s
/data/chembl_22.smi	10.387s
```