### PR TITLE
A corner case of suppress hydrogens, we may have a double bond define…

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -838,8 +838,10 @@ public class AtomContainerManipulator {
                     yNew = findOther(org, v, u, y);
                 }
 
-                // no other atoms connected, invalid double-bond configuration?
-                if (x == null || y == null) continue;
+                // no other atoms connected, invalid double-bond configuration
+                // is removed. example [2H]/C=C/[H]
+                if (x == null || y == null ||
+                    xNew == null || yNew == null) continue;
 
                 // no changes
                 if (x.equals(xNew) && y.equals(yNew)) {
@@ -848,10 +850,12 @@ public class AtomContainerManipulator {
                 }
 
                 // XXX: may perform slow operations but works for now
-                IBond cpyLeft = !Objects.equals(xNew, x) ? org.getBond(u, xNew) : orgLeft;
+                IBond cpyLeft  = !Objects.equals(xNew, x) ? org.getBond(u, xNew) : orgLeft;
                 IBond cpyRight = !Objects.equals(yNew, y) ? org.getBond(v, yNew) : orgRight;
 
-                elements.add(new DoubleBondStereochemistry(orgStereo, new IBond[]{cpyLeft, cpyRight}, conformation));
+                elements.add(new DoubleBondStereochemistry(orgStereo,
+                                                           new IBond[]{cpyLeft, cpyRight},
+                                                           conformation));
             } else if (se instanceof Atropisomeric) {
                 // can not have any H's
                 elements.add(se);
@@ -917,7 +921,7 @@ public class AtomContainerManipulator {
         // is the hydrogen an ion?
         if (atom.getFormalCharge() != null && atom.getFormalCharge() != 0) return false;
         // is the hydrogen deuterium / tritium?
-        if (atom.getMassNumber() != null && atom.getMassNumber() != 1) return false;
+        if (atom.getMassNumber() != null) return false;
         // molecule hydrogen with implicit H?
         if (atom.getImplicitHydrogenCount() != null && atom.getImplicitHydrogenCount() != 0) return false;
         // molecule hydrogen
@@ -968,7 +972,7 @@ public class AtomContainerManipulator {
         // is the hydrogen an ion?
         if (atom.getFormalCharge() != null && atom.getFormalCharge() != 0) return false;
         // is the hydrogen deuterium / tritium?
-        if (atom.getMassNumber() != null && atom.getMassNumber() != 1) return false;
+        if (atom.getMassNumber() != null) return false;
         // hydrogen is either not attached to 0 or 2 neighbors
         if (graph[v].length != 1) return false;
         // non-single bond

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -1277,6 +1278,23 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
         assertThat(molecularWeight, closeTo(48.069, 0.001));
         assertThat(naturalExactMass, closeTo(47.076, 0.001));
         assertThat(exactMass, closeTo(48.053, 0.001));
+    }
+
+    @Test
+    public void removeBondStereo() throws Exception {
+        SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer mol = smipar.parseSmiles("[2H]/C=C/[H]");
+        AtomContainerManipulator.suppressHydrogens(mol);
+        assertThat(mol.stereoElements().iterator().hasNext(),
+                   CoreMatchers.is(false));
+    }
+
+    @Test
+    public void keep1Hisotopes() throws Exception {
+        SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer mol = smipar.parseSmiles("[2H]/C=C/[1H]");
+        AtomContainerManipulator.suppressHydrogens(mol);
+        assertThat(mol.getAtomCount(), is(4));
     }
 
     // util for testing hydrogen removal using SMILES


### PR DESCRIPTION
…d with an explicit hydrogen and need to delete the stereo there. Also the new isotope logic means we should keep H when the mass is specified as 1.