### PR TITLE
Patch/qsarmol nomod

### DIFF
--- a/base/silent/src/main/java/org/openscience/cdk/silent/Polymer.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Polymer.java
@@ -32,7 +32,6 @@ import org.openscience.cdk.interfaces.IStereoElement;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 
 /**
@@ -64,7 +63,7 @@ public class Polymer extends AtomContainer implements java.io.Serializable, IPol
      */
     public Polymer() {
         super();
-        monomers = new Hashtable<String, IMonomer>();
+        monomers = new HashMap<>();
     }
 
     /**
@@ -115,7 +114,7 @@ public class Polymer extends AtomContainer implements java.io.Serializable, IPol
     /**
      * Returns a collection of the names of all <code>Monomer</code>s in this
      * polymer.
-     *
+     *f
      * @return a <code>Collection</code> of all the monomer names.
      */
     @Override
@@ -155,11 +154,11 @@ public class Polymer extends AtomContainer implements java.io.Serializable, IPol
     public IPolymer clone() throws CloneNotSupportedException {
         Polymer clone = (Polymer) super.clone();
         clone.removeAllElements();
-        clone.monomers = new Hashtable<String, IMonomer>();
-        for (String monomerName : getMonomerNames()) {
-            Monomer monomerClone = (Monomer) getMonomer(monomerName).clone();
-            for (IAtom atomInMonomer : monomerClone.atoms()) {
-                clone.addAtom(atomInMonomer, monomerClone);
+        clone.monomers = new HashMap<>();
+        for (Map.Entry<String,IMonomer> e : this.monomers.entrySet()) {
+            IMonomer monomer = e.getValue().clone();
+            for (IAtom atomInMonomer : monomer.atoms()) {
+                clone.addAtom(atomInMonomer, monomer);
             }
         }
 
@@ -227,8 +226,7 @@ public class Polymer extends AtomContainer implements java.io.Serializable, IPol
     }
 
     private boolean atomIsInMonomer(IAtom atom) {
-        for (String monomerName : getMonomerNames()) {
-            IMonomer monomer = getMonomer(monomerName);
+        for (IMonomer monomer : monomers.values()) {
             if (monomer.contains(atom)) return true;
         }
         return false;

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Polymer.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Polymer.java
@@ -114,7 +114,7 @@ public class Polymer extends AtomContainer implements java.io.Serializable, IPol
     /**
      * Returns a collection of the names of all <code>Monomer</code>s in this
      * polymer.
-     *f
+     *
      * @return a <code>Collection</code> of all the monomer names.
      */
     @Override

--- a/descriptor/qsar/src/main/java/org/openscience/cdk/qsar/AbstractMolecularDescriptor.java
+++ b/descriptor/qsar/src/main/java/org/openscience/cdk/qsar/AbstractMolecularDescriptor.java
@@ -23,6 +23,8 @@
 
 package org.openscience.cdk.qsar;
 
+import org.openscience.cdk.interfaces.IAtomContainer;
+
 /**
  * A super class for molecular descriptors allowing default implementations for
  * interface methods.
@@ -32,5 +34,13 @@ package org.openscience.cdk.qsar;
  * @cdk.githash
  */
 public abstract class AbstractMolecularDescriptor extends AbstractDescriptor implements IMolecularDescriptor {
+
+    protected static IAtomContainer clone(IAtomContainer mol) {
+        try {
+            return mol.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException("Could not clone AtomContainer!");
+        }
+    }
 
 }

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptor.java
@@ -114,6 +114,8 @@ public class AcidicGroupCountDescriptor extends AbstractMolecularDescriptor impl
             throw new IllegalStateException("descriptor is not initalised, invoke 'initalise' first");
         }
 
+        atomContainer = clone(atomContainer); // don't mod original
+
         // do aromaticity detection
         if (this.checkAromaticity) {
             try {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/BasicGroupCountDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/BasicGroupCountDescriptor.java
@@ -97,6 +97,8 @@ public class BasicGroupCountDescriptor extends AbstractMolecularDescriptor imple
             throw new IllegalStateException("descriptor is not initalised, invoke 'initalise' first");
         }
 
+        atomContainer = clone(atomContainer);
+
         try {
             int count = 0;
             for (SMARTSQueryTool tool : tools) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/FMFDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/FMFDescriptor.java
@@ -65,6 +65,9 @@ public class FMFDescriptor extends AbstractMolecularDescriptor implements IMolec
      */
     @Override
     public DescriptorValue calculate(IAtomContainer container) {
+
+        container = clone(container); // don't mod original
+
         MurckoFragmenter fragmenter = new MurckoFragmenter(true, 3);
         DoubleResult result;
         try {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptor.java
@@ -140,6 +140,7 @@ public class RotatableBondsCountDescriptor extends AbstractMolecularDescriptor i
      */
     @Override
     public DescriptorValue calculate(IAtomContainer ac) {
+        ac = clone(ac); // don't mod original
         int rotatableBondsCount = 0;
         int degree0;
         int degree1;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RuleOfFiveDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RuleOfFiveDescriptor.java
@@ -142,7 +142,7 @@ public class RuleOfFiveDescriptor extends AbstractMolecularDescriptor implements
      */
     @Override
     public DescriptorValue calculate(IAtomContainer mol) {
-
+        mol = clone(mol); // don't mod original
         int lipinskifailures = 0;
 
         IMolecularDescriptor xlogP = new XLogPDescriptor();

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/VABCDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/VABCDescriptor.java
@@ -85,7 +85,8 @@ public class VABCDescriptor extends AbstractMolecularDescriptor implements IMole
     public DescriptorValue calculate(IAtomContainer atomContainer) {
         double volume;
         try {
-            volume = VABCVolume.calculate(atomContainer);
+            // clone: don't mod original
+            volume = VABCVolume.calculate(clone(atomContainer));
         } catch (CDKException exception) {
             return getDummyDescriptorValue(exception);
         }

--- a/descriptor/qsarprotein/pom.xml
+++ b/descriptor/qsarprotein/pom.xml
@@ -55,6 +55,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-data</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/descriptor/qsarprotein/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/AminoAcidCountDescriptor.java
+++ b/descriptor/qsarprotein/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/AminoAcidCountDescriptor.java
@@ -140,6 +140,7 @@ public class AminoAcidCountDescriptor extends AbstractMolecularDescriptor implem
      */
     @Override
     public DescriptorValue calculate(IAtomContainer ac) {
+        ac = clone(ac); // don't modify input
         int resultLength = substructureSet.getAtomContainerCount();
         IntegerArrayResult results = new IntegerArrayResult(resultLength);
 


### PR DESCRIPTION
I don't like this but it fits with the current design. Note that if you don't assign atom types to the benzene i used in the test... then aromaticity won't get added and it looks okay. As shown here it's not really okay. I would argue this is inconsistent - there require atom types must be set before being called.

Also interesting that the AcidicGroupCount vs BasicGroupCount - one has an aromaticity option the other does not.