### PR TITLE
Exchange RadicalSiteRrDeltaReaction and RadicalSiteRrGammaReaction

### DIFF
--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteHrAlphaReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteHrAlphaReaction.java
@@ -194,7 +194,7 @@ public class RadicalSiteHrAlphaReaction extends ReactionEngine implements IReact
      * The active center will be those which correspond with [A*]-(C)_2-C3[H]
      * <pre>
      * C: Atom with single electron
-     * C5: Atom with Hydrogen
+     * C3: Atom with Hydrogen
      *  </pre>
      *
      * @param reactant The molecule to set the activity

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteHrBetaReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteHrBetaReaction.java
@@ -194,7 +194,7 @@ public class RadicalSiteHrBetaReaction extends ReactionEngine implements IReacti
      * The active center will be those which correspond with [A*]-(C)_3-C4[H]
      * <pre>
      * C: Atom with single electron
-     * C5: Atom with Hydrogen
+     * C4: Atom with Hydrogen
      *  </pre>
      *
      * @param reactant The molecule to set the activity

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteHrDeltaReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteHrDeltaReaction.java
@@ -191,10 +191,10 @@ public class RadicalSiteHrDeltaReaction extends ReactionEngine implements IReact
 
     /**
      * set the active center for this molecule.
-     * The active center will be those which correspond with [A*]-(C)_4-C5[H]
+     * The active center will be those which correspond with [A*]-(C)_5-C6[H]
      * <pre>
      * C: Atom with single electron
-     * C5: Atom with Hydrogen
+     * C6: Atom with Hydrogen
      *  </pre>
      *
      * @param reactant The molecule to set the activity

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteHrGammaReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteHrGammaReaction.java
@@ -192,10 +192,10 @@ public class RadicalSiteHrGammaReaction extends ReactionEngine implements IReact
 
     /**
      * set the active center for this molecule.
-     * The active center will be those which correspond with [A*]=B.
+     * The active center will be those which correspond with [A*]-(C)_4-C5[H]
      * <pre>
      * C: Atom with single electron
-     * C3: Atom with Hydrogen
+     * C5: Atom with Hydrogen
      *  </pre>
      *
      * @param reactant The molecule to set the activity

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteInitiationHReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteInitiationHReaction.java
@@ -180,7 +180,7 @@ public class RadicalSiteInitiationHReaction extends ReactionEngine implements IR
 
     /**
      * set the active center for this molecule.
-     * The active center will be those which correspond with H-B-[c*] .
+     * The active center will be those which correspond with H-B-[C*] .
      * <pre>
      * H: Hydrogen Atom
      * -: bond

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteRrAlphaReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteRrAlphaReaction.java
@@ -200,7 +200,7 @@ public class RadicalSiteRrAlphaReaction extends ReactionEngine implements IReact
      * The active center will be those which correspond with [A*]-(C)_2-C3[R]
      * <pre>
      * C: Atom with single electron
-     * C5: Atom with the R to move
+     * C3: Atom with the R to move
      *  </pre>
      *
      * @param reactant The molecule to set the activity

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteRrBetaReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteRrBetaReaction.java
@@ -197,10 +197,10 @@ public class RadicalSiteRrBetaReaction extends ReactionEngine implements IReacti
 
     /**
      * set the active center for this molecule.
-     * The active center will be those which correspond with [A*]-(C)_2-C3[R]
+     * The active center will be those which correspond with [A*]-(C)_3-C4[R]
      * <pre>
      * C: Atom with single electron
-     * C5: Atom with the R to move
+     * C4: Atom with the R to move
      *  </pre>
      *
      * @param reactant The molecule to set the activity

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteRrDeltaReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteRrDeltaReaction.java
@@ -47,7 +47,7 @@ import java.util.List;
 
 /**
  * <p>
- * This reaction could be represented as [A*]-(C)_4-C5[R] =&gt; A([R])-(C_4)-[C5*]. Due to
+ * This reaction could be represented as [A*]-(C)_5-C6[R] =&gt; A([R])-(C_5)-[C6*]. Due to
  * the single electron of atom A the R is moved.</p>
  * <p>It is processed by the RadicalSiteRearrangementMechanism class</p>
  *
@@ -148,11 +148,11 @@ public class RadicalSiteRrDeltaReaction extends ReactionEngine implements IReact
             IAtom atomi = atomis.next();
             if (atomi.getFlag(CDKConstants.REACTIVE_CENTER) && reactant.getConnectedSingleElectronsCount(atomi) == 1) {
 
-                hcg.getSpheres(reactant, atomi, 3, true);
-                List<IAtom> atom1s = hcg.getNodesInSphere(3);
-
                 hcg.getSpheres(reactant, atomi, 4, true);
-                Iterator<IAtom> atomls = hcg.getNodesInSphere(4).iterator();
+                List<IAtom> atom1s = hcg.getNodesInSphere(4);
+
+                hcg.getSpheres(reactant, atomi, 5, true);
+                Iterator<IAtom> atomls = hcg.getNodesInSphere(5).iterator();
                 while (atomls.hasNext()) {
                     IAtom atoml = atomls.next();
                     if (atoml != null && atoml.getFlag(CDKConstants.REACTIVE_CENTER)
@@ -197,7 +197,7 @@ public class RadicalSiteRrDeltaReaction extends ReactionEngine implements IReact
 
     /**
      * set the active center for this molecule.
-     * The active center will be those which correspond with [A*]-(C)_2-C3[R]
+     * The active center will be those which correspond with [A*]-(C)_5-C6[R]
      * <pre>
      * C: Atom with single electron
      * C5: Atom with the R to move
@@ -213,11 +213,11 @@ public class RadicalSiteRrDeltaReaction extends ReactionEngine implements IReact
             IAtom atomi = atomis.next();
             if (reactant.getConnectedSingleElectronsCount(atomi) == 1) {
 
-                hcg.getSpheres(reactant, atomi, 3, true);
-                List<IAtom> atom1s = hcg.getNodesInSphere(3);
-
                 hcg.getSpheres(reactant, atomi, 4, true);
-                Iterator<IAtom> atomls = hcg.getNodesInSphere(4).iterator();
+                List<IAtom> atom1s = hcg.getNodesInSphere(4);
+
+                hcg.getSpheres(reactant, atomi, 5, true);
+                Iterator<IAtom> atomls = hcg.getNodesInSphere(5).iterator();
                 while (atomls.hasNext()) {
                     IAtom atoml = atomls.next();
                     if (atoml != null && !atoml.getFlag(CDKConstants.ISINRING)

--- a/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteRrGammaReaction.java
+++ b/base/reaction/src/main/java/org/openscience/cdk/reaction/type/RadicalSiteRrGammaReaction.java
@@ -47,7 +47,7 @@ import java.util.List;
 
 /**
  * <p>
- * This reaction could be represented as [A*]-(C)_5-C6[R] =&gt; A([R])-(C_5)-[C6*]. Due to
+ * This reaction could be represented as [A*]-(C)_4-C5[R] =&gt; A([R])-(C_4)-[C5*]. Due to
  * the single electron of atom A the R is moved.</p>
  * <p>It is processed by the RadicalSiteRearrangementMechanism class</p>
  *
@@ -148,11 +148,11 @@ public class RadicalSiteRrGammaReaction extends ReactionEngine implements IReact
             IAtom atomi = atomis.next();
             if (atomi.getFlag(CDKConstants.REACTIVE_CENTER) && reactant.getConnectedSingleElectronsCount(atomi) == 1) {
 
-                hcg.getSpheres(reactant, atomi, 4, true);
-                List<IAtom> atom1s = hcg.getNodesInSphere(4);
+                hcg.getSpheres(reactant, atomi, 3, true);
+                List<IAtom> atom1s = hcg.getNodesInSphere(3);
 
-                hcg.getSpheres(reactant, atomi, 5, true);
-                Iterator<IAtom> atomls = hcg.getNodesInSphere(5).iterator();
+                hcg.getSpheres(reactant, atomi, 4, true);
+                Iterator<IAtom> atomls = hcg.getNodesInSphere(4).iterator();
                 while (atomls.hasNext()) {
                     IAtom atoml = atomls.next();
                     if (atoml != null && atoml.getFlag(CDKConstants.REACTIVE_CENTER)
@@ -197,7 +197,7 @@ public class RadicalSiteRrGammaReaction extends ReactionEngine implements IReact
 
     /**
      * set the active center for this molecule.
-     * The active center will be those which correspond with [A*]-(C)_2-C3[R]
+     * The active center will be those which correspond with [A*]-(C)_4-C5[R]
      * <pre>
      * C: Atom with single electron
      * C5: Atom with the R to move
@@ -213,11 +213,11 @@ public class RadicalSiteRrGammaReaction extends ReactionEngine implements IReact
             IAtom atomi = atomis.next();
             if (reactant.getConnectedSingleElectronsCount(atomi) == 1) {
 
-                hcg.getSpheres(reactant, atomi, 4, true);
-                List<IAtom> atom1s = hcg.getNodesInSphere(4);
+                hcg.getSpheres(reactant, atomi, 3, true);
+                List<IAtom> atom1s = hcg.getNodesInSphere(3);
 
-                hcg.getSpheres(reactant, atomi, 5, true);
-                Iterator<IAtom> atomls = hcg.getNodesInSphere(5).iterator();
+                hcg.getSpheres(reactant, atomi, 4, true);
+                Iterator<IAtom> atomls = hcg.getNodesInSphere(4).iterator();
                 while (atomls.hasNext()) {
                     IAtom atoml = atomls.next();
                     if (atoml != null && !atoml.getFlag(CDKConstants.ISINRING)

--- a/base/reaction/src/test/java/org/openscience/cdk/reaction/type/RadicalSiteRrDeltaReactionTest.java
+++ b/base/reaction/src/test/java/org/openscience/cdk/reaction/type/RadicalSiteRrDeltaReactionTest.java
@@ -53,7 +53,7 @@ import java.util.List;
  */
 public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
 
