### PR TITLE
Deprecate and throw an exception if the bond length is attempted to b…

### DIFF
--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -112,7 +112,7 @@ public class StructureDiagramGenerator {
 
     private IAtomContainer molecule;
     private IRingSet       sssr;
-    private double bondLength = DEFAULT_BOND_LENGTH;
+    private final double bondLength = DEFAULT_BOND_LENGTH;
     private Vector2d firstBondVector;
     private RingPlacer       ringPlacer          = new RingPlacer();
     private AtomPlacer       atomPlacer          = new AtomPlacer();
@@ -2072,13 +2072,27 @@ public class StructureDiagramGenerator {
     }
 
     /**
-     * Set the bond length used for laying out the molecule.
-     * The default value is 1.5.
+     * This method used to set the bond length used for laying out the molecule.
+     * Since bond lengths in 2D are are arbitrary, the preferred way to do this
+     * is with {@link GeometryUtil#scaleMolecule(IAtomContainer, double)}.
+     *
+     * <pre>
+     * IAtomContainer mol = ...;
+     * sdg.generateCoordinates(mol);
+     * int targetBondLength = 28;
+     * double factor = targetBondLength/GeometryUtil.getMedianBondLength(mol);
+     * GeometryUtil.scaleMolecule(mol, factor);
+     * </pre>
      *
      * @param bondLength The new bondLength value
+     * @deprecated use {@link GeometryUtil#scaleMolecule(IAtomContainer, double)}
+     * @throws UnsupportedOperationException not supported
      */
+    @Deprecated
     public void setBondLength(double bondLength) {
-        this.bondLength = bondLength;
+        throw new UnsupportedOperationException(
+            "Bond length should be adjusted post layout"
+            + " with GeometryUtil.scaleMolecule();");
     }
 
     /**

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
@@ -1264,4 +1264,10 @@ public class StructureDiagramGeneratorTest extends CDKTestCase {
         assertThat(numCis, is(2));
         assertThat(numTrans, is(2));
     }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void setBondLength() {
+        StructureDiagramGenerator sdg = new StructureDiagramGenerator();
+        sdg.setBondLength(2);
+    }
 }


### PR DESCRIPTION
…e set in the layout generator.

"Resolves" #384 - Rather than provide 2 ways to do the same thing. It is more modular and similar to direct usage to ```GeometryUtil``` that can scale a molecule in linear time.

