### PR TITLE
Faster AtomContainer Prep Work

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/AtomRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/AtomRef.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+
+import javax.vecmath.Point2d;
+import javax.vecmath.Point3d;
+
+/**
+ * An atom ref, references a CDK {@link IAtom} indirectly. All
+ * methods are passed through to the referenced atom. The reference can
+ * be used to override the behaviour of the base atom.
+ *
+ * @author John Mayfield
+ */
+public class AtomRef extends ChemObjectRef implements IAtom {
+
+    private final IAtom atom;
+
+    /**
+     * Create a pointer for the provided atom.
+     *
+     * @param atom the atom to reference
+     */
+    public AtomRef(IAtom atom) {
+        super(atom);
+        this.atom = atom;
+    }
+
+    /**
+     * Utility method to dereference an atom. If the atom is not
+     * an {@link AtomRef} it simply returns the input.
+     *
+     * @param atom the atom
+     * @return non-pointer atom
+     */
+    public static IAtom deref(IAtom atom) {
+        while (atom instanceof AtomRef)
+            atom = ((AtomRef) atom).deref();
+        return atom;
+    }
+
+    /**
+     * Dereference the atom pointer once providing access to the base
+     * atom.
+     *
+     * @return the atom pointed to
+     */
+    public IAtom deref() {
+        return atom;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Double getCharge() {
+        return atom.getCharge();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCharge(Double charge) {
+        atom.setCharge(charge);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getAtomicNumber() {
+        return atom.getAtomicNumber();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAtomicNumber(Integer atomicNumber) {
+        atom.setAtomicNumber(atomicNumber);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Double getNaturalAbundance() {
+        return atom.getNaturalAbundance();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setNaturalAbundance(Double naturalAbundance) {
+        atom.setNaturalAbundance(naturalAbundance);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getImplicitHydrogenCount() {
+        return atom.getImplicitHydrogenCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setImplicitHydrogenCount(Integer hydrogenCount) {
+        atom.setImplicitHydrogenCount(hydrogenCount);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Double getExactMass() {
+        return atom.getExactMass();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setExactMass(Double exactMass) {
+        atom.setExactMass(exactMass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getSymbol() {
+        return atom.getSymbol();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSymbol(String symbol) {
+        atom.setSymbol(symbol);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getMassNumber() {
+        return atom.getMassNumber();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setMassNumber(Integer massNumber) {
+        atom.setMassNumber(massNumber);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAtomTypeName() {
+        return atom.getAtomTypeName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAtomTypeName(String identifier) {
+        atom.setAtomTypeName(identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IBond.Order getMaxBondOrder() {
+        return atom.getMaxBondOrder();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setMaxBondOrder(IBond.Order maxBondOrder) {
+        atom.setMaxBondOrder(maxBondOrder);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Double getBondOrderSum() {
+        return atom.getBondOrderSum();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setBondOrderSum(Double bondOrderSum) {
+        atom.setBondOrderSum(bondOrderSum);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Point2d getPoint2d() {
+        return atom.getPoint2d();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPoint2d(Point2d point2d) {
+        atom.setPoint2d(point2d);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Point3d getPoint3d() {
+        return atom.getPoint3d();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPoint3d(Point3d point3d) {
+        atom.setPoint3d(point3d);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getFormalCharge() {
+        return atom.getFormalCharge();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFormalCharge(Integer charge) {
+        atom.setFormalCharge(charge);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Point3d getFractionalPoint3d() {
+        return atom.getFractionalPoint3d();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFractionalPoint3d(Point3d point3d) {
+        atom.setFractionalPoint3d(point3d);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getFormalNeighbourCount() {
+        return atom.getFormalNeighbourCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFormalNeighbourCount(Integer count) {
+        atom.setFormalNeighbourCount(count);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getStereoParity() {
+        return atom.getStereoParity();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setStereoParity(Integer stereoParity) {
+        atom.setStereoParity(stereoParity);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Hybridization getHybridization() {
+        return atom.getHybridization();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setHybridization(Hybridization hybridization) {
+        atom.setHybridization(hybridization);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Double getCovalentRadius() {
+        return atom.getCovalentRadius();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCovalentRadius(Double radius) {
+        atom.setCovalentRadius(radius);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer getContainer() {
+        return atom.getContainer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        return atom.getIndex();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getValency() {
+        return atom.getValency();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValency(Integer valency) {
+        atom.setValency(valency);
+    }
+
+    public Iterable<IBond> bonds() {
+        return atom.bonds();
+    }
+
+    public int getBondCount() {
+        return atom.getBondCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAromatic() {
+        return atom.isAromatic();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setIsAromatic(boolean arom) {
+        atom.setIsAromatic(arom);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isInRing() {
+        return atom.isInRing();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setIsInRing(boolean ring) {
+        atom.setIsInRing(ring);
+    }
+
+    @Override
+    public int hashCode() {
+        return atom.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return atom.equals(obj);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom clone() throws CloneNotSupportedException {
+        return atom.clone();
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/BondRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/BondRef.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+
+import javax.vecmath.Point2d;
+import javax.vecmath.Point3d;
+
+/**
+ * A bond ref, references a CDK {@link IBond} indirectly. All
+ * methods are passed through to the referenced bond. The reference can
+ * be used to override the behaviour of the base bond.
+ *
+ * @author John Mayfield
+ */
+public class BondRef extends ChemObjectRef implements IBond {
+
+    private final IBond bond;
+
+    /**
+     * Create a pointer for the provided bond.
+     *
+     * @param bond the bond to reference
+     */
+    public BondRef(IBond bond) {
+        super(bond);
+        this.bond = bond;
+    }
+
+    /**
+     * Utility method to dereference an bond pointer. If the bond is not
+     * an {@link BondRef} it simply returns the input.
+     *
+     * @param bond the bond
+     * @return non-pointer bond
+     */
+    public static IBond deref(IBond bond) {
+        while (bond instanceof BondRef)
+            bond = ((BondRef) bond).deref();
+        return bond;
+    }
+
+    /**
+     * Dereference the bond pointer once providing access to the base
+     * bond.
+     *
+     * @return the bond pointed to
+     */
+    public IBond deref() {
+        return bond;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getElectronCount() {
+        return bond.getElectronCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setElectronCount(Integer count) {
+        bond.setElectronCount(count);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterable<IAtom> atoms() {
+        return bond.atoms();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAtoms(IAtom[] atoms) {
+        bond.setAtoms(atoms);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom getBegin() {
+        return bond.getBegin();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom getEnd() {
+        return bond.getEnd();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        return bond.getIndex();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer getContainer() {
+        return bond.getContainer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getAtomCount() {
+        return bond.getAtomCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom getAtom(int position) {
+        return bond.getAtom(position);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom getConnectedAtom(IAtom atom) {
+        return bond.getConnectedAtom(atom);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom getOther(IAtom atom) {
+        return bond.getOther(atom);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtom[] getConnectedAtoms(IAtom atom) {
+        return bond.getConnectedAtoms(atom);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean contains(IAtom atom) {
+        return bond.contains(atom);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAtom(IAtom atom, int position) {
+        bond.setAtom(atom, position);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Order getOrder() {
+        return bond.getOrder();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setOrder(Order order) {
+        bond.setOrder(order);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stereo getStereo() {
+        return bond.getStereo();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setStereo(Stereo stereo) {
+        bond.setStereo(stereo);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Point2d get2DCenter() {
+        return bond.get2DCenter();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Point3d get3DCenter() {
+        return bond.get3DCenter();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean compare(Object object) {
+        return bond.compare(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isConnectedTo(IBond bond) {
+        return this.bond.isConnectedTo(bond);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAromatic() {
+        return bond.isAromatic();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setIsAromatic(boolean arom) {
+        bond.setIsAromatic(arom);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isInRing() {
+        return bond.isInRing();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setIsInRing(boolean ring) {
+        bond.setIsInRing(ring);
+    }
+
+    @Override
+    public int hashCode() {
+        return bond.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return bond.equals(obj);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IBond clone() throws CloneNotSupportedException {
+        return bond.clone();
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/ChemObjectRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/ChemObjectRef.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk;
+
+import org.openscience.cdk.interfaces.IChemObject;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.interfaces.IChemObjectChangeEvent;
+import org.openscience.cdk.interfaces.IChemObjectListener;
+
+import java.util.Map;
+
+class ChemObjectRef implements IChemObject {
+
+    private final IChemObject chemobj;
+
+    ChemObjectRef(IChemObject chemobj) {
+        if (chemobj == null)
+            throw new NullPointerException("Proxy object can not be null!");
+        this.chemobj = chemobj;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IChemObjectBuilder getBuilder() {
+        return chemobj.getBuilder();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addListener(IChemObjectListener col) {
+        chemobj.addListener(col);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getListenerCount() {
+        return chemobj.getListenerCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeListener(IChemObjectListener col) {
+        chemobj.removeListener(col);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setNotification(boolean bool) {
+        chemobj.setNotification(bool);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getNotification() {
+        return chemobj.getNotification();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void notifyChanged() {
+        chemobj.notifyChanged();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void notifyChanged(IChemObjectChangeEvent evt) {
+        chemobj.notifyChanged(evt);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setProperty(Object description, Object property) {
+        chemobj.setProperty(description, property);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeProperty(Object description) {
+        chemobj.removeProperty(description);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T getProperty(Object description) {
+        return chemobj.getProperty(description);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T getProperty(Object description, Class<T> c) {
+        return chemobj.getProperty(description, c);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<Object, Object> getProperties() {
+        return chemobj.getProperties();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getID() {
+        return chemobj.getID();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setID(String identifier) {
+        chemobj.setID(identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFlag(int mask, boolean value) {
+        chemobj.setFlag(mask, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getFlag(int mask) {
+        return chemobj.getFlag(mask);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setProperties(Map<Object, Object> properties) {
+        chemobj.setProperties(properties);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addProperties(Map<Object, Object> properties) {
+        chemobj.addProperties(properties);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFlags(boolean[] newFlags) {
+        chemobj.setFlags(newFlags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean[] getFlags() {
+        return chemobj.getFlags();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Number getFlagValue() {
+        return chemobj.getFlagValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return new ChemObjectRef((IChemObject) chemobj.clone());
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/DynamicFactory.java
+++ b/base/core/src/main/java/org/openscience/cdk/DynamicFactory.java
@@ -317,7 +317,7 @@ public class DynamicFactory {
             throw new IllegalArgumentException("attempt to register a non-interface interface: " + intf.getSimpleName());
 
         boolean registered = Boolean.FALSE;
-        for (Constructor<?> untyped : impl.getConstructors()) {
+        for (Constructor<?> untyped : impl.getDeclaredConstructors()) {
             @SuppressWarnings("unchecked")
             Constructor<T> typed = (Constructor<T>) untyped;
             registered = register(intf, typed, modifier) || registered;
@@ -378,8 +378,12 @@ public class DynamicFactory {
     public <S extends ICDKObject, T extends S> boolean register(Class<S> intf, Constructor<T> constructor,
             CreationModifier<T> modifier) {
 
-        // do not register private/protected constructors
-        if (!Modifier.isPublic(constructor.getModifiers())) return Boolean.FALSE;
+        // do not register private constructors
+        if (Modifier.isPrivate(constructor.getModifiers()) ||
+            Modifier.isProtected(constructor.getModifiers())) return Boolean.FALSE;
+
+        // maybe package-private, make sure we can call it
+        constructor.setAccessible(true);
 
         return register(key(intf, constructor), constructor, modifier) != null;
 

--- a/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
@@ -155,12 +155,17 @@ public class PathTools {
         List<IBond> bonds = molecule.getConnectedBondsList(root);
         IAtom nextAtom;
         root.setFlag(CDKConstants.VISITED, true);
+        boolean first = path.isEmpty();
+        if (first)
+            path.addAtom(root);
         for (IBond bond : bonds) {
             nextAtom = bond.getOther(root);
             if (!nextAtom.getFlag(CDKConstants.VISITED)) {
                 path.addAtom(nextAtom);
                 path.addBond(bond);
                 if (nextAtom.equals(target)) {
+                    if (first)
+                        path.removeAtomOnly(root);
                     return true;
                 } else {
                     if (!depthFirstTargetSearch(molecule, nextAtom, target, path)) {
@@ -168,11 +173,15 @@ public class PathTools {
                         path.removeAtomOnly(nextAtom);
                         path.removeBond(bond);
                     } else {
+                        if (first)
+                            path.removeAtomOnly(root);
                         return true;
                     }
                 }
             }
         }
+        if (first)
+            path.removeAtomOnly(root);
         return false;
     }
 

--- a/base/core/src/main/java/org/openscience/cdk/graph/SpanningTree.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/SpanningTree.java
@@ -256,7 +256,6 @@ public class SpanningTree {
                 for (int b = 0; b < ring.getBondCount(); b++) {
                     IBond ringBond = ring.getBond(b);
                     if (!fragContainer.contains(ringBond)) {
-                        fragContainer.addBond(ringBond);
                         for (int atomCount = 0; atomCount < ringBond.getAtomCount(); atomCount++) {
                             IAtom atom = ringBond.getAtom(atomCount);
                             if (!fragContainer.contains(atom)) {
@@ -264,6 +263,7 @@ public class SpanningTree {
                                 fragContainer.addAtom(atom);
                             }
                         }
+                        fragContainer.addBond(ringBond);
                     }
                 }
             }

--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -27,7 +27,6 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IElement;
-import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
@@ -650,5 +649,23 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         atom.setFormalCharge(chg);
 
         return pos == len && len > 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof AtomRef)
+            return super.equals(((AtomRef) obj).deref());
+        return super.equals(obj);
     }
 }

--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -24,6 +24,8 @@ package org.openscience.cdk;
 
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
@@ -234,6 +236,38 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             this.charge = ((IAtom) element).getCharge();
             this.stereoParity = ((IAtom) element).getStereoParity();
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer getContainer() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        return -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterable<IBond> bonds() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getBondCount() {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -533,6 +533,24 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BondRef)
+            return super.equals(((BondRef) obj).deref());
+        return super.equals(obj);
+    }
+
+    /**
      * Returns a one line string representation of this Container. This method is
      * conform RFC #9.
      *

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -252,14 +252,14 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      * {@inheritDoc}
      */
     public IAtom getBegin() {
-        return atoms[0];
+        return atomCount < 1 ? null : atoms[0];
     }
 
     /**
      * {@inheritDoc}
      */
     public IAtom getEnd() {
-        return atoms[1];
+        return atomCount < 2 ? null : atoms[1];
     }
 
     /**

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -20,6 +20,7 @@
 package org.openscience.cdk;
 
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 
 import javax.vecmath.Point2d;
@@ -168,6 +169,22 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
                 return new AtomsIterator();
             }
         };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        return -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer getContainer() {
+        return null;
     }
 
     /**

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugAtom.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugAtom.java
@@ -25,6 +25,7 @@ import javax.vecmath.Point3d;
 
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomType;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectChangeEvent;
@@ -69,6 +70,32 @@ public class DebugAtom extends Atom implements IAtom {
     public DebugAtom(IElement element) {
         super(element);
         logger.debug("Instantiated a DebugAtom: element= ", element);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer getContainer() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        logger.debug("Getting index on base Atom class");
+        return -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterable<IBond> bonds() {
+        logger.debug("Getting connected bonds on base Atom class");
+        throw new UnsupportedOperationException();
     }
 
     /** {@inheritDoc} */

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
@@ -144,6 +144,69 @@ public interface IAtom extends IAtomType {
     Integer getStereoParity();
 
     /**
+     * Access the {@link IAtomContainer} of which this atom is a member of. Because atoms
+     * can be in multiple molecules this method will only work if the atom has been accessed
+     * in the context of an {@link IAtomContainer}, for example:
+     *
+     * <pre>{@code
+     * IAtomContainer mol  = new AtomContainer();
+     * IAtom          atom = new Atom(6);
+     *
+     * atom.getContainer(); // null
+     * mol.add(atom);
+     * atom.getContainer(); // still null
+     * mol.getAtom(0).getContainer(); // not-null, returns 'mol'
+     * }</pre>
+     *
+     * @return the atom container or null if not accessed in the context of a
+     *         container
+     */
+    IAtomContainer getContainer();
+
+    /**
+     * Acces the index of an atom in the context of an {@link IAtomContainer}. If the
+     * index is not known, < 0 is returned.
+     *
+     * @return atom index or < 0 if the index is not known
+     */
+    int getIndex();
+
+    /**
+     * Returns the bonds connected to this atom. If the bonds are not
+     * known an exception is thrown. This method will only throw an exception
+     * if {@link #getIndex()} returns < 0 or {@link #getContainer()} returns null.
+     *
+     * <pre>{@code
+     *
+     * IAtom atom = ...;
+     *
+     * if (atom.getIndex() >= 0) {
+     *   for (IBond bond : atom.bonds()) {
+     *
+     *   }
+     * }
+     *
+     * if (atom.getContainer() != null) {
+     *   for (IBond bond : atom.bonds()) {
+     *
+     *   }
+     * }
+     *
+     * IAtomContainer mol = ...;
+     * // guaranteed not throw an exception
+     * for (IBond bond : mol.getAtom(i).bonds()) {
+     *
+     * }
+     * }</pre>
+     *
+     * @return iterable of bonds
+     * @throws UnsupportedOperationException thrown if the bonds are not known
+     */
+    Iterable<IBond> bonds();
+
+    int getBondCount();
+
+    /**
      * Access whether this atom has been marked as aromatic. The default
      * value is false and you must explicitly perceive aromaticity with
      * one of the available models.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtomContainer.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtomContainer.java
@@ -18,6 +18,7 @@
  */
 package org.openscience.cdk.interfaces;
 
+import org.openscience.cdk.exception.NoSuchAtomException;
 import org.openscience.cdk.interfaces.IBond.Order;
 
 import java.util.List;
@@ -487,6 +488,8 @@ public interface IAtomContainer extends IChemObject, IChemObjectListener {
      * Adds a Bond to this AtomContainer.
      *
      * @param bond The bond to added to this container
+     * @throws NoSuchAtomException optionally thrown if the atoms of the bond
+     *         have not yet been added
      */
     void addBond(IBond bond);
 

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -161,6 +161,10 @@ public interface IBond extends IElectronContainer {
      */
     IAtom getEnd();
 
+    int getIndex();
+
+    IAtomContainer getContainer();
+
     /**
      * Returns the number of Atoms in this Bond.
      *

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
@@ -24,6 +24,7 @@ import javax.vecmath.Point3d;
 
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomType;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
@@ -138,6 +139,37 @@ public abstract class QueryAtom extends QueryChemObject implements IQueryAtom {
 
     public QueryAtom(IChemObjectBuilder builder) {
         super(builder);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        return -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IAtomContainer getContainer() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterable<IBond> bonds() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getBondCount() {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -25,6 +25,7 @@ import javax.vecmath.Point3d;
 
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 
@@ -148,6 +149,22 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
                 return new AtomsIterator();
             }
         };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer getContainer() {
+        return null;
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -28,13 +28,13 @@ import java.util.Objects;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
+import org.openscience.cdk.AtomRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IElement;
-import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
 /**
  * Represents the idea of an chemical atom.
@@ -650,5 +650,23 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         atom.setFormalCharge(chg);
 
         return pos == len && len > 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof AtomRef)
+            return super.equals(((AtomRef) obj).deref());
+        return super.equals(obj);
     }
 }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -31,6 +31,8 @@ import javax.vecmath.Point3d;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
@@ -235,6 +237,38 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             this.charge = ((IAtom) element).getCharge();
             this.stereoParity = ((IAtom) element).getStereoParity();
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer getContainer() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        return -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getBondCount() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterable<IBond> bonds() {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
+import org.openscience.cdk.BondRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -522,6 +523,24 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
             }
         }
         return clone;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BondRef)
+            return super.equals(((BondRef) obj).deref());
+        return super.equals(obj);
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -27,6 +27,7 @@ import javax.vecmath.Point3d;
 
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 
 /**
@@ -168,6 +169,22 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
                 return new AtomsIterator();
             }
         };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getIndex() {
+        return -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IAtomContainer getContainer() {
+        return null;
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -251,14 +251,14 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      * {@inheritDoc}
      */
     public IAtom getBegin() {
-        return atoms[0];
+        return atomCount < 1 ? null : atoms[0];
     }
 
     /**
      * {@inheritDoc}
      */
     public IAtom getEnd() {
-        return atoms[1];
+        return atomCount < 2 ? null : atoms[1];
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/SingleElectron.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SingleElectron.java
@@ -94,7 +94,7 @@ public class SingleElectron extends ElectronContainer implements Serializable, I
      */
     @Override
     public IAtom getAtom() {
-        return (Atom) this.atom;
+        return this.atom;
     }
 
     /**

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.collect.Maps;
@@ -822,14 +823,14 @@ public class AtomContainerManipulator {
                 if (x == null || y == null) continue;
 
                 // no changes
-                if (x == xNew && y == yNew) {
+                if (x.equals(xNew) && y.equals(yNew)) {
                     elements.add(db);
                     continue;
                 }
 
                 // XXX: may perform slow operations but works for now
-                IBond cpyLeft = xNew != x ? org.getBond(u, xNew) : orgLeft;
-                IBond cpyRight = yNew != y ? org.getBond(v, yNew) : orgRight;
+                IBond cpyLeft = !Objects.equals(xNew, x) ? org.getBond(u, xNew) : orgLeft;
+                IBond cpyRight = !Objects.equals(yNew, y) ? org.getBond(v, yNew) : orgRight;
 
                 elements.add(new DoubleBondStereochemistry(orgStereo, new IBond[]{cpyLeft, cpyRight}, conformation));
             }
@@ -973,7 +974,7 @@ public class AtomContainerManipulator {
      */
     private static IAtom findOther(IAtomContainer container, IAtom atom, IAtom exclude1, IAtom exclude2) {
         for (IAtom neighbor : container.getConnectedAtomsList(atom)) {
-            if (neighbor != exclude1 && neighbor != exclude2) return neighbor;
+            if (!neighbor.equals(exclude1) && !neighbor.equals(exclude2)) return neighbor;
         }
         return null;
     }

--- a/base/test-core/src/test/java/org/openscience/cdk/AtomRefTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/AtomRefTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk;
+
+import org.junit.Test;
+import org.openscience.cdk.AtomRef;
+import org.openscience.cdk.interfaces.IAtom;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class AtomRefTest {
+
+    @Test public void dereferenceNullPointer() {
+        assertNull(AtomRef.deref(null));
+    }
+
+    @Test public void dereferenceNonPointer() {
+        IAtom mock = mock(IAtom.class);
+        assertThat(AtomRef.deref(mock), is(sameInstance(mock)));
+    }
+
+    @Test public void dereferencePointer() {
+        IAtom mock = mock(IAtom.class);
+        IAtom ptr  = new AtomRef(mock);
+        assertThat(AtomRef.deref(ptr), is(sameInstance(mock)));
+    }
+
+    @Test public void dereferencePointerPointer() {
+        IAtom mock = mock(IAtom.class);
+        IAtom ptr  = new AtomRef(new AtomRef(mock));
+        assertThat(AtomRef.deref(ptr), is(sameInstance(mock)));
+    }
+}

--- a/base/test-core/src/test/java/org/openscience/cdk/BondRefTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/BondRefTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk;
+
+import org.junit.Test;
+import org.openscience.cdk.BondRef;
+import org.openscience.cdk.interfaces.IBond;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class BondRefTest {
+
+    @Test
+    public void dereferenceNullPointer() {
+        assertNull(BondRef.deref(null));
+    }
+
+    @Test
+    public void dereferenceNonPointer() {
+        IBond mock = mock(IBond.class);
+        assertThat(BondRef.deref(mock), is(sameInstance(mock)));
+    }
+
+    @Test
+    public void dereferencePointer() {
+        IBond mock = mock(IBond.class);
+        IBond ptr  = new BondRef(mock);
+        assertThat(BondRef.deref(ptr), is(sameInstance(mock)));
+    }
+
+    @Test
+    public void dereferencePointerPointer() {
+        IBond mock = mock(IBond.class);
+        IBond ptr  = new BondRef(new BondRef(mock));
+        assertThat(BondRef.deref(ptr), is(sameInstance(mock)));
+    }
+}

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
@@ -2465,13 +2465,15 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         IAtomContainer chemObject = (IAtomContainer) newChemObject();
         chemObject.addListener(listener);
 
-        chemObject.addAtom(chemObject.getBuilder().newInstance(IAtom.class));
+        IChemObjectBuilder builder = chemObject.getBuilder();
+        chemObject.addAtom(builder.newInstance(IAtom.class));
         assertTrue(listener.changed);
 
         listener.reset();
         assertFalse(listener.changed);
-        chemObject.addBond(chemObject.getBuilder().newInstance(IBond.class,
-                chemObject.getBuilder().newInstance(IAtom.class), chemObject.getBuilder().newInstance(IAtom.class)));
+        chemObject.addAtom(builder.newAtom());
+        chemObject.addAtom(builder.newAtom());
+        chemObject.addBond(builder.newInstance(IBond.class, chemObject.getAtom(0), chemObject.getAtom(1)));
         assertTrue(listener.changed);
     }
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTesterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTesterTest.java
@@ -240,11 +240,11 @@ public class UniversalIsomorphismTesterTest extends CDKTestCase {
 
         List<IAtomContainer> list = uiTester.getOverlaps(mol1, mol2);
         Assert.assertEquals(1, list.size());
-        Assert.assertEquals(11, ((AtomContainer) list.get(0)).getAtomCount());
+        Assert.assertEquals(11, (list.get(0)).getAtomCount());
 
         list = uiTester.getOverlaps(mol2, mol1);
         Assert.assertEquals(1, list.size());
-        Assert.assertEquals(11, ((AtomContainer) list.get(0)).getAtomCount());
+        Assert.assertEquals(11, (list.get(0)).getAtomCount());
     }
 
     /**
@@ -406,8 +406,8 @@ public class UniversalIsomorphismTesterTest extends CDKTestCase {
         List<IAtomContainer> list2 = uiTester.getOverlaps(mol2, mol1);
         Assert.assertEquals(1, list1.size());
         Assert.assertEquals(1, list2.size());
-        Assert.assertEquals(((AtomContainer) list1.get(0)).getAtomCount(),
-                ((AtomContainer) list2.get(0)).getAtomCount());
+        Assert.assertEquals((list1.get(0)).getAtomCount(),
+                (list2.get(0)).getAtomCount());
     }
 
     @Test

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/ImmutableHydrogen.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/ImmutableHydrogen.java
@@ -29,6 +29,8 @@ import javax.vecmath.Point3d;
 
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IChemObjectChangeEvent;
 import org.openscience.cdk.interfaces.IChemObjectListener;
@@ -602,4 +604,23 @@ class ImmutableHydrogen implements IAtom {
     public void setIsInRing(boolean ring) {
     }
 
+    @Override
+    public IAtomContainer getContainer() {
+        return null;
+    }
+
+    @Override
+    public int getIndex() {
+        return 0;
+    }
+
+    @Override
+    public Iterable<IBond> bonds() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getBondCount() {
+        return 0;
+    }
 }

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSTest.java
@@ -250,11 +250,11 @@ public class CDKMCSTest extends CDKTestCase {
 
         List<IAtomContainer> list = CDKMCS.getOverlaps(mol1, mol2, true);
         Assert.assertEquals(1, list.size());
-        Assert.assertEquals(11, ((AtomContainer) list.get(0)).getAtomCount());
+        Assert.assertEquals(11, (list.get(0)).getAtomCount());
 
         list = CDKMCS.getOverlaps(mol2, mol1, true);
         Assert.assertEquals(1, list.size());
-        Assert.assertEquals(11, ((AtomContainer) list.get(0)).getAtomCount());
+        Assert.assertEquals(11, (list.get(0)).getAtomCount());
     }
 
     /**
@@ -289,8 +289,8 @@ public class CDKMCSTest extends CDKTestCase {
         List<IAtomContainer> list2 = CDKMCS.getOverlaps(mol2, mol1, true);
         Assert.assertEquals(1, list1.size());
         Assert.assertEquals(1, list2.size());
-        Assert.assertEquals(((AtomContainer) list1.get(0)).getAtomCount(),
-                ((AtomContainer) list2.get(0)).getAtomCount());
+        Assert.assertEquals((list1.get(0)).getAtomCount(),
+                (list2.get(0)).getAtomCount());
     }
 
     @Test

--- a/misc/test-extra/src/test/java/org/openscience/cdk/graph/invariant/EquivalentClassPartitionerTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/graph/invariant/EquivalentClassPartitionerTest.java
@@ -31,6 +31,7 @@ import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
@@ -260,7 +261,7 @@ public class EquivalentClassPartitionerTest extends CDKTestCase {
         // check that there are some pseudo-atoms
         boolean hasPseudo = false;
         for (IAtom atom : mol.atoms()) {
-            if (atom instanceof PseudoAtom) hasPseudo = true;
+            if (atom instanceof IPseudoAtom) hasPseudo = true;
         }
         Assert.assertTrue("The molecule should have one or more pseudo atoms", hasPseudo);
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLRXNReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLRXNReaderTest.java
@@ -274,13 +274,13 @@ public class MDLRXNReaderTest extends SimpleChemObjectReaderTest {
     private String getAtomNumber(IReactionSet reactionSet, IChemObject chemObject) throws CDKException {
         for (int i = 0; i < reactionSet.getReaction(0).getReactantCount(); i++) {
             for (int k = 0; k < reactionSet.getReaction(0).getReactants().getAtomContainer(i).getAtomCount(); k++) {
-                if (reactionSet.getReaction(0).getReactants().getAtomContainer(i).getAtom(k) == chemObject)
+                if (reactionSet.getReaction(0).getReactants().getAtomContainer(i).getAtom(k).equals(chemObject))
                     return "reactant:" + i + "_" + k;
             }
         }
         for (int i = 0; i < reactionSet.getReaction(0).getProductCount(); i++) {
             for (int k = 0; k < reactionSet.getReaction(0).getProducts().getAtomContainer(i).getAtomCount(); k++) {
-                if (reactionSet.getReaction(0).getProducts().getAtomContainer(i).getAtom(k) == chemObject)
+                if (reactionSet.getReaction(0).getProducts().getAtomContainer(i).getAtom(k).equals(chemObject))
                     return "product:" + i + "_" + k;
             }
         }

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIToStructureTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIToStructureTest.java
@@ -31,7 +31,6 @@ import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.stereo.ExtendedTetrahedral;
 
@@ -139,7 +138,7 @@ public class InChIToStructureTest extends CDKTestCase {
         IAtomContainer container = parser.getAtomContainer();
         // test if the created IAtomContainer is done with the Silent module...
         // OK, this is not typical use, but maybe the above generate method should be private
-        assertTrue(container instanceof AtomContainer);
+        Assert.assertThat(container, is(instanceOf(SilentChemObjectBuilder.getInstance().newAtomContainer().getClass())));
     }
 
     @Test
@@ -147,7 +146,7 @@ public class InChIToStructureTest extends CDKTestCase {
         InChIToStructure parser = new InChIToStructure("InChI=1S/O", DefaultChemObjectBuilder.getInstance());
         parser.generateAtomContainerFromInchi(SilentChemObjectBuilder.getInstance());
         IAtomContainer container = parser.getAtomContainer();
-        Assert.assertThat(container, is(instanceOf(AtomContainer.class)));
+        Assert.assertThat(container, is(instanceOf(SilentChemObjectBuilder.getInstance().newAtomContainer().getClass())));
         Assert.assertThat(container.getAtom(0).getImplicitHydrogenCount(), is(notNullValue()));
         Assert.assertThat(container.getAtom(0).getImplicitHydrogenCount(), is(0));
     }
@@ -157,8 +156,8 @@ public class InChIToStructureTest extends CDKTestCase {
         InChIToStructure parser = new InChIToStructure("InChI=1S/H2O/h1H2/i1+2", DefaultChemObjectBuilder.getInstance());
         parser.generateAtomContainerFromInchi(SilentChemObjectBuilder.getInstance());
         IAtomContainer container = parser.getAtomContainer();
-        Assert.assertThat(container, is(instanceOf(AtomContainer.class)));
         Assert.assertThat(container.getAtom(0).getImplicitHydrogenCount(), is(notNullValue()));
+        Assert.assertThat(container, is(instanceOf(SilentChemObjectBuilder.getInstance().newAtomContainer().getClass())));        Assert.assertThat(container.getAtom(0).getImplicitHydrogenCount(), is(notNullValue()));
         Assert.assertThat(container.getAtom(0).getImplicitHydrogenCount(), is(2));
         Assert.assertThat(container.getAtom(0).getMassNumber(), is(18));
     }
@@ -169,8 +168,8 @@ public class InChIToStructureTest extends CDKTestCase {
                 DefaultChemObjectBuilder.getInstance());
         parser.generateAtomContainerFromInchi(SilentChemObjectBuilder.getInstance());
         IAtomContainer container = parser.getAtomContainer();
-        Assert.assertThat(container, is(instanceOf(AtomContainer.class)));
         Iterator<IStereoElement> ses = container.stereoElements().iterator();
+        Assert.assertThat(container, is(instanceOf(SilentChemObjectBuilder.getInstance().newAtomContainer().getClass())));
         assertTrue(ses.hasNext());
         IStereoElement se = ses.next();
         assertThat(se, is(instanceOf(IDoubleBondStereochemistry.class)));
@@ -183,8 +182,8 @@ public class InChIToStructureTest extends CDKTestCase {
                 DefaultChemObjectBuilder.getInstance());
         parser.generateAtomContainerFromInchi(SilentChemObjectBuilder.getInstance());
         IAtomContainer container = parser.getAtomContainer();
-        Assert.assertThat(container, is(instanceOf(AtomContainer.class)));
         Iterator<IStereoElement> ses = container.stereoElements().iterator();
+        Assert.assertThat(container, is(instanceOf(SilentChemObjectBuilder.getInstance().newAtomContainer().getClass())));
         assertTrue(ses.hasNext());
         IStereoElement se = ses.next();
         assertThat(se, is(instanceOf(IDoubleBondStereochemistry.class)));
@@ -200,8 +199,8 @@ public class InChIToStructureTest extends CDKTestCase {
                 SilentChemObjectBuilder.getInstance());
         IAtomContainer container = parser.getAtomContainer();
 
-        Assert.assertThat(container, is(instanceOf(AtomContainer.class)));
         Iterator<IStereoElement> ses = container.stereoElements().iterator();
+        Assert.assertThat(container, is(instanceOf(SilentChemObjectBuilder.getInstance().newAtomContainer().getClass())));
         assertTrue(ses.hasNext());
         IStereoElement se = ses.next();
         assertThat(se, is(instanceOf(ExtendedTetrahedral.class)));
@@ -221,8 +220,8 @@ public class InChIToStructureTest extends CDKTestCase {
                 SilentChemObjectBuilder.getInstance());
         IAtomContainer container = parser.getAtomContainer();
 
-        Assert.assertThat(container, is(instanceOf(AtomContainer.class)));
         Iterator<IStereoElement> ses = container.stereoElements().iterator();
+        Assert.assertThat(container, is(instanceOf(SilentChemObjectBuilder.getInstance().newAtomContainer().getClass())));
         assertTrue(ses.hasNext());
         IStereoElement se = ses.next();
         assertThat(se, is(instanceOf(ExtendedTetrahedral.class)));

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
@@ -48,6 +48,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemModel;
+import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.io.CMLReader;
 import org.openscience.cdk.libio.cml.Convertor;
@@ -177,8 +178,8 @@ public class CMLRoundTripTest extends CDKTestCase {
         Assert.assertEquals(1, roundTrippedMol.getAtomCount());
         IAtom roundTrippedAtom = roundTrippedMol.getAtom(0);
         Assert.assertNotNull(roundTrippedAtom);
-        Assert.assertTrue(roundTrippedAtom instanceof PseudoAtom);
-        Assert.assertEquals("Glu55", ((PseudoAtom) roundTrippedAtom).getLabel());
+        Assert.assertTrue(roundTrippedAtom instanceof IPseudoAtom);
+        Assert.assertEquals("Glu55", ((IPseudoAtom) roundTrippedAtom).getLabel());
     }
 
     /**

--- a/storage/pdb/src/test/java/org/openscience/cdk/io/PDBReaderTest.java
+++ b/storage/pdb/src/test/java/org/openscience/cdk/io/PDBReaderTest.java
@@ -41,6 +41,7 @@ import org.openscience.cdk.interfaces.IChemFile;
 import org.openscience.cdk.interfaces.IChemModel;
 import org.openscience.cdk.interfaces.IChemSequence;
 import org.openscience.cdk.interfaces.IMonomer;
+import org.openscience.cdk.interfaces.IPDBAtom;
 import org.openscience.cdk.protein.data.PDBAtom;
 import org.openscience.cdk.protein.data.PDBMonomer;
 import org.openscience.cdk.protein.data.PDBPolymer;
@@ -155,8 +156,8 @@ public class PDBReaderTest extends SimpleChemObjectReaderTest {
 
         IAtom nAtom = oMol.getAtom(0);
         Assert.assertNotNull(nAtom);
-        Assert.assertTrue(nAtom instanceof PDBAtom);
-        PDBAtom oAtom = (PDBAtom) nAtom;
+        Assert.assertTrue(nAtom instanceof IPDBAtom);
+        IPDBAtom oAtom = (IPDBAtom) nAtom;
         Assert.assertEquals(new String("C"), oAtom.getSymbol());
         Assert.assertEquals(1, oAtom.getSerial().intValue());
         Assert.assertEquals("C1", oAtom.getName());
@@ -167,8 +168,8 @@ public class PDBReaderTest extends SimpleChemObjectReaderTest {
 
         nAtom = oMol.getAtom(3);
         Assert.assertNotNull(nAtom);
-        Assert.assertTrue(nAtom instanceof PDBAtom);
-        oAtom = (PDBAtom) nAtom;
+        Assert.assertTrue(nAtom instanceof IPDBAtom);
+        oAtom = (IPDBAtom) nAtom;
         Assert.assertEquals("O", oAtom.getSymbol());
         Assert.assertEquals(4, oAtom.getSerial().intValue());
         Assert.assertEquals("O4", oAtom.getName());
@@ -179,8 +180,8 @@ public class PDBReaderTest extends SimpleChemObjectReaderTest {
 
         nAtom = oMol.getAtom(oMol.getAtomCount()-1);
         Assert.assertNotNull(nAtom);
-        Assert.assertTrue(nAtom instanceof PDBAtom);
-        oAtom = (PDBAtom) nAtom;
+        Assert.assertTrue(nAtom instanceof IPDBAtom);
+        oAtom = (IPDBAtom) nAtom;
         Assert.assertEquals("N", oAtom.getSymbol());
         Assert.assertEquals(14, oAtom.getSerial().intValue());
         Assert.assertEquals("N14", oAtom.getName());

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesGenerator.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesGenerator.java
@@ -755,7 +755,7 @@ public final class SmilesGenerator {
 
         // set the atom labels, values, and coordinates,
         // and build the atom->idx map required by other parts
-        Map<IAtom, Integer> atomidx = new IdentityHashMap<>();
+        Map<IAtom, Integer> atomidx = new HashMap<>();
         for (int idx = 0; idx < mol.getAtomCount(); idx++) {
             IAtom atom = mol.getAtom(idx);
             if (atom instanceof IPseudoAtom) {

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -2355,7 +2355,7 @@ public class SmilesParserTest extends CDKTestCase {
             assertTrue(stereoElement instanceof ITetrahedralChirality);
             ITetrahedralChirality l4Chiral = (ITetrahedralChirality) stereoElement;
             Assert.assertEquals("C", l4Chiral.getChiralAtom().getSymbol());
-            if (l4Chiral.getChiralAtom() == mol.getAtom(0)) {
+            if (l4Chiral.getChiralAtom().equals(mol.getAtom(0))) {
                 IAtom[] ligands = l4Chiral.getLigands();
                 for (IAtom atom : ligands)
                     Assert.assertNotNull(atom);

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -1911,37 +1911,34 @@ public class StructureDiagramGenerator {
      */
     private IAtomContainer placeFirstBond(IBond bond, Vector2d bondVector) {
         IAtomContainer sharedAtoms = null;
-        try {
-            bondVector.normalize();
-            logger.debug("placeFirstBondOfFirstRing->bondVector.length():" + bondVector.length());
-            bondVector.scale(bondLength);
-            logger.debug("placeFirstBondOfFirstRing->bondVector.length() after scaling:" + bondVector.length());
-            IAtom atom;
-            Point2d point = new Point2d(0, 0);
-            atom = bond.getBegin();
-            logger.debug("Atom 1 of first Bond: " + (molecule.indexOf(atom) + 1));
-            atom.setPoint2d(point);
-            atom.setFlag(CDKConstants.ISPLACED, true);
-            point = new Point2d(0, 0);
-            atom = bond.getEnd();
-            logger.debug("Atom 2 of first Bond: " + (molecule.indexOf(atom) + 1));
-            point.add(bondVector);
-            atom.setPoint2d(point);
-            atom.setFlag(CDKConstants.ISPLACED, true);
-            /*
-             * The new ring is layed out relativ to some shared atoms that have
-             * already been placed. Usually this is another ring, that has
-             * already been draw and to which the new ring is somehow connected,
-             * or some other system of atoms in an aliphatic chain. In this
-             * case, it's the first bond that we layout by hand.
-             */
-            sharedAtoms = atom.getBuilder().newInstance(IAtomContainer.class);
-            sharedAtoms.addBond(bond);
-            sharedAtoms.addAtom(bond.getBegin());
-            sharedAtoms.addAtom(bond.getEnd());
-        } catch (Exception exc) {
-            logger.debug(exc);
-        }
+
+        bondVector.normalize();
+        logger.debug("placeFirstBondOfFirstRing->bondVector.length():" + bondVector.length());
+        bondVector.scale(bondLength);
+        logger.debug("placeFirstBondOfFirstRing->bondVector.length() after scaling:" + bondVector.length());
+        IAtom atom;
+        Point2d point = new Point2d(0, 0);
+        atom = bond.getBegin();
+        logger.debug("Atom 1 of first Bond: " + (molecule.indexOf(atom) + 1));
+        atom.setPoint2d(point);
+        atom.setFlag(CDKConstants.ISPLACED, true);
+        point = new Point2d(0, 0);
+        atom = bond.getEnd();
+        logger.debug("Atom 2 of first Bond: " + (molecule.indexOf(atom) + 1));
+        point.add(bondVector);
+        atom.setPoint2d(point);
+        atom.setFlag(CDKConstants.ISPLACED, true);
+        /*
+         * The new ring is layed out relativ to some shared atoms that have
+         * already been placed. Usually this is another ring, that has
+         * already been draw and to which the new ring is somehow connected,
+         * or some other system of atoms in an aliphatic chain. In this
+         * case, it's the first bond that we layout by hand.
+         */
+        sharedAtoms = atom.getBuilder().newInstance(IAtomContainer.class);
+        sharedAtoms.addAtom(bond.getBegin());
+        sharedAtoms.addAtom(bond.getEnd());
+        sharedAtoms.addBond(bond);
         return sharedAtoms;
     }
 

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -1423,9 +1423,9 @@ public class StructureDiagramGenerator {
             IAtom atom2 = bond.getEnd();
             if (isHydrogen(atom1) || isHydrogen(atom2)) continue;
             if (ringAtoms.contains(atom1) ^ ringAtoms.contains(atom2)) {
-                ringWithStubs.addBond(bond);
                 ringWithStubs.addAtom(atom1);
                 ringWithStubs.addAtom(atom2);
+                ringWithStubs.addBond(bond);
             }
         }
 


### PR DESCRIPTION
Towards #278 

These patches add some API points to IAtom/IBond, introduce the AtomRef/BondRef base implementations and make some small changes.

I'm still testing the Faster Implementation locally but these are some independant changes that are needed and should be relatively quick to review (compared to the imminent 'AtomContainer2' implementation).

To IAtom we add these methods:
```java
IAtom atom = ...;
IAtomContainer container = atom.getContainer(); // the 'parent' atom container
int index = atom.getIndex(); // the index in the container
// bonds of the atom
for (IBond bond : atom.bonds()) {

}
int bondCount = atom.getBondCount();
```
Similar for bonds with regard to getIndex() and getContainer().

For 'current' atoms these will return null, -1, or throw unsupported operation exceptions. 

