### PR TITLE
Patch/delocalisedbonds

### DIFF
--- a/display/render/src/main/java/org/openscience/cdk/renderer/SymbolVisibility.java
+++ b/display/render/src/main/java/org/openscience/cdk/renderer/SymbolVisibility.java
@@ -164,8 +164,23 @@ public abstract class SymbolVisibility {
         private static boolean isFourValent(IAtom atom, List<IBond> bonds) {
             Integer valence = atom.getImplicitHydrogenCount();
             if (valence == null) return true;
-            for (final IBond bond : bonds) {
-                valence += bond.getOrder().numeric();
+            if (atom.isAromatic()) {
+                boolean hasUnsetArom = false;
+                for (final IBond bond : bonds) {
+                    if (bond.getOrder() == IBond.Order.UNSET && bond.isAromatic()) {
+                        hasUnsetArom = true;
+                        valence++;
+                    } else {
+                        valence += bond.getOrder().numeric();
+                    }
+                }
+                // valence nudge, we're only dealing with neutral carbons here
+                // and if
+                if (hasUnsetArom)
+                    valence++;
+            } else {
+                for (final IBond bond : bonds)
+                    valence += bond.getOrder().numeric();
             }
             return valence == 4;
         }

--- a/display/render/src/test/java/org/openscience/cdk/renderer/SymbolVisibilityTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/SymbolVisibilityTest.java
@@ -220,13 +220,13 @@ public class SymbolVisibilityTest {
 
         a1.setPoint2d(new Point2d(0, 0));
         a2.setPoint2d(new Point2d(0.5, -0.5));
-        a2.setPoint2d(new Point2d(1, 0));
+        a3.setPoint2d(new Point2d(1, 0));
 
         IBond bond1 = new Bond(a1, a2, IBond.Order.DOUBLE);
         IBond bond2 = new Bond(a2, a3, IBond.Order.SINGLE);
 
         assertTrue(SymbolVisibility.iupacRecommendationsWithoutTerminalCarbon()
-                                   .visible(a1, Arrays.asList(bond1, bond2), new RendererModel()));
+                                   .visible(a1, Collections.singletonList(bond1), new RendererModel()));
     }
 
 }

--- a/display/render/src/test/java/org/openscience/cdk/renderer/SymbolVisibilityTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/SymbolVisibilityTest.java
@@ -229,4 +229,26 @@ public class SymbolVisibilityTest {
                                    .visible(a1, Collections.singletonList(bond1), new RendererModel()));
     }
 
