### PR TITLE
Fix AtomContainer2.setStereoElements(List<IStereoElement>)

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
@@ -257,7 +257,9 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
     @Override
     public void setStereoElements(List<IStereoElement> elements) {
         this.stereo.clear();
-        this.stereo.addAll(elements);
+        for (IStereoElement element : elements)
+            if (!this.stereo.contains(element))
+                this.addStereoElement(element);
         notifyChanged();
     }
 

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer2.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer2.java
@@ -259,7 +259,9 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
     @Override
     public void setStereoElements(List<IStereoElement> elements) {
         this.stereo.clear();
-        this.stereo.addAll(elements);
+        for (IStereoElement element : elements)
+            if (!this.stereo.contains(element))
+                this.addStereoElement(element);
     }
 
     /**

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomContainerTest.java
@@ -575,6 +575,27 @@ public abstract class AbstractAtomContainerTest extends AbstractChemObjectTest {
         assertThat("incorrect chiral atom", cloneChirality.getChiralAtom(), sameInstance(clone.getAtom(0)));
 
     }
+    
+    @Test
+    public void testSetStereoElements_Dup() {
+        IAtomContainer container = (IAtomContainer) newChemObject();
+        IChemObjectBuilder builder = container.getBuilder();
+        IAtom atom = builder.newAtom();
+        IAtom a1 = builder.newAtom();
+        IAtom a2 = builder.newAtom();
+        IAtom a3 = builder.newAtom();
+        IAtom a4 = builder.newAtom();
+        
+        List<IStereoElement> tetrahedralElements = new ArrayList<IStereoElement>();
+        IStereoElement stereo = new TetrahedralChirality(atom, new IAtom[]{a1, a2, a3, a4}, ITetrahedralChirality.Stereo.CLOCKWISE);
+        tetrahedralElements.add(stereo);
+        tetrahedralElements.add(stereo);
+        container.setStereoElements(tetrahedralElements);
+        Iterator<IStereoElement> iter = container.stereoElements().iterator();
+        assertThat(iter.hasNext(), is(true));
+        iter.next();
+        assertThat(iter.hasNext(), is(false));
+    }
 
     @Test
     public void testSetStereoElements_List() {


### PR DESCRIPTION
AtomContainer.setStereoElements(List <IStereoElement> element) checks for duplicate elements as described in the StereoElementFactory's comment, but AtomContainer2 version does not.