### PR TITLE
Patch/beamconvspeedup

### DIFF
--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -26,6 +26,7 @@ package org.openscience.cdk.io;
 
 import com.google.common.collect.ImmutableSet;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.config.IsotopeFactory;
 import org.openscience.cdk.config.Isotopes;
 import org.openscience.cdk.exception.CDKException;
@@ -1280,9 +1281,11 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
      * @throws CDKException the symbol is not allowed
      */
     private IAtom createAtom(String symbol, IChemObjectBuilder builder, int lineNum) throws CDKException {
-        if (isPeriodicElement(symbol)) {
+        final Elements elem = Elements.ofString(symbol);
+        if (elem != Elements.Unknown) {
             IAtom atom = builder.newAtom();
-            atom.setSymbol(symbol);
+            atom.setSymbol(elem.symbol());
+            atom.setAtomicNumber(elem.number());
             return atom;
         }
         if (symbol.equals("D") && interpretHydrogenIsotopes.isSet()) {
@@ -1315,17 +1318,6 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
         return atom;
     }
 
-    /**
-     * Is the symbol a periodic element.
-     *
-     * @param symbol a symbol from the input
-     * @return the symbol is a pseudo atom
-     */
-    private static boolean isPeriodicElement(final String symbol) {
-        // XXX: PeriodicTable is slow - switch without file IO would be optimal
-        Integer elem = PeriodicTable.getAtomicNumber(symbol);
-        return elem != null && elem > 0;
-    }
 
     /**
      * Is the atom symbol a non-periodic element (i.e. pseudo). Valid pseudo

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/BeamToCDKTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/BeamToCDKTest.java
@@ -153,39 +153,6 @@ public class BeamToCDKTest {
     }
 
     @Test
-    public void singleBondEdge() {
-        IAtom[] atoms = new IAtom[]{mock(IAtom.class), mock(IAtom.class), mock(IAtom.class), mock(IAtom.class),
-                mock(IAtom.class), mock(IAtom.class)};
-        IBond b = g2c.toCDKBond(Bond.SINGLE.edge(0, 5), atoms, true);
-        assertThat(b.getOrder(), is(IBond.Order.SINGLE));
-        assertFalse(b.getFlag(CDKConstants.ISAROMATIC));
-        assertThat(b.getAtom(0), is(atoms[0]));
-        assertThat(b.getAtom(1), is(atoms[5]));
-    }
-
-    @Test
-    public void aromaticBondEdge() {
-        IAtom[] atoms = new IAtom[]{mock(IAtom.class), mock(IAtom.class), mock(IAtom.class), mock(IAtom.class),
-                mock(IAtom.class), mock(IAtom.class)};
-        IBond b = g2c.toCDKBond(Bond.AROMATIC.edge(0, 5), atoms, true);
-        assertThat(b.getOrder(), is(IBond.Order.SINGLE));
-        assertTrue(b.getFlag(CDKConstants.ISAROMATIC));
-        assertThat(b.getAtom(0), is(atoms[0]));
-        assertThat(b.getAtom(1), is(atoms[5]));
-    }
-
-    @Test
-    public void doubleBondEdge() {
-        IAtom[] atoms = new IAtom[]{mock(IAtom.class), mock(IAtom.class), mock(IAtom.class), mock(IAtom.class),
-                mock(IAtom.class), mock(IAtom.class)};
-        IBond b = g2c.toCDKBond(Bond.DOUBLE.edge(0, 5), atoms, true);
-        assertThat(b.getOrder(), is(IBond.Order.DOUBLE));
-        assertFalse(b.getFlag(CDKConstants.ISAROMATIC));
-        assertThat(b.getAtom(0), is(atoms[0]));
-        assertThat(b.getAtom(1), is(atoms[5]));
-    }
-
-    @Test
     public void benzene() throws IOException {
         IAtomContainer ac = convert("c1ccccc1");
         assertThat(ac.getAtomCount(), is(6));


### PR DESCRIPTION
Squeeze some more speed out of the SMILES reader at the Beam->CDK handoff. This might be a bit of a no-op as testing the AtomRef patching (on going) I lose about a second in the SMILES Parser, so the solution is to squeeze an extra second out of the current implementation... thus balance is restored.

### Current
/data/chembl_22.smi	11.063s
/data/chembl_22.smi	10.401s
/data/chembl_22.smi	10.385s
/data/chembl_22.smi	10.385s
/data/chembl_22.smi	10.387s

### Patch
/data/chembl_22.smi	10.021s
/data/chembl_22.smi	9.403s
/data/chembl_22.smi	9.391s
/data/chembl_22.smi	9.371s
/data/chembl_22.smi	9.357s

Times will go back to ~10.5 seconds if I get the AtomRef integrated nicely.