### PR TITLE
Patch/stereoapi

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.stereo;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObject;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.interfaces.IStereoElement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
+    implements IStereoElement<F, C> {
+
+    private int     value;
+    private F       focus;
+    private List<C> carriers;
+    private IChemObjectBuilder builder;
+
+    AbstractStereo(F focus, C[] carriers, int value) {
+        if (focus == null)
+            throw new NullPointerException("Focus of stereochemistry can not be null!");
+        if (carriers == null)
+            throw new NullPointerException("Carriers of the configuration can not be null!");
+        if (carriers.length != ((value >>> 12) & 0xf))
+            throw new IllegalArgumentException("Unexpected number of stereo carriers! expected " + ((value >>> 12) & 0xf) + " was " + carriers.length);
+        for (C carrier : carriers) {
+            if (carrier == null)
+                throw new NullPointerException("A carrier was undefined!");
+        }
+        this.value    = value;
+        this.focus    = focus;
+        this.carriers = new ArrayList<>();
+        Collections.addAll(this.carriers, carriers);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public F getFocus() {
+        return focus;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<C> getCarriers() {
+        return carriers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getConfigClass() {
+        return value & CLS_MASK;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getConfig() {
+        return value & CFG_MASK;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setConfig(int cfg) {
+        value = getConfigClass() | cfg;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean contains(IAtom atom) {
+        if (focus.equals(atom) || (focus instanceof IBond && ((IBond) focus).contains(atom)))
+            return true;
+        for (C carrier : carriers) {
+            if (carrier.equals(atom) ||
+                (carrier instanceof IBond && ((IBond) carrier).contains(atom)))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IStereoElement<F,C> map(Map<IAtom, IAtom> atoms,
+                                   Map<IBond, IBond> bonds) {
+        if (atoms == null)
+            throw new IllegalArgumentException("Atom map should be non-null");
+        if (bonds == null)
+            throw new IllegalArgumentException("Bond map should be non-null");
+        Map<IChemObject,IChemObject> map = new HashMap<>(atoms.size() + bonds.size());
+        map.putAll(atoms);
+        map.putAll(bonds);
+        return map(map);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public IStereoElement<F, C> map(Map<IChemObject, IChemObject> chemobjs) {
+        if (chemobjs == null)
+            throw new NullPointerException("chemobj map was not provided!");
+        F newfocus = (F) chemobjs.get(focus);
+        if (newfocus == null)
+            newfocus = focus;
+        List<C> newcarriers = carriers;
+        for (int i = 0; i < newcarriers.size(); i++) {
+            C newcarrier = (C) chemobjs.get(newcarriers.get(i));
+            if (newcarrier != null) {
+                // make a copy if this is the first change
+                if (newcarriers == carriers)
+                    newcarriers = new ArrayList<>(carriers);
+                newcarriers.set(i, newcarrier);
+            }
+        }
+        // no change, return self
+        if (newfocus == focus && newcarriers == carriers)
+            return this;
+        return create(newfocus, newcarriers, value);
+    }
+
+    protected abstract IStereoElement<F,C> create(F focus, List<C> carriers, int cfg);
+
+    /**
+     *{@inheritDoc}
+     */
+    @Override
+    public IChemObjectBuilder getBuilder() {
+        if (builder == null)
+            throw new UnsupportedOperationException("Non-domain object!");
+        return this.builder;
+    }
+
+    protected void setBuilder(IChemObjectBuilder builder) {
+        this.builder = builder;
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/stereo/Atropisomeric.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/Atropisomeric.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.stereo;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IStereoElement;
+
+import java.util.List;
+
+/**
+ * Restricted axial rotation around Aryl-Aryl bonds. The atropisomer is
+ * stored in a similar manner to {@link ExtendedTetrahedral} (and
+ * {@link TetrahedralChirality}) except instead of storing the central atom
+ * we store the sigma bond around which the rotation is restricted and the
+ * four carriers are connect to either end atom of the 'focus' bond.
+ * <br>
+ * <pre>
+ *      a     b'
+ *     /       \
+ *    Ar --f-- Ar
+ *     \      /
+ *      a'   b
+ * f: focus
+ * Ar: Aryl (carriers connected to either end of 'f')
+ * a,a',b,b': ortho substituted on the Aryl
+ * </pre>
+ * <br>
+ * Typical examples include <a href="https://en.wikipedia.org/wiki/BINOL">
+ * BiNOL</a>, and <a href="https://en.wikipedia.org/wiki/BINAP">BiNAP</a>.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Atropisomer">Atropisomer (Wikipedia)</a>
+ */
+public class Atropisomeric extends AbstractStereo<IBond,IAtom> {
+
+    public Atropisomeric(IBond focus, IAtom[] carriers, int value) {
+        super(focus, carriers, IStereoElement.AT | value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected IStereoElement<IBond, IAtom> create(IBond focus,
+                                                  List<IAtom> carriers,
+                                                  int cfg) {
+        return new Atropisomeric(focus, carriers.toArray(new IAtom[4]), cfg);
+    }
+}

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IDoubleBondStereochemistry.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IDoubleBondStereochemistry.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * @cdk.module interfaces
  * @cdk.githash
  */
-public interface IDoubleBondStereochemistry extends IStereoElement {
+public interface IDoubleBondStereochemistry extends IStereoElement<IBond,IBond> {
 
     /**
      * Enumeration that defines the two possible values for this stereochemistry type.
@@ -45,6 +45,28 @@ public interface IDoubleBondStereochemistry extends IStereoElement {
     public enum Conformation {
         TOGETHER, //  as in Z-but-2-ene
         OPPOSITE; //  as in E-but-2-ene
+
+        public static Conformation toConformation(int config) {
+            switch (config) {
+                case IStereoElement.TOGETHER:
+                    return TOGETHER;
+                case IStereoElement.OPPOSITE:
+                    return OPPOSITE;
+                default:
+                    throw new IllegalArgumentException("Cannot map config to enum: " + config);
+            }
+        }
+
+        public static int toConfig(Conformation conformation) {
+            switch (conformation) {
+                case TOGETHER:
+                    return IStereoElement.TOGETHER;
+                case OPPOSITE:
+                    return IStereoElement.OPPOSITE;
+                default:
+                    throw new IllegalArgumentException("Cannot map enum to config: " + conformation);
+            }
+        }
 
         /**
          * Invert this conformation, inv(together) = opposite, inv(opposite)

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
@@ -126,7 +126,40 @@ public interface IStereoElement<F extends IChemObject, C extends IChemObject>
     public static final int HBPY8 = 0x81_00;
 
     /** Heptagonal Bipyramidal (HBPY-9) */
-    public static final int HBPY9 = 0x82_00;
+    public static final int HBPY9 = 0x91_00;
+
+    /** Geomeric CisTrans (e.g. but-2-ene) */
+    public static final int CisTrans              = CT;
+
+    /** Tetrahedral (T-4) (e.g. butan-2-ol)*/
+    public static final int Tetrahedral           = TH;
+
+    /** ExtendedTetrahedral (e.g. 2,3-pentadiene) */
+    public static final int Allenal               = AL;
+
+    /** Atropisomeric (e.g. BiNAP) */
+    public static final int Atropisomeric         = AT;
+
+    /** Square Planar (SP-4) (e.g. cisplatin) */
+    public static final int SquarePlanar          = SP;
+
+    /** Square Pyramidal (SPY-5) */
+    public static final int SquarePyramidal       = SPY;
+
+    /** Trigonal Bipyramidal (TBPY-5) */
+    public static final int TrigonalBipyramidal   = TBPY;
+
+    /** Octahedral (OC-6) */
+    public static final int Octahedral            = OC;
+
+    /** Pentagonal Bipyramidal (PBPY-7) */
+    public static final int PentagonalBipyramidal = PBPY;
+
+    /** Hexagonal Bipyramidal (HBPY-8) */
+    public static final int HexagonalBipyramidal  = HBPY8;
+
+    /** Heptagonal Bipyramidal (HBPY-9) */
+    public static final int HeptagonalBipyramidal = HBPY9;
 
     /**
      * The focus atom or bond at the 'centre' of the stereo-configuration.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2010  Egon Willighagen <egonw@users.sf.net>
+ *               2017  John Mayfield
  *
  * Contact: cdk-devel@lists.sourceforge.net
  *
@@ -22,20 +23,140 @@
  */
 package org.openscience.cdk.interfaces;
 
+import java.util.List;
 import java.util.Map;
 
 /**
- * Represents the concept of a stereo element in the molecule. Stereo elements can be
- * that of quadrivalent atoms, cis/trans isomerism around double bonds, but also include
- * axial and helical stereochemistry.
+ * Representation of stereochemical configuration. The abstract configuration
+ * is described by three pieces of information:
+ * <ul>
+ *  <li>the <b>focus</b> of the stereo chemistry</li>
+ *  <li>the <b>carriers</b> of the configuration</li>
+ *  <li>the <b>configuration</b> of the <i>carriers</i></li>
+ * </ul>
+ * <br>
+ * The focus/carriers may be either atoms or bonds. For example in the case of
+ * common tetrahedral stereochemistry the focus is the chiral atom, and the
+ * carriers are the bonds (or atoms) connected to it. The configuration is then
+ * either left-handed (anti-clockwise) or right-handed (clockwise).
+ * <br><br>
+ * <b><u>Configuration</u></b>
+ * <br>
+ * The configuration is stored as an integral value. Although the common
+ * geometries like tetrahedral and cis/trans bonds only have 2 possible
+ * configurations (e.g. left vs right) more complex geometries like square
+ * planar and octahedral require more to describe. For convenience the
+ * constants {@link #LEFT} and {@link #RIGHT} are provided but are synonymous
+ * with the values {@code 1} (odd) and {@code 2} (even).<br>
+ * Special values (e.g. 0) may be used to represent unknown/unspecified or
+ * racemic in future but are currently undefined.
+ * <br><br>
+ * <b><u>Configuration Class</u></b>
+ * <br>
+ * There stereo class defines the type of stereochemistry/geometry that is
+ * captured. The stereo class is also defined as a integral value. The
+ * following classes are available with varied support through out the
+ * toolkit. Each class is named with a short mnemonic code:
+ * <ul>
+ *     <li>{@link #TH}: Tetrahedral</li>
+ *     <li>{@link #CT}: CisTrans a double-bond</li>
+ *     <li>{@link #AL}: Extended Tetrahedral (Allenal)</li>
+ *     <li>{@link #AT}: Atropisomeric</li>
+ *     <li>{@link #SP}: Square Planar</li>
+ *     <li>{@link #SPY}: Square Pyramidal</li>
+ *     <li>{@link #TBPY}: Trigonal Bipyramidal</li>
+ *     <li>{@link #PBPY}: Pentagonal Bipyramidal</li>
+ *     <li>{@link #OC}: Octahedral</li>
+ *     <li>{@link #HBPY8}: Hexagonal Bipyramidal</li>
+ *     <li>{@link #HBPY9}: Heptagonal Bipyramidal</li>
+ * </ul>
  *
  * @cdk.module interfaces
  * @cdk.githash
  *
- * @author      egonw
+ * @author      Egon Willighagen
+ * @author      John Mayfield
  * @cdk.keyword stereochemistry
  */
-public interface IStereoElement extends ICDKObject {
+public interface IStereoElement<F extends IChemObject, C extends IChemObject>
+    extends ICDKObject {
+
+    public static final int CLS_MASK = 0xff_00;
+    public static final int CFG_MASK = 0x00_ff;
+
+    public static final int LEFT        = 0x00_01;
+    public static final int RIGHT       = 0x00_02;
+    public static final int OPPOSITE    = LEFT;
+    public static final int TOGETHER    = RIGHT;
+
+    /*
+     * Important! The forth nibble of the stereo-class defines the number of
+     * carriers (or coordination number) the third nibble just increments when
+     * there are two geometries with the same number of carriers.
+     */
+
+    /** Geomeric CisTrans (e.g. but-2-ene) */
+    public static final int CT   = 0x21_00;
+
+    /** Tetrahedral (T-4) (e.g. butan-2-ol)*/
+    public static final int TH   = 0x42_00;
+
+    /** ExtendedTetrahedral (e.g. 2,3-pentadiene) */
+    public static final int AL   = 0x43_00;
+
+    /** Atropisomeric (e.g. BiNAP) */
+    public static final int AT   = 0x44_00;
+
+    /** Square Planar (SP-4) (e.g. cisplatin) */
+    public static final int SP   = 0x45_00;
+
+    /** Square Pyramidal (SPY-5) */
+    public static final int SPY  = 0x51_00;
+
+    /** Trigonal Bipyramidal (TBPY-5) */
+    public static final int TBPY = 0x52_00;
+
+    /** Octahedral (OC-6) */
+    public static final int OC   = 0x61_00;
+
+    /** Pentagonal Bipyramidal (PBPY-7) */
+    public static final int PBPY = 0x71_00;
+
+    /** Hexagonal Bipyramidal (HBPY-8) */
+    public static final int HBPY8 = 0x81_00;
+
+    /** Heptagonal Bipyramidal (HBPY-9) */
+    public static final int HBPY9 = 0x82_00;
+
+    /**
+     * The focus atom or bond at the 'centre' of the stereo-configuration.
+     * @return the focus
+     */
+    F getFocus();
+
+    /**
+     * The carriers of the stereochemistry
+     * @return the carriers
+     */
+    List<C> getCarriers();
+
+    /**
+     * The configuration class of the stereochemistry.
+     * @return configuration class
+     */
+    int getConfigClass();
+
+    /**
+     * The configuration of the stereochemistry.
+     * @return configuration
+     */
+    int getConfig();
+
+    /**
+     * Set the configuration of the stereochemistry.
+     * @param cfg the new configuration
+     */
+    void setConfig(int cfg);
 
     /**
      * Does the stereo element contain the provided atom.
@@ -45,6 +166,7 @@ public interface IStereoElement extends ICDKObject {
      */
     boolean contains(final IAtom atom);
 
+    IStereoElement<F,C> map(Map<IChemObject, IChemObject> chemobjs);
     /**
      * Map the atoms/bonds in this instance to a new stereo element using the
      * provided atom/bond mapping. This allows the stereo element to be transferred

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/ITetrahedralChirality.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/ITetrahedralChirality.java
@@ -38,13 +38,35 @@ import java.util.Map;
  * @cdk.module interfaces
  * @cdk.githash
  */
-public interface ITetrahedralChirality extends IStereoElement {
+public interface ITetrahedralChirality extends IStereoElement<IAtom, IAtom> {
 
     /**
      * Enumeration that defines the two possible chiralities for this stereochemistry type.
      */
     enum Stereo {
         CLOCKWISE, ANTI_CLOCKWISE;
+
+        public static int toConfig(Stereo stereo) {
+            switch (stereo) {
+                case ANTI_CLOCKWISE:
+                    return LEFT;
+                case CLOCKWISE:
+                    return RIGHT;
+                default:
+                    throw new IllegalArgumentException("Unknown enum value: " + stereo);
+            }
+        }
+
+        public static Stereo toStereo(int cfg) {
+            switch (cfg) {
+                case LEFT:
+                    return ANTI_CLOCKWISE;
+                case RIGHT:
+                    return CLOCKWISE;
+                default:
+                    throw new IllegalArgumentException("Cannot map to enum value: " + cfg);
+            }
+        }
 
         /**
          * Invert this conformation, inv(clockwise) = anti_clockwise,

--- a/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
@@ -26,6 +26,7 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.ILonePair;
 import org.openscience.cdk.interfaces.ISingleElectron;
@@ -118,19 +119,15 @@ public class ConnectivityChecker {
             componentsMap.get(lonePair.getAtom()).addLonePair(lonePair);
 
         for (IStereoElement stereo : container.stereoElements()) {
-            if (stereo instanceof ITetrahedralChirality) {
-                IAtom a = ((ITetrahedralChirality) stereo).getChiralAtom();
-                if (componentsMap.containsKey(a)) componentsMap.get(a).addStereoElement(stereo);
-            } else if (stereo instanceof IDoubleBondStereochemistry) {
-                IBond bond = ((IDoubleBondStereochemistry) stereo).getStereoBond();
-                if (componentsMap.containsKey(bond.getBegin()) && componentsMap.containsKey(bond.getEnd()))
-                    componentsMap.get(bond.getBegin()).addStereoElement(stereo);
-            } else if (stereo instanceof ExtendedTetrahedral) {
-                IAtom atom = ((ExtendedTetrahedral) stereo).focus();
-                if (componentsMap.containsKey(atom)) componentsMap.get(atom).addStereoElement(stereo);
+            IChemObject focus = stereo.getFocus();
+            if (focus instanceof IAtom) {
+                if (componentsMap.containsKey(focus))
+                    componentsMap.get(focus).addStereoElement(stereo);
+            } else if (focus instanceof IBond) {
+                if (componentsMap.containsKey(((IBond) focus).getBegin()))
+                    componentsMap.get(((IBond) focus).getBegin()).addStereoElement(stereo);
             } else {
-                System.err.println("New stereochemistry element is not currently partitioned with ConnectivityChecker:"
-                        + stereo.getClass());
+                throw new IllegalStateException("New stereo element not using an atom/bond for focus?");
             }
         }
 

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
@@ -121,8 +121,10 @@ public abstract class StereoElementFactory {
     public List<IStereoElement> createAll() {
 
         Stereocenters centers = new Stereocenters(container, graph, bondMap);
-        if (check)
+        if (check) {
             centers.checkSymmetry();
+        }
+
         List<IStereoElement> elements = new ArrayList<IStereoElement>();
 
         // projection recognition (note no action in constructors)
@@ -145,9 +147,18 @@ public abstract class StereoElementFactory {
                         }
                     }
                     break;
+                case Tetracoordinate:
+                    IStereoElement element = createTetrahedral(v, centers);
+                    if (element != null) elements.add(element);
+                    break;
+            }
+        }
+
+        // always need to verify for db...
+        centers.checkSymmetry();
+        for (int v = 0; v < graph.length; v++) {
+            switch (centers.elementType(v)) {
                 case Tricoordinate:
-                    // always need to verify for now...
-                    centers.checkSymmetry();
                     if (!centers.isStereocenter(v))
                         continue;
                     for (int w : graph[v]) {
@@ -159,10 +170,6 @@ public abstract class StereoElementFactory {
                             break;
                         }
                     }
-                    break;
-                case Tetracoordinate:
-                    IStereoElement element = createTetrahedral(v, centers);
-                    if (element != null) elements.add(element);
                     break;
             }
         }

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
@@ -141,7 +141,10 @@ public abstract class StereoElementFactory {
                     int t1 = graph[v][1];
                     if (centers.elementType(t0) == Stereocenters.Type.Tricoordinate
                             && centers.elementType(t1) == Stereocenters.Type.Tricoordinate) {
-                        if (centers.isStereocenter(t0) && centers.isStereocenter(t1)) {
+                        if (check && centers.isStereocenter(t0) && centers.isStereocenter(t1)) {
+                            IStereoElement element = createExtendedTetrahedral(v, centers);
+                            if (element != null) elements.add(element);
+                        } else {
                             IStereoElement element = createExtendedTetrahedral(v, centers);
                             if (element != null) elements.add(element);
                         }

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
@@ -165,8 +165,11 @@ public abstract class StereoElementFactory {
                         if (w > v &&
                             centers.elementType(w) == Stereocenters.Type.Tricoordinate &&
                             bond.getOrder() == IBond.Order.SINGLE &&
-                            !bond.isInRing()) {
-                            System.err.println("Atropisomer!");
+                            !bond.isInRing() &&
+                            bond.getBegin().isInRing() && bond.getEnd().isInRing()) {
+                            element = createAtropisomer(v, w, centers);
+                            if (element != null)
+                                elements.add(element);
                             break;
                         }
                     }
@@ -486,10 +489,120 @@ public abstract class StereoElementFactory {
             return new TetrahedralChirality(focus, neighbors, winding);
         }
 
+        private static boolean isHydrogen(IAtom atom) {
+            Integer elem = atom.getAtomicNumber();
+            return elem != null && elem == 1;
+        }
+
+        private static boolean isWedged(IBond bond) {
+            switch (bond.getStereo()) {
+                case UP:
+                case DOWN:
+                case UP_INVERTED:
+                case DOWN_INVERTED:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         @Override
-        IStereoElement createAtropisomer(int v, int w,
+        IStereoElement createAtropisomer(int u, int v,
                                          Stereocenters stereocenters) {
-            throw new UnsupportedOperationException();
+            IAtom end1 = container.getAtom(u);
+            IAtom end2 = container.getAtom(v);
+
+            if (hasUnspecifiedParity(end1) || hasUnspecifiedParity(end2))
+                return null;
+
+            if (graph[u].length != 3 || graph[v].length != 3)
+                return null;
+
+            // check degrees of connected atoms, we only create the
+            // atropisomer if the rings are 3x ortho substituted
+            // CC1=CC=CC(C)=C1-C1=C(C)C=CC=C1C yes (sum1=9,sum2=9)
+            // CC1=CC=CC=C1-C1=C(C)C=CC=C1C yes    (sum1=8,sum2=9)
+            // CC1=CC=CC(C)=C1-C1=CC=CC=C1 no      (sum1=7,sum2=9)
+            // CC1=CC=CC=C1-C1=C(C)C=CC=C1 no      (sum1=8,sum2=8)
+            int sum1 = graph[graph[u][0]].length +
+                    graph[graph[u][1]].length +
+                    graph[graph[u][2]].length;
+            int sum2 = graph[graph[v][0]].length +
+                       graph[graph[v][1]].length +
+                       graph[graph[v][2]].length;
+            if (sum1 > 9 || sum1 < 8)
+                return null;
+            if (sum2 > 9 || sum2 < 8)
+                return null;
+            if (sum1 + sum2 < 17)
+                return null;
+
+            IAtom[] carriers = new IAtom[4];
+            int[]   elevation = new int[4];
+
+            int n = 0;
+            for (int w : graph[u]) {
+                IBond bond = bondMap.get(u, w);
+                if (w == v) continue;
+                if (isUnspecified(bond)) return null;
+
+                carriers[n] = container.getAtom(w);
+                elevation[n] = elevationOf(end1, bond);
+
+                for (int w2 : graph[w]) {
+                    if (isHydrogen(container.getAtom(w2)))
+                        sum1--;
+                    else if (elevation[n] == 0 &&
+                             isWedged(bondMap.get(w, w2))) {
+                        elevation[n] = elevationOf(container.getAtom(w), bondMap.get(w, w2));
+                    }
+                }
+
+
+                n++;
+            }
+            n = 2;
+            for (int w : graph[v]) {
+                IBond bond = bondMap.get(v, w);
+                if (w == u) continue;
+                if (isUnspecified(bond)) return null;
+
+                carriers[n] = container.getAtom(w);
+                elevation[n] = elevationOf(end2, bond);
+
+                for (int w2 : graph[w]) {
+                    if (isHydrogen(container.getAtom(w2)))
+                        sum2--;
+                    else if (elevation[n] == 0 &&
+                             isWedged(bondMap.get(w, w2))) {
+                        elevation[n] = elevationOf(container.getAtom(w), bondMap.get(w, w2));
+                    }
+                }
+
+                n++;
+            }
+
+            // recheck now we have account for explicit hydrogens
+            if (sum1 > 9 || sum1 < 8)
+                return null;
+            if (sum2 > 9 || sum2 < 8)
+                return null;
+            if (sum1 + sum2 < 17)
+                return null;
+
+            if (elevation[0] != 0 || elevation[1] != 0) {
+                if (elevation[2] != 0 || elevation[3] != 0) return null;
+            } else {
+                if (elevation[2] == 0 && elevation[3] == 0) return null; // undefined configuration
+            }
+
+            IAtom tmp = end1.getBuilder().newAtom();
+            tmp.setPoint2d(new Point2d((end1.getPoint2d().x + end2.getPoint2d().x)/2,
+                                       (end2.getPoint2d().y + end2.getPoint2d().y)/2));
+            int parity = parity(tmp, carriers, elevation);
+            int cfg    = parity > 0 ? IStereoElement.LEFT : IStereoElement.RIGHT;
+
+            return new Atropisomeric(container.getBond(end1, end2), carriers, cfg);
         }
 
         /**{@inheritDoc} */
@@ -798,9 +911,10 @@ public abstract class StereoElementFactory {
         }
 
         @Override
-        IStereoElement createAtropisomer(int v, int w,
+        IStereoElement createAtropisomer(int u, int v,
                                          Stereocenters stereocenters) {
-            throw new UnsupportedOperationException();
+            // ToDo
+            return null;
         }
 
         /**{@inheritDoc} */

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
@@ -131,7 +131,9 @@ public final class Stereocenters {
     /** basic cycle information (i.e. is atom/bond cyclic) and cycle systems. */
     private final RingSearch      ringSearch;
 
-    private final int numStereoElements;
+    private int numStereoElements;
+
+    private boolean checkSymmetry = false;
 
     /**
      * Determine the stereocenter atoms in the provided container based on
@@ -177,7 +179,9 @@ public final class Stereocenters {
     }
 
     void checkSymmetry() {
-        if (numStereoElements > 0) {
+        if (!checkSymmetry) {
+            checkSymmetry = true;
+            numStereoElements = createElements();
             int[] symmetry = toIntArray(Canon.symmetry(container, g));
             labelTrueCenters(symmetry);
             labelIsolatedPara(symmetry);
@@ -497,7 +501,8 @@ public final class Stereocenters {
         int q = charge(atom);
 
         // more than one hydrogen
-        if (h > 1) return Type.None;
+        if (checkSymmetry && h > 1)
+            return Type.None;
 
         switch (atomicNumber(atom)) {
             case 0: // stop the nulls on pseudo atoms messing up anything else
@@ -577,6 +582,9 @@ public final class Stereocenters {
      *         hydrogen count of > 0
      */
     private boolean verifyTerminalHCount(int v) {
+
+        if (!checkSymmetry)
+            return true;
 
         int[] counts = new int[6];
         int[][] atoms = new int[6][g[v].length];

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
@@ -313,10 +313,6 @@ public final class Stereocenters {
                         continue;
                     }
 
-                    // TODO: we reject all cyclic double bonds but could
-                    // TODO: allow flexible rings (> 7 atoms)
-                    if (ringSearch.cyclic(w, u)) continue;
-
                     stereocenters[w] = Stereocenter.Potential;
                     stereocenters[u] = Stereocenter.Potential;
                     elements[u] = new Tricoordinate(u, w, g[u]);

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
@@ -123,13 +123,15 @@ public final class Stereocenters {
     private final EdgeToBondMap   bondMap;
 
     /** the type of stereo center - indexed by atom. */
-    private final Stereocenter[]  stereocenters;
+    private Stereocenter[]  stereocenters;
 
     /** the stereo elements - indexed by atom. */
-    private final StereoElement[] elements;
+    private StereoElement[] elements;
 
     /** basic cycle information (i.e. is atom/bond cyclic) and cycle systems. */
     private final RingSearch      ringSearch;
+
+    private final int numStereoElements;
 
     /**
      * Determine the stereocenter atoms in the provided container based on
@@ -151,7 +153,9 @@ public final class Stereocenters {
     public static Stereocenters of(IAtomContainer container) {
         EdgeToBondMap bondMap = EdgeToBondMap.withSpaceFor(container);
         int[][] g = GraphUtil.toAdjList(container, bondMap);
-        return new Stereocenters(container, g, bondMap);
+        Stereocenters stereocenters = new Stereocenters(container, g, bondMap);
+        stereocenters.checkSymmetry();
+        return stereocenters;
     }
 
     /**
@@ -163,21 +167,21 @@ public final class Stereocenters {
      * @param bondMap   fast lookup bonds by atom index
      */
     Stereocenters(IAtomContainer container, int[][] graph, EdgeToBondMap bondMap) {
-
         this.container = container;
         this.bondMap = bondMap;
         this.g = graph;
         this.ringSearch = new RingSearch(container, graph);
+        this.elements = new StereoElement[g.length];
+        this.stereocenters = new Stereocenter[g.length];
+        this.numStereoElements = createElements();
+    }
 
-        this.stereocenters = new Stereocenter[graph.length];
-        this.elements = new StereoElement[graph.length];
-
-        if (createElements() == 0) return;
-
-        int[] symmetry = toIntArray(Canon.symmetry(container, graph));
-
-        labelTrueCenters(symmetry);
-        labelIsolatedPara(symmetry);
+    void checkSymmetry() {
+        if (numStereoElements > 0) {
+            int[] symmetry = toIntArray(Canon.symmetry(container, g));
+            labelTrueCenters(symmetry);
+            labelIsolatedPara(symmetry);
+        }
     }
 
     /**
@@ -195,8 +199,10 @@ public final class Stereocenters {
      * @return the type of element
      */
     public Type elementType(final int v) {
-        if (stereocenters[v] == Stereocenter.Non || elements[v] == null) return Type.None;
-        return elements[v].type;
+        if (stereocenters[v] == Stereocenter.Non || elements[v] == null)
+            return Type.None;
+        else
+            return elements[v].type;
     }
 
     /**

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -444,6 +444,13 @@ public class AtomContainerManipulator {
         return hCount;
     }
 
+    private static final void replaceAtom(IAtom[] atoms, IAtom org, IAtom rep) {
+        for (int i = 0; i < atoms.length; i++) {
+            if (atoms[i].equals(org))
+                atoms[i] = rep;
+        }
+    }
+
     /**
      * Adds explicit hydrogens (without coordinates) to the IAtomContainer,
      * equaling the number of set implicit hydrogens.
@@ -483,28 +490,38 @@ public class AtomContainerManipulator {
         for (IBond bond : newBonds)
             atomContainer.addBond(bond);
 
-        // update tetrahedral elements with an implicit part
+        // update stereo elements with an implicit part
         List<IStereoElement> stereos = new ArrayList<>();
         for (IStereoElement stereo : atomContainer.stereoElements()) {
             if (stereo instanceof ITetrahedralChirality) {
                 ITetrahedralChirality tc = (ITetrahedralChirality) stereo;
 
-                IAtom focus = tc.getChiralAtom();
-                IAtom[] neighbors = tc.getLigands();
-                IAtom hydrogen = hNeighbor.get(focus);
+                IAtom   focus    = tc.getFocus();
+                IAtom[] carriers = tc.getCarriers().toArray(new IAtom[4]);
+                IAtom   hydrogen = hNeighbor.get(focus);
 
                 // in sulfoxide - the implicit part of the tetrahedral centre
                 // is a lone pair
 
                 if (hydrogen != null) {
-                    for (int i = 0; i < 4; i++) {
-                        if (neighbors[i] == focus) {
-                            neighbors[i] = hydrogen;
-                            break;
-                        }
-                    }
-                    // neighbors is a copy so need to create a new stereocenter
-                    stereos.add(new TetrahedralChirality(focus, neighbors, tc.getStereo()));
+                    replaceAtom(carriers, focus, hydrogen);
+                    stereos.add(new TetrahedralChirality(focus, carriers, tc.getStereo()));
+                } else {
+                    stereos.add(stereo);
+                }
+            } else if (stereo instanceof ExtendedTetrahedral) {
+                ExtendedTetrahedral tc = (ExtendedTetrahedral) stereo;
+
+                IAtom   focus    = tc.getFocus();
+                IAtom[] carriers = tc.getCarriers().toArray(new IAtom[4]);
+                IAtom   hydrogen = hNeighbor.get(focus);
+
+                // in sulfoxide - the implicit part of the tetrahedral centre
+                // is a lone pair
+
+                if (hydrogen != null) {
+                    replaceAtom(carriers, focus, hydrogen);
+                    stereos.add(new TetrahedralChirality(focus, carriers, tc.getConfig()));
                 } else {
                     stereos.add(stereo);
                 }

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -63,7 +63,9 @@ import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.ringsearch.RingSearch;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
+import org.openscience.cdk.stereo.Atropisomeric;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
+import org.openscience.cdk.stereo.ExtendedTetrahedral;
 import org.openscience.cdk.stereo.TetrahedralChirality;
 
 /**
@@ -832,6 +834,9 @@ public class AtomContainerManipulator {
                 IBond cpyRight = yNew != y ? org.getBond(v, yNew) : orgRight;
 
                 elements.add(new DoubleBondStereochemistry(orgStereo, new IBond[]{cpyLeft, cpyRight}, conformation));
+            } else if (se instanceof Atropisomeric) {
+                // can not have any H's
+                elements.add(se);
             }
         }
 

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/DoubleBondStereochemistryTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/DoubleBondStereochemistryTest.java
@@ -36,6 +36,7 @@ import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -81,10 +82,11 @@ public class DoubleBondStereochemistryTest extends CDKTestCase {
      */
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_TooManyBonds() {
-
         IChemObjectBuilder builder = DefaultChemObjectBuilder.getInstance();
-
-        new DoubleBondStereochemistry(builder.newInstance(IBond.class), new IBond[3], Conformation.OPPOSITE);
+        IBond b1 = builder.newBond();
+        IBond b2 = builder.newBond();
+        IBond b3 = builder.newBond();
+        new DoubleBondStereochemistry(builder.newInstance(IBond.class), new IBond[]{b1,b2,b3}, Conformation.OPPOSITE);
     }
 
     @Test
@@ -98,7 +100,6 @@ public class DoubleBondStereochemistryTest extends CDKTestCase {
     public void testBuilder() {
         DoubleBondStereochemistry stereo = new DoubleBondStereochemistry(molecule.getBond(1), ligands,
                 Conformation.OPPOSITE);
-        Assert.assertNull(stereo.getBuilder());
         stereo.setBuilder(DefaultChemObjectBuilder.getInstance());
         Assert.assertEquals(DefaultChemObjectBuilder.getInstance(), stereo.getBuilder());
     }
@@ -223,25 +224,6 @@ public class DoubleBondStereochemistryTest extends CDKTestCase {
 
         // map the existing element a new element - should through an IllegalArgumentException
         IDoubleBondStereochemistry mapped = original.map(Collections.EMPTY_MAP, null);
-
-    }
-
-    @Test
-    public void testMap_Map_Map_NullElement() throws CloneNotSupportedException {
-
-        IChemObjectBuilder builder = DefaultChemObjectBuilder.getInstance();
-
-        // new stereo element
-        IDoubleBondStereochemistry original = new DoubleBondStereochemistry(null, new IBond[2], null);
-
-        // map the existing element a new element
-        IDoubleBondStereochemistry mapped = original.map(Collections.EMPTY_MAP, Collections.EMPTY_MAP);
-
-        Assert.assertNull(mapped.getStereoBond());
-        Assert.assertNull(mapped.getBonds()[0]);
-        Assert.assertNull(mapped.getBonds()[1]);
-        Assert.assertNull(mapped.getStereo());
-
     }
 
     @Test
@@ -265,10 +247,7 @@ public class DoubleBondStereochemistryTest extends CDKTestCase {
         // map the existing element a new element - should through an IllegalArgumentException
         IDoubleBondStereochemistry mapped = original.map(Collections.EMPTY_MAP, Collections.EMPTY_MAP);
 
-        Assert.assertThat(mapped.getStereoBond(), is(original.getStereoBond()));
-        Assert.assertThat(mapped.getBonds(), is(original.getBonds()));
-        Assert.assertNotNull(mapped.getStereo());
-
+        Assert.assertThat(mapped, is(sameInstance(original)));
     }
 
     @Test

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/TetrahedralChiralityTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/TetrahedralChiralityTest.java
@@ -78,7 +78,6 @@ public class TetrahedralChiralityTest extends CDKTestCase {
     @Test
     public void testBuilder() {
         TetrahedralChirality chirality = new TetrahedralChirality(molecule.getAtom(1), ligands, Stereo.CLOCKWISE);
-        Assert.assertNull(chirality.getBuilder());
         chirality.setBuilder(DefaultChemObjectBuilder.getInstance());
         Assert.assertEquals(DefaultChemObjectBuilder.getInstance(), chirality.getBuilder());
     }
@@ -184,32 +183,6 @@ public class TetrahedralChiralityTest extends CDKTestCase {
     }
 
     @Test
-    public void testMap_Map_Map_NullElement() throws CloneNotSupportedException {
-
-        IChemObjectBuilder builder = DefaultChemObjectBuilder.getInstance();
-
-        IAtom c1 = builder.newInstance(IAtom.class, "C");
-        IAtom o2 = builder.newInstance(IAtom.class, "O");
-        IAtom n3 = builder.newInstance(IAtom.class, "N");
-        IAtom c4 = builder.newInstance(IAtom.class, "C");
-        IAtom h5 = builder.newInstance(IAtom.class, "H");
-
-        // new stereo element
-        ITetrahedralChirality original = new TetrahedralChirality(null, new IAtom[4], null);
-
-        // map the existing element a new element
-        ITetrahedralChirality mapped = original.map(Collections.EMPTY_MAP, Collections.EMPTY_MAP);
-
-        Assert.assertNull(mapped.getChiralAtom());
-        Assert.assertNull(mapped.getLigands()[0]);
-        Assert.assertNull(mapped.getLigands()[1]);
-        Assert.assertNull(mapped.getLigands()[2]);
-        Assert.assertNull(mapped.getLigands()[3]);
-        Assert.assertNull(mapped.getStereo());
-
-    }
-
-    @Test
     public void testMap_Map_Map_EmptyMapping() throws CloneNotSupportedException {
 
         IChemObjectBuilder builder = DefaultChemObjectBuilder.getInstance();
@@ -226,10 +199,7 @@ public class TetrahedralChiralityTest extends CDKTestCase {
         // map the existing element a new element - should through an IllegalArgumentException
         ITetrahedralChirality mapped = original.map(Collections.EMPTY_MAP, Collections.EMPTY_MAP);
 
-        Assert.assertThat(mapped.getChiralAtom(), is(original.getChiralAtom()));
-        Assert.assertThat(mapped.getLigands(), is(original.getLigands()));
-        Assert.assertNotNull(mapped.getStereo());
-
+        Assert.assertThat(mapped, is(sameInstance(original)));
     }
 
     @Test

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
@@ -580,12 +580,20 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
     public void testSetStereoElements_List() {
 
         IAtomContainer container = (IAtomContainer) newChemObject();
+        IAtom atom = container.getBuilder().newAtom();
+        IBond bond = container.getBuilder().newBond();
+        IAtom a1 = container.getBuilder().newAtom();
+        IAtom a2 = container.getBuilder().newAtom();
+        IAtom a3 = container.getBuilder().newAtom();
+        IAtom a4 = container.getBuilder().newAtom();
+        IBond b1 = container.getBuilder().newBond();
+        IBond b2 = container.getBuilder().newBond();
 
         Assert.assertThat("empty container had stereo elements", container.stereoElements().iterator().hasNext(),
                 is(false));
 
         List<IStereoElement> dbElements = new ArrayList<IStereoElement>();
-        dbElements.add(new DoubleBondStereochemistry(null, new IBond[2],
+        dbElements.add(new DoubleBondStereochemistry(bond, new IBond[]{b1, b2},
                 IDoubleBondStereochemistry.Conformation.TOGETHER));
         container.setStereoElements(dbElements);
         Iterator<IStereoElement> first = container.stereoElements().iterator();
@@ -594,7 +602,7 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         Assert.assertThat("container had more then one stereo element", first.hasNext(), is(false));
 
         List<IStereoElement> tetrahedralElements = new ArrayList<IStereoElement>();
-        tetrahedralElements.add(new TetrahedralChirality(null, new IAtom[4], ITetrahedralChirality.Stereo.CLOCKWISE));
+        tetrahedralElements.add(new TetrahedralChirality(atom, new IAtom[]{a1, a2, a3, a4}, ITetrahedralChirality.Stereo.CLOCKWISE));
         container.setStereoElements(tetrahedralElements);
         Iterator<IStereoElement> second = container.stereoElements().iterator();
         Assert.assertThat("container did not have stereo elements", second.hasNext(), is(true));
@@ -901,8 +909,15 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
     public void testRemoveAllElements_StereoElements() {
 
         IAtomContainer container = (IAtomContainer) newChemObject();
-        container.addStereoElement(new TetrahedralChirality(container.getBuilder().newInstance(IAtom.class),
-                new IAtom[4], ITetrahedralChirality.Stereo.CLOCKWISE));
+        IChemObjectBuilder builder = container.getBuilder();
+        IAtom focus = builder.newAtom();
+        IAtom a1 = builder.newAtom();
+        IAtom a2 = builder.newAtom();
+        IAtom a3 = builder.newAtom();
+        IAtom a4 = builder.newAtom();
+        container.addStereoElement(new TetrahedralChirality(focus,
+                                                            new IAtom[]{a1,a2,a3,a4},
+                                                            ITetrahedralChirality.Stereo.CLOCKWISE));
 
         int count = 0;
         for (IStereoElement element : container.stereoElements()) {

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/CyclicCarbohydrateRecognitionTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/CyclicCarbohydrateRecognitionTest.java
@@ -152,9 +152,11 @@ public class CyclicCarbohydrateRecognitionTest {
         
         EdgeToBondMap                 bondMap = EdgeToBondMap.withSpaceFor(m);
         int[][]                       graph   = GraphUtil.toAdjList(m, bondMap);
-        CyclicCarbohydrateRecognition recon   = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                                  new Stereocenters(m, graph, bondMap));
-        
+        Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+        stereocenters.checkSymmetry();
+        CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
+                                                                                stereocenters);
+
         List<IStereoElement> elements = recon.recognise(Collections.singleton(Projection.Haworth));
         assertTetrahedralCenter(elements.get(0),
                                 m.getAtom(1),
@@ -211,8 +213,11 @@ public class CyclicCarbohydrateRecognitionTest {
 
         EdgeToBondMap                 bondMap = EdgeToBondMap.withSpaceFor(m);
         int[][]                       graph   = GraphUtil.toAdjList(m, bondMap);
-        CyclicCarbohydrateRecognition recon   = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                                  new Stereocenters(m, graph, bondMap));
+        Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+        stereocenters.checkSymmetry();
+        CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
+                                                                                stereocenters);
+
 
         List<IStereoElement> elements = recon.recognise(Collections.singleton(Projection.Chair));
         assertTetrahedralCenter(elements.get(0),
@@ -280,8 +285,11 @@ public class CyclicCarbohydrateRecognitionTest {
         EdgeToBondMap      bondMap    = EdgeToBondMap.withSpaceFor(m);
         int[][]            graph      = GraphUtil.toAdjList(m, bondMap);
 
+        Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+        stereocenters.checkSymmetry();
         CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                 new Stereocenters(m, graph, bondMap));
+                                                                                stereocenters);
+
         List<IStereoElement> elements = recon.recognise(Collections.singleton(Projection.Haworth));
         assertTetrahedralCenter(elements.get(0),
                                 m.getAtom(1),
@@ -351,8 +359,11 @@ public class CyclicCarbohydrateRecognitionTest {
         EdgeToBondMap      bondMap    = EdgeToBondMap.withSpaceFor(m);
         int[][]            graph      = GraphUtil.toAdjList(m, bondMap);
 
+        Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+        stereocenters.checkSymmetry();
         CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                                new Stereocenters(m, graph, bondMap));
+                                                                                stereocenters);
+
         List<IStereoElement> elements = recon.recognise(Collections.singleton(Projection.Haworth));
         assertTetrahedralCenter(elements.get(0),
                                 m.getAtom(2),
@@ -449,8 +460,11 @@ public class CyclicCarbohydrateRecognitionTest {
         EdgeToBondMap      bondMap    = EdgeToBondMap.withSpaceFor(m);
         int[][]            graph      = GraphUtil.toAdjList(m, bondMap);
 
+        Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+        stereocenters.checkSymmetry();
         CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                                       new Stereocenters(m, graph, bondMap));
+                                                                                stereocenters);
+
         List<IStereoElement> elements = recon.recognise(Collections.singleton(Projection.Haworth));
         assertTetrahedralCenter(elements.get(0),
                                 m.getAtom(1),
@@ -503,8 +517,11 @@ public class CyclicCarbohydrateRecognitionTest {
         EdgeToBondMap      bondMap    = EdgeToBondMap.withSpaceFor(m);
         int[][]            graph      = GraphUtil.toAdjList(m, bondMap);
 
+        Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+        stereocenters.checkSymmetry();
         CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                                new Stereocenters(m, graph, bondMap));
+                                                                                stereocenters);
+
         assertTrue(recon.recognise(Collections.singleton(Projection.Haworth)).isEmpty());
     }
 
@@ -550,8 +567,11 @@ public class CyclicCarbohydrateRecognitionTest {
             
             EdgeToBondMap bondMap = EdgeToBondMap.withSpaceFor(m);
             int[][] graph = GraphUtil.toAdjList(m, bondMap);
+            Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+            stereocenters.checkSymmetry();
             CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                                    new Stereocenters(m, graph, bondMap));
+                                                                                    stereocenters);
+
 
             List<IStereoElement> elements = recon.recognise(Collections.singleton(Projection.Chair));
             m.setStereoElements(elements);
@@ -608,8 +628,11 @@ public class CyclicCarbohydrateRecognitionTest {
 
         EdgeToBondMap bondMap = EdgeToBondMap.withSpaceFor(m);
         int[][] graph = GraphUtil.toAdjList(m, bondMap);
+        Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+        stereocenters.checkSymmetry();
         CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                                new Stereocenters(m, graph, bondMap));
+                                                                                stereocenters);
+
 
         List<IStereoElement> elements = recon.recognise(Collections.singleton(Projection.Haworth));
         assertTrue(elements.isEmpty());
@@ -639,8 +662,10 @@ public class CyclicCarbohydrateRecognitionTest {
         m.addBond(6, 7, IBond.Order.SINGLE);
         EdgeToBondMap bondMap = EdgeToBondMap.withSpaceFor(m);
         int[][] graph = GraphUtil.toAdjList(m, bondMap);
+        Stereocenters stereocenters = new Stereocenters(m, graph, bondMap);
+        stereocenters.checkSymmetry();
         CyclicCarbohydrateRecognition recon = new CyclicCarbohydrateRecognition(m, graph, bondMap,
-                                                                                new Stereocenters(m, graph, bondMap));
+                                                                                stereocenters);
 
         List<IStereoElement> elements = recon.recognise(Collections.singleton(Projection.Haworth));
         assertTrue(elements.isEmpty());

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/FischerRecognitionTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/FischerRecognitionTest.java
@@ -77,7 +77,7 @@ public class FischerRecognitionTest {
         FischerRecognition recogniser = new FischerRecognition(m,
                                                                graph,
                                                                bondMap,
-                                                               new Stereocenters(m, graph, bondMap));
+                                                               Stereocenters.of(m));
         List<IStereoElement> elements = recogniser.recognise(Collections.singleton(Projection.Fischer));
         Assert.assertThat(elements.size(), is(1));
         assertTetrahedralCenter(elements.get(0),
@@ -112,7 +112,7 @@ public class FischerRecognitionTest {
         FischerRecognition recogniser = new FischerRecognition(m,
                                                                graph,
                                                                bondMap,
-                                                               new Stereocenters(m, graph, bondMap));
+                                                               Stereocenters.of(m));
         List<IStereoElement> elements = recogniser.recognise(Collections.singleton(Projection.Fischer));
         Assert.assertThat(elements.size(), is(1));
         assertTetrahedralCenter(elements.get(0),
@@ -145,7 +145,7 @@ public class FischerRecognitionTest {
         FischerRecognition recogniser = new FischerRecognition(m,
                                                                graph,
                                                                bondMap,
-                                                               new Stereocenters(m, graph, bondMap));
+                                                               Stereocenters.of(m));
         List<IStereoElement> elements = recogniser.recognise(Collections.singleton(Projection.Fischer));
         Assert.assertThat(elements.size(), is(1));
         assertTetrahedralCenter(elements.get(0),
@@ -188,7 +188,7 @@ public class FischerRecognitionTest {
         FischerRecognition recogniser = new FischerRecognition(m,
                                                                graph,
                                                                bondMap,
-                                                               new Stereocenters(m, graph, bondMap));
+                                                               Stereocenters.of(m));
         List<IStereoElement> elements = recogniser.recognise(Collections.singleton(Projection.Fischer));
 
         Assert.assertThat(elements.size(), is(4));
@@ -562,7 +562,7 @@ public class FischerRecognitionTest {
         FischerRecognition recogniser = new FischerRecognition(m,
                                                                graph,
                                                                bondMap,
-                                                               new Stereocenters(m, graph, bondMap));
+                                                               Stereocenters.of(m));
         Assert.assertTrue(recogniser.recognise(Collections.singleton(Projection.Fischer)).isEmpty());
     }
 
@@ -602,7 +602,7 @@ public class FischerRecognitionTest {
         FischerRecognition recogniser = new FischerRecognition(m,
                                                                graph,
                                                                bondMap,
-                                                               new Stereocenters(m, graph, bondMap));
+                                                               Stereocenters.of(m));
         Assert.assertTrue(recogniser.recognise(Collections.singleton(Projection.Fischer)).isEmpty());
     }
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -608,7 +608,7 @@ public class StereoElementFactoryTest {
         m.addBond(2, 3, IBond.Order.DOUBLE, IBond.Stereo.NONE);
         m.addBond(3, 4, IBond.Order.SINGLE);
         m.addBond(3, 5, IBond.Order.SINGLE);
-        m.setStereoElements(StereoElementFactory.using2DCoordinates(m).createAll());
+        m.setStereoElements(StereoElementFactory.using2DCoordinates(m).checkSymmetry(true).createAll());
         assertFalse(m.stereoElements().iterator().hasNext());
     }
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -34,6 +34,7 @@ import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.io.MDLV2000Reader;
+import org.openscience.cdk.io.MDLV2000Writer;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.smiles.SmiFlavor;
@@ -547,8 +548,10 @@ public class StereoElementFactoryTest {
         m.addBond(1, 6, IBond.Order.SINGLE);
         m.addBond(3, 5, IBond.Order.SINGLE);
 
-        ExtendedTetrahedral et = StereoElementFactory.using3DCoordinates(m).createExtendedTetrahedral(2,
-                Stereocenters.of(m));
+        List<IStereoElement> stereos = StereoElementFactory.using3DCoordinates(m).createAll();
+        assertThat(stereos.size(), is(1));
+        assertThat(stereos.get(0), instanceOf(ExtendedTetrahedral.class));
+        ExtendedTetrahedral et = (ExtendedTetrahedral) stereos.get(0);
         assertThat(et.winding(), is(ITetrahedralChirality.Stereo.CLOCKWISE));
         assertThat(et.peripherals(), is(new IAtom[]{m.getAtom(0), m.getAtom(6), m.getAtom(4), m.getAtom(5)}));
         assertThat(et.focus(), is(m.getAtom(2)));
@@ -557,13 +560,13 @@ public class StereoElementFactoryTest {
     @Test
     public void createExtendedTetrahedralFrom3DCoordinates_ccw() throws Exception {
         IAtomContainer m = new AtomContainer(7, 6, 0, 0);
-        m.addAtom(atom("C", 3, 1.3810, -0.7495, -1.4012));
+        m.addAtom(atom("C", 3, -1.4096, -2.1383, 0.6392));
         m.addAtom(atom("C", 0, -0.4383, -2.0366, 0.8166));
         m.addAtom(atom("C", 0, 0.2349, -1.2464, 0.0943));
         m.addAtom(atom("C", 0, 0.9377, -0.4327, -0.5715));
         m.addAtom(atom("C", 3, 1.0851, 0.9388, -0.1444));
+        m.addAtom(atom("H", 0, 1.3810, -0.7495, -1.4012));
         m.addAtom(atom("H", 0, 0.1925, -2.7911, 1.8739));
-        m.addAtom(atom("H", 0, -1.4096, -2.1383, 0.6392));
         m.addBond(1, 0, IBond.Order.SINGLE);
         m.addBond(1, 2, IBond.Order.DOUBLE);
         m.addBond(2, 3, IBond.Order.DOUBLE);
@@ -571,8 +574,10 @@ public class StereoElementFactoryTest {
         m.addBond(1, 6, IBond.Order.SINGLE);
         m.addBond(3, 5, IBond.Order.SINGLE);
 
-        ExtendedTetrahedral et = StereoElementFactory.using3DCoordinates(m).createExtendedTetrahedral(2,
-                Stereocenters.of(m));
+        List<IStereoElement> stereos = StereoElementFactory.using3DCoordinates(m).createAll();
+        assertThat(stereos.size(), is(1));
+        assertThat(stereos.get(0), instanceOf(ExtendedTetrahedral.class));
+        ExtendedTetrahedral et = (ExtendedTetrahedral) stereos.get(0);
         assertThat(et.winding(), is(ITetrahedralChirality.Stereo.ANTI_CLOCKWISE));
         assertThat(et.peripherals(), is(new IAtom[]{m.getAtom(0), m.getAtom(6), m.getAtom(4), m.getAtom(5)}));
         assertThat(et.focus(), is(m.getAtom(2)));
@@ -666,6 +671,29 @@ public class StereoElementFactoryTest {
 
         List<IStereoElement> elements = StereoElementFactory.using2DCoordinates(m).createAll();
         assertThat(elements.size(), is(3));
+    }
+
+
+    /**
+     * Watch out for cumulated bonds with a kink in 3d. The generation program
+     * has not understood the chemistry completely.
+     *
+     * @cdk.smiles CC=[C@]=CC
+     */
+    @Test
+    public void badlyOptimizedAllene() {
+        IAtomContainer m = new AtomContainer();
+        m.addAtom(atom("C", 1, -4.02, 3.96, -1.09));
+        m.addAtom(atom("C", 0, -4.96, 3.82, 0.13));
+        m.addAtom(atom("C", 3, -3.70, 5.35, -1.67));
+        m.addAtom(atom("C", 1, -5.27, 2.44, 0.71));
+        m.addAtom(atom("C", 3, -6.21, 2.30, 1.92));
+        m.addBond(0, 1, IBond.Order.DOUBLE);
+        m.addBond(0, 2, IBond.Order.SINGLE);
+        m.addBond(1, 3, IBond.Order.DOUBLE);
+        m.addBond(3, 4, IBond.Order.SINGLE);
+        List<IStereoElement> elements = StereoElementFactory.using3DCoordinates(m).createAll();
+        assertThat(elements.size(), is(0));
     }
 
     @Test

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -1252,6 +1252,49 @@ public class StereoElementFactoryTest {
         assertThat(stereo.size(), is(0));
     }
 
+    /**
+     * @cdk.smiles CC1=CC=CC(Cl)=C1C1=C(C)C=CC=C1
+     */
+    @Test
+    public void atropisomer3D() {
+        IAtomContainer m = new AtomContainer();
+        m.addAtom(atom("C", 1, -4.95, 1.27));
+        m.addAtom(atom("C", 1, -4.26, 1.73));
+        m.addAtom(atom("C", 0, -2.85, 1.74));
+        m.addAtom(atom("C", 0, -2.12, 1.25));
+        m.addAtom(atom("C", 0, -2.83, 0.80));
+        m.addAtom(atom("C", 1, -4.23, 0.82));
+        m.addAtom(atom("C", 3, -2.16, 2.26));
+        m.addAtom(atom("Cl", 0, -2.04, 0.24));
+        m.addAtom(atom("C", 0, -0.70, 1.20));
+        m.addAtom(atom("C", 1, 0.00, 2.39));
+        m.addAtom(atom("C", 1, 1.41, 2.39));
+        m.addAtom(atom("C", 1, 2.12, 1.22));
+        m.addAtom(atom("C", 1, 1.44, 0.04));
+        m.addAtom(atom("C", 0, 0.02, 0.01));
+        m.addAtom(atom("C", 3, -0.62, -1.29));
+        m.addBond(0, 1, IBond.Order.SINGLE);
+        m.addBond(1, 2, IBond.Order.DOUBLE);
+        m.addBond(3, 2, IBond.Order.SINGLE);
+        m.addBond(3, 4, IBond.Order.DOUBLE);
+        m.addBond(4, 5, IBond.Order.SINGLE);
+        m.addBond(0, 5, IBond.Order.DOUBLE);
+        m.addBond(2, 6, IBond.Order.SINGLE);
+        m.addBond(4, 7, IBond.Order.SINGLE);
+        m.addBond(3, 8, IBond.Order.SINGLE);
+        m.addBond(9, 10, IBond.Order.DOUBLE);
+        m.addBond(10, 11, IBond.Order.SINGLE);
+        m.addBond(11, 12, IBond.Order.DOUBLE);
+        m.addBond(12, 13, IBond.Order.SINGLE);
+        m.addBond(8, 9, IBond.Order.SINGLE);
+        m.addBond(8, 13, IBond.Order.DOUBLE);
+        m.addBond(13, 14, IBond.Order.SINGLE);
+        List<IStereoElement> stereo =
+            StereoElementFactory.using3DCoordinates(m)
+                                .createAll();
+        assertThat(stereo.size(), is(1));
+    }
+
     static IAtom atom(String symbol, int h, double x, double y) {
         IAtom a = new Atom(symbol);
         a.setImplicitHydrogenCount(h);


### PR DESCRIPTION
Improvements to how we represent stereochemistry - backwards compatible but much of details are pushed down to the abstract API. More in the JavaDoc but essentially we describe stereochemistry with a focus (or maybe foci in future), two or more carriers, and a configuration.