### PR TITLE
Patch/stereoapi2

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
@@ -43,12 +43,16 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
     private List<C> carriers;
     private IChemObjectBuilder builder;
 
+    protected static int numCarriers(int cfg) {
+        return ((cfg >>> 12) & 0xf);
+    }
+
     AbstractStereo(F focus, C[] carriers, int value) {
         if (focus == null)
             throw new NullPointerException("Focus of stereochemistry can not be null!");
         if (carriers == null)
             throw new NullPointerException("Carriers of the configuration can not be null!");
-        if (carriers.length != ((value >>> 12) & 0xf))
+        if (carriers.length != numCarriers(value))
             throw new IllegalArgumentException("Unexpected number of stereo carriers! expected " + ((value >>> 12) & 0xf) + " was " + carriers.length);
         for (C carrier : carriers) {
             if (carrier == null)
@@ -88,7 +92,7 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
      * {@inheritDoc}
      */
     @Override
-    public int getConfig() {
+    public int getConfigOrder() {
         return value & CFG_MASK;
     }
 
@@ -96,7 +100,15 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
      * {@inheritDoc}
      */
     @Override
-    public void setConfig(int cfg) {
+    public int getConfig() {
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setConfigOrder(int cfg) {
         value = getConfigClass() | cfg;
     }
 
@@ -169,5 +181,16 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
 
     protected void setBuilder(IChemObjectBuilder builder) {
         this.builder = builder;
+    }
+
+    // labels for describing permutation
+    protected static final int A = 0, B = 1, C = 2, D = 3, E = 4, F = 5;
+
+    // apply the inverse of a permutation
+    protected static <T> T[] invapply(T[] src, int[] perm) {
+        T[] res = src.clone();
+        for (int i = 0; i < src.length; i++)
+            res[i] = src[perm[i]];
+        return res;
     }
 }

--- a/base/core/src/main/java/org/openscience/cdk/stereo/DoubleBondStereochemistry.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/DoubleBondStereochemistry.java
@@ -75,7 +75,7 @@ public class DoubleBondStereochemistry
     /** {@inheritDoc} */
     @Override
     public Conformation getStereo() {
-        return Conformation.toConformation(getConfig());
+        return Conformation.toConformation(getConfigOrder());
     }
 
     @Override

--- a/base/core/src/main/java/org/openscience/cdk/stereo/ExtendedTetrahedral.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/ExtendedTetrahedral.java
@@ -27,12 +27,9 @@ package org.openscience.cdk.stereo;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IStereoElement;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import static org.openscience.cdk.interfaces.ITetrahedralChirality.Stereo;
 
@@ -128,7 +125,7 @@ public final class ExtendedTetrahedral
      * @return winding configuration
      */
     public Stereo winding() {
-        return Stereo.toStereo(getConfig());
+        return Stereo.toStereo(getConfigOrder());
     }
 
     /**

--- a/base/core/src/main/java/org/openscience/cdk/stereo/Octahedral.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/Octahedral.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.stereo;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IStereoElement;
+
+import java.util.List;
+
+/**
+ * Represents an octahedral configuration of an atom six neighbors. The
+ * configuration order is defined as between 1 and 30 using the same permutation
+ * tables as SMILES (e.g. @OH1 .. @OH30). This allows the 720 permutations of
+ * atom ordering to be described.
+ * <br>
+ * Normalizing the representation (with {@link #normalize()} returns a
+ * configuration reordered such that the configuration order is 1. For example
+ * <pre>C[Co@OH8](F)(Br)(Cl)(I)S</pre>
+ * is the same as
+ * <pre>C[Co@OH1](F)(Cl)(Br)(I)S</pre>. The normalised form is easy to work
+ * with as the first and last carriers form an axis, the middle four equatorial
+ * carriers are arranged anti-clockwise looking from the first carrier.
+ *
+ * <pre>
+ *      c
+ *      | a
+ *      |/
+ *  d---x---b = OH1
+ *     /|       where a: first carrier, b: second carried, etc
+ *    f |             x: focus
+ *      e             'a' is in front of the focus 'x', 'f' is behind
+ * </pre>
+ *
+ * @see <a href="http://opensmiles.org/opensmiles.html#_octahedral_centers">
+ *     Octahedral Centers, OpenSMILES</a>
+ * @see TrigonalBipyramidal
+ * @see SquarePlanar
+ */
+public final class Octahedral extends AbstractStereo<IAtom,IAtom> {
+
+    private static final int[][] PERMUTATIONS = new int[][]{
+// @OH1
+{A, B, C, D, E, F,  A, C, D, E, B, F,  A, D, E, B, C, F,  A, E, B, C, D, F,
+ B, A, E, F, C, D,  B, C, A, E, F, D,  B, E, F, C, A, D,  B, F, C, A, E, D,
+ C, A, B, F, D, E,  C, B, F, D, A, E,  C, D, A, B, F, E,  C, F, D, A, B, E,
+ D, A, C, F, E, B,  D, C, F, E, A, B,  D, E, A, C, F, B,  D, F, E, A, C, B,
+ E, A, D, F, B, C,  E, B, A, D, F, C,  E, D, F, B, A, C,  E, F, B, A, D, C,
+ F, B, E, D, C, A,  F, C, B, E, D, A,  F, D, C, B, E, A,  F, E, D, C, B, A},
+// @OH2
+{A, B, E, D, C, F,  A, C, B, E, D, F,  A, D, C, B, E, F,  A, E, D, C, B, F,
+ B, A, C, F, E, D,  B, C, F, E, A, D,  B, E, A, C, F, D,  B, F, E, A, C, D,
+ C, A, D, F, B, E,  C, B, A, D, F, E,  C, D, F, B, A, E,  C, F, B, A, D, E,
+ D, A, E, F, C, B,  D, C, A, E, F, B,  D, E, F, C, A, B,  D, F, C, A, E, B,
+ E, A, B, F, D, C,  E, B, F, D, A, C,  E, D, A, B, F, C,  E, F, D, A, B, C,
+ F, B, C, D, E, A,  F, C, D, E, B, A,  F, D, E, B, C, A,  F, E, B, C, D, A},
+// @OH3
+{A, B, C, D, F, E,  A, C, D, F, B, E,  A, D, F, B, C, E,  A, F, B, C, D, E,
+ B, A, F, E, C, D,  B, C, A, F, E, D,  B, E, C, A, F, D,  B, F, E, C, A, D,
+ C, A, B, E, D, F,  C, B, E, D, A, F,  C, D, A, B, E, F,  C, E, D, A, B, F,
+ D, A, C, E, F, B,  D, C, E, F, A, B,  D, E, F, A, C, B,  D, F, A, C, E, B,
+ E, B, F, D, C, A,  E, C, B, F, D, A,  E, D, C, B, F, A,  E, F, D, C, B, A,
+ F, A, D, E, B, C,  F, B, A, D, E, C,  F, D, E, B, A, C,  F, E, B, A, D, C},
+// @OH4
+{A, B, C, E, D, F,  A, C, E, D, B, F,  A, D, B, C, E, F,  A, E, D, B, C, F,
+ B, A, D, F, C, E,  B, C, A, D, F, E,  B, D, F, C, A, E,  B, F, C, A, D, E,
+ C, A, B, F, E, D,  C, B, F, E, A, D,  C, E, A, B, F, D,  C, F, E, A, B, D,
+ D, A, E, F, B, C,  D, B, A, E, F, C,  D, E, F, B, A, C,  D, F, B, A, E, C,
+ E, A, C, F, D, B,  E, C, F, D, A, B,  E, D, A, C, F, B,  E, F, D, A, C, B,
+ F, B, D, E, C, A,  F, C, B, D, E, A,  F, D, E, C, B, A,  F, E, C, B, D, A},
+// @OH5
+{A, B, C, F, D, E,  A, C, F, D, B, E,  A, D, B, C, F, E,  A, F, D, B, C, E,
+ B, A, D, E, C, F,  B, C, A, D, E, F,  B, D, E, C, A, F,  B, E, C, A, D, F,
+ C, A, B, E, F, D,  C, B, E, F, A, D,  C, E, F, A, B, D,  C, F, A, B, E, D,
+ D, A, F, E, B, C,  D, B, A, F, E, C,  D, E, B, A, F, C,  D, F, E, B, A, C,
+ E, B, D, F, C, A,  E, C, B, D, F, A,  E, D, F, C, B, A,  E, F, C, B, D, A,
+ F, A, C, E, D, B,  F, C, E, D, A, B,  F, D, A, C, E, B,  F, E, D, A, C, B},
+// @OH6
+{A, B, C, E, F, D,  A, C, E, F, B, D,  A, E, F, B, C, D,  A, F, B, C, E, D,
+ B, A, F, D, C, E,  B, C, A, F, D, E,  B, D, C, A, F, E,  B, F, D, C, A, E,
+ C, A, B, D, E, F,  C, B, D, E, A, F,  C, D, E, A, B, F,  C, E, A, B, D, F,
+ D, B, F, E, C, A,  D, C, B, F, E, A,  D, E, C, B, F, A,  D, F, E, C, B, A,
+ E, A, C, D, F, B,  E, C, D, F, A, B,  E, D, F, A, C, B,  E, F, A, C, D, B,
+ F, A, E, D, B, C,  F, B, A, E, D, C,  F, D, B, A, E, C,  F, E, D, B, A, C},
+// @OH7
+{A, B, C, F, E, D,  A, C, F, E, B, D,  A, E, B, C, F, D,  A, F, E, B, C, D,
+ B, A, E, D, C, F,  B, C, A, E, D, F,  B, D, C, A, E, F,  B, E, D, C, A, F,
+ C, A, B, D, F, E,  C, B, D, F, A, E,  C, D, F, A, B, E,  C, F, A, B, D, E,
+ D, B, E, F, C, A,  D, C, B, E, F, A,  D, E, F, C, B, A,  D, F, C, B, E, A,
+ E, A, F, D, B, C,  E, B, A, F, D, C,  E, D, B, A, F, C,  E, F, D, B, A, C,
+ F, A, C, D, E, B,  F, C, D, E, A, B,  F, D, E, A, C, B,  F, E, A, C, D, B},
+// @OH8
+{A, B, D, C, E, F,  A, C, E, B, D, F,  A, D, C, E, B, F,  A, E, B, D, C, F,
+ B, A, E, F, D, C,  B, D, A, E, F, C,  B, E, F, D, A, C,  B, F, D, A, E, C,
+ C, A, D, F, E, B,  C, D, F, E, A, B,  C, E, A, D, F, B,  C, F, E, A, D, B,
+ D, A, B, F, C, E,  D, B, F, C, A, E,  D, C, A, B, F, E,  D, F, C, A, B, E,
+ E, A, C, F, B, D,  E, B, A, C, F, D,  E, C, F, B, A, D,  E, F, B, A, C, D,
+ F, B, E, C, D, A,  F, C, D, B, E, A,  F, D, B, E, C, A,  F, E, C, D, B, A},
+// @OH9
+{A, B, D, C, F, E,  A, C, F, B, D, E,  A, D, C, F, B, E,  A, F, B, D, C, E,
+ B, A, F, E, D, C,  B, D, A, F, E, C,  B, E, D, A, F, C,  B, F, E, D, A, C,
+ C, A, D, E, F, B,  C, D, E, F, A, B,  C, E, F, A, D, B,  C, F, A, D, E, B,
+ D, A, B, E, C, F,  D, B, E, C, A, F,  D, C, A, B, E, F,  D, E, C, A, B, F,
+ E, B, F, C, D, A,  E, C, D, B, F, A,  E, D, B, F, C, A,  E, F, C, D, B, A,
+ F, A, C, E, B, D,  F, B, A, C, E, D,  F, C, E, B, A, D,  F, E, B, A, C, D},
+// @OH10
+{A, B, E, C, D, F,  A, C, D, B, E, F,  A, D, B, E, C, F,  A, E, C, D, B, F,
+ B, A, D, F, E, C,  B, D, F, E, A, C,  B, E, A, D, F, C,  B, F, E, A, D, C,
+ C, A, E, F, D, B,  C, D, A, E, F, B,  C, E, F, D, A, B,  C, F, D, A, E, B,
+ D, A, C, F, B, E,  D, B, A, C, F, E,  D, C, F, B, A, E,  D, F, B, A, C, E,
+ E, A, B, F, C, D,  E, B, F, C, A, D,  E, C, A, B, F, D,  E, F, C, A, B, D,
+ F, B, D, C, E, A,  F, C, E, B, D, A,  F, D, C, E, B, A,  F, E, B, D, C, A},
+// @OH11
+{A, B, F, C, D, E,  A, C, D, B, F, E,  A, D, B, F, C, E,  A, F, C, D, B, E,
+ B, A, D, E, F, C,  B, D, E, F, A, C,  B, E, F, A, D, C,  B, F, A, D, E, C,
+ C, A, F, E, D, B,  C, D, A, F, E, B,  C, E, D, A, F, B,  C, F, E, D, A, B,
+ D, A, C, E, B, F,  D, B, A, C, E, F,  D, C, E, B, A, F,  D, E, B, A, C, F,
+ E, B, D, C, F, A,  E, C, F, B, D, A,  E, D, C, F, B, A,  E, F, B, D, C, A,
+ F, A, B, E, C, D,  F, B, E, C, A, D,  F, C, A, B, E, D,  F, E, C, A, B, D},
+// @OH12
+{A, B, E, C, F, D,  A, C, F, B, E, D,  A, E, C, F, B, D,  A, F, B, E, C, D,
+ B, A, F, D, E, C,  B, D, E, A, F, C,  B, E, A, F, D, C,  B, F, D, E, A, C,
+ C, A, E, D, F, B,  C, D, F, A, E, B,  C, E, D, F, A, B,  C, F, A, E, D, B,
+ D, B, F, C, E, A,  D, C, E, B, F, A,  D, E, B, F, C, A,  D, F, C, E, B, A,
+ E, A, B, D, C, F,  E, B, D, C, A, F,  E, C, A, B, D, F,  E, D, C, A, B, F,
+ F, A, C, D, B, E,  F, B, A, C, D, E,  F, C, D, B, A, E,  F, D, B, A, C, E},
+// @OH13
+{A, B, F, C, E, D,  A, C, E, B, F, D,  A, E, B, F, C, D,  A, F, C, E, B, D,
+ B, A, E, D, F, C,  B, D, F, A, E, C,  B, E, D, F, A, C,  B, F, A, E, D, C,
+ C, A, F, D, E, B,  C, D, E, A, F, B,  C, E, A, F, D, B,  C, F, D, E, A, B,
+ D, B, E, C, F, A,  D, C, F, B, E, A,  D, E, C, F, B, A,  D, F, B, E, C, A,
+ E, A, C, D, B, F,  E, B, A, C, D, F,  E, C, D, B, A, F,  E, D, B, A, C, F,
+ F, A, B, D, C, E,  F, B, D, C, A, E,  F, C, A, B, D, E,  F, D, C, A, B, E},
+// @OH14
+{A, B, D, E, C, F,  A, C, B, D, E, F,  A, D, E, C, B, F,  A, E, C, B, D, F,
+ B, A, C, F, D, E,  B, C, F, D, A, E,  B, D, A, C, F, E,  B, F, D, A, C, E,
+ C, A, E, F, B, D,  C, B, A, E, F, D,  C, E, F, B, A, D,  C, F, B, A, E, D,
+ D, A, B, F, E, C,  D, B, F, E, A, C,  D, E, A, B, F, C,  D, F, E, A, B, C,
+ E, A, D, F, C, B,  E, C, A, D, F, B,  E, D, F, C, A, B,  E, F, C, A, D, B,
+ F, B, C, E, D, A,  F, C, E, D, B, A,  F, D, B, C, E, A,  F, E, D, B, C, A},
+// @OH15
+{A, B, D, F, C, E,  A, C, B, D, F, E,  A, D, F, C, B, E,  A, F, C, B, D, E,
+ B, A, C, E, D, F,  B, C, E, D, A, F,  B, D, A, C, E, F,  B, E, D, A, C, F,
+ C, A, F, E, B, D,  C, B, A, F, E, D,  C, E, B, A, F, D,  C, F, E, B, A, D,
+ D, A, B, E, F, C,  D, B, E, F, A, C,  D, E, F, A, B, C,  D, F, A, B, E, C,
+ E, B, C, F, D, A,  E, C, F, D, B, A,  E, D, B, C, F, A,  E, F, D, B, C, A,
+ F, A, D, E, C, B,  F, C, A, D, E, B,  F, D, E, C, A, B,  F, E, C, A, D, B},
+// @OH16
+{A, B, F, D, C, E,  A, C, B, F, D, E,  A, D, C, B, F, E,  A, F, D, C, B, E,
+ B, A, C, E, F, D,  B, C, E, F, A, D,  B, E, F, A, C, D,  B, F, A, C, E, D,
+ C, A, D, E, B, F,  C, B, A, D, E, F,  C, D, E, B, A, F,  C, E, B, A, D, F,
+ D, A, F, E, C, B,  D, C, A, F, E, B,  D, E, C, A, F, B,  D, F, E, C, A, B,
+ E, B, C, D, F, A,  E, C, D, F, B, A,  E, D, F, B, C, A,  E, F, B, C, D, A,
+ F, A, B, E, D, C,  F, B, E, D, A, C,  F, D, A, B, E, C,  F, E, D, A, B, C},
+// @OH17
+{A, B, E, F, C, D,  A, C, B, E, F, D,  A, E, F, C, B, D,  A, F, C, B, E, D,
+ B, A, C, D, E, F,  B, C, D, E, A, F,  B, D, E, A, C, F,  B, E, A, C, D, F,
+ C, A, F, D, B, E,  C, B, A, F, D, E,  C, D, B, A, F, E,  C, F, D, B, A, E,
+ D, B, C, F, E, A,  D, C, F, E, B, A,  D, E, B, C, F, A,  D, F, E, B, C, A,
+ E, A, B, D, F, C,  E, B, D, F, A, C,  E, D, F, A, B, C,  E, F, A, B, D, C,
+ F, A, E, D, C, B,  F, C, A, E, D, B,  F, D, C, A, E, B,  F, E, D, C, A, B},
+// @OH18
+{A, B, F, E, C, D,  A, C, B, F, E, D,  A, E, C, B, F, D,  A, F, E, C, B, D,
+ B, A, C, D, F, E,  B, C, D, F, A, E,  B, D, F, A, C, E,  B, F, A, C, D, E,
+ C, A, E, D, B, F,  C, B, A, E, D, F,  C, D, B, A, E, F,  C, E, D, B, A, F,
+ D, B, C, E, F, A,  D, C, E, F, B, A,  D, E, F, B, C, A,  D, F, B, C, E, A,
+ E, A, F, D, C, B,  E, C, A, F, D, B,  E, D, C, A, F, B,  E, F, D, C, A, B,
+ F, A, B, D, E, C,  F, B, D, E, A, C,  F, D, E, A, B, C,  F, E, A, B, D, C},
+// @OH19
+{A, B, D, E, F, C,  A, D, E, F, B, C,  A, E, F, B, D, C,  A, F, B, D, E, C,
+ B, A, F, C, D, E,  B, C, D, A, F, E,  B, D, A, F, C, E,  B, F, C, D, A, E,
+ C, B, F, E, D, A,  C, D, B, F, E, A,  C, E, D, B, F, A,  C, F, E, D, B, A,
+ D, A, B, C, E, F,  D, B, C, E, A, F,  D, C, E, A, B, F,  D, E, A, B, C, F,
+ E, A, D, C, F, B,  E, C, F, A, D, B,  E, D, C, F, A, B,  E, F, A, D, C, B,
+ F, A, E, C, B, D,  F, B, A, E, C, D,  F, C, B, A, E, D,  F, E, C, B, A, D},
+// @OH20
+{A, B, D, F, E, C,  A, D, F, E, B, C,  A, E, B, D, F, C,  A, F, E, B, D, C,
+ B, A, E, C, D, F,  B, C, D, A, E, F,  B, D, A, E, C, F,  B, E, C, D, A, F,
+ C, B, E, F, D, A,  C, D, B, E, F, A,  C, E, F, D, B, A,  C, F, D, B, E, A,
+ D, A, B, C, F, E,  D, B, C, F, A, E,  D, C, F, A, B, E,  D, F, A, B, C, E,
+ E, A, F, C, B, D,  E, B, A, F, C, D,  E, C, B, A, F, D,  E, F, C, B, A, D,
+ F, A, D, C, E, B,  F, C, E, A, D, B,  F, D, C, E, A, B,  F, E, A, D, C, B},
+// @OH21
+{A, B, E, D, F, C,  A, D, F, B, E, C,  A, E, D, F, B, C,  A, F, B, E, D, C,
+ B, A, F, C, E, D,  B, C, E, A, F, D,  B, E, A, F, C, D,  B, F, C, E, A, D,
+ C, B, F, D, E, A,  C, D, E, B, F, A,  C, E, B, F, D, A,  C, F, D, E, B, A,
+ D, A, E, C, F, B,  D, C, F, A, E, B,  D, E, C, F, A, B,  D, F, A, E, C, B,
+ E, A, B, C, D, F,  E, B, C, D, A, F,  E, C, D, A, B, F,  E, D, A, B, C, F,
+ F, A, D, C, B, E,  F, B, A, D, C, E,  F, C, B, A, D, E,  F, D, C, B, A, E},
+// @OH22
+{A, B, F, D, E, C,  A, D, E, B, F, C,  A, E, B, F, D, C,  A, F, D, E, B, C,
+ B, A, E, C, F, D,  B, C, F, A, E, D,  B, E, C, F, A, D,  B, F, A, E, C, D,
+ C, B, E, D, F, A,  C, D, F, B, E, A,  C, E, D, F, B, A,  C, F, B, E, D, A,
+ D, A, F, C, E, B,  D, C, E, A, F, B,  D, E, A, F, C, B,  D, F, C, E, A, B,
+ E, A, D, C, B, F,  E, B, A, D, C, F,  E, C, B, A, D, F,  E, D, C, B, A, F,
+ F, A, B, C, D, E,  F, B, C, D, A, E,  F, C, D, A, B, E,  F, D, A, B, C, E},
+// @OH23
+{A, B, E, F, D, C,  A, D, B, E, F, C,  A, E, F, D, B, C,  A, F, D, B, E, C,
+ B, A, D, C, E, F,  B, C, E, A, D, F,  B, D, C, E, A, F,  B, E, A, D, C, F,
+ C, B, D, F, E, A,  C, D, F, E, B, A,  C, E, B, D, F, A,  C, F, E, B, D, A,
+ D, A, F, C, B, E,  D, B, A, F, C, E,  D, C, B, A, F, E,  D, F, C, B, A, E,
+ E, A, B, C, F, D,  E, B, C, F, A, D,  E, C, F, A, B, D,  E, F, A, B, C, D,
+ F, A, E, C, D, B,  F, C, D, A, E, B,  F, D, A, E, C, B,  F, E, C, D, A, B},
+// @OH24
+{A, B, F, E, D, C,  A, D, B, F, E, C,  A, E, D, B, F, C,  A, F, E, D, B, C,
+ B, A, D, C, F, E,  B, C, F, A, D, E,  B, D, C, F, A, E,  B, F, A, D, C, E,
+ C, B, D, E, F, A,  C, D, E, F, B, A,  C, E, F, B, D, A,  C, F, B, D, E, A,
+ D, A, E, C, B, F,  D, B, A, E, C, F,  D, C, B, A, E, F,  D, E, C, B, A, F,
+ E, A, F, C, D, B,  E, C, D, A, F, B,  E, D, A, F, C, B,  E, F, C, D, A, B,
+ F, A, B, C, E, D,  F, B, C, E, A, D,  F, C, E, A, B, D,  F, E, A, B, C, D},
+// @OH25
+{A, C, D, E, F, B,  A, D, E, F, C, B,  A, E, F, C, D, B,  A, F, C, D, E, B,
+ B, C, F, E, D, A,  B, D, C, F, E, A,  B, E, D, C, F, A,  B, F, E, D, C, A,
+ C, A, F, B, D, E,  C, B, D, A, F, E,  C, D, A, F, B, E,  C, F, B, D, A, E,
+ D, A, C, B, E, F,  D, B, E, A, C, F,  D, C, B, E, A, F,  D, E, A, C, B, F,
+ E, A, D, B, F, C,  E, B, F, A, D, C,  E, D, B, F, A, C,  E, F, A, D, B, C,
+ F, A, E, B, C, D,  F, B, C, A, E, D,  F, C, A, E, B, D,  F, E, B, C, A, D},
+// @OH26
+{A, C, D, F, E, B,  A, D, F, E, C, B,  A, E, C, D, F, B,  A, F, E, C, D, B,
+ B, C, E, F, D, A,  B, D, C, E, F, A,  B, E, F, D, C, A,  B, F, D, C, E, A,
+ C, A, E, B, D, F,  C, B, D, A, E, F,  C, D, A, E, B, F,  C, E, B, D, A, F,
+ D, A, C, B, F, E,  D, B, F, A, C, E,  D, C, B, F, A, E,  D, F, A, C, B, E,
+ E, A, F, B, C, D,  E, B, C, A, F, D,  E, C, A, F, B, D,  E, F, B, C, A, D,
+ F, A, D, B, E, C,  F, B, E, A, D, C,  F, D, B, E, A, C,  F, E, A, D, B, C},
+// @OH27
+{A, C, E, D, F, B,  A, D, F, C, E, B,  A, E, D, F, C, B,  A, F, C, E, D, B,
+ B, C, F, D, E, A,  B, D, E, C, F, A,  B, E, C, F, D, A,  B, F, D, E, C, A,
+ C, A, F, B, E, D,  C, B, E, A, F, D,  C, E, A, F, B, D,  C, F, B, E, A, D,
+ D, A, E, B, F, C,  D, B, F, A, E, C,  D, E, B, F, A, C,  D, F, A, E, B, C,
+ E, A, C, B, D, F,  E, B, D, A, C, F,  E, C, B, D, A, F,  E, D, A, C, B, F,
+ F, A, D, B, C, E,  F, B, C, A, D, E,  F, C, A, D, B, E,  F, D, B, C, A, E},
+// @OH28
+{A, C, F, D, E, B,  A, D, E, C, F, B,  A, E, C, F, D, B,  A, F, D, E, C, B,
+ B, C, E, D, F, A,  B, D, F, C, E, A,  B, E, D, F, C, A,  B, F, C, E, D, A,
+ C, A, E, B, F, D,  C, B, F, A, E, D,  C, E, B, F, A, D,  C, F, A, E, B, D,
+ D, A, F, B, E, C,  D, B, E, A, F, C,  D, E, A, F, B, C,  D, F, B, E, A, C,
+ E, A, D, B, C, F,  E, B, C, A, D, F,  E, C, A, D, B, F,  E, D, B, C, A, F,
+ F, A, C, B, D, E,  F, B, D, A, C, E,  F, C, B, D, A, E,  F, D, A, C, B, E},
+// @OH29
+{A, C, E, F, D, B,  A, D, C, E, F, B,  A, E, F, D, C, B,  A, F, D, C, E, B,
+ B, C, D, F, E, A,  B, D, F, E, C, A,  B, E, C, D, F, A,  B, F, E, C, D, A,
+ C, A, D, B, E, F,  C, B, E, A, D, F,  C, D, B, E, A, F,  C, E, A, D, B, F,
+ D, A, F, B, C, E,  D, B, C, A, F, E,  D, C, A, F, B, E,  D, F, B, C, A, E,
+ E, A, C, B, F, D,  E, B, F, A, C, D,  E, C, B, F, A, D,  E, F, A, C, B, D,
+ F, A, E, B, D, C,  F, B, D, A, E, C,  F, D, A, E, B, C,  F, E, B, D, A, C},
+// @OH30
+{A, C, F, E, D, B,  A, D, C, F, E, B,  A, E, D, C, F, B,  A, F, E, D, C, B,
+ B, C, D, E, F, A,  B, D, E, F, C, A,  B, E, F, C, D, A,  B, F, C, D, E, A,
+ C, A, D, B, F, E,  C, B, F, A, D, E,  C, D, B, F, A, E,  C, F, A, D, B, E,
+ D, A, E, B, C, F,  D, B, C, A, E, F,  D, C, A, E, B, F,  D, E, B, C, A, F,
+ E, A, F, B, D, C,  E, B, D, A, F, C,  E, D, A, F, B, C,  E, F, B, D, A, C,
+ F, A, C, B, E, D,  F, B, E, A, C, D,  F, C, B, E, A, D,  F, E, A, C, B, D}
+    };
+
+    /**
+     * Create a new octahedral configuration.
+     * @param focus    the focus
+     * @param carriers the carriers
+     * @param order    the order of the configuration 0-30.
+     */
+    public Octahedral(IAtom focus, IAtom[] carriers, int order) {
+        super(focus, carriers, IStereoElement.OC | (order & 0xff));
+        if (getConfigOrder() < 0 || getConfigOrder() > 30)
+            throw new IllegalArgumentException("Invalid configuration order!"
+                                               + "Should be in range 1-30");
+    }
+
+    /**
+     * Normalize the configuration to the lowest order (1). For example
+     * <pre>C[Co@OH8](F)(Br)(Cl)(I)S</pre>
+     * is the same as
+     * <pre>C[Co@OH1](F)(Cl)(Br)(I)S</pre>. The normalised form is easy to
+     * work with as the first and last carriers form an axis, the middle four
+     * equatorial carriers are arranged anti-clockwise looking from the first carrier.
+     * @return the normalized form
+     */
+    public Octahedral normalize() {
+        int cfg = getConfigOrder();
+        if (cfg == 1)
+          return this;
+        if (cfg < 1 || cfg > 30)
+            throw new IllegalArgumentException(
+                "Invalid config order: " + cfg + ", octahedral should be"
+                + "1 <= order <= 30!");
+        IAtom[] carriers = invapply(getCarriers().toArray(new IAtom[6]),
+                                    PERMUTATIONS[cfg-1]);
+        return new Octahedral(getFocus(), carriers, 1);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Octahedral create(IAtom focus, List<IAtom> carriers, int cfg) {
+        return new Octahedral(focus,
+                              carriers.toArray(new IAtom[6]),
+                              cfg);
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/stereo/SquarePlanar.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/SquarePlanar.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.stereo;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IStereoElement;
+
+import java.util.List;
+
+/**
+ * Describes square planar configuration. The configuration around a square
+ * planar is described by 3 possible values (1:U, 2:4, or 3:Z) based on the
+ * ordering of the planar carries around the focus:
+ * <pre>{@code
+ * Configurations:
+ *
+ *     a                a                a
+ *     |                |                |
+ *  d--f--b = U      c--f--d = 4      b--f--c = Z
+ *     |                |                |
+ *     c                b                d
+ *
+ *    SP1              SP2              SP3
+ * }</pre>
+ * cis-platin can be represented as any of the following:
+ * <pre>
+ * [NH3][Pt@SP1]([NH3])(Cl)Cl
+ * [NH3][Pt@SP3]([NH3])(Cl)Cl
+ * [NH3][Pt@SP2](Cl)([NH3])Cl
+ * [NH3][Pt@SP1](Cl)(Cl)[NH3]
+ * </pre>
+ * trans-platin can be represented as any of the following:
+ * <pre>
+ * [NH3][Pt@SP2]([NH3])(Cl)Cl
+ * [NH3][Pt@SP1](Cl)([NH3])Cl
+ * [NH3][Pt@SP1](Cl)([NH3])Cl
+ * [NH3][Pt@SP3](Cl)(Cl)[NH3]
+ * </pre>
+ *
+ * The normalize function ({@link #normalize()}) create a new
+ * <pre>IStereoElement</pre> where the carriers have been reorder such that the
+ * configuration is in a <code>U</code> shape (order=1).
+ *
+ * @see <a href="http://opensmiles.org/opensmiles.html#_square_planar_centers">
+ *     Square Planar Centers, OpenSMILES</a>
+ * @see TrigonalBipyramidal
+ * @see Octahedral
+ */
+public final class SquarePlanar extends AbstractStereo<IAtom,IAtom> {
+
+    private static final int[][] PERMUTATIONS = new int[][]{
+        {A, B, C, D,  A, D, C, B,
+         B, C, D, A,  B, A, D, C,
+         C, D, A, B,  C, B, A, D,
+         D, C, B, A,  D, A, B, C}, // SP1 (U)
+        {A, C, B, D,  A, D, B, C,
+         B, D, A, C,  B, C, A, D,
+         C, A, D, B,  C, B, D, A,
+         D, B, C, A,  D, A, C, B}, // SP2 (4)
+        {A, B, D, C,  A, C, D, B,
+         B, A, C, D,  B, D, C, A,
+         C, D, B, A,  C, A, B, D,
+         D, C, A, B,  D, B, A, C}  // SP3 (Z)
+    };
+
+    /**
+     * Create a square-planar configuration around a provided focus atom. The
+     * carriers are flat in the plane and their arrangement is either, U-shape,
+     * 4-shape, or Z-shape.
+     *
+     * @param focus the focus
+     * @param carriers the carriers
+     * @param order the configuration order, 1-3
+     */
+    public SquarePlanar(IAtom focus, IAtom[] carriers, int order) {
+        super(focus, carriers, IStereoElement.SP | order & 0xff);
+        if (getConfigOrder() < 0 || getConfigOrder() > 3)
+            throw new IllegalArgumentException("Invalid configuration order,"
+                                               + "should be between 1-3");
+    }
+
+    /**
+     * Normalize the configuration to the lowest configuration order (1) -
+     * U-shaped.
+     * @return the normalized configuration
+     */
+    public SquarePlanar normalize() {
+        int cfg = getConfigOrder();
+        if (cfg == 1)
+            return this;
+        IAtom[] carriers = invapply(getCarriers().toArray(new IAtom[4]),
+                                     PERMUTATIONS[cfg-1]);
+        return new SquarePlanar(getFocus(),
+                                carriers,
+                                SPU);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected SquarePlanar create(IAtom focus, List<IAtom> carriers, int cfg) {
+        return new SquarePlanar(focus, carriers.toArray(new IAtom[4]), cfg);
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/stereo/TetrahedralChirality.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/TetrahedralChirality.java
@@ -68,12 +68,12 @@ public class TetrahedralChirality
 
     @Override
     public Stereo getStereo() {
-        return Stereo.toStereo(getConfig());
+        return Stereo.toStereo(getConfigOrder());
     }
 
     @Override
     public void setStereo(Stereo stereo) {
-        setConfig(Stereo.toConfig(stereo));
+        setConfigOrder(Stereo.toConfig(stereo));
     }
 
     @Override

--- a/base/core/src/main/java/org/openscience/cdk/stereo/TrigonalBipyramidal.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/TrigonalBipyramidal.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.stereo;
+
+import org.openscience.cdk.interfaces.IAtom;
+
+import java.util.List;
+
+/**
+ * Describes a trigonal-bipyramidal configuration. The configuration carriers
+ * are arranged with two co-linear on an axis and three equatorial. The
+ * configuration order is between 1 and 20 and follows the same meaning as
+ * SMILES.
+ * <pre>
+ *    d   c     TB1
+ *     \ /
+ *  a---x---e   where a: first carrier, b: second carrier, ... *
+ *      |             x: focus
+ *      b             'c' is in front of 'x', 'd' is behind
+ * </pre>
+ *
+ * The configuration can be normalized to the lowest order (1) using the
+ * {@link #normalize()} function.
+ *
+ * @see <a href="http://opensmiles.org/opensmiles.html#_trigonal_bipyramidal_centers">
+ *     Trigonal Bipyramidal, OpenSMILES</a>
+ * @see Octahedral
+ * @see SquarePlanar
+ */
+public final class TrigonalBipyramidal extends AbstractStereo<IAtom,IAtom> {
+
+    private static final int[][] PERMUTATIONS = new int[][]{
+        {A, B, C, D, E,  A, C, D, B, E,  A, D, B, C, E,
+         E, D, C, B, A,  E, B, D, C, A,  E, C, B, D, A }, // TB1 a -> e @
+        {A, D, C, B, E,  A, C, B, D, E,  A, B, D, C, E,
+         E, B, C, D, A,  E, D, B, C, A,  E, C, D, B, A }, // TB2 a -> e @@
+        {A, B, C, E, D,  A, C, E, B, D,  A, E, B, C, D,
+         D, E, C, B, A,  D, B, E, C, A,  D, C, B, E, A }, // TB3 a -> d @
+        {A, E, C, B, D,  A, C, B, E, D,  A, B, E, C, D,
+         D, B, C, E, A,  D, E, B, C, A,  D, C, E, B, A }, // TB4 a -> d @@
+        {A, B, D, E, C,  A, D, E, B, C,  A, E, B, D, C,
+         C, E, D, B, A,  C, B, E, D, A,  C, D, B, E, A }, // TB5 a -> c @
+        {A, E, D, B, C,  A, D, B, E, C,  A, B, E, D, C,
+         C, B, D, E, A,  C, E, B, D, A,  C, D, E, B, A }, // TB6 a -> c @@
+        {A, C, D, E, B,  A, D, E, C, B,  A, E, C, D, B,
+         B, E, D, C, A,  B, C, E, D, A,  B, D, C, E, A }, // TB7 a -> b @
+        {A, E, D, C, B,  A, D, C, E, B,  A, C, E, D, B,
+         B, C, D, E, A,  B, E, C, D, A,  B, D, E, C, A }, // TB8 a -> b @@
+        {B, A, C, D, E,  B, C, D, A, E,  B, D, A, C, E,
+         E, D, C, A, B,  E, A, D, C, B,  E, C, A, D, B }, // TB9 b -> e @
+        {B, A, C, E, D,  B, C, E, A, D,  B, E, A, C, D,
+         D, E, C, A, B,  D, A, E, C, B,  D, C, A, E, B }, // TB10 b -> d @
+        {B, D, C, A, E,  B, C, A, D, E,  B, A, D, C, E,
+         E, A, C, D, B,  E, D, A, C, B,  E, C, D, A, B }, // TB11 b -> e @@
+        {B, E, C, A, D,  B, C, A, E, D,  B, A, E, C, D,
+         D, A, C, E, B,  D, E, A, C, B,  D, C, E, A, B }, // TB12 b -> d @@
+        {B, A, D, E, C,  B, D, E, A, C,  B, E, A, D, C,
+         C, E, D, A, B,  C, A, E, D, B,  C, D, A, E, B }, // TB13 b -> c @
+        {B, E, D, A, C,  B, D, A, E, C,  B, A, E, D, C,
+         C, A, D, E, B,  C, E, A, D, B,  C, D, E, A, B }, // TB14 b -> c @@
+        {C, A, B, D, E,  C, B, D, A, E,  C, D, A, B, E,
+         E, D, B, A, C,  E, A, D, B, C,  E, B, A, D, C }, // TB15 c -> e @
+        {C, A, B, E, D,  C, B, E, A, D,  C, E, A, B, D,
+         D, E, B, A, C,  D, A, E, B, C,  D, B, A, E, C }, // TB16 c -> d @
+        {D, A, B, C, E,  D, B, C, A, E,  D, C, A, B, E,
+         E, C, B, A, D,  E, A, C, B, D,  E, B, A, C, D }, // TB17 d -> e @
+        {D, C, B, A, E,  D, B, A, C, E,  D, A, C, B, E,
+         E, A, B, C, D,  E, C, A, B, D,  E, B, C, A, D }, // TB18 d -> e @@
+        {C, E, B, A, D,  C, B, A, E, D,  C, A, E, B, D,
+         D, A, B, E, C,  D, E, A, B, C,  D, B, E, A, C }, // TB19 c -> d @@
+        {C, D, B, A, E,  C, B, A, D, E,  C, A, D, B, E,
+         E, A, B, D, C,  E, D, A, B, C,  E, B, D, A, C }, // TB20 c -> e @@
+    };
+
+    /**
+     * Create a new trigonal bipyramidal configuration.
+     * @param focus the focus
+     * @param carriers the carriers
+     * @param order the order (1-20)
+     */
+    public TrigonalBipyramidal(IAtom focus, IAtom[] carriers, int order) {
+        super(focus, carriers, TrigonalBipyramidal | order & 0xff);
+        if (getConfigOrder() < 0 || getConfigOrder() > 20)
+            throw new IllegalArgumentException("Invalid configuration order,"
+                                               + "should be between 1-20");
+    }
+
+    /**
+     * Normalize the configuration to the lowest configuration order (1) -
+     * the axis goes from the first to last carrier, the three middle carriers
+     * are anti-clockwise looking from the first carrier.
+     * @return the normalized configuration
+     */
+    public TrigonalBipyramidal normalize() {
+        int cfg = getConfigOrder();
+        if (cfg == 1)
+          return this;
+        IAtom[] carriers = invapply(getCarriers().toArray(new IAtom[5]),
+                                    PERMUTATIONS[cfg-1]);
+        return new TrigonalBipyramidal(getFocus(),
+                                       carriers,
+                                       1);
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected TrigonalBipyramidal create(IAtom focus, List<IAtom> carriers, int cfg) {
+        return new TrigonalBipyramidal(focus, carriers.toArray(new IAtom[5]), cfg);
+    }
+}

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
@@ -161,6 +161,13 @@ public interface IStereoElement<F extends IChemObject, C extends IChemObject>
     /** Heptagonal Bipyramidal (HBPY-9) */
     public static final int HeptagonalBipyramidal = HBPY9;
 
+    /** Square Planar Configutation in U Shape */
+    public static final int SPU = SP | 1;
+    /** Square Planar Configutation in 4 Shape */
+    public static final int SP4 = SP | 2;
+    /** Square Planar Configutation in Z Shape */
+    public static final int SPZ = SP | 3;
+
     /**
      * The focus atom or bond at the 'centre' of the stereo-configuration.
      * @return the focus
@@ -180,16 +187,22 @@ public interface IStereoElement<F extends IChemObject, C extends IChemObject>
     int getConfigClass();
 
     /**
-     * The configuration of the stereochemistry.
+     * The configuration order of the stereochemistry.
      * @return configuration
      */
-    int getConfig();
+    int getConfigOrder();
 
     /**
-     * Set the configuration of the stereochemistry.
+     * Set the configuration order of the stereochemistry.
      * @param cfg the new configuration
      */
-    void setConfig(int cfg);
+    void setConfigOrder(int cfg);
+
+    /**
+     * Access the configuration order and class of the stereochemistry.
+     * @return the configuration
+     */
+    int getConfig();
 
     /**
      * Does the stereo element contain the provided atom.

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -522,7 +522,7 @@ public class AtomContainerManipulator {
 
                 if (hydrogen != null) {
                     replaceAtom(carriers, focus, hydrogen);
-                    stereos.add(new TetrahedralChirality(focus, carriers, tc.getConfig()));
+                    stereos.add(new TetrahedralChirality(focus, carriers, tc.getConfigOrder()));
                 } else {
                     stereos.add(stereo);
                 }

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/OctahedralTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/OctahedralTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.stereo;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class OctahedralTest {
+
+
+    @Test public void normalizeOh() throws InvalidSmilesException {
+        SmilesParser             smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer           mol    = smipar.parseSmiles("C[Co@OH8](F)(Br)(Cl)(I)S");
+        Iterator<IStereoElement> ses    = mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(Octahedral.class));
+        assertThat(se.getConfigOrder(), is(8));
+        Octahedral oh = (Octahedral) se;
+        Octahedral ohNorm = oh.normalize();
+        assertThat(ohNorm.getCarriers(), is(Arrays.asList(
+            mol.getAtom(0),
+            mol.getAtom(2),
+            mol.getAtom(4),
+            mol.getAtom(3),
+            mol.getAtom(5),
+            mol.getAtom(6)
+        )));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooManyCarriers() {
+        IAtom a0 = Mockito.mock(IAtom.class);
+        IAtom a1 = Mockito.mock(IAtom.class);
+        IAtom a2 = Mockito.mock(IAtom.class);
+        IAtom a3 = Mockito.mock(IAtom.class);
+        IAtom a4 = Mockito.mock(IAtom.class);
+        IAtom a5 = Mockito.mock(IAtom.class);
+        IAtom a6 = Mockito.mock(IAtom.class);
+        IAtom a7 = Mockito.mock(IAtom.class);
+        new Octahedral(a0, new IAtom[]{a1,a2,a3,a4,a5,a6,a7}, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void badConfigurationOrder() {
+        IAtom a0 = Mockito.mock(IAtom.class);
+        IAtom a1 = Mockito.mock(IAtom.class);
+        IAtom a2 = Mockito.mock(IAtom.class);
+        IAtom a3 = Mockito.mock(IAtom.class);
+        IAtom a4 = Mockito.mock(IAtom.class);
+        IAtom a5 = Mockito.mock(IAtom.class);
+        IAtom a6 = Mockito.mock(IAtom.class);
+        new Octahedral(a0, new IAtom[]{a1,a2,a3,a4,a5,a6}, 32);
+    }
+}

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/SquarePlanarTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/SquarePlanarTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.stereo;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class SquarePlanarTest {
+
+    @Test public void normalize() throws InvalidSmilesException {
+        SmilesParser             smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer           mol    = smipar.parseSmiles("Cl[Pt@SP3](Cl)([NH3])[NH3]");
+        Iterator<IStereoElement> ses    = mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(SquarePlanar.class));
+        assertThat(se.getConfigOrder(), is(3));
+        SquarePlanar sp = (SquarePlanar) se;
+        SquarePlanar spNorm = sp.normalize();
+        assertThat(spNorm.getCarriers(), is(Arrays.asList(
+            mol.getAtom(0),
+            mol.getAtom(2),
+            mol.getAtom(4),
+            mol.getAtom(3)
+        )));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooManyCarriers() {
+        IAtom a0 = Mockito.mock(IAtom.class);
+        IAtom a1 = Mockito.mock(IAtom.class);
+        IAtom a2 = Mockito.mock(IAtom.class);
+        IAtom a3 = Mockito.mock(IAtom.class);
+        IAtom a4 = Mockito.mock(IAtom.class);
+        IAtom a5 = Mockito.mock(IAtom.class);
+        new SquarePlanar(a0, new IAtom[]{a1,a2,a3,a4,a5}, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void badConfigurationOrder() {
+        IAtom a0 = Mockito.mock(IAtom.class);
+        IAtom a1 = Mockito.mock(IAtom.class);
+        IAtom a2 = Mockito.mock(IAtom.class);
+        IAtom a3 = Mockito.mock(IAtom.class);
+        IAtom a4 = Mockito.mock(IAtom.class);
+        new SquarePlanar(a0, new IAtom[]{a1,a2,a3,a4}, 32);
+    }
+}

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/TrigonalBipyramidalTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/TrigonalBipyramidalTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.stereo;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class TrigonalBipyramidalTest {
+
+    @Test public void normalize() throws InvalidSmilesException {
+        SmilesParser             smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer           mol    = smipar.parseSmiles("C[As@TB3](Cl)(Cl)(C)Cl");
+        Iterator<IStereoElement> ses    = mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(TrigonalBipyramidal.class));
+        assertThat(se.getConfigOrder(), is(3));
+        TrigonalBipyramidal tb = (TrigonalBipyramidal) se;
+        TrigonalBipyramidal tbNorm = tb.normalize();
+        assertThat(tbNorm.getCarriers(), is(Arrays.asList(
+            mol.getAtom(0),
+            mol.getAtom(2),
+            mol.getAtom(3),
+            mol.getAtom(5),
+            mol.getAtom(4)
+        )));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooManyCarriers() {
+        IAtom a0 = Mockito.mock(IAtom.class);
+        IAtom a1 = Mockito.mock(IAtom.class);
+        IAtom a2 = Mockito.mock(IAtom.class);
+        IAtom a3 = Mockito.mock(IAtom.class);
+        IAtom a4 = Mockito.mock(IAtom.class);
+        IAtom a5 = Mockito.mock(IAtom.class);
+        IAtom a6 = Mockito.mock(IAtom.class);
+        new TrigonalBipyramidal(a0, new IAtom[]{a1,a2,a3,a4,a5,a6}, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void badConfigurationOrder() {
+        IAtom a0 = Mockito.mock(IAtom.class);
+        IAtom a1 = Mockito.mock(IAtom.class);
+        IAtom a2 = Mockito.mock(IAtom.class);
+        IAtom a3 = Mockito.mock(IAtom.class);
+        IAtom a4 = Mockito.mock(IAtom.class);
+        IAtom a5 = Mockito.mock(IAtom.class);
+        new TrigonalBipyramidal(a0, new IAtom[]{a1,a2,a3,a4,a5}, 32);
+    }
+}

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -34,7 +34,6 @@ import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.io.MDLV2000Writer;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.smiles.SmiFlavor;
@@ -44,7 +43,6 @@ import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -1172,8 +1170,8 @@ public class StereoElementFactoryTest {
         IStereoElement s2 = stereoDown.get(0);
         assertThat(s1.getFocus(), is(s2.getFocus()));
         assertThat(s1.getCarriers(), is(s2.getCarriers()));
-        assertThat(s1.getConfig(), is(IStereoElement.RIGHT));
-        assertThat(s2.getConfig(), is(IStereoElement.LEFT));
+        assertThat(s1.getConfigOrder(), is(IStereoElement.RIGHT));
+        assertThat(s2.getConfigOrder(), is(IStereoElement.LEFT));
 
         // now test placement of wedges else where
         m.getBond(12).setStereo(IBond.Stereo.NONE);
@@ -1185,7 +1183,7 @@ public class StereoElementFactoryTest {
         IStereoElement s3 = stereoUpOther.get(0);
         assertThat(s3.getFocus(), is(s2.getFocus()));
         assertThat(s3.getCarriers(), is(s2.getCarriers()));
-        assertThat(s3.getConfig(), is(s2.getConfig()));
+        assertThat(s3.getConfigOrder(), is(s2.getConfigOrder()));
 
         m.getBond(m.getAtom(9), m.getAtom(12)).setStereo(IBond.Stereo.DOWN);
         List<IStereoElement> stereoDownOther =
@@ -1195,7 +1193,7 @@ public class StereoElementFactoryTest {
         IStereoElement s4 = stereoDownOther.get(0);
         assertThat(s4.getFocus(), is(s1.getFocus()));
         assertThat(s4.getCarriers(), is(s1.getCarriers()));
-        assertThat(s4.getConfig(), is(s1.getConfig()));
+        assertThat(s4.getConfigOrder(), is(s1.getConfigOrder()));
     }
 
     /**

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -378,7 +378,7 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
 
                     // defines how the element is aligned on the atom point, when
                     // aligned to the left, the first character 'e.g. Cl' is used.
-                    if (visNeighbors.size() > 0) {
+                    if (visNeighbors.size() < 4) {
                         if (hPosition == Left) {
                             symbols[i] = symbols[i].alignTo(AtomSymbol.SymbolAlignment.Right);
                         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,14 @@
         </site>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            
+        </repository>
+    </repositories>
+
     <prerequisites>
         <maven>3.0</maven>
     </prerequisites>
@@ -386,12 +394,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-core</artifactId>
-                <version>1.0</version>
+                <version>1.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-func</artifactId>
-                <version>1.0</version>
+                <version>1.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
@@ -32,7 +32,10 @@ import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
+import org.openscience.cdk.stereo.Octahedral;
+import org.openscience.cdk.stereo.SquarePlanar;
 import org.openscience.cdk.stereo.TetrahedralChirality;
+import org.openscience.cdk.stereo.TrigonalBipyramidal;
 import uk.ac.ebi.beam.Atom;
 import uk.ac.ebi.beam.Bond;
 import uk.ac.ebi.beam.Configuration;
@@ -204,6 +207,21 @@ final class BeamToCDK {
                     }
                     case DoubleBond: {
                         checkBondStereo = true;
+                        break;
+                    }
+                    case SquarePlanar: {
+                        IStereoElement se = newSquarePlanar(u, g.neighbors(u), atoms, c);
+                        if (se != null) ac.addStereoElement(se);
+                        break;
+                    }
+                    case TrigonalBipyramidal: {
+                        IStereoElement se = newTrigonalBipyramidal(u, g.neighbors(u), atoms, c);
+                        if (se != null) ac.addStereoElement(se);
+                        break;
+                    }
+                    case Octahedral: {
+                        IStereoElement se = newOctahedral(u, g.neighbors(u), atoms, c);
+                        if (se != null) ac.addStereoElement(se);
                         break;
                     }
                 }
@@ -394,6 +412,58 @@ final class BeamToCDK {
 
         return new TetrahedralChirality(atoms[u], new IAtom[]{atoms[vs[0]], atoms[vs[1]], atoms[vs[2]], atoms[vs[3]]},
                 stereo);
+    }
+
+    private IStereoElement newSquarePlanar(int u, int[] vs, IAtom[] atoms, Configuration c) {
+
+        if (vs.length != 4)
+            return null;
+
+        int order;
+        switch (c) {
+            case SP1:
+                order = IStereoElement.SP | 1;
+                break;
+            case SP2:
+                order = IStereoElement.SP | 2;
+                break;
+            case SP3:
+                order = IStereoElement.SP | 3;
+                break;
+            default:
+                return null;
+        }
+
+        return new SquarePlanar(atoms[u],
+                                new IAtom[]{atoms[vs[0]], atoms[vs[1]], atoms[vs[2]], atoms[vs[3]]},
+                                order);
+    }
+
+    private IStereoElement newTrigonalBipyramidal(int u, int[] vs, IAtom[] atoms, Configuration c) {
+        if (vs.length != 5)
+            return null;
+        int order = 1 + c.ordinal() - Configuration.TB1.ordinal();
+        if (order < 1 || order > 20)
+            return null;
+        return new TrigonalBipyramidal(atoms[u],
+                                       new IAtom[]{atoms[vs[0]], atoms[vs[1]], atoms[vs[2]], atoms[vs[3]], atoms[vs[4]]},
+                                       order);
+    }
+
+    private IStereoElement newOctahedral(int u, int[] vs, IAtom[] atoms, Configuration c) {
+        if (vs.length != 6)
+            return null;
+        int order = 1 + c.ordinal() - Configuration.OH1.ordinal();
+        if (order < 1 || order > 30)
+            return null;
+        return new Octahedral(atoms[u],
+                              new IAtom[]{atoms[vs[0]],
+                                          atoms[vs[1]],
+                                          atoms[vs[2]],
+                                          atoms[vs[3]],
+                                          atoms[vs[4]],
+                                          atoms[vs[5]]},
+                              order);
     }
 
     private IStereoElement newExtendedTetrahedral(int u, Graph g, IAtom[] atoms) {

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -53,12 +53,16 @@ import org.openscience.cdk.interfaces.ITetrahedralChirality.Stereo;
 import org.openscience.cdk.isomorphism.IsomorphismTester;
 import org.openscience.cdk.isomorphism.UniversalIsomorphismTester;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.stereo.Octahedral;
+import org.openscience.cdk.stereo.SquarePlanar;
+import org.openscience.cdk.stereo.TrigonalBipyramidal;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.AtomTypeManipulator;
 import org.openscience.cdk.tools.manipulator.BondManipulator;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -2526,6 +2530,76 @@ public class SmilesParserTest extends CDKTestCase {
             if (bond.getOrder() == null || bond.getOrder() == IBond.Order.UNSET)
                 fail("Unset bond order");
         }
+    }
+
+    @Test
+    public void cisplatin() throws Exception {
+        IAtomContainer mol = load("[NH3][Pt@SP1]([NH3])(Cl)Cl");
+        Iterator<IStereoElement> ses =mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(SquarePlanar.class));
+        assertThat(((SquarePlanar) se).getConfigOrder(), is(1));
+    }
+
+    @Test
+    public void cisplatin_Z() throws Exception {
+        IAtomContainer mol = load("[NH3][Pt@SP3]([NH3])(Cl)Cl");
+        Iterator<IStereoElement> ses =mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(SquarePlanar.class));
+        assertThat(((SquarePlanar) se).getConfigOrder(), is(3));
+    }
+
+    @Test
+    public void transplatin() throws Exception {
+        IAtomContainer mol = load("[NH3][Pt@SP2]([NH3])(Cl)Cl");
+        Iterator<IStereoElement> ses =mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(SquarePlanar.class));
+        assertThat(((SquarePlanar) se).getConfigOrder(), is(2));
+    }
+
+    @Test
+    public void tbpy1() throws Exception {
+        IAtomContainer mol = load("S[As@TB1](F)(Cl)(Br)N");
+        Iterator<IStereoElement> ses =mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(TrigonalBipyramidal.class));
+        assertThat(((TrigonalBipyramidal) se).getConfigOrder(), is(1));
+    }
+
+    @Test
+    public void tbpy2() throws Exception {
+        IAtomContainer mol = load("S[As@TB2](F)(Cl)(Br)N");
+        Iterator<IStereoElement> ses =mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(TrigonalBipyramidal.class));
+        assertThat(((TrigonalBipyramidal) se).getConfigOrder(), is(2));
+    }
+
+    @Test
+    public void oh1() throws Exception {
+        IAtomContainer mol = load("C[Co@](F)(Cl)(Br)(I)S");
+        Iterator<IStereoElement> ses =mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(Octahedral.class));
+        assertThat(se.getConfigOrder(), is(1));
+    }
+
+    @Test
+    public void oh8() throws Exception {
+        IAtomContainer mol = load("C[Co@OH8](F)(Br)(Cl)(I)S");
+        Iterator<IStereoElement> ses =mol.stereoElements().iterator();
+        assertTrue(ses.hasNext());
+        IStereoElement se = ses.next();
+        assertThat(se, instanceOf(Octahedral.class));
+        assertThat(se.getConfigOrder(), is(8));
     }
 
     /**

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/MacroCycleLayout.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/MacroCycleLayout.java
@@ -211,7 +211,7 @@ final class MacroCycleLayout {
                     } else {
                         cfg = IStereoElement.OPPOSITE;
                     }
-                    if (cfg == se.getConfig()) {
+                    if (cfg == se.getConfigOrder()) {
                         nCorrectStereo++;
                     } else {
                         nIncorrectStereo++;

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -288,7 +288,7 @@ final class NonplanarBonds {
         final IBond[] bonds = new IBond[4];
 
         int p = 0;
-        switch (element.getConfig()) {
+        switch (element.getConfigOrder()) {
             case IStereoElement.LEFT:
                 p = +1;
                 break;

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -782,7 +782,7 @@ public class StructureDiagramGenerator {
                                 if (begBonds.size() != 1 || endBonds.size() != 1)
                                     continue;
                                 boolean flipped = begBonds.contains(firstCarrier) != endBonds.contains(secondCarrier);
-                                int cfg = flipped ? se.getConfig() ^ 0x3 : se.getConfig();
+                                int cfg = flipped ? se.getConfigOrder() ^ 0x3 : se.getConfigOrder();
                                 ring.addStereoElement(new DoubleBondStereochemistry(stereoBond,
                                                                                     new IBond[]{begBonds.get(0), endBonds.get(0)},
                                                                                     cfg));

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -615,6 +615,7 @@ public class StructureDiagramGenerator {
         refinePlacement(molecule);
         finalizeLayout(molecule);
 
+        // stereo must be after refinement (due to flipping!)
         if (!isSubLayout)
             assignStereochem(molecule);
 


### PR DESCRIPTION
* Change the API (not in current release) to make explicit the configuration order is being accessed.
* Add more geometries supported by SMILES, and generate depictions


```
Cl[Pt@SP1](Cl)([NH3])[NH3] cis-platin
Cl[Pt@SP2](Cl)([NH3])[NH3] trans-platin
```

![image](http://simolecule.com/cdkdepict/depict/bow/svg?smi=Cl[Pt@SP1](Cl)([NH3])[NH3]%20cis-platin&abbr=on&hdisp=bridgehead&showtitle=true&zoom=1.6&annotate=none) ![image](http://simolecule.com/cdkdepict/depict/bow/svg?smi=Cl[Pt@SP2](Cl)([NH3])[NH3]%20trans-platin&abbr=on&hdisp=bridgehead&showtitle=true&zoom=1.6&annotate=none)

```
O=N[Co@]([NH3])([NH3])([NH3])([NH3])N=O trans-[Co(NH3)4(NO)2]
O=N[Co@OH3]([NH3])([NH3])([NH3])([NH3])N=O cis-[Co(NH3)4(NO)2]
O=N[Co@](N=O)([NH3])([NH3])([NH3])N=O mer-[Co(NH3)3(NO)3]
O=N[Co@OH3](N=O)([NH3])([NH3])([NH3])N=O fac-[Co(NH3)3(NO)3]
```

![image](http://simolecule.com/cdkdepict/depict/bow/svg?smi=O=N[Co@]([NH3])([NH3])([NH3])([NH3])N(=O)%20trans-[Co(NH3)4(NO)2]&abbr=on&hdisp=bridgehead&showtitle=true&zoom=1.6&annotate=none) ![image](http://simolecule.com/cdkdepict/depict/bow/svg?smi=O=N[Co@OH3]([NH3])([NH3])([NH3])([NH3])N(=O)%20cis-[Co(NH3)4(NO)2]&abbr=on&hdisp=bridgehead&showtitle=true&zoom=1.6&annotate=none) ![image](http://simolecule.com/cdkdepict/depict/bow/svg?smi=O=N[Co@](N=O)([NH3])([NH3])([NH3])N(=O)%20mer-[Co(NH3)3(NO)3]&abbr=on&hdisp=bridgehead&showtitle=true&zoom=1.6&annotate=none) ![image](http://simolecule.com/cdkdepict/depict/bow/svg?smi=O=N[Co@OH3](N=O)([NH3])([NH3])([NH3])N(=O)%20fac-[Co(NH3)3(NO)3]&abbr=on&hdisp=bridgehead&showtitle=true&zoom=1.6&annotate=none)

