### PR TITLE
Don't set mass if < 0 (-1 is now used as a sentinel value for unstabl…

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -906,8 +906,11 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                     for (int i = 0, st = 10; i < count && st + 7 <= length; i++, st += 8) {
                         index = readMolfileInt(line, st) - 1;
                         int mass = readMolfileInt(line, st + 4);
-                        container.getAtom(offset + index).setMassNumber(mass);
-                    }
+                        if (mass < 0)
+                            handleError("Absolute mass number should be >= 0, " + line);
+                        else
+                            container.getAtom(offset + index).setMassNumber(mass);
+                      }
                     break;
 
                 // M  RADnn8 aaa vvv ...

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -1197,8 +1197,10 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
 
         // check of ill specified atomic mass
         for (IAtom atom : container.atoms()) {
-            if (atom.getMassNumber() != null && atom.getMassNumber() < 0)
-                throw new CDKException("Unstable use of mass delta on " + atom.getSymbol() + " please use M  ISO");
+            if (atom.getMassNumber() != null && atom.getMassNumber() < 0) {
+              handleError("Unstable use of mass delta on " + atom.getSymbol() + " please use M  ISO");
+              atom.setMassNumber(null);
+            }
         }
 
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -1701,7 +1701,7 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test(expected = CDKException.class)
     public void seaborgiumMassDelta() throws Exception {
         try (InputStream in = getClass().getResourceAsStream("seaborgium.mol");
-             MDLV2000Reader mdlr = new MDLV2000Reader(in)) {
+             MDLV2000Reader mdlr = new MDLV2000Reader(in, Mode.STRICT)) {
             IAtomContainer mol = mdlr.read(new AtomContainer());
         }
     }
@@ -1709,7 +1709,7 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     public void seaborgiumAbsMass() throws Exception {
         try (InputStream in = getClass().getResourceAsStream("seaborgium_abs.mol");
-             MDLV2000Reader mdlr = new MDLV2000Reader(in)) {
+             MDLV2000Reader mdlr = new MDLV2000Reader(in, Mode.STRICT)) {
             IAtomContainer mol = mdlr.read(new AtomContainer());
             assertThat(mol.getAtom(0).getMassNumber(), is(261));
         }


### PR DESCRIPTION
…e definitions)

Some old garbage molfiles had unexpected values. Since -1 is now used to temporarily mark atoms with bad isotope definitions we get a problem is the absolute mass (M ISO) is specified as -1.