### PR TITLE
Patch/equals

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -447,9 +447,9 @@ public class Abbreviations implements Iterable<String> {
                     IAtom atom = frag.getAtom(i);
                     usedAtoms.add(atom);
                     sgroup.addAtom(atom);
-                    if (attachBond.getBegin() == atom)
+                    if (attachBond.getBegin().equals(atom))
                         attachAtom = attachBond.getEnd();
-                    else if (attachBond.getEnd() == atom)
+                    else if (attachBond.getEnd().equals(atom))
                         attachAtom = attachBond.getBegin();
                 }
 

--- a/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
+++ b/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
@@ -1003,7 +1003,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
             // check the second sphere
             for (IAtom atom2 : container.getConnectedAtomsList(atom1)) {
 
-                if (atom2 != atom && container.getBond(atom1, atom2).isAromatic()
+                if (!atom2.equals(atom) && container.getBond(atom1, atom2).isAromatic()
                         && !"C".equals(atom2.getSymbol())) {
                     return false;
                 }

--- a/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
@@ -160,7 +160,7 @@ public class PathTools {
             if (!nextAtom.getFlag(CDKConstants.VISITED)) {
                 path.addAtom(nextAtom);
                 path.addBond(bond);
-                if (nextAtom == target) {
+                if (nextAtom.equals(target)) {
                     return true;
                 } else {
                     if (!depthFirstTargetSearch(molecule, nextAtom, target, path)) {
@@ -214,7 +214,7 @@ public class PathTools {
         IAtom[] returnValue = new IAtom[mol.getAtomCount() - 1];
         int k = 0;
         for (int i = 0; i < mol.getAtomCount(); i++) {
-            if (mol.getAtom(i) != atom) {
+            if (!mol.getAtom(i).equals(atom)) {
                 returnValue[k] = mol.getAtom(i);
                 k++;
             }
@@ -315,7 +315,7 @@ public class PathTools {
                 }
                 nextAtom = bond.getOther(atom);
                 if (!nextAtom.getFlag(CDKConstants.VISITED)) {
-                    if (nextAtom == target) {
+                    if (nextAtom.equals(target)) {
                         return pathLength;
                     }
                     newSphere.add(nextAtom);
@@ -515,7 +515,7 @@ public class PathTools {
 
     private static void findPathBetween(List<List<IAtom>> allPaths, IAtomContainer atomContainer, IAtom start,
             IAtom end, List<IAtom> path) {
-        if (start == end) {
+        if (start.equals(end)) {
             path.add(start);
             allPaths.add(new ArrayList<IAtom>(path));
             path.remove(path.size() - 1);

--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.tools.periodictable.PeriodicTable;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Represents the idea of an chemical atom.
@@ -415,10 +416,11 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             return false;
         }
         Atom atom = (Atom) object;
+        // XXX: floating point comparision!
         if (((point2d == atom.point2d) || ((point2d != null) && (point2d.equals(atom.point2d))))
-                && ((point3d == atom.point3d) || ((point3d != null) && (point3d.equals(atom.point3d))))
-                && (hydrogenCount == atom.hydrogenCount) && (stereoParity == atom.stereoParity)
-                && (charge == atom.charge)) {
+            && ((point3d == atom.point3d) || ((point3d != null) && (point3d.equals(atom.point3d))))
+            && (Objects.equals(hydrogenCount, atom.hydrogenCount)) && (Objects.equals(stereoParity, atom.stereoParity))
+            && (Objects.equals(charge, atom.charge))) {
             return true;
         }
         return false;

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -480,7 +480,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public int indexOf(IAtom atom) {
         for (int i = 0; i < atomCount; i++) {
-            if (atoms[i] == atom) return i;
+            if (atoms[i].equals(atom)) return i;
         }
         return -1;
     }
@@ -537,7 +537,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public IBond getBond(IAtom atom1, IAtom atom2) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1) == atom2) {
+            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1).equals(atom2)) {
                 return bonds[i];
             }
         }
@@ -1206,7 +1206,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public boolean contains(IAtom atom) {
         for (int i = 0; i < getAtomCount(); i++) {
-            if (atom == atoms[i]) return true;
+            if (atoms[i].equals(atom)) return true;
         }
         return false;
     }

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -491,7 +491,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public int indexOf(IBond bond) {
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i] == bond) return i;
+            if (bonds[i].equals(bond)) return i;
         }
         return -1;
     }
@@ -1217,7 +1217,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public boolean contains(IBond bond) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bond == bonds[i]) return true;
+            if (bonds[i].equals(bond)) return true;
         }
         return false;
     }

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -250,9 +250,9 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      */
     @Override
     public IAtom getOther(IAtom atom) {
-        if (atoms[0] == atom)
+        if (atoms[0].equals(atom))
             return atoms[1];
-        else if (atoms[1] == atom)
+        else if (atoms[1].equals(atom))
             return atoms[0];
         return null;
     }
@@ -262,11 +262,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      */
     @Override
     public IAtom getConnectedAtom(IAtom atom) {
-        if (atoms[0] == atom)
-            return atoms[1];
-        else if (atoms[1] == atom)
-            return atoms[0];
-        return null;
+        return getOther(atom);
     }
 
     /**
@@ -278,7 +274,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
         IAtom[] connected = new IAtom[atomCount-1];
         int j = 0;
         for (int i = 0; i < atomCount; i++) {
-            if (this.atoms[i] != atom) {
+            if (!this.atoms[i].equals(atom)) {
                 if (j >= connected.length)
                     return null;
                 connected[j++] = this.atoms[i];
@@ -297,7 +293,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     public boolean contains(IAtom atom) {
         if (atoms == null) return false;
         for (IAtom localAtom : atoms) {
-            if (localAtom == atom) return true;
+            if (localAtom.equals(atom)) return true;
         }
         return false;
     }

--- a/base/data/src/main/java/org/openscience/cdk/LonePair.java
+++ b/base/data/src/main/java/org/openscience/cdk/LonePair.java
@@ -112,7 +112,7 @@ public class LonePair extends ElectronContainer implements Serializable, ILonePa
      */
     @Override
     public boolean contains(IAtom atom) {
-        return (this.atom == atom);
+        return (this.atom.equals(atom));
     }
 
     /**

--- a/base/data/src/main/java/org/openscience/cdk/Ring.java
+++ b/base/data/src/main/java/org/openscience/cdk/Ring.java
@@ -116,7 +116,7 @@ public class Ring extends AtomContainer implements java.io.Serializable, IRing {
         IBond tempBond;
         for (int f = 0; f < getBondCount(); f++) {
             tempBond = getBond(f);
-            if (tempBond.contains(atom) && bond != tempBond) return tempBond;
+            if (tempBond.contains(atom) && !tempBond.equals(bond)) return tempBond;
         }
         return null;
     }

--- a/base/data/src/main/java/org/openscience/cdk/SingleElectron.java
+++ b/base/data/src/main/java/org/openscience/cdk/SingleElectron.java
@@ -118,7 +118,7 @@ public class SingleElectron extends ElectronContainer implements Serializable, I
      */
     @Override
     public boolean contains(IAtom atom) {
-        return (this.atom == atom) ? true : false;
+        return this.atom.equals(atom);
     }
 
     /**

--- a/base/data/src/main/java/org/openscience/cdk/formula/AdductFormula.java
+++ b/base/data/src/main/java/org/openscience/cdk/formula/AdductFormula.java
@@ -21,6 +21,7 @@ package org.openscience.cdk.formula;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAdductFormula;
@@ -342,10 +343,10 @@ public class AdductFormula implements Iterable<IMolecularFormula>, IAdductFormul
      * @return             True, if both isotope are the same
      */
     private boolean isTheSame(IIsotope isotopeOne, IIsotope isotopeTwo) {
-
-        if (isotopeOne.getSymbol() != isotopeTwo.getSymbol()) return false;
-        if (isotopeOne.getNaturalAbundance() != isotopeTwo.getNaturalAbundance()) return false;
-        if (isotopeOne.getExactMass() != isotopeTwo.getExactMass()) return false;
+        // XXX: floating point comparision!
+        if (!Objects.equals(isotopeOne.getSymbol(), isotopeTwo.getSymbol())) return false;
+        if (!Objects.equals(isotopeOne.getNaturalAbundance(), isotopeTwo.getNaturalAbundance())) return false;
+        if (!Objects.equals(isotopeOne.getExactMass(), isotopeTwo.getExactMass())) return false;
 
         return true;
     }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
@@ -208,7 +208,7 @@ final class StereoMatch implements Predicate<int[]> {
         // bond is undirected so we need to ensure v1 is the first atom in the bond
         // we also need to to swap the substituents later
         boolean swap = false;
-        if (targetElement.getStereoBond().getBegin() != target.getAtom(v1)) {
+        if (!targetElement.getStereoBond().getBegin().equals(target.getAtom(v1))) {
             int tmp = v1;
             v1 = v2;
             v2 = tmp;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
@@ -636,7 +636,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     @Override
     public int indexOf(IBond bond) {
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i] == bond) return i;
+            if (bonds[i].equals(bond)) return i;
         }
         return -1;
     }
@@ -1439,7 +1439,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     @Override
     public boolean contains(IBond bond) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bond == bonds[i]) return true;
+            if (bonds[i].equals(bond)) return true;
         }
         return false;
     }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
@@ -628,7 +628,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     @Override
     public int indexOf(IAtom atom) {
         for (int i = 0; i < atomCount; i++) {
-            if (atoms[i] == atom) return i;
+            if (atoms[i].equals(atom)) return i;
         }
         return -1;
     }
@@ -684,7 +684,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     @Override
     public IBond getBond(IAtom atom1, IAtom atom2) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1) == atom2) {
+            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1).equals(atom2)) {
                 return bonds[i];
             }
         }