-    private IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
+	private IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
 
     /**
      *  The JUnit setup method
@@ -89,7 +89,7 @@ public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
 
         molecule.getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, true);
-        molecule.getAtom(5).setFlag(CDKConstants.REACTIVE_CENTER, true);
+        molecule.getAtom(6).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getBond(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
 
         List<IParameterReact> paramList = new ArrayList<IParameterReact>();
@@ -130,9 +130,9 @@ public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
         molecule.addBond(3, 4, IBond.Order.SINGLE);
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
-        molecule.getAtom(5).setFormalCharge(1);
         molecule.addBond(4, 5, IBond.Order.SINGLE);
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
+        molecule.getAtom(6).setFormalCharge(1);
         molecule.addBond(5, 6, IBond.Order.SINGLE);
 
         try {
@@ -141,8 +141,8 @@ public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
             e.printStackTrace();
         }
 
-        molecule.getAtom(5).setFormalCharge(0);
-        molecule.addSingleElectron(new SingleElectron(molecule.getAtom(5)));
+        molecule.getAtom(6).setFormalCharge(0);
+        molecule.addSingleElectron(new SingleElectron(molecule.getAtom(6)));
 
         try {
             AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
@@ -176,7 +176,7 @@ public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
         molecule.addBond(4, 5, IBond.Order.SINGLE);
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
-        molecule.addBond(4, 6, IBond.Order.SINGLE);
+        molecule.addBond(5, 6, IBond.Order.SINGLE);
 
         try {
             addExplicitHydrogens(molecule);
@@ -213,7 +213,7 @@ public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
         /* manually put the reactive center */
         molecule.getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, true);
