### PR TITLE
Patch/ctfile dimension field

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -314,6 +314,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
 
         int linecount = 0;
         String title = null;
+        String program = null;
         String remark = null;
         String line = "";
 
@@ -333,6 +334,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
             }
             line = input.readLine();
             linecount++;
+            program = line;
             line = input.readLine();
             linecount++;
             if (line.length() > 0) {
@@ -406,8 +408,10 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                     }
                 }
             } else if (!hasZ) {
-
-                if (!forceReadAs3DCoords.isSet()) {
+                //'  CDK     09251712073D'
+                // 0123456789012345678901
+                if (!(program.length() >= 22 && program.substring(20, 22).equals("3D"))
+                    && !forceReadAs3DCoords.isSet()) {
                     for (IAtom atomToUpdate : atoms) {
                         Point3d p3d = atomToUpdate.getPoint3d();
                         if (p3d != null) {

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -86,7 +86,7 @@ import static org.openscience.cdk.CDKConstants.ATOM_ATOM_MAPPING;
 public final class MDLV3000Writer extends DefaultChemObjectWriter {
 
     public static final  SimpleDateFormat HEADER_DATE_FORMAT = new SimpleDateFormat("MMddyyHHmm");
-    public static final  NumberFormat     DECIMAL_FORMAT     = new DecimalFormat(".####");
+    public static final  NumberFormat     DECIMAL_FORMAT     = new DecimalFormat("#.####");
     private static final Pattern          R_GRP_NUM          = Pattern.compile("R(\\d+)");
     private V30LineWriter writer;
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -562,6 +562,24 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     }
 
     /**
+     * @cdk.bug 1732307
+     */
+    @Test
+    public void testZeroZCoordinates3DMarked() throws Exception {
+        String filename = "data/mdl/nozcoord.sdf";
+        logger.info("Testing: " + filename);
+        InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
+        MDLV2000Reader reader = new MDLV2000Reader(ins);
+        IAtomContainer mol = reader.read(DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class));
+        reader.close();
+        Assert.assertNotNull(mol);
+        Assert.assertEquals(5, mol.getAtomCount());
+
+        boolean has3d = GeometryUtil.has3DCoordinates(mol);
+        assertTrue(has3d);
+    }
+
+    /**
      * @cdk.bug 1826577
      */
     @Test

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
@@ -833,4 +833,34 @@ public class MDLV2000WriterTest extends ChemObjectIOTest {
         }
         assertThat(sw.toString(), containsString("  1  2  4  0  0  0  0 \n"));
     }
+
+    @Test
+    public void writeDimensionField() throws Exception {
+        IAtomContainer mol = builder.newAtomContainer();
+        IAtom atom = builder.newAtom();
+        atom.setSymbol("C");
+        atom.setImplicitHydrogenCount(4);
+        atom.setPoint2d(new Point2d(0.5, 0.5));
+        mol.addAtom(atom);
+        StringWriter sw = new StringWriter();
+        try (MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
+            mdlw.write(mol);
+        }
+        assertThat(sw.toString(), containsString("2D"));
+    }
+
+    @Test
+    public void writeDimensionField3D() throws Exception {
+        IAtomContainer mol = builder.newAtomContainer();
+        IAtom atom = builder.newAtom();
+        atom.setSymbol("C");
+        atom.setImplicitHydrogenCount(4);
+        atom.setPoint3d(new Point3d(0.5, 0.5, 0.1));
+        mol.addAtom(atom);
+        StringWriter sw = new StringWriter();
+        try (MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
+            mdlw.write(mol);
+        }
+        assertThat(sw.toString(), containsString("3D"));
+    }
 }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
@@ -54,6 +54,7 @@ import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IChemModel;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
+import org.openscience.cdk.interfaces.ISingleElectron;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.io.listener.PropertiesListener;
 import org.openscience.cdk.sgroup.Sgroup;
@@ -862,5 +863,22 @@ public class MDLV2000WriterTest extends ChemObjectIOTest {
             mdlw.write(mol);
         }
         assertThat(sw.toString(), containsString("3D"));
+    }
+
+    @Test
+    public void writeMoreThan8Radicals() throws Exception {
+        IAtomContainer mol = builder.newAtomContainer();
+        for (int i = 0; i < 20; i++) {
+            IAtom atom = builder.newAtom();
+            atom.setSymbol("C");
+            mol.addAtom(atom);
+            mol.addSingleElectron(builder.newInstance(ISingleElectron.class, atom));
+        }
+        StringWriter sw = new StringWriter();
+        try (MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
+            mdlw.write(mol);
+        }
+        assertThat(sw.toString(),
+                   containsString("M  RAD  8   9   2  10   2  11   2  12   2  13   2  14   2  15   2  16   2"));
     }
 }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -368,9 +368,9 @@ public class MDLV3000WriterTest {
             assertThat(res, CoreMatchers.containsString("M  V30 1 SRU 0 ATOMS=(1 2) XBONDS=(2 1 2) LABEL=n CONNECT=HT BRKXYZ=(9 -2.5742-\n"
                                                         + "M  V30  4.207 0 -3.0692 3.3497 0 0 0 0) BRKXYZ=(9 -3.1626 3.3497 0 -3.6576 4.2-\n"
                                                         + "M  V30 07 0 0 0 0) BRKTYP=PAREN\n"
-                                                        + "M  V30 2 SRU 0 ATOMS=(1 5) XBONDS=(2 3 4) LABEL=n CONNECT=HT BRKXYZ=(9 .9542 4-\n"
-                                                        + "M  V30 .1874 0 .4592 3.33 0 0 0 0) BRKXYZ=(9 .3658 3.33 0 -.1292 4.1874 0 0 0 -\n"
-                                                        + "M  V30 0) BRKTYP=PAREN\n"));
+                                                        + "M  V30 2 SRU 0 ATOMS=(1 5) XBONDS=(2 3 4) LABEL=n CONNECT=HT BRKXYZ=(9 0.9542 -\n"
+                                                        + "M  V30 4.1874 0 0.4592 3.33 0 0 0 0) BRKXYZ=(9 0.3658 3.33 0 -0.1292 4.1874 0 -\n"
+                                                        + "M  V30 0 0 0) BRKTYP=PAREN"));
         }
     }
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -39,6 +39,7 @@ import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 import org.openscience.cdk.stereo.TetrahedralChirality;
 
