### PR TITLE
Fix CircularFingerprinter.rubricTetrahedralsCdk()

### DIFF
--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -870,7 +870,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
                     else
                         adj[i] = mol.indexOf(carriers.get(i));
                 }
-                switch (th.getConfig()) {
+                switch (th.getConfigOrder()) {
                     case IStereoElement.LEFT:
                         int i = adj[2];
                         adj[2] = adj[3];


### PR DESCRIPTION
Use getConfigOrder instead of getConfig. Test case is not created yet, but BayesianTest.testFolding will pass with this fix.