### PR TITLE
PerceiveStereo option for Bayesian class

### DIFF
--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -970,9 +970,15 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         int[] adj = atomAdj[aidx];
         if (adjc == 3) {
             adj = appendInteger(adj, -1);
-            xp[3] = x0;
-            yp[3] = y0;
-            zp[3] = z0;
+            xp[3] = -(xp[0] + xp[1] + xp[2]); 
+            yp[3] = -(yp[0] + yp[1] + yp[2]); 
+            zp[3] = -(zp[0] + zp[1] + zp[2]); 
+            float dsq = xp[3] * xp[3] + yp[3] * yp[3] + zp[3] * zp[3]; 
+            if (dsq < 0.01f * 0.01f) return null; 
+            float inv = 1.0f / (float) Math.sqrt(dsq); 
+            xp[3] *= inv; 
+            yp[3] *= inv; 
+            zp[3] *= inv; 
         }
 
         // make the call on permutational parity

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -970,15 +970,9 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         int[] adj = atomAdj[aidx];
         if (adjc == 3) {
             adj = appendInteger(adj, -1);
-            xp[3] = -(xp[0] + xp[1] + xp[2]); 
-            yp[3] = -(yp[0] + yp[1] + yp[2]); 
-            zp[3] = -(zp[0] + zp[1] + zp[2]); 
-            float dsq = xp[3] * xp[3] + yp[3] * yp[3] + zp[3] * zp[3]; 
-            if (dsq < 0.01f * 0.01f) return null; 
-            float inv = 1.0f / (float) Math.sqrt(dsq); 
-            xp[3] *= inv; 
-            yp[3] *= inv; 
-            zp[3] *= inv; 
+            xp[3] = x0;
+            yp[3] = y0;
+            zp[3] = z0;
         }
 
         // make the call on permutational parity

