### PR TITLE
BEAM v1.0 with fix for axial stereo with ring closures (corner case).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,12 +386,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-core</artifactId>
-                <version>0.9.4</version>
+                <version>1.0</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-func</artifactId>
-                <version>0.9.4</version>
+                <version>1.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Bumps BEAM to v1.0.  Minor change related to handling axial stereochemistry on ring closures in SMILES. Also some other corner cases - https://github.com/johnmay/beam/commits/master

![image](https://user-images.githubusercontent.com/983232/32511755-a78e704c-c3ec-11e7-9a32-f6a6a687d9dd.png)

Previously these two input were the same structure hen clearly one should be the inverse.

```
CC([H])=[C@]=C1OCCCC1
CC([H])=[C@]=C(OCCCC1)1
```

![image](https://user-images.githubusercontent.com/983232/32511916-27c7d208-c3ed-11e7-87d6-66acf753aa40.png)