### PR TITLE
Use central atom as coordinates of implicit hydrogen or lone pair. 

### DIFF
--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -916,15 +916,9 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         int[] adj = atomAdj[aidx];
         if (adjc == 3) {
             adj = appendInteger(adj, -1);
-            xp[3] = -(xp[0] + xp[1] + xp[2]);
-            yp[3] = -(yp[0] + yp[1] + yp[2]);
-            zp[3] = -(zp[0] + zp[1] + zp[2]);
-            float dsq = xp[3] * xp[3] + yp[3] * yp[3] + zp[3] * zp[3];
-            if (dsq < 0.01f * 0.01f) return null;
-            float inv = 1.0f / (float) Math.sqrt(dsq);
-            xp[3] *= inv;
-            yp[3] *= inv;
-            zp[3] *= inv;
+            xp[3] = x0;
+            yp[3] = y0;
+            zp[3] = z0;
         }
 
         // make the call on permutational parity


### PR DESCRIPTION
Fixes #377. The issue with the described input was stereo was being perceived as different between the two cases - due to where the hydrogen was being position.

Would be good to have Alex review