--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -970,9 +970,9 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
         int[] adj = atomAdj[aidx];
         if (adjc == 3) {
             adj = appendInteger(adj, -1);
-            xp[3] = x0;
-            yp[3] = y0;
-            zp[3] = z0;
+            xp[3] = 0;
+            yp[3] = 0;
+            zp[3] = 0;
         }
 
         // make the call on permutational parity

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/CircularFingerprinterTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/CircularFingerprinterTest.java
@@ -68,6 +68,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import javax.vecmath.Point2d;
+import javax.vecmath.Point3d;
 
 /**
  * @cdk.module test-standard
@@ -365,6 +366,39 @@ public class CircularFingerprinterTest extends CDKTestCase {
         CircularFingerprinter circ = new CircularFingerprinter(CircularFingerprinter.CLASS_ECFP6);
         assertNotNull(circ.getBitFingerprint(m));
     }
+
+	@Test
+	public void testNonZZeroPlaner() throws Exception {
+	    IAtomContainer mol = new AtomContainer();
+	    Atom[] atoms = new Atom[] {
+	        new Atom("C"),
+	        new Atom("F"),
+	        new Atom("N"),
+	        new Atom("O"),
+	    };
+	    atoms[0].setPoint3d(new Point3d(0, 0, -10));
+	    atoms[1].setPoint3d(new Point3d(0, 1, -10));
+	    atoms[2].setPoint3d(new Point3d(-1, -1, -10));
+	    atoms[3].setPoint3d(new Point3d(1, -1, -10));
+	    mol.setAtoms(atoms);
+	    mol.addBond(0, 1, IBond.Order.SINGLE);
+	    mol.addBond(0, 2, IBond.Order.SINGLE);
+	    mol.addBond(0, 3, IBond.Order.SINGLE);
+	    mol.getBond(0).setStereo(IBond.Stereo.UP);
+	    
+	    CircularFingerprinter circ = new CircularFingerprinter(CircularFingerprinter.CLASS_ECFP6);
+	    circ.setPerceiveStereo(true);
+	    IBitFingerprint fp0 = circ.getBitFingerprint(mol);
+	    
+	    for (int i = 0; i < atoms.length; i++) {
+	        Point3d p = atoms[i].getPoint3d();
+	        atoms[i].setPoint3d(new Point3d(p.getX(), p.getY(), p.getZ() + 20));
+	    }
+	
+	    IBitFingerprint fp1 = circ.getBitFingerprint(mol);
+	    
+	    Assert.assertThat(fp0, is(fp1));
+	}
     
     static IAtom atom(String symbol, int q, int h) {
         IAtom a = new Atom(symbol);

--- a/tool/model/src/main/java/org/openscience/cdk/fingerprint/model/Bayesian.java
+++ b/tool/model/src/main/java/org/openscience/cdk/fingerprint/model/Bayesian.java
@@ -114,6 +114,7 @@ public class Bayesian {
     // optional text attributes (serialisable)
     private String                 noteTitle    = null, noteOrigin = null;
     private String[]               noteComments = null;
+    private boolean optPerceiveStereo = false;
 
     private static final Pattern   PTN_HASHLINE = Pattern.compile("^(-?\\d+)=([\\d\\.Ee-]+)");
 
@@ -149,6 +150,17 @@ public class Bayesian {
     }
 
     /**
+     * Sets whether stereochemistry should be re-perceived from 2D/3D
+     * coordinates. By default stereochemistry encoded as {@link IStereoElement}s
+     * are used.
+     *
+     * @param val perceived from 2D
+     */
+    public void setPerceiveStereo(boolean val) {
+        this.optPerceiveStereo = val;
+    }
+    
+    /**
      * Access to the fingerprint type.
      * 
      * @return fingerprint class, one of CircularFingerprinter.CLASS_*
@@ -177,6 +189,7 @@ public class Bayesian {
         if (mol == null || mol.getAtomCount() == 0) throw new CDKException("Molecule cannot be blank or null.");
 
         CircularFingerprinter circ = new CircularFingerprinter(classType);
+        circ.setPerceiveStereo(optPerceiveStereo);
         circ.calculate(mol);
 
         // gather all of the (folded) fingerprints into a sorted set
@@ -261,6 +274,7 @@ public class Bayesian {
         if (mol == null || mol.getAtomCount() == 0) throw new CDKException("Molecule cannot be blank or null.");
 
         CircularFingerprinter circ = new CircularFingerprinter(classType);
+        circ.setPerceiveStereo(optPerceiveStereo);
         circ.calculate(mol);
 
         // gather all of the (folded) fingerprints (eliminating duplicates)

--- a/tool/model/src/test/java/org/openscience/cdk/fingerprint/model/BayesianTest.java
+++ b/tool/model/src/test/java/org/openscience/cdk/fingerprint/model/BayesianTest.java
@@ -193,10 +193,10 @@ public class BayesianTest {
     public void testExample1() throws Exception {
         logger.info("Bayesian/Fingerprints test: using dataset of binding data to compare to reference data");
 
-        runTest("Binders.sdf", "active", CircularFingerprinter.CLASS_ECFP6, 1024, 0, "Binders-ECFP6-1024-loo.bayesian");
+        runTest("Binders.sdf", "active", CircularFingerprinter.CLASS_ECFP6, 1024, 0, "Binders-ECFP6-1024-loo.bayesian", true);
         runTest("Binders.sdf", "active", CircularFingerprinter.CLASS_ECFP6, 32768, 5,
-                "Binders-ECFP6-32768-xv5.bayesian");
-        runTest("Binders.sdf", "active", CircularFingerprinter.CLASS_FCFP6, 0, 0, "Binders-FCFP6-0-loo.bayesian");
+                "Binders-ECFP6-32768-xv5.bayesian", true);
+        runTest("Binders.sdf", "active", CircularFingerprinter.CLASS_FCFP6, 0, 0, "Binders-FCFP6-0-loo.bayesian", true);
     }
 
     @Test
@@ -372,6 +372,11 @@ public class BayesianTest {
     // that has been previously serialised
     private void runTest(String sdfile, String actvField, int classType, int folding, int xval, String modelFN)
             throws CDKException {
+    	runTest(sdfile, actvField, classType, folding, xval, modelFN, false);
+    }
+    
+    private void runTest(String sdfile, String actvField, int classType, int folding, int xval, String modelFN, boolean perceiveStereo)
+            throws CDKException {
         writeln("[" + modelFN + "]");
         writeln("    Loading " + sdfile);
 
@@ -379,6 +384,7 @@ public class BayesianTest {
             InputStream in = this.getClass().getClassLoader().getResourceAsStream("data/cdd/" + sdfile);
             IteratingSDFReader rdr = new IteratingSDFReader(in, DefaultChemObjectBuilder.getInstance());
             Bayesian model = new Bayesian(classType, folding);
+            model.setPerceiveStereo(perceiveStereo);
 
             int row = 0, numActives = 0;
             while (rdr.hasNext()) {


### PR DESCRIPTION
A flag whether to perceive stereo or not is added to Bayesian class.
Rolling back CircularFingerprinter.rubricTetrahedral(int) method is also included.