+import javax.vecmath.Point2d;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -170,6 +171,15 @@ public class MDLV3000WriterTest {
         mol.getAtom(1).setImplicitHydrogenCount(1);
         String res = writeToStr(mol);
         assertThat(res, CoreMatchers.containsString("M  V30 1 1 2 1 CFG=3\n"));
+    }
+
+    @Test
+    public void writeLeadingZero() throws IOException, CDKException {
+        IAtomContainer mol = new AtomContainer();
+        Atom           atom   = new Atom("C");
+        atom.setPoint2d(new Point2d(0.5, 1.2));
+        mol.addAtom(atom);
+        assertThat(writeToStr(mol), CoreMatchers.containsString("0.5 1.2"));
     }
 
     @Test

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
@@ -37,16 +38,19 @@ import org.openscience.cdk.sgroup.SgroupType;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.stereo.TetrahedralChirality;
 
 import javax.vecmath.Point2d;
+import javax.vecmath.Point3d;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
 
 public class MDLV3000WriterTest {
 
@@ -408,6 +412,38 @@ public class MDLV3000WriterTest {
             String res = writeToStr(mol);
             assertThat(res, CoreMatchers.containsString("M  V30 8 1 8 9 ATTACH=ANY ENDPTS=(5 2 3 4 5 6)\n"));
         }
+    }
+
+    @Test
+    public void writeDimensionField() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
+        IAtomContainer mol = builder.newAtomContainer();
+        IAtom atom = builder.newAtom();
+        atom.setSymbol("C");
+        atom.setImplicitHydrogenCount(4);
+        atom.setPoint2d(new Point2d(0.5, 0.5));
+        mol.addAtom(atom);
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
+            mdlw.write(mol);
+        }
+        assertThat(sw.toString(), containsString("2D"));
+    }
+
+    @Test
+    public void writeDimensionField3D() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
+        IAtomContainer mol = builder.newAtomContainer();
+        IAtom atom = builder.newAtom();
+        atom.setSymbol("C");
+        atom.setImplicitHydrogenCount(4);
+        atom.setPoint3d(new Point3d(0.5, 0.5, 0.1));
+        mol.addAtom(atom);
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
+            mdlw.write(mol);
+        }
+        assertThat(sw.toString(), containsString("3D"));
     }
 
     private String writeToStr(IAtomContainer mol) throws IOException, CDKException {


### PR DESCRIPTION
Molfiles can have 2D/3D written in the second line to indicate the number of dimensions. This information is now read and written by CDK.