+    @Test
+    public void delocalisedCarbons() {
+        IAtom a1 = new Atom("CH");
+        IAtom a2 = new Atom("CH");
+        IAtom a3 = new Atom("CH");
+
+        a1.setPoint2d(new Point2d(0, 0));
+        a2.setPoint2d(new Point2d(0.5, -0.5));
+        a3.setPoint2d(new Point2d(1, 0));
+
+        IBond bond1 = new Bond(a1, a2, IBond.Order.UNSET);
+        IBond bond2 = new Bond(a2, a3, IBond.Order.UNSET);
+        bond1.setIsAromatic(true);
+        bond2.setIsAromatic(true);
+        a1.setIsAromatic(true);
+        a2.setIsAromatic(true);
+        a3.setIsAromatic(true);
+
+        assertFalse(SymbolVisibility.iupacRecommendationsWithoutTerminalCarbon()
+                                    .visible(a2, Arrays.asList(bond1, bond2), new RendererModel()));
+    }
+
 }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -122,8 +122,9 @@ final class StandardBondGenerator {
     private final Color                      foreground, annotationColor;
     private final boolean                    fancyBoldWedges, fancyHashedWedges;
     private final double                     annotationDistance, annotationScale;
-    private final Font                       font;
-    private final ElementGroup               annotations;
+    private final Font         font;
+    private final ElementGroup annotations;
+    private final boolean      forceDelocalised;
 
     /**
      * Create a new standard bond generator for the provided structure (container) with the laid out
@@ -162,6 +163,7 @@ final class StandardBondGenerator {
                 * (parameters.get(BondLength.class) / scale);
         this.annotationScale = (1 / scale) * parameters.get(StandardGenerator.AnnotationFontScale.class);
         this.annotationColor = parameters.get(StandardGenerator.AnnotationColor.class);
+        this.forceDelocalised = parameters.get(StandardGenerator.ForceDelocalisedBondDisplay.class);
         this.font = font;
 
         // foreground is based on the carbon color
@@ -211,10 +213,14 @@ final class StandardBondGenerator {
 
         switch (order) {
             case SINGLE:
-                elem = generateSingleBond(bond, atom1, atom2);
+                if (bond.isAromatic() && forceDelocalised)
+                    elem = generateDoubleBond(bond, true);
+                else
+                    elem = generateSingleBond(bond, atom1, atom2);
                 break;
             case DOUBLE:
-                elem = generateDoubleBond(bond, false);
+                elem = generateDoubleBond(bond,
+                                          bond.isAromatic() && forceDelocalised);
                 break;
             case TRIPLE:
                 elem =  generateTripleBond(bond, atom1, atom2);

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -55,7 +55,6 @@ import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -164,7 +163,8 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
             fancyHashedWedges = new FancyHashedWedges(), highlighting = new Highlighting(),
             glowWidth = new OuterGlowWidth(), annCol = new AnnotationColor(), annDist = new AnnotationDistance(),
             annFontSize = new AnnotationFontScale(), sgroupBracketDepth = new SgroupBracketDepth(),
-            sgroupFontScale = new SgroupFontScale(), omitMajorIsotopes = new OmitMajorIsotopes();
+            sgroupFontScale = new SgroupFontScale(), omitMajorIsotopes = new OmitMajorIsotopes(),
+            forceDonuts = new ForceDelocalisedBondDisplay();
 
     /**
      * Create a new standard generator that utilises the specified font to display atom symbols.
@@ -559,7 +559,7 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
     public List<IGeneratorParameter<?>> getParameters() {
         return Arrays.asList(atomColor, visibility, strokeRatio, separationRatio, wedgeRatio, marginRatio,
                 hatchSections, dashSections, waveSections, fancyBoldWedges, fancyHashedWedges, highlighting, glowWidth,
-                annCol, annDist, annFontSize, sgroupBracketDepth, sgroupFontScale, omitMajorIsotopes);
+                annCol, annDist, annFontSize, sgroupBracketDepth, sgroupFontScale, omitMajorIsotopes, forceDonuts);
     }
 
     static String getAnnotationLabel(IChemObject chemObject) {
@@ -1079,6 +1079,26 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
      * Whether Major Isotopes e.g. 12C, 16O should be omitted.
      */
     public static final class OmitMajorIsotopes extends AbstractGeneratorParameter<Boolean> {
+
+        /**{@inheritDoc} */
+        @Override
+        public Boolean getDefault() {
+            return false;
+        }
+    }
+
+    /**
+     * Indicate delocalised/aromatic bonds should always be rendered, even when
+     * there is a valid Kekule structure. Delocalised bonds will either be
+     * rendered as a dashed bond to the side or as a circle/donut/life buoy
+     * inside small rings. This depiction is used by default when a bond does
+     * not have an order assigned (e.g. null/unset). Turning this option on
+     * means all delocalised bonds will be rendered this way.
+     * <br>
+     * <b>As recommended by IUPAC, their usage is discouraged and the Kekule
+     * representation is more clear.</b>
+     */
+    public static final class ForceDelocalisedBondDisplay extends AbstractGeneratorParameter<Boolean> {
 
         /**{@inheritDoc} */
         @Override


### PR DESCRIPTION
Better depiction of aromatic bonds that have a undefined bond order. Kekule structures are preferred by IUPAC, but when a structure has no valid kekule form it is useful to depict them as delocalised. I will add pretty rendering for small rings (e.g. use a circle) in future but the most generally applicable method is to show a dashed bond to the side - we can't put circles in the macrocycle of porphyrin for example.

Kekule rendering:

![image](https://user-images.githubusercontent.com/983232/34442936-825f3cb2-ecbd-11e7-93da-8dd44244bd2f.png)

When not kekulize or the 'force delocalised rendering' is set:

![image](https://user-images.githubusercontent.com/983232/34442941-8d2c4afe-ecbd-11e7-98f9-e9ac90f8c425.png)