@@ -1425,7 +1425,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     @Override
     public boolean contains(IAtom atom) {
         for (int i = 0; i < getAtomCount(); i++) {
-            if (atom == atoms[i]) return true;
+            if (atoms[i].equals(atom)) return true;
         }
         return false;
     }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -230,9 +230,9 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
      */
     @Override
     public IAtom getOther(IAtom atom) {
-        if (atoms[0] == atom)
+        if (atoms[0].equals(atom))
             return atoms[1];
-        else if (atoms[1] == atom)
+        else if (atoms[1].equals(atom))
             return atoms[0];
         return null;
     }
@@ -242,11 +242,7 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
      */
     @Override
     public IAtom getConnectedAtom(IAtom atom) {
-        if (atoms[0] == atom)
-            return atoms[1];
-        else if (atoms[1] == atom)
-            return atoms[0];
-        return null;
+        return getOther(atom);
     }
 
     /**
@@ -258,7 +254,7 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
         IAtom[] connected = new IAtom[atomCount-1];
         int j = 0;
         for (int i = 0; i < atomCount; i++) {
-            if (this.atoms[i] != atom) {
+            if (!this.atoms[i].equals(atom)) {
                 if (j >= connected.length)
                     return null;
                 connected[j++] = this.atoms[i];
@@ -277,7 +273,7 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
     public boolean contains(IAtom atom) {
         if (atoms == null) return false;
         for (IAtom localAtom : atoms) {
-            if (localAtom == atom) return true;
+            if (localAtom.equals(atom)) return true;
         }
         return false;
     }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/SymbolChargeIDQueryAtom.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/SymbolChargeIDQueryAtom.java
@@ -21,6 +21,8 @@ package org.openscience.cdk.isomorphism.matchers;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 
+import java.util.Objects;
+
 /**
  * @cdk.module  isomorphism
  * @cdk.githash
@@ -43,8 +45,8 @@ public class SymbolChargeIDQueryAtom extends QueryAtom implements IQueryAtom {
 
     @Override
     public boolean matches(IAtom atom) {
-        return this.getSymbol().equals(atom.getSymbol()) && this.getFormalCharge() == atom.getFormalCharge()
-                && this.getID().equals(atom.getID());
+        return this.getSymbol().equals(atom.getSymbol()) && Objects.equals(this.getFormalCharge(), atom.getFormalCharge())
+               && this.getID().equals(atom.getID());
     };
 
     @Override

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AdductFormula.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AdductFormula.java
@@ -21,6 +21,7 @@ package org.openscience.cdk.silent;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.openscience.cdk.interfaces.IAdductFormula;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
@@ -338,9 +339,10 @@ public class AdductFormula implements Iterable<IMolecularFormula>, IAdductFormul
      */
     private boolean isTheSame(IIsotope isotopeOne, IIsotope isotopeTwo) {
 
-        if (isotopeOne.getSymbol() != isotopeTwo.getSymbol()) return false;
-        if (isotopeOne.getNaturalAbundance() != isotopeTwo.getNaturalAbundance()) return false;
-        if (isotopeOne.getExactMass() != isotopeTwo.getExactMass()) return false;
+        // XXX - floating point equality!
+        if (!Objects.equals(isotopeOne.getSymbol(), isotopeTwo.getSymbol())) return false;
+        if (!Objects.equals(isotopeOne.getNaturalAbundance(), isotopeTwo.getNaturalAbundance())) return false;
+        if (!Objects.equals(isotopeOne.getExactMass(), isotopeTwo.getExactMass())) return false;
 
         return true;
     }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -23,6 +23,7 @@
 package org.openscience.cdk.silent;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
@@ -411,9 +412,9 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         }
         Atom atom = (Atom) object;
         if (((point2d == atom.point2d) || ((point2d != null) && (point2d.equals(atom.point2d))))
-                && ((point3d == atom.point3d) || ((point3d != null) && (point3d.equals(atom.point3d))))
-                && (hydrogenCount == atom.hydrogenCount) && (stereoParity == atom.stereoParity)
-                && (charge == atom.charge)) {
+            && ((point3d == atom.point3d) || ((point3d != null) && (point3d.equals(atom.point3d))))
+            && (Objects.equals(hydrogenCount, atom.hydrogenCount)) && (Objects.equals(stereoParity, atom.stereoParity))
+            && (Objects.equals(charge, atom.charge))) {
             return true;
         }
         return false;

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
@@ -459,7 +459,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public int indexOf(IAtom atom) {
         for (int i = 0; i < atomCount; i++) {
-            if (atoms[i] == atom) return i;
+            if (atoms[i].equals(atom)) return i;
         }
         return -1;
     }
@@ -516,7 +516,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public IBond getBond(IAtom atom1, IAtom atom2) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1) == atom2) {
+            if (bonds[i].contains(atom1) && bonds[i].getOther(atom1).equals(atom2)) {
                 return bonds[i];
             }
         }
@@ -1141,7 +1141,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public boolean contains(IAtom atom) {
         for (int i = 0; i < getAtomCount(); i++) {
-            if (atom == atoms[i]) return true;
+            if (atoms[i].equals(atom)) return true;
         }
         return false;
     }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
@@ -470,7 +470,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public int indexOf(IBond bond) {
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i] == bond) return i;
+            if (bonds[i].equals(bond)) return i;
         }
         return -1;
     }
@@ -1152,7 +1152,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     @Override
     public boolean contains(IBond bond) {
         for (int i = 0; i < getBondCount(); i++) {
-            if (bond == bonds[i]) return true;
+            if (bonds[i].equals(bond)) return true;
         }
         return false;
     }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -249,9 +249,9 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      */
     @Override
     public IAtom getOther(IAtom atom) {
-        if (atoms[0] == atom)
+        if (atoms[0].equals(atom))
             return atoms[1];
-        else if (atoms[1] == atom)
+        else if (atoms[1].equals(atom))
             return atoms[0];
         return null;
     }