-        molecule.getAtom(5).setFlag(CDKConstants.REACTIVE_CENTER, true);
+        molecule.getAtom(6).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getBond(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
 
         List<IParameterReact> paramList = new ArrayList<IParameterReact>();
@@ -232,8 +232,8 @@ public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
         Assert.assertTrue(reactant.getAtom(0).getFlag(CDKConstants.REACTIVE_CENTER));
         Assert.assertTrue(molecule.getAtom(1).getFlag(CDKConstants.REACTIVE_CENTER));
         Assert.assertTrue(reactant.getAtom(1).getFlag(CDKConstants.REACTIVE_CENTER));
-        Assert.assertTrue(molecule.getAtom(5).getFlag(CDKConstants.REACTIVE_CENTER));
-        Assert.assertTrue(reactant.getAtom(5).getFlag(CDKConstants.REACTIVE_CENTER));
+        Assert.assertTrue(molecule.getAtom(6).getFlag(CDKConstants.REACTIVE_CENTER));
+        Assert.assertTrue(reactant.getAtom(6).getFlag(CDKConstants.REACTIVE_CENTER));
         Assert.assertTrue(molecule.getBond(0).getFlag(CDKConstants.REACTIVE_CENTER));
         Assert.assertTrue(reactant.getBond(0).getFlag(CDKConstants.REACTIVE_CENTER));
     }
