### PR TITLE
Fix DescriptorValue.getName

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/qsar/DescriptorValue.java
+++ b/base/standard/src/main/java/org/openscience/cdk/qsar/DescriptorValue.java
@@ -112,8 +112,8 @@ public class DescriptorValue implements Serializable {
      * a <code>DescriptorValue</code> object, it should supply an array of names equal
      * in length to the number of descriptor calculated.
      * 
-     * In many cases, these names can be as simple as X1, X2, ..., XN where X is a prefix
-     * and 1, 2, ..., N are the indices. On the other hand it is also possible to return
+     * In many cases, these names can be as simple as X0, X1, ..., XN where X is a prefix
+     * and 0, 1, ..., N are the indices. On the other hand it is also possible to return
      * other arbitrary names, which should be documented in the JavaDocs for the descriptor
      * (e.g., the CPSA descriptor).
      * 
@@ -140,7 +140,7 @@ public class DescriptorValue implements Serializable {
                     ndesc = value.length();
                 }
                 descriptorNames = new String[ndesc];
-                for (int i = 1; i < ndesc + 1; i++)
+                for (int i = 0; i < ndesc; i++)
                     descriptorNames[i] = title + i;
             }
         }

--- a/base/test-standard/src/test/java/org/openscience/cdk/qsar/DescriptorValueTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/qsar/DescriptorValueTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.qsar.result.DoubleArrayResult;
 import org.openscience.cdk.qsar.result.DoubleResult;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -92,8 +93,18 @@ public class DescriptorValueTest extends CDKTestCase {
         DescriptorSpecification spec = new DescriptorSpecification(DESC_REF, DESC_IMPL_TITLE, DESC_IMPL_ID,
                 DESC_IMPL_VENDOR);
         DoubleResult doubleVal = new DoubleResult(0.7);
-        DescriptorValue value = new DescriptorValue(spec, new String[0], new Object[0], doubleVal, new String[]{"bla"});
+        DoubleArrayResult doubleVals = new DoubleArrayResult();
+        doubleVals.add(Double.valueOf(0.1));
+        doubleVals.add(Double.valueOf(0.2));
+        DescriptorValue value;
+        value = new DescriptorValue(spec, new String[0], new Object[0], doubleVal, new String[]{"bla"});
         Assert.assertEquals(1, value.getNames().length);
+        value = new DescriptorValue(spec, new String[0], new Object[0], doubleVal, new String[]{ });
+        Assert.assertEquals(1, value.getNames().length);
+        value = new DescriptorValue(spec, new String[0], new Object[0], doubleVal, null);
+        Assert.assertEquals(1, value.getNames().length);
+        value = new DescriptorValue(spec, new String[0], new Object[0], doubleVals, null);
+        Assert.assertEquals(2, value.getNames().length);
     }
 
     @Test


### PR DESCRIPTION
It throws exception when descriptorNames is empty and value is (Integer|Double)ArrayResult