@@ -261,11 +261,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      */
     @Override
     public IAtom getConnectedAtom(IAtom atom) {
-        if (atoms[0] == atom)
-            return atoms[1];
-        else if (atoms[1] == atom)
-            return atoms[0];
-        return null;
+        return getOther(atom);
     }
 
     /**
@@ -277,7 +273,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
         IAtom[] connected = new IAtom[atomCount-1];
         int j = 0;
         for (int i = 0; i < atomCount; i++) {
-            if (this.atoms[i] != atom) {
+            if (!this.atoms[i].equals(atom)) {
                 if (j >= connected.length)
                     return null;
                 connected[j++] = this.atoms[i];
@@ -296,7 +292,7 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     public boolean contains(IAtom atom) {
         if (atoms == null) return false;
         for (IAtom localAtom : atoms) {
-            if (localAtom == atom) return true;
+            if (localAtom.equals(atom)) return true;
         }
         return false;
     }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/LonePair.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/LonePair.java
@@ -111,7 +111,7 @@ public class LonePair extends ElectronContainer implements Serializable, ILonePa
      */
     @Override
     public boolean contains(IAtom atom) {
-        return (this.atom == atom);
+        return this.atom.equals(atom);
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Ring.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Ring.java
@@ -116,7 +116,7 @@ public class Ring extends AtomContainer implements java.io.Serializable, IRing {
         IBond tempBond;
         for (int f = 0; f < getBondCount(); f++) {
             tempBond = getBond(f);
-            if (tempBond.contains(atom) && bond != tempBond) return tempBond;
+            if (tempBond.contains(atom) && !tempBond.equals(bond)) return tempBond;
         }
         return null;
     }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/SingleElectron.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SingleElectron.java
@@ -117,7 +117,7 @@ public class SingleElectron extends ElectronContainer implements Serializable, I
      */
     @Override
     public boolean contains(IAtom atom) {
-        return (this.atom == atom) ? true : false;
+        return this.atom.equals(atom);
     }
 
     /**

--- a/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
+++ b/base/standard/src/main/java/org/openscience/cdk/fingerprint/Fingerprinter.java
@@ -338,7 +338,7 @@ public class Fingerprinter extends AbstractFingerprinter implements IFingerprint
             throw new CDKException("Too many paths! Structure is likely a cage, reduce path length or increase path limit");
         if (state.apath.size() < state.maxDepth) {
             for (IBond bond : state.getBonds(beg)) {
-                if (bond == prev)
+                if (bond.equals(prev))
                     continue;
                 final IAtom nbr = bond.getOther(beg);
                 if (state.visit(nbr)) {

--- a/base/standard/src/main/java/org/openscience/cdk/geometry/BondTools.java
+++ b/base/standard/src/main/java/org/openscience/cdk/geometry/BondTools.java
@@ -62,7 +62,7 @@ public class BondTools {
         List<IAtom> connectedAtoms = container.getConnectedAtomsList(bond.getBegin());
         IAtom from = null;
         for (IAtom connectedAtom : connectedAtoms) {
-            if (connectedAtom != bond.getEnd()) {
+            if (!connectedAtom.equals(bond.getEnd())) {
                 from = connectedAtom;
             }
         }
@@ -132,7 +132,7 @@ public class BondTools {
      */
     public static boolean closeEnoughToBond(IAtom atom1, IAtom atom2, double distanceFudgeFactor) {
 
-        if (atom1 != atom2) {
+        if (!atom1.equals(atom2)) {
             double distanceBetweenAtoms = atom1.getPoint3d().distance(atom2.getPoint3d());
             double bondingDistance = atom1.getCovalentRadius() + atom2.getCovalentRadius();
             if (distanceBetweenAtoms <= (distanceFudgeFactor * bondingDistance)) {
@@ -223,9 +223,9 @@ public class BondTools {
                 IAtom one = null;
                 IAtom two = null;
                 for (IAtom conAtom : atoms) {
-                    if (conAtom != parent && one == null) {
+                    if (!conAtom.equals(parent) && one == null) {
                         one = conAtom;
-                    } else if (conAtom != parent && one != null) {
+                    } else if (!conAtom.equals(parent) && one != null) {
                         two = conAtom;
                     }
                 }
@@ -273,14 +273,14 @@ public class BondTools {
         boolean doubleBond = false;
         IAtom nextAtom = null;
         for (IAtom atom : atoms) {
-            if (atom != parent && container.getBond(atom, a).getOrder() == Order.DOUBLE
+            if (!atom.equals(parent) && container.getBond(atom, a).getOrder() == Order.DOUBLE
                     && isEndOfDoubleBond(container, atom, a, doubleBondConfiguration)) {
                 doubleBond = true;
                 nextAtom = atom;
             }
-            if (atom != nextAtom && one == null) {
+            if (!atom.equals(nextAtom) && one == null) {
                 one = atom;
-            } else if (atom != nextAtom && one != null) {
+            } else if (!atom.equals(nextAtom) && one != null) {
                 two = atom;
             }
         }

--- a/base/standard/src/main/java/org/openscience/cdk/geometry/GeometryUtil.java
+++ b/base/standard/src/main/java/org/openscience/cdk/geometry/GeometryUtil.java
@@ -714,7 +714,7 @@ public final class GeometryUtil {
         Point2d atomPosition = atom.getPoint2d();
         for (int i = 0; i < atomCon.getAtomCount(); i++) {
             IAtom currentAtom = atomCon.getAtom(i);
-            if (currentAtom != atom) {
+            if (!currentAtom.equals(atom)) {
                 double d = atomPosition.distance(currentAtom.getPoint2d());
                 if (d < min) {
                     min = d;
@@ -747,7 +747,7 @@ public final class GeometryUtil {
         double atomY;
         for (int i = 0; i < atomCon.getAtomCount(); i++) {
             currentAtom = atomCon.getAtom(i);
-            if (currentAtom != toignore) {
+            if (!currentAtom.equals(toignore)) {
                 atomX = currentAtom.getPoint2d().x;
                 atomY = currentAtom.getPoint2d().y;
                 mouseSquaredDistance = Math.pow(atomX - xPosition, 2) + Math.pow(atomY - yPosition, 2);
@@ -1222,7 +1222,7 @@ public final class GeometryUtil {
         }
         Map<Double, IAtom> atomsByDistance = new TreeMap<Double, IAtom>();
         for (IAtom atom : container.atoms()) {
-            if (atom != startAtom) {
+            if (!atom.equals(startAtom)) {
                 if (atom.getPoint3d() == null) {
                     throw new CDKException("No point3d, but findClosestInSpace is working on point3ds");
                 }

--- a/base/standard/src/main/java/org/openscience/cdk/geometry/GeometryUtil.java
+++ b/base/standard/src/main/java/org/openscience/cdk/geometry/GeometryUtil.java
@@ -1303,6 +1303,7 @@ public final class GeometryUtil {
             int posSecondAtom) {
         IAtom firstAtom = firstAC.getAtom(posFirstAtom);
         IAtom secondAtom = secondAC.getAtom(posSecondAtom);
+        // XXX: floating point comparision!
         return firstAtom.getSymbol().equals(secondAtom.getSymbol())
                 && firstAC.getConnectedAtomsList(firstAtom).size() == secondAC.getConnectedAtomsList(secondAtom).size()
                 && firstAtom.getBondOrderSum().equals(secondAtom.getBondOrderSum())

--- a/base/standard/src/main/java/org/openscience/cdk/graph/rebond/RebondTool.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/rebond/RebondTool.java
@@ -99,7 +99,7 @@ public class RebondTool {
         Point tupleAtom = new Point(atom.getPoint3d().x, atom.getPoint3d().y, atom.getPoint3d().z);
         for (Bspt.EnumerateSphere e = bspt.enumHemiSphere(tupleAtom, searchRadius); e.hasMoreElements();) {
             IAtom atomNear = ((TupleAtom) e.nextElement()).getAtom();
-            if (atomNear != atom && container.getBond(atom, atomNear) == null) {
+            if (!atomNear.equals(atom) && container.getBond(atom, atomNear) == null) {
                 boolean bonded = isBonded(myCovalentRadius, atomNear.getCovalentRadius(), e.foundDistance2());
                 if (bonded) {
                     IBond bond = atom.getBuilder().newInstance(IBond.class, atom, atomNear, IBond.Order.SINGLE);

--- a/base/standard/src/main/java/org/openscience/cdk/isomorphism/AtomMappingTools.java
+++ b/base/standard/src/main/java/org/openscience/cdk/isomorphism/AtomMappingTools.java
@@ -24,6 +24,7 @@ package org.openscience.cdk.isomorphism;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
@@ -88,10 +89,11 @@ public class AtomMappingTools {
             int posSecondAtom) {
         IAtom firstAtom = firstAC.getAtom(posFirstAtom);
         IAtom secondAtom = secondAC.getAtom(posSecondAtom);
+        // XXX: floating point comparision!
         if (firstAtom.getSymbol().equals(secondAtom.getSymbol())
-                && firstAC.getConnectedAtomsList(firstAtom).size() == secondAC.getConnectedAtomsList(secondAtom).size()
-                && firstAtom.getBondOrderSum() == secondAtom.getBondOrderSum()
-                && firstAtom.getMaxBondOrder() == secondAtom.getMaxBondOrder()) {
+            && firstAC.getConnectedAtomsList(firstAtom).size() == secondAC.getConnectedAtomsList(secondAtom).size()
+            && Objects.equals(firstAtom.getBondOrderSum(), secondAtom.getBondOrderSum())
+            && firstAtom.getMaxBondOrder() == secondAtom.getMaxBondOrder()) {
             return true;
         } else {
             return false;

--- a/base/standard/src/main/java/org/openscience/cdk/isomorphism/IsomorphismTester.java
+++ b/base/standard/src/main/java/org/openscience/cdk/isomorphism/IsomorphismTester.java
@@ -25,6 +25,7 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * A too simplistic implementation of an isomorphism test for chemical graphs.
@@ -105,7 +106,7 @@ public class IsomorphismTester implements java.io.Serializable {
                     atom1 = base.getAtom(f);
                     atom2 = compare.getAtom(g);
                     if (!(atom1.getSymbol().equals(atom2.getSymbol()))
-                            && atom1.getImplicitHydrogenCount() == atom2.getImplicitHydrogenCount()) {
+                        && Objects.equals(atom1.getImplicitHydrogenCount(), atom2.getImplicitHydrogenCount())) {
                         return false;
                     }
                     found = true;

--- a/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
+++ b/base/standard/src/main/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTester.java
@@ -686,7 +686,7 @@ public class UniversalIsomorphismTester {
             for (int j = 0; j < 2; j++) {
                 List<IBond> bondsConnectedToAtom1j = g1.getConnectedBondsList(atom1[j]);
                 for (int k = 0; k < bondsConnectedToAtom1j.size(); k++) {
-                    if (bondsConnectedToAtom1j.get(k) != bond1) {
+                    if (!bondsConnectedToAtom1j.get(k).equals(bond1)) {
                         IBond testBond = (IBond) bondsConnectedToAtom1j.get(k);
                         for (int m = 0; m < l.size(); m++) {
                             IBond testBond2;

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/FischerRecognition.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/FischerRecognition.java
@@ -162,9 +162,9 @@ final class FischerRecognition {
             IAtom east = element.getLigands()[EAST];
             IAtom west = element.getLigands()[WEST];
             
-            if (east != focus && !isTerminal(east, atomToIndex))
+            if (!east.equals(focus) && !isTerminal(east, atomToIndex))
                 continue;
-            if (west != focus && !isTerminal(west, atomToIndex))
+            if (!west.equals(focus) && !isTerminal(west, atomToIndex))
                 continue;
             
             elements.add(element);

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
@@ -665,13 +665,13 @@ public abstract class StereoElementFactory {
         private int elevationOf(IAtom focus, IBond bond) {
             switch (bond.getStereo()) {
                 case UP:
-                    return bond.getBegin() == focus ? +1 : 0;
+                    return bond.getBegin().equals(focus) ? +1 : 0;
                 case UP_INVERTED:
-                    return bond.getEnd() == focus ? +1 : 0;
+                    return bond.getEnd().equals(focus) ? +1 : 0;
                 case DOWN:
-                    return bond.getBegin() == focus ? -1 : 0;
+                    return bond.getBegin().equals(focus) ? -1 : 0;
                 case DOWN_INVERTED:
-                    return bond.getEnd() == focus ? -1 : 0;
+                    return bond.getEnd().equals(focus) ? -1 : 0;
             }
             return 0;
         }

--- a/base/standard/src/main/java/org/openscience/cdk/tools/HOSECodeGenerator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/HOSECodeGenerator.java
@@ -394,7 +394,7 @@ public class HOSECodeGenerator implements java.io.Serializable {
                 } else {
                     for (int j = 0; j < conAtoms.size(); j++) {
                         toNode = conAtoms.get(j);
-                        if (toNode != treeNode.source.atom) {
+                        if (!toNode.equals(treeNode.source.atom)) {
                             bond = atomContainer.getBond(node, toNode);
                             if (bond.getFlag(CDKConstants.ISAROMATIC)) {
                                 nextSphereNodes.add(new TreeNode(toNode.getSymbol(), treeNode, toNode, 4, atomContainer
@@ -504,12 +504,12 @@ public class HOSECodeGenerator implements java.io.Serializable {
         for (int i = 0; i < sphereNodes.size(); i++) {
             treeNode = sphereNodes.get(i);
             tempCode = new StringBuffer();
-            if (!treeNode.source.stopper && treeNode.source.atom != branch) {
+            if (!treeNode.source.stopper && !treeNode.source.atom.equals(branch)) {
                 branch = treeNode.source.atom;
                 code.append(',');
             }
 
-            if (!treeNode.source.stopper && treeNode.source.atom == branch) {
+            if (!treeNode.source.stopper && treeNode.source.atom.equals(branch)) {
                 if (treeNode.bondType <= 4) {
                     tempCode.append(bondSymbols[(int) treeNode.bondType]);
                 } else {
@@ -729,7 +729,7 @@ public class HOSECodeGenerator implements java.io.Serializable {
         @Override
         public boolean equals(Object o) {
             try {
-                if (this.atom == ((TreeNode) o).atom) {
+                if (this.atom.equals(((TreeNode) o).atom)) {
                     return true;
                 }
             } catch (Exception exc) {

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -156,7 +156,7 @@ public class AtomContainerManipulator {
                     updated = true;
                     Sgroup cpy = new Sgroup();
                     for (IAtom atom : org.getAtoms()) {
-                        if (oldAtom.equals(atom))
+                        if (!oldAtom.equals(atom))
                             cpy.addAtom(atom);
                         else
                             cpy.addAtom(newAtom);
@@ -534,7 +534,7 @@ public class AtomContainerManipulator {
                             if (bondStereo != null && bondStereo != IBond.Stereo.NONE) addToRemove = false;
                             IAtom neighboursNeighbour = bond.getOther(neighbour);
                             // remove in any case if the hetero atom is connected to more than one hydrogen
-                            if (neighboursNeighbour.getSymbol().equals("H") && neighboursNeighbour != atom) {
+                            if (neighboursNeighbour.getSymbol().equals("H") && !neighboursNeighbour.equals(atom)) {
                                 addToRemove = true;
                                 break;
                             }

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/RingSetManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/RingSetManipulator.java
@@ -249,7 +249,7 @@ public class RingSetManipulator {
             if (ring.getBondCount() == newRing.getBondCount()) {
                 for (IBond newBond : newRing.bonds()) {
                     for (IBond bond : ring.bonds()) {
-                        if (newBond == bond) {
+                        if (newBond.equals(bond)) {
                             equals = true;
                             equalCount++;
                             break;

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/RingSetManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/RingSetManipulator.java
@@ -182,7 +182,7 @@ public class RingSetManipulator {
                     if (ring1 != ring2) {
                         for (int l = 0; l < ring2.getAtomCount(); l++) {
                             atom2 = ring2.getAtom(l);
-                            if (atom1 == atom2) {
+                            if (atom1.equals(atom2)) {
                                 neighbors[i]++;
                                 neighbors[k]++;
                                 break;

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/CIPTool.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/CIPTool.java
@@ -179,8 +179,8 @@ public class CIPTool {
         if (leftLigands.length > 2 || rightLigands.length > 2) return CIP_CHIRALITY.NONE;
 
         // invert if x/y aren't in the first position
-        if (leftLigands[0].getLigandAtom() != x) conformation = conformation.invert();
-        if (rightLigands[0].getLigandAtom() != y) conformation = conformation.invert();
+        if (!leftLigands[0].getLigandAtom().equals(x)) conformation = conformation.invert();
+        if (!rightLigands[0].getLigandAtom().equals(y)) conformation = conformation.invert();
 
         int p = permParity(leftLigands) * permParity(rightLigands);
 
@@ -211,7 +211,7 @@ public class CIPTool {
 
         int i = 0;
         for (IAtom neighbor : neighbors) {
-            if (neighbor != exclude) ligands[i++] = new Ligand(container, new VisitedAtoms(), atom, neighbor);
+            if (!neighbor.equals(exclude)) ligands[i++] = new Ligand(container, new VisitedAtoms(), atom, neighbor);
         }
 
         return ligands;

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/LigancyFourChirality.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/LigancyFourChirality.java
@@ -28,6 +28,8 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.interfaces.ITetrahedralChirality.Stereo;
 
+import java.util.Objects;
+
 /**
  * Stereochemistry specification for quadrivalent atoms to be used for the CIP algorithm only.
  *
@@ -76,7 +78,7 @@ class LigancyFourChirality {
         VisitedAtoms visitedAtoms = new VisitedAtoms();
         for (int i = 0; i < ligandAtoms.length; i++) {
             // ITetrahedralChirality stores a impl hydrogen as the central atom
-            if (ligandAtoms[i] == chiralAtom) {
+            if (ligandAtoms[i].equals(chiralAtom)) {
                 this.ligands[i] = new ImplicitHydrogenLigand(container, visitedAtoms, chiralAtom);
             } else {
                 this.ligands[i] = new Ligand(container, visitedAtoms, chiralAtom, ligandAtoms[i]);
@@ -126,11 +128,11 @@ class LigancyFourChirality {
 
         // now move atoms around to match the newOrder
         for (int i = 0; i < 3; i++) {
-            if (newAtoms[i].getLigandAtom() != newOrder[i].getLigandAtom()) {
+            if (!newAtoms[i].getLigandAtom().equals(newOrder[i].getLigandAtom())) {
                 // OK, not in the right position
                 // find the incorrect, old position
                 for (int j = i; j < 4; j++) {
-                    if (newAtoms[j].getLigandAtom() == newOrder[i].getLigandAtom()) {
+                    if (newAtoms[j].getLigandAtom().equals(newOrder[i].getLigandAtom())) {
                         // found the incorrect position
                         swap(newAtoms, i, j);
                         // and swap the stereochemistry

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -898,7 +898,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
                 IBond.Stereo stereo = bond.getStereo();
                 xp[n] = (float) (o2d.x - x0);
                 yp[n] = (float) (o2d.y - y0);
-                zp[n] = other == bond.getBegin() ? 0 : stereo == IBond.Stereo.UP ? 1 : stereo == IBond.Stereo.DOWN ? -1
+                zp[n] = other.equals(bond.getBegin()) ? 0 : stereo == IBond.Stereo.UP ? 1 : stereo == IBond.Stereo.DOWN ? -1
                                                                                                                    : 0;
             } else {
                 return null; // no 2D coordinates on some atom

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
@@ -1287,7 +1287,7 @@ public class XLogPDescriptor extends AbstractMolecularDescriptor implements IMol
             bonds = ac.getConnectedBondsList(neighbour);
             for (int j = 0; j < bonds.size(); j++) {
                 IBond bond = (IBond) bonds.get(j);
-                if (bond.getOrder() != IBond.Order.SINGLE && bond.getOther(neighbour) != atom
+                if (bond.getOrder() != IBond.Order.SINGLE && !bond.getOther(neighbour).equals(atom)
                         && !neighbour.getSymbol().equals("P") && !neighbour.getSymbol().equals("S")) {
                     picounter += 1;
                 }/*

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -710,13 +710,13 @@ final class StandardBondGenerator {
         if (bond.getStereo() == null) return false;
         switch (bond.getStereo()) {
             case UP:
-                return bond.getEnd() == atom;
+                return bond.getEnd().equals(atom);
             case UP_INVERTED:
-                return bond.getBegin() == atom;
+                return bond.getBegin().equals(atom);
             case DOWN:
-                return bond.getEnd() == atom;
+                return bond.getEnd().equals(atom);
             case DOWN_INVERTED:
-                return bond.getBegin() == atom;
+                return bond.getBegin().equals(atom);
             default:
                 return false;
         }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
@@ -113,7 +113,7 @@ final class StandardSgroupGenerator {
             if (sgroup.getType() == SgroupType.CtabAbbreviation) {
                 Boolean expansion = sgroup.getValue(SgroupKey.CtabExpansion);
                 // abbreviation is displayed as expanded
-                if (expansion != null && expansion == Boolean.TRUE)
+                if (expansion != null && expansion)
                     continue;
                 // no or empty label, skip it
                 if (sgroup.getSubscript() == null || sgroup.getSubscript().isEmpty())

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
@@ -243,10 +243,10 @@ final class StandardSgroupGenerator {
                 IAtom beg = bond.getBegin();
                 IAtom end = bond.getEnd();
                 if (atoms.contains(beg)) {
-                    if (internal != null && internal != beg) return; // can't do it
+                    if (internal != null && !internal.equals(beg)) return; // can't do it
                     internal = beg;
                 } else if (atoms.contains(end)) {
-                    if (internal != null && internal != end) return; // can't do it
+                    if (internal != null && !internal.equals(end)) return; // can't do it
                     internal = end;
                 }
             }

--- a/display/renderextra/src/main/java/org/openscience/cdk/renderer/generators/AtomMassGenerator.java
+++ b/display/renderextra/src/main/java/org/openscience/cdk/renderer/generators/AtomMassGenerator.java
@@ -53,7 +53,7 @@ public class AtomMassGenerator extends BasicAtomGenerator {
         if (massNumber != null) {
             try {
                 Integer expectedMassNumber = Isotopes.getInstance().getMajorIsotope(atom.getSymbol()).getMassNumber();
-                if (massNumber != expectedMassNumber) return true;
+                if (!massNumber.equals(expectedMassNumber)) return true;
             } catch (IOException e) {
                 logger.warn(e);
             }

--- a/legacy/src/main/java/org/openscience/cdk/geometry/GeometryTools.java
+++ b/legacy/src/main/java/org/openscience/cdk/geometry/GeometryTools.java
@@ -707,7 +707,7 @@ public class GeometryTools {
         Point2d atomPosition = atom.getPoint2d();
         for (int i = 0; i < atomCon.getAtomCount(); i++) {
             IAtom currentAtom = atomCon.getAtom(i);
-            if (currentAtom != atom) {
+            if (!currentAtom.equals(atom)) {
                 double d = atomPosition.distance(currentAtom.getPoint2d());
                 if (d < min) {
                     min = d;
@@ -740,7 +740,7 @@ public class GeometryTools {
         double atomY;
         for (int i = 0; i < atomCon.getAtomCount(); i++) {
             currentAtom = atomCon.getAtom(i);
-            if (currentAtom != toignore) {
+            if (!currentAtom.equals(toignore)) {
                 atomX = currentAtom.getPoint2d().x;
                 atomY = currentAtom.getPoint2d().y;
                 mouseSquaredDistance = Math.pow(atomX - xPosition, 2) + Math.pow(atomY - yPosition, 2);
@@ -1250,7 +1250,7 @@ public class GeometryTools {
         }
         Map<Double, IAtom> atomsByDistance = new TreeMap<Double, IAtom>();
         for (IAtom atom : container.atoms()) {
-            if (atom != startAtom) {
+            if (!atom.equals(startAtom)) {
                 if (atom.getPoint3d() == null) {
                     throw new CDKException("No point3d, but findClosestInSpace is working on point3ds");
                 }

--- a/legacy/src/main/java/org/openscience/cdk/geometry/GeometryTools.java
+++ b/legacy/src/main/java/org/openscience/cdk/geometry/GeometryTools.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -1356,9 +1357,9 @@ public class GeometryTools {
         IAtom firstAtom = firstAC.getAtom(posFirstAtom);
         IAtom secondAtom = secondAC.getAtom(posSecondAtom);
         if (firstAtom.getSymbol().equals(secondAtom.getSymbol())
-                && firstAC.getConnectedAtomsList(firstAtom).size() == secondAC.getConnectedAtomsList(secondAtom).size()
-                && firstAtom.getBondOrderSum() == secondAtom.getBondOrderSum()
-                && firstAtom.getMaxBondOrder() == secondAtom.getMaxBondOrder()) {
+            && firstAC.getConnectedAtomsList(firstAtom).size() == secondAC.getConnectedAtomsList(secondAtom).size()
+            && Objects.equals(firstAtom.getBondOrderSum(), secondAtom.getBondOrderSum())
+            && firstAtom.getMaxBondOrder() == secondAtom.getMaxBondOrder()) {
             return true;
         } else {
             return false;

--- a/legacy/src/main/java/org/openscience/cdk/normalize/SMSDNormalizer.java
+++ b/legacy/src/main/java/org/openscience/cdk/normalize/SMSDNormalizer.java
@@ -357,14 +357,14 @@ public class SMSDNormalizer extends AtomContainerManipulator {
             bonds[index] = new Bond();
             int indexI = 999;
             for (int i = 0; i < container.getAtomCount(); i++) {
-                if (container.getBond(index).getBegin() == container.getAtom(i)) {
+                if (container.getBond(index).getBegin().equals(container.getAtom(i))) {
                     indexI = i;
                     break;
                 }
             }
             int indexJ = 999;
             for (int j = 0; j < container.getAtomCount(); j++) {
-                if (container.getBond(index).getEnd() == container.getAtom(j)) {
+                if (container.getBond(index).getEnd().equals(container.getAtom(j))) {
                     indexJ = j;
                     break;
                 }

--- a/legacy/src/main/java/org/openscience/cdk/ringsearch/FiguerasSSSRFinder.java
+++ b/legacy/src/main/java/org/openscience/cdk/ringsearch/FiguerasSSSRFinder.java
@@ -218,7 +218,7 @@ public class FiguerasSSSRFinder {
             mAtoms = molecule.getConnectedAtomsList(node);
             for (int f = 0; f < mAtoms.size(); f++) {
                 mAtom = (IAtom) mAtoms.get(f);
-                if (mAtom != ((List) node.getProperty(PATH)).get(((List<IAtom>) node.getProperty(PATH)).size() - 2)) {
+                if (!mAtom.equals(((List) node.getProperty(PATH)).get(((List<IAtom>) node.getProperty(PATH)).size() - 2))) {
                     if (((List) mAtom.getProperty(PATH)).size() > 0) {
                         intersection = getIntersection((List) node.getProperty(PATH), (List) mAtom.getProperty(PATH));
                         if (intersection.size() == 1) {

--- a/legacy/src/main/java/org/openscience/cdk/smiles/FixBondOrdersTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/FixBondOrdersTool.java
@@ -26,6 +26,7 @@ package org.openscience.cdk.smiles;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
@@ -195,10 +196,10 @@ public class FixBondOrdersTool {
             Matrix M = new Matrix(atomNos.size(), bondNos.size());
             for (int x = 0; x < M.getRows(); x++) {
                 for (int y = 0; y < M.getCols(); y++) {
-                    if (atomNos.get(x) == atomNoPairs.get(y)[0]) {
+                    if (Objects.equals(atomNos.get(x), atomNoPairs.get(y)[0])) {
                         M.set(x, y, 1);
                     } else {
-                        if (atomNos.get(x) == atomNoPairs.get(y)[1]) {
+                        if (Objects.equals(atomNos.get(x), atomNoPairs.get(y)[1])) {
                             M.set(x, y, 1);
                         } else {
                             M.set(x, y, 0);
@@ -298,7 +299,7 @@ public class FixBondOrdersTool {
                     for (int l = 0; l < rBondsArray.get(k).length; l++) { //for each ring in each ring
 
                         //Is there a bond in common? Then add both rings
-                        if (rBondsArray.get(i)[j] == rBondsArray.get(k)[l]) {
+                        if (Objects.equals(rBondsArray.get(i)[j], rBondsArray.get(k)[l])) {
                             if (i != k) {
                                 ringGroups.add(new ArrayList<Integer>());
                                 ringGroups.get(ringGroups.size() - 1).add(i);

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/TargetProcessor.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/mcgregor/TargetProcessor.java
@@ -24,6 +24,8 @@
 package org.openscience.cdk.smsd.algorithm.mcgregor;
 
 import java.util.List;
+import java.util.Objects;
+
 import org.openscience.cdk.interfaces.IAtomContainer;
 
 /**
@@ -99,7 +101,7 @@ public class TargetProcessor {
                     normalBond = unMappedAtomsEqualsIndexI(target, mappingSize, atomIndex, counter, mappedAtoms,
                             indexI, indexJ, order);
                     bondConsidered = true;
-                } else if (unmappedAtomsMolB.get(b) == indexJ) {
+                } else if (Objects.equals(unmappedAtomsMolB.get(b), indexJ)) {
                     normalBond = unMappedAtomsEqualsIndexJ(target, mappingSize, atomIndex, counter, mappedAtoms,
                             indexI, indexJ, order);
                     bondConsidered = true;

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCS.java
@@ -728,7 +728,7 @@ public class CDKMCS {
             for (int j = 0; j < 2; j++) {
                 List<IBond> bondsConnectedToAtom1j = sourceGraph.getConnectedBondsList(atom1[j]);
                 for (int k = 0; k < bondsConnectedToAtom1j.size(); k++) {
-                    if (bondsConnectedToAtom1j.get(k) != bond1) {
+                    if (!bondsConnectedToAtom1j.get(k).equals(bond1)) {
                         IBond testBond = bondsConnectedToAtom1j.get(k);
                         for (int m = 0; m < list.size(); m++) {
                             IBond testBond2;

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
@@ -350,7 +350,7 @@ public class CDKRMapHandler {
                 for (int j = 0; j < 2; j++) {
                     List<IBond> bondsConnectedToAtom1j = graph1.getConnectedBondsList(qAtoms[j]);
                     for (int k = 0; k < bondsConnectedToAtom1j.size(); k++) {
-                        if (bondsConnectedToAtom1j.get(k) != qBond) {
+                        if (!bondsConnectedToAtom1j.get(k).equals(qBond)) {
                             IBond testBond = bondsConnectedToAtom1j.get(k);
                             for (int m = 0; m < rMapList.size(); m++) {
                                 IBond testBond2;

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/single/SingleMapping.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/single/SingleMapping.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
@@ -133,7 +134,7 @@ public class SingleMapping {
                             Order order = bond.getOrder();
                             totalOrder += order.numeric() + be.getEnergies(bond);
                         }
-                        if (targetAtom.getFormalCharge() != sourceAtom.getFormalCharge()) {
+                        if (!Objects.equals(targetAtom.getFormalCharge(), sourceAtom.getFormalCharge())) {
                             totalOrder += 0.5;
                         }
                         connectedBondOrder.put(counter, totalOrder);
@@ -162,7 +163,7 @@ public class SingleMapping {
                             Order order = bond.getOrder();
                             totalOrder += order.numeric() + be.getEnergies(bond);
                         }
-                        if (targetAtom.getFormalCharge() != sourceAtom.getFormalCharge()) {
+                        if (!Objects.equals(targetAtom.getFormalCharge(), sourceAtom.getFormalCharge())) {
                             totalOrder += 0.5;
                         }
                         connectedBondOrder.put(counter, totalOrder);
@@ -192,7 +193,7 @@ public class SingleMapping {
                             Order order = bond.getOrder();
                             totalOrder += order.numeric() + be.getEnergies(bond);
                         }
-                        if (sourceAtoms.getFormalCharge() != targetAtom.getFormalCharge()) {
+                        if (!Objects.equals(sourceAtoms.getFormalCharge(), targetAtom.getFormalCharge())) {
                             totalOrder += 0.5;
                         }
                         connectedBondOrder.put(counter, totalOrder);

--- a/legacy/src/main/java/org/openscience/cdk/smsd/filters/ChemicalFilters.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/filters/ChemicalFilters.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -603,33 +604,33 @@ public class ChemicalFilters {
             IAtom patom2 = pBond.getEnd();
 
             if (ratom1.getSymbol().equals(patom1.getSymbol()) && ratom1.getSymbol().equals(patom1.getSymbol())) {
-                if ((ratom1.getFormalCharge() != patom1.getFormalCharge())
-                        || ratom2.getFormalCharge() != patom2.getFormalCharge()) {
+                if ((!Objects.equals(ratom1.getFormalCharge(), patom1.getFormalCharge()))
+                    || !Objects.equals(ratom2.getFormalCharge(), patom2.getFormalCharge())) {
                     if (convertBondOrder(rBond) != convertBondOrder(pBond)) {
                         score += 5 * Math.abs(convertBondOrder(rBond) + convertBondOrder(pBond));
                     }
                 }
-                if (ratom1.getFormalCharge() == patom1.getFormalCharge()
-                        && (convertBondOrder(rBond) - convertBondOrder(pBond)) == 0) {
+                if (Objects.equals(ratom1.getFormalCharge(), patom1.getFormalCharge())
+                    && (convertBondOrder(rBond) - convertBondOrder(pBond)) == 0) {
                     score += 100;
                 }
-                if (ratom2.getFormalCharge() == patom2.getFormalCharge()
-                        && (convertBondOrder(rBond) - convertBondOrder(pBond)) == 0) {
+                if (Objects.equals(ratom2.getFormalCharge(), patom2.getFormalCharge())
+                    && (convertBondOrder(rBond) - convertBondOrder(pBond)) == 0) {
                     score += 100;
                 }
             } else if (ratom1.getSymbol().equals(patom2.getSymbol()) && ratom2.getSymbol().equals(patom1.getSymbol())) {
-                if ((ratom1.getFormalCharge() != patom2.getFormalCharge())
-                        || ratom2.getFormalCharge() != patom1.getFormalCharge()) {
+                if ((!Objects.equals(ratom1.getFormalCharge(), patom2.getFormalCharge()))
+                    || !Objects.equals(ratom2.getFormalCharge(), patom1.getFormalCharge())) {
                     if (convertBondOrder(rBond) != convertBondOrder(pBond)) {
                         score += 5 * Math.abs(convertBondOrder(rBond) + convertBondOrder(pBond));
                     }
                 }
-                if (ratom1.getFormalCharge() == patom2.getFormalCharge()
-                        && (convertBondOrder(rBond) - convertBondOrder(pBond)) == 0) {
+                if (Objects.equals(ratom1.getFormalCharge(), patom2.getFormalCharge())
+                    && (convertBondOrder(rBond) - convertBondOrder(pBond)) == 0) {
                     score += 100;
                 }
-                if (ratom2.getFormalCharge() == patom1.getFormalCharge()
-                        && (convertBondOrder(rBond) - convertBondOrder(pBond)) == 0) {
+                if (Objects.equals(ratom2.getFormalCharge(), patom1.getFormalCharge())
+                    && (convertBondOrder(rBond) - convertBondOrder(pBond)) == 0) {
                     score += 100;
                 }
             }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/ring/PathEdge.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/ring/PathEdge.java
@@ -92,11 +92,11 @@ public class PathEdge {
         IAtom intersection = getIntersection(other.atoms);
         List<IAtom> newAtoms = new ArrayList<IAtom>(atoms);
 
-        if (atoms.get(0) == intersection) {
+        if (atoms.get(0).equals(intersection)) {
             Collections.reverse(newAtoms);
         }
 
-        if (other.atoms.get(0) == intersection) {
+        if (other.atoms.get(0).equals(intersection)) {
             for (int i = 1; i < other.atoms.size(); i++) {
                 newAtoms.add(other.atoms.get(i));
             }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/ring/PathGraph.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/ring/PathGraph.java
@@ -142,7 +142,7 @@ public class PathGraph {
                     result.add(edge);
                 }
             } else {
-                if ((edge.getSource() == atom) || (edge.getTarget() == atom)) {
+                if ((edge.getSource().equals(atom)) || (edge.getTarget().equals(atom))) {
                     result.add(edge);
                 }
             }

--- a/legacy/src/main/java/org/openscience/cdk/smsd/tools/ExtAtomContainerManipulator.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/tools/ExtAtomContainerManipulator.java
@@ -356,14 +356,14 @@ public class ExtAtomContainerManipulator extends AtomContainerManipulator {
             bonds[index] = new Bond();
             int indexI = 999;
             for (int i = 0; i < container.getAtomCount(); i++) {
-                if (container.getBond(index).getBegin() == container.getAtom(i)) {
+                if (container.getBond(index).getBegin().equals(container.getAtom(i))) {
                     indexI = i;
                     break;
                 }
             }
             int indexJ = 999;
             for (int j = 0; j < container.getAtomCount(); j++) {
-                if (container.getBond(index).getEnd() == container.getAtom(j)) {
+                if (container.getBond(index).getEnd().equals(container.getAtom(j))) {
                     indexJ = j;
                     break;
                 }

--- a/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
@@ -106,7 +106,7 @@ public class DeAromatizationTool {
                 int count = 0;
                 while (done != 2) {
                     bond = getNextBond(atom, bond, ring);
-                    if (bond.getBegin() == atom)
+                    if (bond.getBegin().equals(atom))
                         atom = bond.getEnd();
                     else
                         atom = bond.getBegin();

--- a/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/tools/DeAromatizationTool.java
@@ -125,7 +125,7 @@ public class DeAromatizationTool {
     private static IBond getNextBond(IAtom atom, IBond bond, IRing ring) {
         List<IBond> bonds = ring.getConnectedBondsList(atom);
         for (int i = 0; i < bonds.size(); i++)
-            if (bonds.get(i) != bond) return (IBond) bonds.get(i);
+            if (!bonds.get(i).equals(bond)) return (IBond) bonds.get(i);
         return null;
     }
 
@@ -556,7 +556,7 @@ public class DeAromatizationTool {
             List<IBond> bonds = ring.getConnectedBondsList(curAtom);
             for (IBond bond : bonds)
             {
-                if (bond!=curBond)
+                if (!bond.equals(curBond))
                 {
                     curBond = bond;
                     break;

--- a/misc/diff/src/main/java/org/openscience/cdk/tools/diff/tree/BooleanDifference.java
+++ b/misc/diff/src/main/java/org/openscience/cdk/tools/diff/tree/BooleanDifference.java
@@ -18,6 +18,8 @@
  */
 package org.openscience.cdk.tools.diff.tree;
 
+import java.util.Objects;
+
 /**
  * {@link IDifference} between two {@link Boolean}s.
  *
@@ -46,7 +48,7 @@ public class BooleanDifference implements IDifference {
      * @return       an {@link IDifference} reflecting the differences between the first and second object
      */
     public static IDifference construct(String name, Boolean first, Boolean second) {
-        if (first == second) {
+        if (Objects.equals(first, second)) {
             return null;
         }
         return new BooleanDifference(name, first, second);
@@ -59,7 +61,7 @@ public class BooleanDifference implements IDifference {
      */
     @Override
     public String toString() {
-        return name + ":" + (first == null ? "NA" : (first == true ? "T" : "F")) + "/"
-                + (second == null ? "NA" : (second == true ? "T" : "F"));
+        return name + ":" + (first == null ? "NA" : (first ? "T" : "F")) + "/"
+               + (second == null ? "NA" : (second ? "T" : "F"));
     }
 }

--- a/misc/extra/src/main/java/org/openscience/cdk/Association.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/Association.java
@@ -96,6 +96,7 @@ public class Association extends ElectronContainer implements java.io.Serializab
      */
     public void setAtoms(IAtom[] atoms) {
         this.atoms = atoms;
+        this.atomCount = atoms.length;
         notifyChanged();
     }
 
@@ -137,8 +138,8 @@ public class Association extends ElectronContainer implements java.io.Serializab
      * @return     true if the atom participates in this Association
      */
     public boolean contains(IAtom atom) {
-        for (IAtom atom1 : atoms) {
-            if (atom1 == atom) {
+        for (int i = 0; i < atomCount; i++) {
+            if (atoms[i].equals(atom)) {
                 return true;
             }
         }

--- a/misc/extra/src/main/java/org/openscience/cdk/geometry/RDFCalculator.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/geometry/RDFCalculator.java
@@ -141,7 +141,7 @@ public class RDFCalculator {
         Iterator<IAtom> atomsInContainer = container.atoms().iterator();
         while (atomsInContainer.hasNext()) {
             IAtom atomInContainer = (IAtom) atomsInContainer.next();
-            if (atom == atomInContainer) continue; // don't include the central atom
+            if (atomInContainer.equals(atom)) continue; // don't include the central atom
             distance = atomPoint.distance(atomInContainer.getPoint3d());
             index = (int) ((distance - startCutoff) / this.resolution);
             double weight = 1.0;

--- a/misc/extra/src/main/java/org/openscience/cdk/validate/BasicValidator.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/validate/BasicValidator.java
@@ -20,6 +20,7 @@
 package org.openscience.cdk.validate;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.openscience.cdk.config.AtomTypeFactory;
 import org.openscience.cdk.config.Isotopes;
@@ -266,7 +267,7 @@ public class BasicValidator extends AbstractValidator {
             if (isotope.getMassNumber() != 0) {
                 boolean foundKnownIsotope = false;
                 for (int i = 0; i < isotopes.length; i++) {
-                    if (isotopes[i].getMassNumber() == isotope.getMassNumber()) {
+                    if (Objects.equals(isotopes[i].getMassNumber(), isotope.getMassNumber())) {
                         foundKnownIsotope = true;
                     }
                 }
@@ -304,7 +305,7 @@ public class BasicValidator extends AbstractValidator {
                 boolean foundMatchingAtomType = false;
                 for (int j = 0; j < atomTypes.length; j++) {
                     IAtomType type = atomTypes[j];
-                    if (atom.getFormalCharge() == type.getFormalCharge()) {
+                    if (Objects.equals(atom.getFormalCharge(), type.getFormalCharge())) {
                         foundMatchingAtomType = true;
                         if (bos == type.getBondOrderSum()) {
                             // skip this atom type

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
@@ -469,16 +469,16 @@ public class InChIGenerator {
                 // we now need to move all the atoms into the correct positions
                 // everytime we exchange atoms the configuration inverts
                 for (int i = 0; i < peripherals.length; i++) {
-                    if (i != 0 && t0Neighbor == peripherals[i]) {
+                    if (i != 0 && t0Neighbor.equals(peripherals[i])) {
                         swap(peripherals, i, 0);
                         winding = winding.invert();
-                    } else if (i != 1 && terminals[0] == peripherals[i]) {
+                    } else if (i != 1 && terminals[0].equals(peripherals[i])) {
                         swap(peripherals, i, 1);
                         winding = winding.invert();
-                    } else if (i != 2 && terminals[1] == peripherals[i]) {
+                    } else if (i != 2 && terminals[1].equals(peripherals[i])) {
                         swap(peripherals, i, 2);
                         winding = winding.invert();
-                    } else if (i != 3 && t1Neighbor == peripherals[i]) {
+                    } else if (i != 3 && t1Neighbor.equals(peripherals[i])) {
                         swap(peripherals, i, 3);
                         winding = winding.invert();
                     }

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
@@ -303,13 +303,13 @@ public class InChIToStructure {
                     // test these first - but handle the other indices just in
                     // case
                     for (IAtom terminal : terminals) {
-                        if (peripherals[1] == terminal) {
+                        if (peripherals[1].equals(terminal)) {
                             peripherals[1] = findOtherSinglyBonded(molecule, terminal, peripherals[0]);
-                        } else if (peripherals[2] == terminal) {
+                        } else if (peripherals[2].equals(terminal)) {
                             peripherals[2] = findOtherSinglyBonded(molecule, terminal, peripherals[3]);
-                        } else if (peripherals[0] == terminal) {
+                        } else if (peripherals[0].equals(terminal)) {
                             peripherals[0] = findOtherSinglyBonded(molecule, terminal, peripherals[1]);
-                        } else if (peripherals[3] == terminal) {
+                        } else if (peripherals[3].equals(terminal)) {
                             peripherals[3] = findOtherSinglyBonded(molecule, terminal, peripherals[2]);
                         }
                     }

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -1523,7 +1523,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
         final IAtom atom = container.getAtom(index);
         final IPseudoAtom pseudoAtom = atom instanceof IPseudoAtom ? (IPseudoAtom) atom : container.getBuilder()
                 .newInstance(IPseudoAtom.class);
-        if (atom == pseudoAtom) {
+        if (atom.equals(pseudoAtom)) {
             pseudoAtom.setLabel(label);
         } else {
             pseudoAtom.setSymbol(label);

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
@@ -457,7 +457,7 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
                 int hidx = -1;
                 for (int i = 0; i < 4; i++) {
                     // hydrogen position
-                    if (carriers[i] == focus || carriers[i].getAtomicNumber() == 1) {
+                    if (carriers[i].equals(focus) || carriers[i].getAtomicNumber() == 1) {
                         if (hidx >= 0) parity = 0;
                         hidx = i;
                     }

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -581,7 +581,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                                                                                 original);
                             }
                             ((IPseudoAtom) replacement).setLabel(label);
-                            if (replacement != original)
+                            if (!replacement.equals(original))
                                 AtomContainerManipulator.replaceAtomByAtom(readData, original, replacement);
                         }
                     }

--- a/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -187,7 +187,7 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
         assert neighbours.length == 4;
         for (int i = 0; i < 4; i++) {
             // impl H is last
-            if (neighbours[i] == stereo.getChiralAtom()) {
+            if (stereo.getChiralAtom().equals(neighbours[i])) {
                 neighbourIdx[i] = Integer.MAX_VALUE;
             } else {
                 neighbourIdx[i] = idxs.get(neighbours[i]);

--- a/storage/io/src/main/java/org/openscience/cdk/io/cml/CMLCoreModule.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/cml/CMLCoreModule.java
@@ -1611,7 +1611,7 @@ public class CMLCoreModule implements ICMLModule {
 
                 if (aroms.hasNext()) {
                     Object nextArom = aroms.next();
-                    if (nextArom != null && nextArom == Boolean.TRUE) {
+                    if (nextArom != null && ((boolean) nextArom)) {
                         currentBond.setFlag(CDKConstants.ISAROMATIC, true);
                     }
                 }

--- a/storage/libiocml/src/main/java/org/openscience/cdk/libio/cml/Convertor.java
+++ b/storage/libiocml/src/main/java/org/openscience/cdk/libio/cml/Convertor.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.dict.DictRef;
@@ -613,7 +614,7 @@ public class Convertor {
                     Iterator<IAtom> atoms = (bonds.next()).atoms().iterator();
                     while (atoms.hasNext()) {
                         IAtom atom = atoms.next();
-                        if ("H".equals(atom.getSymbol()) && atom != cdkAtom) totalHydrogen++;
+                        if ("H".equals(atom.getSymbol()) && !Objects.equals(atom, cdkAtom)) totalHydrogen++;
                     }
                 }
             } // else: it is the implicit hydrogen count

--- a/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
+++ b/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
@@ -508,7 +508,7 @@ public class PDBReader extends DefaultChemObjectReader {
             IBond existingBond = (IBond) bondsFromConnectRecords.get(i);
             IAtom a = existingBond.getBegin();
             IAtom b = existingBond.getEnd();
-            if ((a == firstAtom && b == secondAtom) || (b == firstAtom && a == secondAtom)) {
+            if ((a.equals(firstAtom) && b.equals(secondAtom)) || (b.equals(firstAtom) && a.equals(secondAtom))) {
                 // already stored
                 return;
             }

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
@@ -537,7 +537,7 @@ public class AtomPlacer3D {
         List<IBond> bonds = molecule.getConnectedBondsList(atomA);
         for (IBond bond : bonds) {
             IAtom connectedAtom = bond.getOther(atomA);
-            if (isPlacedHeavyAtom(connectedAtom) && connectedAtom != atomB) {
+            if (isPlacedHeavyAtom(connectedAtom) && !connectedAtom.equals(atomB)) {
                 return connectedAtom;
             }
         }

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomTetrahedralLigandPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomTetrahedralLigandPlacer3D.java
@@ -25,6 +25,7 @@ package org.openscience.cdk.modeling.builder3d;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.vecmath.AxisAngle4d;
 import javax.vecmath.Matrix3d;
@@ -871,7 +872,7 @@ public class AtomTetrahedralLigandPlacer3D {
         IAtom atom = null;
         for (int i = 0; i < atoms.size(); i++) {
             IAtom curAtom = (IAtom) atoms.get(i);
-            if (curAtom.getFlag(CDKConstants.ISPLACED) && !curAtom.getSymbol().equals("H") && curAtom != atomB) {
+            if (curAtom.getFlag(CDKConstants.ISPLACED) && !curAtom.getSymbol().equals("H") && !Objects.equals(curAtom, atomB)) {
                 return curAtom;
             }
         }

--- a/tool/builder3dtools/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateExtractor.java
+++ b/tool/builder3dtools/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateExtractor.java
@@ -476,7 +476,7 @@ public class TemplateExtractor {
     public IAtomContainer removeLoopBonds(IAtomContainer molecule, int position) {
         for (int i = 0; i < molecule.getBondCount(); i++) {
             IBond bond = molecule.getBond(i);
-            if (bond.getBegin() == bond.getEnd()) {
+            if (bond.getBegin().equals(bond.getEnd())) {
                 System.out.println("Loop found! Molecule:" + position);
                 molecule.removeBond(bond);
             }

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/Polarizability.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/Polarizability.java
@@ -131,7 +131,7 @@ public class Polarizability {
 
         polarizabilitiy += getKJPolarizabilityFactor(acH, atom);
         for (int i = 0; i < acH.getAtomCount(); i++) {
-            if (acH.getAtom(i) != atom) {
+            if (!acH.getAtom(i).equals(atom)) {
                 bond = PathTools.breadthFirstTargetSearch(acH, startAtom, acH.getAtom(i), 0, influenceSphereCutOff);
                 if (bond == 1) {
                     polarizabilitiy += getKJPolarizabilityFactor(acH, acH.getAtom(i));
@@ -173,7 +173,7 @@ public class Polarizability {
 
         polarizabilitiy += getKJPolarizabilityFactor(acH, atom);
         for (int i = 0; i < acH.getAtomCount(); i++) {
-            if (acH.getAtom(i) != atom) {
+            if (!acH.getAtom(i).equals(atom)) {
                 int atomIndex = atomContainer.indexOf(atom);
                 bond = distanceMatrix[atomIndex][i];
                 if (bond == 1) {

--- a/tool/formula/src/main/java/org/openscience/cdk/formula/MolecularFormulaRange.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/MolecularFormulaRange.java
@@ -21,6 +21,7 @@ package org.openscience.cdk.formula;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 import org.openscience.cdk.interfaces.IIsotope;
 
@@ -215,8 +216,9 @@ public class MolecularFormulaRange implements Cloneable {
     private boolean isTheSame(IIsotope isotopeOne, IIsotope isotopeTwo) {
 
         if (!isotopeOne.getSymbol().equals(isotopeTwo.getSymbol())) return false;
-        if (isotopeOne.getNaturalAbundance() != isotopeTwo.getNaturalAbundance()) return false;
-        if (isotopeOne.getExactMass() != isotopeTwo.getExactMass()) return false;
+        // XXX: floating point comparision!
+        if (!Objects.equals(isotopeOne.getNaturalAbundance(), isotopeTwo.getNaturalAbundance())) return false;
+        if (!Objects.equals(isotopeOne.getExactMass(), isotopeTwo.getExactMass())) return false;
 
         return true;
     }

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import org.openscience.cdk.CDKConstants;
@@ -944,7 +945,7 @@ public class MolecularFormulaManipulator {
      */
     public static boolean compare(IMolecularFormula formula1, IMolecularFormula formula2) {
 
-        if (formula1.getCharge() != formula2.getCharge()) return false;
+        if (!Objects.equals(formula1.getCharge(), formula2.getCharge())) return false;
 
         if (formula1.getIsotopeCount() != formula2.getIsotopeCount()) return false;
 

--- a/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
+++ b/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
@@ -463,7 +463,7 @@ public class PharmacophoreMatcher {
                     for (int j = 0; j < unique.size(); j++) {
                         if (i == j) continue;
                         IAtom[] seq2 = unique.get(j);
-                        if (seq1[1] == seq2[1] && seq1[0] == seq2[2] && seq1[2] == seq2[0]) {
+                        if (seq1[1].equals(seq2[1]) && seq1[0].equals(seq2[2]) && seq1[2].equals(seq2[0])) {
                             isRepeat = true;
                         }
                     }

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
@@ -182,7 +182,7 @@ final class CorrectGeometricConfiguration {
         IAtom otherSubstituent = focus;
         for (int w : graph[atomToIndex.get(focus)]) {
             IAtom atom = container.getAtom(w);
-            if (atom != substituent && atom != otherFocus) otherSubstituent = atom;
+            if (!atom.equals(substituent) && !atom.equals(otherFocus)) otherSubstituent = atom;
         }
         return new IAtom[]{substituent, otherSubstituent, otherFocus};
     }

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -719,8 +719,8 @@ final class NonplanarBonds {
                 continue;
 
             // stereo bond, ignore it depiction is correct
-            if ((doubleBondElements[beg] != null && doubleBondElements[beg].getStereoBond() == bond) ||
-                    (doubleBondElements[end] != null && doubleBondElements[end].getStereoBond() == bond))
+            if ((doubleBondElements[beg] != null && doubleBondElements[beg].getStereoBond().equals(bond)) ||
+                    (doubleBondElements[end] != null && doubleBondElements[end].getStereoBond().equals(bond)))
                 continue;
 
             // is actually a tetrahedral centre
@@ -839,7 +839,7 @@ final class NonplanarBonds {
             IBond adjBond = edgeToBond.get(v, neighbor);
             // non single bonds
             if (adjBond.getOrder().numeric() > 1) {
-                if (allowedDoubleBond != adjBond) {
+                if (!allowedDoubleBond.equals(adjBond)) {
                     return false;
                 }
             }

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -290,7 +290,7 @@ final class NonplanarBonds {
         if (p == 0) return;
 
         for (int i = 0; i < 4; i++) {
-            if (atoms[i] == focus) {
+            if (atoms[i].equals(focus)) {
                 p *= parity(i); // implicit H, adjust parity
             } else {
                 bonds[n] = container.getBond(focus, atoms[i]);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/RingPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/RingPlacer.java
@@ -250,7 +250,7 @@ public class RingPlacer {
         IAtom bondAtom2 = bridgeAtoms[1];
         List<IAtom> otherAtoms = new ArrayList<>();
         for (IAtom atom : sharedAtoms.atoms())
-            if (atom != bondAtom1 && atom != bondAtom2)
+            if (!atom.equals(bondAtom1) && !atom.equals(bondAtom2))
                 otherAtoms.add(atom);
 
         final boolean snap = ring.getProperty(SNAP_HINT) != null && ring.getProperty(SNAP_HINT, Boolean.class);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -2321,7 +2321,7 @@ public class StructureDiagramGenerator {
                                     if (!visited.contains(other) && newvisit.add(other)) {
                                         visit(newvisit, adjlist, other);
                                     }
-                                } else if (e2.getValue() == visitedAtom) {
+                                } else if (e2.getValue().equals(visitedAtom)) {
                                     int other = idxs.get(e2.getKey().iterator().next());
                                     if (!visited.contains(other) && newvisit.add(other)) {
                                         visit(newvisit, adjlist, other);

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
@@ -216,7 +216,7 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
         // bond is undirected so we need to ensure v1 is the first atom in the bond
         // we also need to to swap the substituents later
         boolean swap = false;
-        if (targetElement.getStereoBond().getBegin() != target.getAtom(v1)) {
+        if (!targetElement.getStereoBond().getBegin().equals(target.getAtom(v1))) {
             int tmp = v1;
             v1 = v2;
             v2 = tmp;

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/FormalChargeAtom.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/FormalChargeAtom.java
@@ -21,6 +21,8 @@ package org.openscience.cdk.isomorphism.matchers.smarts;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 
+import java.util.Objects;
+
 /**
  * This matcher checks the formal charge of the Atom.
  *
@@ -50,7 +52,7 @@ public class FormalChargeAtom extends SMARTSAtom {
      */
     @Override
     public boolean matches(IAtom atom) {
-        return atom.getFormalCharge() == this.formalCharge;
+        return Objects.equals(atom.getFormalCharge(), this.formalCharge);
     }
 
     /*

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/StereoBond.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/StereoBond.java
@@ -53,9 +53,10 @@ public class StereoBond extends SMARTSBond {
     }
 
     public Direction direction(IAtom atom) {
-        if (atom == getBegin())
+        if (getBegin().equals(atom))
             return direction;
-        else if (atom == getEnd()) return inv(direction);
+        else if (getEnd().equals(atom))
+            return inv(direction);
         throw new IllegalArgumentException("atom is not a memeber of this bond");
     }
 

--- a/tool/structgen/src/main/java/org/openscience/cdk/structgen/SingleStructureRandomGenerator.java
+++ b/tool/structgen/src/main/java/org/openscience/cdk/structgen/SingleStructureRandomGenerator.java
@@ -149,14 +149,14 @@ public class SingleStructureRandomGenerator {
 
         for (int f = next; f < atomContainer.getAtomCount(); f++) {
             atom = atomContainer.getAtom(f);
-            if (!satCheck.isSaturated(atom, atomContainer) && exclusionAtom != atom
+            if (!satCheck.isSaturated(atom, atomContainer) && !exclusionAtom.equals(atom)
                     && !atomContainer.getConnectedAtomsList(exclusionAtom).contains(atom)) {
                 return atom;
             }
         }
         for (int f = 0; f < next; f++) {
             atom = atomContainer.getAtom(f);
-            if (!satCheck.isSaturated(atom, atomContainer) && exclusionAtom != atom
+            if (!satCheck.isSaturated(atom, atomContainer) && !exclusionAtom.equals(atom)
                     && !atomContainer.getConnectedAtomsList(exclusionAtom).contains(atom)) {
                 return atom;
             }


### PR DESCRIPTION
Clean up reference equality comparisons. The IAtom/IBond are no-ops at the moment but will make sense with the planned introduction of AtomRef/BondRef. I also fixed those found by find bugs with the Double/Integer boxed primitives.