### PR TITLE
Patch/runtimeexception

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/exception/CDKException.java
+++ b/base/core/src/main/java/org/openscience/cdk/exception/CDKException.java
@@ -28,7 +28,7 @@ package org.openscience.cdk.exception;
  * @cdk.module core
  * @cdk.githash
  */
-public class CDKException extends RuntimeException {
+public class CDKException extends Exception {
 
     private static final long serialVersionUID = 8371328769230823678L;
 

--- a/base/core/src/main/java/org/openscience/cdk/exception/NoSuchAtomException.java
+++ b/base/core/src/main/java/org/openscience/cdk/exception/NoSuchAtomException.java
@@ -30,7 +30,7 @@ package org.openscience.cdk.exception;
  * @cdk.module core
  * @cdk.githash
  */
-public class NoSuchAtomException extends CDKException {
+public class NoSuchAtomException extends RuntimeException {
 
     private static final long serialVersionUID = -6367051798808824272L;
 


### PR DESCRIPTION
Reverts a patch from the other week. Whilst valid, there are some areas that currently use CDKException for control flow (i.e. the caller needs to know to expect and exception). This is bad in general but switching to a RuntimeException means the IDE won't give a hint.

The NoSuchAtomException is converted to a RuntimeException - technically an API break but should be safe-ish. The exception is thrown for programmer error (accessing an atom that doesn't exisit).