### PR TITLE
Fix NoSuchAtomException issue in MDLV2000Reader

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -465,7 +465,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                     IAtom focus = e.getKey();
                     IAtom[] carriers = new IAtom[4];
                     int hidx = -1;
-                    for (IAtom nbr : molecule.getConnectedAtomsList(focus)) {
+                    for (IAtom nbr : outputContainer.getConnectedAtomsList(focus)) {
                         if (idx == 4)
                             continue Parities; // too many neighbors
                         if (nbr.getAtomicNumber() == 1) {
@@ -487,7 +487,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                         // we adjust the winding as needed
                         if (hidx == 0 || hidx == 2)
                             winding = winding.invert();
-                        molecule.addStereoElement(new TetrahedralChirality(focus, carriers, winding));
+                        outputContainer.addStereoElement(new TetrahedralChirality(focus, carriers, winding));
                     }
                 }
             }


### PR DESCRIPTION
In two lines of code, method 'readAtomContainer' of class
'MDLV2000Reader' uses variable 'molecule' instead of variable
'outputContainer'. If a loaded molfile contains a query bond, then
'molecule' and 'outputContainer' do not reference the same container.
This can cause an issue in next parts of the code because atoms are
searched in the empty container referenced by 'molecule'.


To reproduce the issue, you can use the following code:

import java.net.URL;
import org.openscience.cdk.io.MDLV2000Reader;
import org.openscience.cdk.silent.AtomContainer;

public class Test
{
    public static void main(String[] args) throws Exception
    {
        URL url = new URL("http://www.ebi.ac.uk/chebi/saveStructure.do?"
                + "sdf=true&chebiId=48572");
        new MDLV2000Reader(url.openStream()).read(new AtomContainer());
    }
}