@@ -253,7 +253,7 @@ public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
         /* automatic search of the center active */
         molecule.getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, true);
-        molecule.getAtom(5).setFlag(CDKConstants.REACTIVE_CENTER, true);
+        molecule.getAtom(6).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getBond(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
 
         List<IParameterReact> paramList = new ArrayList<IParameterReact>();
@@ -275,8 +275,8 @@ public class RadicalSiteRrDeltaReactionTest extends ReactionProcessTest {
                 molecule.getAtom(1));
         Assert.assertEquals(mappedProductA2, product.getAtom(1));
         IAtom mappedProductA3 = (IAtom) ReactionManipulator.getMappedChemObject(setOfReactions.getReaction(0),
-                molecule.getAtom(5));
-        Assert.assertEquals(mappedProductA3, product.getAtom(5));
+                molecule.getAtom(6));
+        Assert.assertEquals(mappedProductA3, product.getAtom(6));
     }
 
     /**

--- a/base/reaction/src/test/java/org/openscience/cdk/reaction/type/RadicalSiteRrGammaReactionTest.java
+++ b/base/reaction/src/test/java/org/openscience/cdk/reaction/type/RadicalSiteRrGammaReactionTest.java
@@ -89,7 +89,7 @@ public class RadicalSiteRrGammaReactionTest extends ReactionProcessTest {
 
         molecule.getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, true);
-        molecule.getAtom(6).setFlag(CDKConstants.REACTIVE_CENTER, true);
+        molecule.getAtom(5).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getBond(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
 
         List<IParameterReact> paramList = new ArrayList<IParameterReact>();
@@ -130,9 +130,9 @@ public class RadicalSiteRrGammaReactionTest extends ReactionProcessTest {
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
         molecule.addBond(3, 4, IBond.Order.SINGLE);
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
+        molecule.getAtom(5).setFormalCharge(1);
         molecule.addBond(4, 5, IBond.Order.SINGLE);
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
-        molecule.getAtom(6).setFormalCharge(1);
         molecule.addBond(5, 6, IBond.Order.SINGLE);
 
         try {
@@ -141,8 +141,8 @@ public class RadicalSiteRrGammaReactionTest extends ReactionProcessTest {
             e.printStackTrace();
         }
 
-        molecule.getAtom(6).setFormalCharge(0);
-        molecule.addSingleElectron(new SingleElectron(molecule.getAtom(6)));
+        molecule.getAtom(5).setFormalCharge(0);
+        molecule.addSingleElectron(new SingleElectron(molecule.getAtom(5)));
 
         try {
             AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
@@ -176,7 +176,7 @@ public class RadicalSiteRrGammaReactionTest extends ReactionProcessTest {
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
         molecule.addBond(4, 5, IBond.Order.SINGLE);
         molecule.addAtom(builder.newInstance(IAtom.class, "C"));
-        molecule.addBond(5, 6, IBond.Order.SINGLE);
+        molecule.addBond(4, 6, IBond.Order.SINGLE);
 
         try {
             addExplicitHydrogens(molecule);
@@ -213,7 +213,7 @@ public class RadicalSiteRrGammaReactionTest extends ReactionProcessTest {
         /* manually put the reactive center */
         molecule.getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, true);
