### PR TITLE
Ensure attachment points are displayed okay on transparent backgrounds.

### DIFF
--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -51,6 +51,8 @@ import javax.vecmath.Vector2d;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Shape;
+import java.awt.geom.Area;
+import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.nio.charset.StandardCharsets;
@@ -453,16 +455,16 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
                     maxRadius = r;
             }
 
-            final Color bg = parameters.get(BasicSceneGenerator.BackgroundColor.class);
-
             for (TextOutline outline : attachNumOutlines) {
                 ElementGroup group = new ElementGroup();
-                group.add(new OvalElement(outline.getCenter().getX(),
-                                          outline.getCenter().getY(),
-                                          2*stroke + maxRadius,
-                                          true,
-                                          foreground));
-                group.add(GeneralPath.shapeOf(outline.getOutline(), bg));
+                double radius = 2*stroke + maxRadius;
+                Shape shape = new Ellipse2D.Double(outline.getCenter().getX() - radius,
+                                                   outline.getCenter().getY() - radius,
+                                                   2*radius,
+                                                   2*radius);
+                Area area1 = new Area(shape);
+                area1.subtract(new Area(outline.getOutline()));
+                group.add(GeneralPath.shapeOf(area1, foreground));
                 annotations.add(group);
             }
 


### PR DESCRIPTION
Recently added an option to have transparent backgrounds in CDK depict. This leads to a quirk where the color used for attachment numbers is also transparent. Minor but easy to fix:

Before:
![image](https://user-images.githubusercontent.com/983232/33211446-7a268fe0-d116-11e7-882b-f1d082138fa7.png)

After:
![image](https://user-images.githubusercontent.com/983232/33211400-4297b856-d116-11e7-806e-e5a75fea91a5.png)
