### PR TITLE
Fix symbol visibility such that carbons with a charge are always shown.

### DIFF
--- a/display/render/src/main/java/org/openscience/cdk/renderer/SymbolVisibility.java
+++ b/display/render/src/main/java/org/openscience/cdk/renderer/SymbolVisibility.java
@@ -123,6 +123,10 @@ public abstract class SymbolVisibility {
             // abnormal valence, could be due to charge or unpaired electrons
             if (!isFourValent(atom, bonds)) return true;
 
+            // charge, normally caught by previous rule but can have bad input: C=[CH-]C
+            if (atom.getFormalCharge() != null &&
+                atom.getFormalCharge() != 0) return true;
+
             // carbon isotopes are displayed
             Integer mass = atom.getMassNumber();
             if (mass != null && !isMajorIsotope(element.number(), mass)) return true;

--- a/display/render/src/test/java/org/openscience/cdk/renderer/SymbolVisibilityTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/SymbolVisibilityTest.java
@@ -212,4 +212,21 @@ public class SymbolVisibilityTest {
                                    .visible(a1, Collections.singletonList(bond1), new RendererModel()));
     }
 
+    @Test
+    public void alwaysDisplayCharges() {
+        IAtom a1 = new Atom("CH-");
+        IAtom a2 = new Atom("CH2");
+        IAtom a3 = new Atom("CH3");
+
+        a1.setPoint2d(new Point2d(0, 0));
+        a2.setPoint2d(new Point2d(0.5, -0.5));
+        a2.setPoint2d(new Point2d(1, 0));
+
+        IBond bond1 = new Bond(a1, a2, IBond.Order.DOUBLE);
+        IBond bond2 = new Bond(a2, a3, IBond.Order.SINGLE);
+
+        assertTrue(SymbolVisibility.iupacRecommendationsWithoutTerminalCarbon()
+                                   .visible(a1, Arrays.asList(bond1, bond2), new RendererModel()));
+    }
+
 }


### PR DESCRIPTION
Noel put in a dodgey SMILES and found a corner case I forgot to handle. The rule of thumb for showing a carbon in a depicition is if the valence isn't 4, or if it's colinear. In this central atom is a 4 valent carbon with a charge and so wasn't being displayed.

```C=[CH-]C```