### PR TITLE
Throw exception when passed any other object but IAtomContainer.

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -144,7 +144,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
         if (object instanceof IAtomContainer) {
             return (T) readMolecule(object.getBuilder());
         }
-        return null;
+        throw new CDKException("Only supports AtomContainer objects.");
     }
 
     public IAtomContainer readMolecule(IChemObjectBuilder builder) throws CDKException {


### PR DESCRIPTION
I noticed MDLV3000Reader.read accepts ChemObjects but fails silently when passed anything other than IAtomContainer objects (e.g. ChemFile). This throws an exception in that case.