### PR TITLE
Patch/stereo perception

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/graph/invariant/Canon.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/invariant/Canon.java
@@ -389,7 +389,10 @@ public final class Canon {
         // we specifically don't check for null atomic number, this must be set.
         // if not, something major is wrong
         for (int i = 0; i < ac.getAtomCount(); i++) {
-            hydrogens[i] = ac.getAtom(i).getAtomicNumber() == 1 && g[i].length == 1;
+            IAtom atom = ac.getAtom(i);
+            hydrogens[i] = atom.getAtomicNumber() == 1 &&
+                           atom.getMassNumber() == null &&
+                           g[i].length == 1;
         }
 
         return hydrogens;

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
@@ -260,13 +260,16 @@ public final class Stereocenters {
             // determine hydrogen count, connectivity and valence
             int h = container.getAtom(i).getImplicitHydrogenCount();
             int x = g[i].length + h;
+            int d = g[i].length;
             int v = h;
 
             if (x < 2 || x > 4 || h > 1) continue;
 
             int piNeighbor = 0;
             for (int w : g[i]) {
-                if (atomicNumber(container.getAtom(w)) == 1) h++;
+                if (atomicNumber(container.getAtom(w)) == 1 &&
+                    container.getAtom(w).getMassNumber() == null)
+                    h++;
                 switch (bondMap.get(i, w).getOrder()) {
                     case SINGLE:
                         v++;
@@ -282,7 +285,7 @@ public final class Stereocenters {
             }
 
             // check the type of stereo chemistry supported
-            switch (supportedType(i, v, h, x)) {
+            switch (supportedType(i, v, d, h, x)) {
                 case Bicoordinate:
                     stereocenters[i] = Stereocenter.Potential;
                     elements[i] = new Bicoordinate(i, g[i]);
@@ -479,7 +482,7 @@ public final class Stereocenters {
      * @param x connectivity
      * @return type of stereo chemistry
      */
-    private Type supportedType(int i, int v, int h, int x) {
+    private Type supportedType(int i, int v, int d, int h, int x) {
 
         IAtom atom = container.getAtom(i);
 
@@ -513,7 +516,8 @@ public final class Stereocenters {
                 if (x == 4) return Type.Tetracoordinate;
                 return Type.None;
             case 7: // nitrogen
-                if (x == 2 && v == 3 && h == 0 && q == 0) return Type.Tricoordinate;
+                if (x == 2 && v == 3 && d == 2 && q == 0)
+                    return Type.Tricoordinate;
                 if (x == 3 && v == 4 && q == 1) return Type.Tricoordinate;
                 if (x == 4 && h == 0 && (q == 0 && v == 5 || q == 1 && v == 4))
                     return verifyTerminalHCount(i) ? Type.Tetracoordinate : Type.None;
@@ -598,14 +602,17 @@ public final class Stereocenters {
         for (int i = 1; i < counts.length; i++) {
             if (counts[i] < 2) continue;
 
-            int terminalCount = 0;
+            int terminalCount  = 0;
             int terminalHCount = 0;
 
             for (int j = 0; j < counts[i]; j++) {
-                int hCount = 0;
-                int[] ws = g[atoms[i][j]];
+                int   hCount = 0;
+                int[] ws     = g[atoms[i][j]];
                 for (int w : g[atoms[i][j]]) {
-                    if (atomicNumber(container.getAtom(w)) == 1) hCount++;
+                    IAtom atom = container.getAtom(w);
+                    if (atomicNumber(atom) == 1 && atom.getMassNumber() == null) {
+                        hCount++;
+                    }
                 }
 
                 // is terminal?

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
@@ -521,7 +521,8 @@ public final class Stereocenters {
                 if (x == 3 && v == 4 && q == 1) return Type.Tricoordinate;
                 if (x == 4 && h == 0 && (q == 0 && v == 5 || q == 1 && v == 4))
                     return verifyTerminalHCount(i) ? Type.Tetracoordinate : Type.None;
-                return x == 3 && h == 0 && inThreeMemberRing(i) ? Type.Tetracoordinate : Type.None;
+                // note: bridgehead not allowed by InChI but makes sense
+                return x == 3 && h == 0 && (isBridgeHeadNitrogen(i) || inThreeMemberRing(i)) ? Type.Tetracoordinate : Type.None;
 
             case 14: // silicon
                 if (v != 4 || q != 0) return Type.None;
@@ -670,6 +671,14 @@ public final class Stereocenters {
             for (int u : g[w])
                 if (adj.get(u)) return true;
         return false;
+    }
+
+    private boolean isBridgeHeadNitrogen(int v) {
+        if (g[v].length != 3)
+            return false;
+        return ringSearch.cyclic(v, g[v][0]) &&
+               ringSearch.cyclic(v, g[v][1]) &&
+               ringSearch.cyclic(v, g[v][2]);
     }
 
     /**

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -63,6 +63,87 @@ import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conforma
  */
 public class StereoElementFactoryTest {
 
+    // don't create double bond configs in benzene
+    @Test
+    public void benzene() {
+        IAtomContainer mol = new AtomContainer();
+        mol.addAtom(atom("C", 1, 1.30, -0.75));
+        mol.addAtom(atom("C", 1, -0.00, -1.50));
+        mol.addAtom(atom("C", 1, -1.30, -0.75));
+        mol.addAtom(atom("C", 1, -1.30, 0.75));
+        mol.addAtom(atom("C", 1, 0.00, 1.50));
+        mol.addAtom(atom("C", 1, 1.30, 0.75));
+        mol.addBond(0, 1, IBond.Order.DOUBLE);
+        mol.addBond(1, 2, IBond.Order.SINGLE);
+        mol.addBond(2, 3, IBond.Order.DOUBLE);
+        mol.addBond(3, 4, IBond.Order.SINGLE);
+        mol.addBond(4, 5, IBond.Order.DOUBLE);
+        mol.addBond(0, 5, IBond.Order.SINGLE);
+        StereoElementFactory factory = StereoElementFactory.using2DCoordinates(mol);
+        assertThat(factory.createAll().size(), is(0));
+    }
+
+    // >=8 is okay for db stereo (ala inchi)
+    @Test
+    public void cyclooctatetraene() {
+        IAtomContainer mol = new AtomContainer();
+        mol.addAtom(atom("C", 1, -10.46, 6.36));
+        mol.addAtom(atom("C", 1, -11.34, 5.15));
+        mol.addAtom(atom("C", 1, -10.46, 3.93));
+        mol.addAtom(atom("C", 1, -9.03, 4.40));
+        mol.addAtom(atom("C", 1, -7.60, 3.93));
+        mol.addAtom(atom("C", 1, -6.72, 5.15));
+        mol.addAtom(atom("C", 1, -7.60, 6.36));
+        mol.addAtom(atom("C", 1, -9.03, 5.90));
+        mol.addBond(0, 1, IBond.Order.DOUBLE);
+        mol.addBond(1, 2, IBond.Order.SINGLE);
+        mol.addBond(2, 3, IBond.Order.DOUBLE);
+        mol.addBond(3, 4, IBond.Order.SINGLE);
+        mol.addBond(4, 5, IBond.Order.DOUBLE);
+        mol.addBond(5, 6, IBond.Order.SINGLE);
+        mol.addBond(6, 7, IBond.Order.DOUBLE);
+        mol.addBond(0, 7, IBond.Order.SINGLE);
+        StereoElementFactory factory = StereoElementFactory.using2DCoordinates(mol);
+        assertThat(factory.createAll().size(), is(4));
+    }
+
+    // not okay... but technically the trans form exists
+    @Test
+    public void doubleBondInSevenMemberedRing() {
+        IAtomContainer mol = new AtomContainer();
+        mol.addAtom(atom("C", 1, -10.46, 6.36));
+        mol.addAtom(atom("C", 1, -11.34, 5.15));
+        mol.addAtom(atom("C", 1, -10.46, 3.93));
+        mol.addAtom(atom("C", 1, -9.03, 4.40));
+        mol.addAtom(atom("C", 1, -7.60, 3.93));
+        mol.addAtom(atom("C", 1, -6.72, 5.15));
+        mol.addAtom(atom("C", 1, -7.60, 6.36));
+        mol.addBond(0, 1, IBond.Order.DOUBLE);
+        mol.addBond(1, 2, IBond.Order.SINGLE);
+        mol.addBond(2, 3, IBond.Order.SINGLE);
+        mol.addBond(3, 4, IBond.Order.SINGLE);
+        mol.addBond(4, 5, IBond.Order.SINGLE);
+        mol.addBond(5, 6, IBond.Order.SINGLE);
+        mol.addBond(6, 0, IBond.Order.SINGLE);
+        StereoElementFactory factory = StereoElementFactory.using2DCoordinates(mol);
+        assertThat(factory.createAll().size(), is(0));
+    }
+
+    @Test
+    public void hydrogenIsotope() {
+        IAtomContainer mol = new AtomContainer();
+        mol.addAtom(atom("C", 3, 0.00, 0.00));
+        mol.addAtom(atom("C", 1, 1.30, -0.75));
+        mol.addAtom(atom("C", 1, 2.60, -0.00));
+        mol.addAtom(atom("H", 0, 3.90, -0.75));
+        mol.getAtom(3).setMassNumber(2);
+        mol.addBond(0, 1, IBond.Order.SINGLE);
+        mol.addBond(1, 2, IBond.Order.DOUBLE);
+        mol.addBond(2, 3, IBond.Order.SINGLE);
+        StereoElementFactory factory = StereoElementFactory.using2DCoordinates(mol);
+        assertThat(factory.createAll().size(), is(1));
+    }
+
     @Test
     public void e_but2ene() {
         IAtomContainer m = new AtomContainer(4, 3, 0, 0);

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -145,6 +145,28 @@ public class StereoElementFactoryTest {
     }
 
     @Test
+    public void bridgeHeadNitrogen() {
+        IAtomContainer mol = new AtomContainer();
+        mol.addAtom(atom("C", 2, 1.23, 0.75));
+        mol.addAtom(atom("C", 2, 1.23, -0.75));
+        mol.addAtom(atom("N", 0, -0.07, -1.50));
+        mol.addAtom(atom("C", 2, -1.36, -0.75));
+        mol.addAtom(atom("C", 2, -1.36, 0.75));
+        mol.addAtom(atom("N", 0, -0.07, 1.50));
+        mol.addAtom(atom("C", 2, 0.39, -0.00));
+        mol.addBond(0, 1, IBond.Order.SINGLE, IBond.Stereo.NONE);
+        mol.addBond(2, 1, IBond.Order.SINGLE, IBond.Stereo.UP);
+        mol.addBond(2, 3, IBond.Order.SINGLE, IBond.Stereo.NONE);
+        mol.addBond(3, 4, IBond.Order.SINGLE, IBond.Stereo.NONE);
+        mol.addBond(4, 5, IBond.Order.SINGLE, IBond.Stereo.NONE);
+        mol.addBond(5, 0, IBond.Order.SINGLE, IBond.Stereo.UP);
+        mol.addBond(5, 6, IBond.Order.SINGLE, IBond.Stereo.NONE);
+        mol.addBond(2, 6, IBond.Order.SINGLE, IBond.Stereo.NONE);
+        StereoElementFactory factory = StereoElementFactory.using2DCoordinates(mol);
+        assertThat(factory.createAll().size(), is(2));
+    }
+
+    @Test
     public void e_but2ene() {
         IAtomContainer m = new AtomContainer(4, 3, 0, 0);
         m.addAtom(atom("C", 1, -2.19d, 1.64d));

--- a/pom.xml
+++ b/pom.xml
@@ -380,12 +380,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-core</artifactId>
-                <version>0.9.2</version>
+                <version>0.9.4</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-func</artifactId>
-                <version>0.9.2</version>
+                <version>0.9.4</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIToStructureTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIToStructureTest.java
@@ -231,4 +231,13 @@ public class InChIToStructureTest extends CDKTestCase {
         assertThat(element.focus(), is(container.getAtom(4)));
         assertThat(element.winding(), is(ITetrahedralChirality.Stereo.CLOCKWISE));
     }
+
+    @Test
+    public void diazene() throws Exception {
+        InChIToStructure parse = new InChIToStructure("InChI=1S/H2N2/c1-2/h1-2H/b2-1+",
+                                                      SilentChemObjectBuilder.getInstance());
+        IAtomContainer mol = parse.getAtomContainer();
+        assertThat(mol.getAtomCount(), is(4));
+        assertThat(mol.stereoElements().iterator().hasNext(), is(true));
+    }
 }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
@@ -33,23 +33,19 @@ import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.stereo.TetrahedralChirality;
-import uk.ac.ebi.beam.Graph;
 import uk.ac.ebi.beam.Atom;
 import uk.ac.ebi.beam.Bond;
 import uk.ac.ebi.beam.Configuration;
 import uk.ac.ebi.beam.Edge;
 import uk.ac.ebi.beam.Element;
+import uk.ac.ebi.beam.Graph;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static org.openscience.cdk.CDKConstants.ATOM_ATOM_MAPPING;
-import static org.openscience.cdk.CDKConstants.ISAROMATIC;
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation;
 import static org.openscience.cdk.interfaces.ITetrahedralChirality.Stereo;
-import static uk.ac.ebi.beam.Configuration.Type.DoubleBond;
-import static uk.ac.ebi.beam.Configuration.Type.ExtendedTetrahedral;
-import static uk.ac.ebi.beam.Configuration.Type.Tetrahedral;
 
 /**
  * Convert the Beam toolkit object model to the CDK. Currently the aromatic

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
@@ -738,7 +738,7 @@ public class SmilesGeneratorTest extends CDKTestCase {
         IAtomContainer mol1 = reader.read(new AtomContainer());
         SmilesGenerator sg = new SmilesGenerator();
         String moleculeSmile = sg.create(mol1);
-        Assert.assertEquals("C1=CCCCCCC1", moleculeSmile);
+        Assert.assertEquals("C\\1=C\\CCCCCC1", moleculeSmile);
     }
 
     /**
@@ -752,7 +752,7 @@ public class SmilesGeneratorTest extends CDKTestCase {
         IAtomContainer mol1 = reader.read(new AtomContainer());
         SmilesGenerator sg = new SmilesGenerator();
         String moleculeSmile = sg.create(mol1);
-        Assert.assertEquals("C1C=CCCCCC1", moleculeSmile);
+        Assert.assertEquals("C1/C=C\\CCCCC1", moleculeSmile);
     }
 
     /**
@@ -766,7 +766,7 @@ public class SmilesGeneratorTest extends CDKTestCase {
         IAtomContainer mol1 = reader.read(DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class));
         SmilesGenerator sg = new SmilesGenerator();
         String moleculeSmile = sg.create(mol1);
-        Assert.assertEquals("C=1CCC=CCCC1", moleculeSmile);
+        Assert.assertEquals("C=1\\CC/C=C\\CC/C1", moleculeSmile);
     }
 
     /**
@@ -786,6 +786,7 @@ public class SmilesGeneratorTest extends CDKTestCase {
 
     /**
      * @cdk.bug 1089770
+     * @see <a href="https://sourceforge.net/p/cdk/bugs/242/">CDK Bug 1089770</a>
      */
     @Test
     public void testSFBug1089770_2() throws Exception {
@@ -796,7 +797,7 @@ public class SmilesGeneratorTest extends CDKTestCase {
         SmilesGenerator sg = new SmilesGenerator();
         String moleculeSmile = sg.create(mol1);
         //logger.debug(filename + " -> " + moleculeSmile);
-        Assert.assertEquals("C=1CCC=CCCC1", moleculeSmile);
+        Assert.assertEquals("C=1\\CC/C=C\\CC/C1", moleculeSmile);
     }
 
     /**


### PR DESCRIPTION
Some stereochemistry corner cases
 - Allow double bonds in rings providing the ring >7 bonds
 - Allow nitrogen tetrahedral stereochemistry
 - Allow diazine double bond stereochemistry ``[H]/N=N/[H]``