### PR TITLE
Not to keep flags in VABCVolume.calculate(IAtomContainer)

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/geometry/volume/VABCVolume.java
+++ b/base/standard/src/main/java/org/openscience/cdk/geometry/volume/VABCVolume.java
@@ -103,7 +103,6 @@ public class VABCVolume {
         }
         sum -= 5.92 * (molecule.getBondCount() + totalHCount);
 
-        boolean[] originalFlags = molecule.getFlags();
         Aromaticity.cdkLegacy().apply(molecule);
         IRingSet ringSet = Cycles.sssr(molecule).toRingSet();
         if (ringSet.getAtomContainerCount() > 0) {
@@ -116,7 +115,6 @@ public class VABCVolume {
                     nonAromRingCount++;
                 }
             }
-            molecule.setFlags(originalFlags);
             sum -= 14.7 * aromRingCount;
             sum -= 3.8 * nonAromRingCount;
         }


### PR DESCRIPTION
Current implementation keeps only molecule's flags. It makes inconsistency between a molecule and containing atoms/bonds. 