### PR TITLE
Make CDKException a RuntimeException.

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/exception/CDKException.java
+++ b/base/core/src/main/java/org/openscience/cdk/exception/CDKException.java
@@ -28,7 +28,7 @@ package org.openscience.cdk.exception;
  * @cdk.module core
  * @cdk.githash
  */
-public class CDKException extends Exception {
+public class CDKException extends RuntimeException {
 
     private static final long serialVersionUID = 8371328769230823678L;
 


### PR DESCRIPTION
This is a safe transformation and allows the exception to be thrown as an unchecked exception. If an API currently declares it as thrown then it must be caught and that's not a problem. It allows ``NoSuchAtomException`` to be thrown if a method is miss-used.

See Josh Bloch API design: "Favor Unchecked Exceptions"
[How To Design A Good API and Why it Matters - YouTube](https://www.google.co.uk/url?sa=t&rct=j&q=&esrc=s&source=video&cd=1&cad=rja&uact=8&ved=0ahUKEwjbucmx3djTAhULKMAKHclxAvYQtwIIIzAA&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Dheh4OeB9A-c&usg=AFQjCNEpnSSsP1_UMlhWNzmFPl_oGyX4rA&sig2=R29l8kzw5k9UO5oOwFnY8g)
http://www.cs.bc.edu/~muller/teaching/cs102/s06/lib/pdf/api-design.pdf 