### PR TITLE
removing a for loop for setting bond order single in constructtautomers

### DIFF
--- a/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
+++ b/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
@@ -481,6 +481,7 @@ public final class InChITautomerGenerator {
         int doubleBondCount = 0;
         for (IBond bond : skeleton.bonds()) {
             if (bond.getOrder().equals(IBond.Order.DOUBLE)) {
+            	bond.setOrder(IBond.Order.SINGLE);
                 doubleBondCount++;
             }
         }
@@ -490,11 +491,7 @@ public final class InChITautomerGenerator {
             atom.setImplicitHydrogenCount(0);
         }
 
-        for (IBond bond : skeleton.bonds()) {
-            if (bond.getOrder().equals(IBond.Order.DOUBLE)) {
-                bond.setOrder(IBond.Order.SINGLE);
-            }
-        }
+       
 
         // Make combinations for mobile Hydrogen attachments
         List<List<Integer>> combinations = new ArrayList<List<Integer>>();


### PR DESCRIPTION
removing a for loop for setting bond order single in constructtautomers method, so that it reduces looping and time will be saved