-        molecule.getAtom(6).setFlag(CDKConstants.REACTIVE_CENTER, true);
+        molecule.getAtom(5).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getBond(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
 
         List<IParameterReact> paramList = new ArrayList<IParameterReact>();
@@ -232,8 +232,8 @@ public class RadicalSiteRrGammaReactionTest extends ReactionProcessTest {
         Assert.assertTrue(reactant.getAtom(0).getFlag(CDKConstants.REACTIVE_CENTER));
         Assert.assertTrue(molecule.getAtom(1).getFlag(CDKConstants.REACTIVE_CENTER));
         Assert.assertTrue(reactant.getAtom(1).getFlag(CDKConstants.REACTIVE_CENTER));
-        Assert.assertTrue(molecule.getAtom(6).getFlag(CDKConstants.REACTIVE_CENTER));
-        Assert.assertTrue(reactant.getAtom(6).getFlag(CDKConstants.REACTIVE_CENTER));
+        Assert.assertTrue(molecule.getAtom(5).getFlag(CDKConstants.REACTIVE_CENTER));
+        Assert.assertTrue(reactant.getAtom(5).getFlag(CDKConstants.REACTIVE_CENTER));
         Assert.assertTrue(molecule.getBond(0).getFlag(CDKConstants.REACTIVE_CENTER));
         Assert.assertTrue(reactant.getBond(0).getFlag(CDKConstants.REACTIVE_CENTER));
     }
@@ -253,7 +253,7 @@ public class RadicalSiteRrGammaReactionTest extends ReactionProcessTest {
         /* automatic search of the center active */
         molecule.getAtom(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getAtom(1).setFlag(CDKConstants.REACTIVE_CENTER, true);
-        molecule.getAtom(6).setFlag(CDKConstants.REACTIVE_CENTER, true);
+        molecule.getAtom(5).setFlag(CDKConstants.REACTIVE_CENTER, true);
         molecule.getBond(0).setFlag(CDKConstants.REACTIVE_CENTER, true);
 
         List<IParameterReact> paramList = new ArrayList<IParameterReact>();
@@ -275,8 +275,8 @@ public class RadicalSiteRrGammaReactionTest extends ReactionProcessTest {
                 molecule.getAtom(1));
         Assert.assertEquals(mappedProductA2, product.getAtom(1));
         IAtom mappedProductA3 = (IAtom) ReactionManipulator.getMappedChemObject(setOfReactions.getReaction(0),
-                molecule.getAtom(6));
-        Assert.assertEquals(mappedProductA3, product.getAtom(6));
+                molecule.getAtom(5));
+        Assert.assertEquals(mappedProductA3, product.getAtom(5));
     }
 
     /**


### PR DESCRIPTION
I believe RadicalSiteRrDeltaReaction and RadicalSiteRrGammaReaction must be exchanged. 
It means magic numbers 3 and 4 in RadicalSiteRrDeltaReaction are correctly 4 and 5, and 4 and 5 in RadicalSiteRrGammaReaction are correctly 3 and 4.