### PR TITLE
Patch/svg units

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
@@ -92,6 +92,16 @@ public abstract class Depiction {
      */
     public static final String GIF_FMT = "gif";
 
+    /**
+     * Units in MM (specific to SVG).
+     */
+    public static final String UNITS_MM = "mm";
+
+    /**
+     * Units in PX (specific to SVG).
+     */
+    public static final String UNITS_PX = "px";
+
     static final double ACS_1996_BOND_LENGTH_MM = 5.08;
 
     private static final char DOT = '.';
@@ -120,7 +130,19 @@ public abstract class Depiction {
      * @return svg XML content
      */
     public final String toSvgStr() {
-        return toVecStr(SVG_FMT);
+        return toSvgStr(UNITS_MM);
+    }
+
+    /**
+     * Render the image to an SVG image.
+     *
+     * @param units the units for SVG - 'px' or 'mm'
+     * @return svg XML content
+     */
+    public final String toSvgStr(String units) {
+        if (!units.equals(UNITS_MM) && !units.equals(UNITS_PX))
+            throw new IllegalArgumentException("Units must be 'px' or 'mm'!");
+        return toVecStr(SVG_FMT, units);
     }
 
     /**
@@ -129,7 +151,7 @@ public abstract class Depiction {
      * @return eps content
      */
     public final String toEpsStr() {
-        return toVecStr(PS_FMT);
+        return toVecStr(PS_FMT, UNITS_MM);
     }
 
     /**
@@ -138,7 +160,7 @@ public abstract class Depiction {
      * @return pdf content
      */
     public final String toPdfStr() {
-        return toVecStr(PDF_FMT);
+        return toVecStr(PDF_FMT, UNITS_MM);
     }
 
     /**
@@ -174,9 +196,10 @@ public abstract class Depiction {
      * rendering.
      *
      * @param fmt the vector graphics format
+     * @param units the units to use (px or mm)
      * @return the vector graphics format string
      */
-    abstract String toVecStr(String fmt);
+    abstract String toVecStr(String fmt, String units);
 
     /**
      * List the available formats that can be rendered.

--- a/app/depict/src/main/java/org/openscience/cdk/depict/MolGridDepiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/MolGridDepiction.java
@@ -182,17 +182,21 @@ final class MolGridDepiction extends Depiction {
     }
 
     @Override
-    String toVecStr(String fmt) {
+    String toVecStr(String fmt, String units) {
 
         // format margins and padding for raster images
-        double margin  = getMarginValue(DepictionGenerator.DEFAULT_MM_MARGIN);
+        double margin  = getMarginValue(units.equals(Depiction.UNITS_MM) ? DepictionGenerator.DEFAULT_MM_MARGIN
+                                                                         : DepictionGenerator.DEFAULT_PX_MARGIN);
         double padding = getPaddingValue(DEFAULT_PADDING_FACTOR * margin);
         final double scale   = model.get(BasicSceneGenerator.Scale.class);
+
+        double zoom = model.get(BasicSceneGenerator.ZoomFactor.class);
 
         // All vector graphics will be written in mm not px to we need to
         // adjust the size of the molecules accordingly. For now the rescaling
         // is fixed to the bond length proposed by ACS 1996 guidelines (~5mm)
-        double zoom = model.get(BasicSceneGenerator.ZoomFactor.class) * rescaleForBondLength(Depiction.ACS_1996_BOND_LENGTH_MM);
+        if (units.equals(Depiction.UNITS_MM))
+            zoom *= rescaleForBondLength(Depiction.ACS_1996_BOND_LENGTH_MM);
 
         // PDF and PS units are in Points (1/72 inch) in FreeHEP so need to adjust for that
         if (fmt.equals(PDF_FMT) || fmt.equals(PS_FMT)) {
@@ -215,7 +219,7 @@ final class MolGridDepiction extends Depiction {
         FreeHepWrapper wrapper = null;
         if (!fmt.equals(SVG_FMT))
             wrapper = new FreeHepWrapper(fmt, total.w, total.h);
-        final IDrawVisitor visitor = fmt.equals(SVG_FMT) ? new SvgDrawVisitor(total.w, total.h)
+        final IDrawVisitor visitor = fmt.equals(SVG_FMT) ? new SvgDrawVisitor(total.w, total.h, units)
                                                          : AWTDrawVisitor.forVectorGraphics(wrapper.g2);
 
         if (fmt.equals(SVG_FMT)) {

--- a/app/depict/src/main/java/org/openscience/cdk/depict/ReactionDepiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/ReactionDepiction.java
@@ -344,17 +344,22 @@ final class ReactionDepiction extends Depiction {
     }
 
     @Override
-    String toVecStr(String fmt) {
+    String toVecStr(String fmt, String units) {
         // format margins and padding for raster images
         final double scale = model.get(BasicSceneGenerator.Scale.class);
 
-        double margin = getMarginValue(DepictionGenerator.DEFAULT_MM_MARGIN);
+        double margin = getMarginValue(units.equals(Depiction.UNITS_MM)
+                                       ? DepictionGenerator.DEFAULT_MM_MARGIN
+                                       : DepictionGenerator.DEFAULT_PX_MARGIN);
         double padding = getPaddingValue(DEFAULT_PADDING_FACTOR * margin);
 
         // All vector graphics will be written in mm not px to we need to
         // adjust the size of the molecules accordingly. For now the rescaling
         // is fixed to the bond length proposed by ACS 1996 guidelines (~5mm)
-        double zoom = model.get(BasicSceneGenerator.ZoomFactor.class) * rescaleForBondLength(Depiction.ACS_1996_BOND_LENGTH_MM);
+        double zoom = model.get(BasicSceneGenerator.ZoomFactor.class);
+
+        if (units.equals(Depiction.UNITS_MM))
+            zoom *= rescaleForBondLength(Depiction.ACS_1996_BOND_LENGTH_MM);
 
         // PDF and PS units are in Points (1/72 inch) in FreeHEP so need to adjust for that
         if (fmt.equals(PDF_FMT) || fmt.equals(PS_FMT)) {
@@ -382,7 +387,7 @@ final class ReactionDepiction extends Depiction {
         FreeHepWrapper wrapper = null;
         if (!fmt.equals(SVG_FMT))
             wrapper = new FreeHepWrapper(fmt, total.w, total.h);
-        final IDrawVisitor visitor = fmt.equals(SVG_FMT) ? new SvgDrawVisitor(total.w, total.h)
+        final IDrawVisitor visitor = fmt.equals(SVG_FMT) ? new SvgDrawVisitor(total.w, total.h, "mm")
                                                          : AWTDrawVisitor.forVectorGraphics(wrapper.g2);
         if (fmt.equals(SVG_FMT)) {
             svgPrevisit(fmt, scale * zoom * fitting, (SvgDrawVisitor) visitor, mainComp);

--- a/app/depict/src/main/java/org/openscience/cdk/depict/SvgDrawVisitor.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/SvgDrawVisitor.java
@@ -83,22 +83,23 @@ final class SvgDrawVisitor implements IDrawVisitor {
     /**
      * Create an SvgDrawVisitor with the specified width/height
      *
-     * @param w width of canvas in mm
-     * @param h height of canvas in mm
+     * @param w width of canvas in 'units'
+     * @param h height of canvas in 'units'
+     * @param units 'px' or 'mm'
      */
-    SvgDrawVisitor(double w, double h) {
-        writeHeader(w, h);
+    SvgDrawVisitor(double w, double h, String units) {
+        writeHeader(w, h, units);
     }
 
-    private void writeHeader(double w, double h) {
+    private void writeHeader(double w, double h, String units) {
         sb.append("<?xml version='1.0' encoding='UTF-8'?>\n")
           .append("<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n");
         sb.append("<svg")
           .append(" version='1.2'")
           .append(" xmlns='http://www.w3.org/2000/svg'")
           .append(" xmlns:xlink='http://www.w3.org/1999/xlink'")
-          .append(" width='").append(toStr(w)).append("mm'")
-          .append(" height='").append(toStr(h)).append("mm'")
+          .append(" width='").append(toStr(w)).append(units).append('\'')
+          .append(" height='").append(toStr(h)).append(units).append('\'')
           .append(" viewBox='0 0 ").append(toStr(w)).append(" ").append(toStr(h)).append("'")
           .append(">\n");
         indentLvl += 2;

--- a/app/depict/src/test/java/org/openscience/cdk/depict/SvgDrawVisitorTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/SvgDrawVisitorTest.java
@@ -41,7 +41,7 @@ public class SvgDrawVisitorTest {
 
     @Test
     public void empty() {
-        String empty = new SvgDrawVisitor(50, 50).toString();
+        String empty = new SvgDrawVisitor(50, 50, Depiction.UNITS_MM).toString();
         assertThat(empty, is("<?xml version='1.0' encoding='UTF-8'?>\n"
                              + "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n"
                              + "<svg version='1.2' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='50.0mm' height='50.0mm' viewBox='0 0 50.0 50.0'>\n"
@@ -51,7 +51,7 @@ public class SvgDrawVisitorTest {
 
     @Test
     public void markedElement() {
-        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50);
+        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50, Depiction.UNITS_MM);
         visitor.visit(MarkedElement.markup(new LineElement(0, 0, 1, 1, 0.5, Color.RED),
                                            "test-class"));
         assertThat(visitor.toString(), is("<?xml version='1.0' encoding='UTF-8'?>\n"
@@ -66,7 +66,7 @@ public class SvgDrawVisitorTest {
 
     @Test
     public void translatedLine() {
-        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50);
+        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50, Depiction.UNITS_MM);
         visitor.visit(new LineElement(0, 0, 1, 1, 0.5, Color.RED));
         visitor.setTransform(AffineTransform.getTranslateInstance(10, 10));
         visitor.visit(new LineElement(0, 0, 1, 1, 0.5, Color.RED));
@@ -83,7 +83,7 @@ public class SvgDrawVisitorTest {
 
     @Test
     public void scaledStroke() {
-        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50);
+        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50, Depiction.UNITS_MM);
         visitor.visit(new LineElement(0, 0, 1, 1, 0.5, Color.RED));
         visitor.setTransform(AffineTransform.getScaleInstance(2, 2));
         visitor.visit(new LineElement(0, 0, 1, 1, 0.5, Color.RED));
@@ -100,7 +100,7 @@ public class SvgDrawVisitorTest {
 
     @Test
     public void filledPath() {
-        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50);
+        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50, Depiction.UNITS_MM);
         visitor.visit(GeneralPath.shapeOf(new RoundRectangle2D.Double(0,0,10,10,2,2), Color.BLUE));
         assertThat(visitor.toString(), is("<?xml version='1.0' encoding='UTF-8'?>\n"
                                           + "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n"
@@ -114,7 +114,7 @@ public class SvgDrawVisitorTest {
 
     @Test
     public void transformedPath() {
-        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50);
+        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50, Depiction.UNITS_MM);
         visitor.setTransform(AffineTransform.getTranslateInstance(15, 15));
         visitor.visit(GeneralPath.shapeOf(new RoundRectangle2D.Double(0, 0, 10, 10, 2, 2), Color.BLUE));
         assertThat(visitor.toString(), is("<?xml version='1.0' encoding='UTF-8'?>\n"
@@ -129,7 +129,7 @@ public class SvgDrawVisitorTest {
 
     @Test
     public void textElements() {
-        final SvgDrawVisitor visitor = new SvgDrawVisitor(100, 100);
+        final SvgDrawVisitor visitor = new SvgDrawVisitor(100, 100, Depiction.UNITS_MM);
         visitor.visit(new TextElement(50, 50, "PNG < EPS < SVG", Color.RED));
         assertThat(visitor.toString(), is("<?xml version='1.0' encoding='UTF-8'?>\n"
                                           + "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n"
@@ -143,7 +143,7 @@ public class SvgDrawVisitorTest {
 
     @Test
     public void rectElements() {
-        final SvgDrawVisitor visitor = new SvgDrawVisitor(100, 100);
+        final SvgDrawVisitor visitor = new SvgDrawVisitor(100, 100, Depiction.UNITS_MM);
         visitor.visit(new RectangleElement(0,0,100,100, Color.WHITE));
         assertThat(visitor.toString(), is("<?xml version='1.0' encoding='UTF-8'?>\n"
                                           + "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n"


### PR DESCRIPTION
Adds the option to generate SVG in PX rather than the default MM. MM is useful as does not change with resolution but when you need something to fit a particular box in pixels this helps.