### PR TITLE
Hush a bye CDK builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: java
-script: mvn test -fn
+script: mvn test -fn -q

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomTypeTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractAtomTypeTest.java
@@ -352,7 +352,6 @@ public abstract class AbstractAtomTypeTest extends AbstractIsotopeTest {
         IAtomType at = (IAtomType) newChemObject();
         at.setAtomTypeName("N.sp2.3");
         String description = at.toString();
-        System.out.println(description);
         Assert.assertTrue(description.contains("N.sp2.3"));
     }
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/GraphOnlyFingerprinterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/GraphOnlyFingerprinterTest.java
@@ -58,7 +58,6 @@ public class GraphOnlyFingerprinterTest extends AbstractFixedLengthFingerprinter
         IFingerprinter printer = new GraphOnlyFingerprinter();
 
         IBitFingerprint bs1 = printer.getBitFingerprint(parser.parseSmiles("C=C-C#N"));
-        System.out.println("----");
         IBitFingerprint bs2 = printer.getBitFingerprint(parser.parseSmiles("CCCN"));
 
         Assert.assertEquals(bs1, bs2);

--- a/base/valencycheck/src/main/java/org/openscience/cdk/tools/CDKValencyChecker.java
+++ b/base/valencycheck/src/main/java/org/openscience/cdk/tools/CDKValencyChecker.java
@@ -69,7 +69,6 @@ public class CDKValencyChecker implements IValencyChecker {
 
     @Override
     public boolean isSaturated(IAtom atom, IAtomContainer container) throws CDKException {
-        System.out.println(atom.getAtomTypeName());
         IAtomType type = atomTypeList.getAtomType(atom.getAtomTypeName());
         if (type == null)
             throw new CDKException("Atom type is not a recognized CDK atom type: " + atom.getAtomTypeName());

--- a/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/CIPToolTest.java
+++ b/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/CIPToolTest.java
@@ -307,13 +307,11 @@ public class CIPToolTest extends CDKTestCase {
         for (IAtom atom : mol.atoms()) {
             List<IAtom> neighbors = mol.getConnectedAtomsList(atom);
             if (neighbors.size() == 4) {
-                System.out.println("Atom " + mol.indexOf(atom));
                 Stereo stereo = StereoTool.getStereo(neighbors.get(0), neighbors.get(1), neighbors.get(2),
                         neighbors.get(3));
                 ITetrahedralChirality stereoCenter = new TetrahedralChirality(mol.getAtom(0),
                         neighbors.toArray(new IAtom[]{}), stereo);
                 CIP_CHIRALITY chirality = CIPTool.getCIPChirality(mol, stereoCenter);
-                System.out.println("chirality: " + chirality);
             }
         }
     }

--- a/descriptor/qsarcml/src/test/java/org/openscience/cdk/io/cml/QSARCMLRoundTripTest.java
+++ b/descriptor/qsarcml/src/test/java/org/openscience/cdk/io/cml/QSARCMLRoundTripTest.java
@@ -68,9 +68,7 @@ public class QSARCMLRoundTripTest {
         IAtomContainer roundTrippedMol = CMLRoundTripTool.roundTripMolecule(convertor, molecule);
 
         Assert.assertEquals(1, roundTrippedMol.getProperties().size());
-        System.out.println("" + roundTrippedMol.getProperties().keySet());
         Object object = roundTrippedMol.getProperties().keySet().toArray()[0];
-        System.out.println("" + object);
         Assert.assertTrue(object instanceof DescriptorSpecification);
         DescriptorSpecification spec = (DescriptorSpecification) object;
         Assert.assertEquals(descriptor.getSpecification().getSpecificationReference(), spec.getSpecificationReference());

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/graph/matrix/TopologicalMatrixTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/graph/matrix/TopologicalMatrixTest.java
@@ -3,6 +3,7 @@ package org.openscience.cdk.graph.matrix;
 import java.io.InputStream;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKTestCase;
@@ -15,7 +16,7 @@ import org.openscience.cdk.io.MDLV2000Reader;
  */
 public class TopologicalMatrixTest extends CDKTestCase {
 
-    @Test
+    @Ignore // not actually asserting anything
     public void testTopologicalMatrix_IAtomContainer() throws Exception {
         String filename = "data/mdl/clorobenzene.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/LargestPiSystemDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/LargestPiSystemDescriptorTest.java
@@ -30,8 +30,7 @@ public class LargestPiSystemDescriptorTest extends MolecularDescriptorTest {
         descriptor.setParameters(params);
         SmilesParser sp = new SmilesParser(DefaultChemObjectBuilder.getInstance());
         IAtomContainer mol = sp.parseSmiles("c1ccccc1"); // benzol
-        //Assert.assertEquals(6, ((IntegerResult)descriptor.calculate(mol).getValue()).intValue());
-        System.out.println("test1>:" + ((IntegerResult) descriptor.calculate(mol).getValue()).intValue());
+        Assert.assertEquals(6, ((IntegerResult)descriptor.calculate(mol).getValue()).intValue());
     }
 
     @Test

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/MDEDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/MDEDescriptorTest.java
@@ -40,9 +40,6 @@ public class MDEDescriptorTest extends MolecularDescriptorTest {
 
         DoubleArrayResult result = (DoubleArrayResult) descriptor.calculate(ac).getValue();
 
-        for (int i = 0; i < 19; i++)
-            System.out.println(result.get(i));
-
         Assert.assertEquals(0.0000, result.get(MDEDescriptor.MDEO11), 0.0001);
         Assert.assertEquals(1.1547, result.get(MDEDescriptor.MDEO12), 0.0001);
         Assert.assertEquals(2.9416, result.get(MDEDescriptor.MDEO22), 0.0001);

--- a/descriptor/signature/src/test/java/org/openscience/cdk/signature/MoleculeSignatureTest.java
+++ b/descriptor/signature/src/test/java/org/openscience/cdk/signature/MoleculeSignatureTest.java
@@ -314,7 +314,6 @@ public class MoleculeSignatureTest extends CDKTestCase {
         }
 
         MoleculeSignature molSignature = new MoleculeSignature(benzeneRing);
-        System.out.println("" + molSignature.toFullString());
         List<AbstractVertexSignature> signatures = molSignature.getVertexSignatures();
         for (AbstractVertexSignature signature : signatures) {
             for (int i = 0; i < 6; i++) {

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/VecmathUtilTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/VecmathUtilTest.java
@@ -203,7 +203,6 @@ public class VecmathUtilTest {
     public void intersection2() {
         Tuple2d intersect = VecmathUtil.intersection(new Point2d(6, 1), new Vector2d(-4, -2), new Point2d(1, 6),
                 new Vector2d(2, 4));
-        System.out.println(intersect);
         assertThat(intersect.x, closeTo(-4, 0.01));
         assertThat(intersect.y, closeTo(-4, 0.01));
     }

--- a/legacy/src/main/java/org/openscience/cdk/tools/IonizationPotentialTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/tools/IonizationPotentialTool.java
@@ -236,7 +236,8 @@ public class IonizationPotentialTool {
         try {
             peoe.assignGasteigerMarsiliSigmaPartialCharges(container, true);
         } catch (Exception e) {
-            e.printStackTrace();
+            // ignored, underlying classes are logging this and this class
+            // is deprecated
         }
         results[2] = atom.getCharge();
         // partialPiCharge

--- a/legacy/src/test/java/org/openscience/cdk/math/GaussiansCalculationTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/math/GaussiansCalculationTest.java
@@ -64,7 +64,6 @@ public class GaussiansCalculationTest {
     public GaussiansCalculationTest(String inFile) {
         try {
             ISimpleChemObjectReader reader;
-            System.out.println("Loading: " + inFile);
             if (inFile.endsWith(".xyz")) {
                 reader = new XYZReader(new FileReader(inFile));
                 System.out.println("Expecting XYZ format...");

--- a/legacy/src/test/java/org/openscience/cdk/smsd/SMSDBondSensitiveTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/SMSDBondSensitiveTest.java
@@ -64,8 +64,6 @@ public class SMSDBondSensitiveTest {
         Isomorphism sbf = new Isomorphism(Algorithm.SubStructure, true);
         sbf.init(Benzene, Napthalene, true, true);
         sbf.setChemFilters(false, false, false);
-        System.out.println("Match " + sbf.getTanimotoSimilarity());
-        System.out.println("Match count: " + sbf.getAllAtomMapping().size());
         Assert.assertTrue(sbf.isSubgraph());
         Assert.assertEquals(24, sbf.getAllAtomMapping().size());
     }

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/Molecules.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/Molecules.java
@@ -145,11 +145,6 @@ public class Molecules {
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(result.getBuilder());
         adder.addImplicitHydrogens(result);
         Aromaticity.cdkLegacy().apply(result);
-
-        SmilesGenerator sg = new SmilesGenerator();
-        String oldSmiles = sg.create(result);
-        System.out.println("Propane " + oldSmiles);
-
         return result;
     }
 
@@ -192,11 +187,6 @@ public class Molecules {
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(result.getBuilder());
         adder.addImplicitHydrogens(result);
         Aromaticity.cdkLegacy().apply(result);
-
-        SmilesGenerator sg = new SmilesGenerator();
-        String oldSmiles = sg.create(result);
-        System.out.println("Hexane " + oldSmiles);
-
         return result;
     }
 
@@ -241,11 +231,6 @@ public class Molecules {
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(result.getBuilder());
         adder.addImplicitHydrogens(result);
         Aromaticity.cdkLegacy().apply(result);
-
-        SmilesGenerator sg = new SmilesGenerator();
-        String oldSmiles = sg.create(result);
-        System.out.println("Benzene " + oldSmiles);
-
         return result;
     }
 
@@ -312,11 +297,6 @@ public class Molecules {
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(result.getBuilder());
         adder.addImplicitHydrogens(result);
         Aromaticity.cdkLegacy().apply(result);
-
-        SmilesGenerator sg = new SmilesGenerator();
-        String oldSmiles = sg.create(result);
-        System.out.println("Naphthalene " + oldSmiles);
-
         return result;
     }
 
@@ -828,11 +808,6 @@ public class Molecules {
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(result.getBuilder());
         adder.addImplicitHydrogens(result);
         Aromaticity.cdkLegacy().apply(result);
-
-        SmilesGenerator sg = new SmilesGenerator();
-        String oldSmiles = sg.create(result);
-        System.out.println("SimpleImine " + oldSmiles);
-
         return result;
     }
 

--- a/legacy/src/test/java/org/openscience/cdk/smsd/tools/TimeManagerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/tools/TimeManagerTest.java
@@ -91,17 +91,10 @@ public class TimeManagerTest extends CDKTestCase {
     }
 
     public void myMethod(long timeMillis) {
-        System.out.println("Starting......");
-
-        // pause for a while
-        Thread thisThread = Thread.currentThread();
         try {
-            thisThread.sleep(timeMillis);
-        } catch (Throwable t) {
-
-            throw new OutOfMemoryError("An Error has occurred");
+            Thread.sleep(timeMillis);
+        } catch (InterruptedException e) {
+            // ignored
         }
-        System.out.println("Ending......");
-
     }
 }

--- a/misc/test-extra/src/test/java/org/openscience/cdk/config/isotopes/IsotopeReaderTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/config/isotopes/IsotopeReaderTest.java
@@ -21,12 +21,12 @@ package org.openscience.cdk.config.isotopes;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openscience.cdk.ChemObject;
-import org.openscience.cdk.config.isotopes.IsotopeReader;
-import org.openscience.cdk.interfaces.IIsotope;
 import org.openscience.cdk.CDKTestCase;
+import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.interfaces.IIsotope;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -44,7 +44,8 @@ public class IsotopeReaderTest extends CDKTestCase {
 
     @Test
     public void testReadIsotopes() {
-        IsotopeReader reader = new IsotopeReader(new ByteArrayInputStream(new byte[0]), new ChemObject().getBuilder());
+        IsotopeReader reader = new IsotopeReader(new ByteArrayInputStream("<?xml version=\"1.0\"?><list></list>".getBytes(StandardCharsets.UTF_8)),
+                                                 new ChemObject().getBuilder());
         Assert.assertNotNull(reader);
         List<IIsotope> isotopes = reader.readIsotopes();
         Assert.assertNotNull(isotopes);

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLReader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLReader.java
@@ -594,7 +594,6 @@ public class MDLReader extends DefaultChemObjectReader {
             }
 
         } catch (IOException | CDKException | IllegalArgumentException exception) {
-            exception.printStackTrace();
             String error = "Error while parsing line " + linecount + ": " + line + " -> " + exception.getMessage();
             logger.error(error);
             logger.debug(exception);

--- a/storage/io/src/test/java/org/openscience/cdk/io/CMLReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/CMLReaderTest.java
@@ -305,7 +305,6 @@ public class CMLReaderTest extends SimpleChemObjectReaderTest {
 
             // OK, now test that the residue identifier is properly read
             Assert.assertEquals("ALAA116", container.getID());
-            System.out.println("" + container);
         } finally {
             reader.close();
         }

--- a/storage/iordf/pom.xml
+++ b/storage/iordf/pom.xml
@@ -30,6 +30,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/storage/iordf/src/test/java/org/openscience/cdk/io/rdf/CDKOWLReaderTest.java
+++ b/storage/iordf/src/test/java/org/openscience/cdk/io/rdf/CDKOWLReaderTest.java
@@ -57,7 +57,7 @@ public class CDKOWLReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         CDKOWLReader reader = new CDKOWLReader(new InputStreamReader(ins));
-        IAtomContainer mol = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(new AtomContainer());
         reader.close();
 
         Assert.assertNotNull(mol);

--- a/storage/iordf/src/test/java/org/openscience/cdk/io/rdf/CDKOWLWriterTest.java
+++ b/storage/iordf/src/test/java/org/openscience/cdk/io/rdf/CDKOWLWriterTest.java
@@ -22,6 +22,9 @@
  */
 package org.openscience.cdk.io.rdf;
 
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,6 +50,8 @@ public class CDKOWLWriterTest extends ChemObjectWriterTest {
 
     @Test
     public void testWriteMolecule() throws Exception {
+        BasicConfigurator.configure();
+        Logger.getRootLogger().setLevel(Level.ERROR);
         StringWriter output = new StringWriter();
         CDKOWLWriter writer = new CDKOWLWriter(output);
 

--- a/storage/libiomd/src/main/java/org/openscience/cdk/io/cml/MDMoleculeConvention.java
+++ b/storage/libiomd/src/main/java/org/openscience/cdk/io/cml/MDMoleculeConvention.java
@@ -125,7 +125,6 @@ public class MDMoleculeConvention extends CMLCoreModule {
             //Switching Atom
             if ("md:switchingAtom".equals(DICTREF)) {
                 //Set current atom as switching atom
-                System.out.println("Adding Switching atom: " + currentAtom);
                 currentChargeGroup.setSwitchingAtom(currentAtom);
             } else {
                 super.startElement(xpath, uri, local, raw, atts);

--- a/storage/pdbcml/src/test/java/org/openscience/cdk/io/cml/PDBAtomCustomizerTest.java
+++ b/storage/pdbcml/src/test/java/org/openscience/cdk/io/cml/PDBAtomCustomizerTest.java
@@ -77,7 +77,6 @@ public class PDBAtomCustomizerTest extends CDKTestCase {
         cmlWriter.write(polymer1);
         cmlWriter.close();
         String cmlContent1 = writer.toString();
-        System.out.println(cmlContent1.substring(0, 500));
 
         CMLReader reader2 = new CMLReader(new ByteArrayInputStream(cmlContent1.getBytes()));
         IChemFile chemFil2 = (IChemFile) reader2.read(new ChemFile());
@@ -100,7 +99,6 @@ public class PDBAtomCustomizerTest extends CDKTestCase {
         cmlWriter.write(polymer2);
         cmlWriter.close();
         String cmlContent2 = writer.toString();
-        System.out.println(cmlContent2.substring(0, 500));
 
         String conte1 = cmlContent1.substring(0, 1000);
         String conte2 = cmlContent2.substring(0, 1000);

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
@@ -995,8 +995,7 @@ public class SmilesGeneratorTest extends CDKTestCase {
         Assert.assertEquals(1, containersList.size());
         IAtomContainer container = containersList.get(0);
         SmilesGenerator smilesGenerator = new SmilesGenerator();
-        String genSmiles = smilesGenerator.create(container);
-        System.out.println(genSmiles);
+        Assert.assertNotNull(smilesGenerator.create(container));
     }
 
     /**

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
@@ -34,6 +34,8 @@ import org.openscience.cdk.geometry.GeometryUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
 
 /**
  * Place aliphatic <b>chains</b> with Z matrix method. Please use {@link
@@ -61,6 +63,8 @@ public class AtomPlacer3D {
     private final static double DEFAULT_SP3_ANGLE       = 109.471;
     private final static double DEFAULT_SP2_ANGLE       = 120.000;
     private final static double DEFAULT_SP_ANGLE        = 180.000;
+
+    private final ILoggingTool logger = LoggingToolFactory.createLoggingTool(AtomPlacer3D.class);
 
     AtomPlacer3D() {}
 
@@ -327,8 +331,8 @@ public class AtomPlacer3D {
         } else if (pSet.containsKey(("bond" + id2 + ";" + id1))) {
             dkey = "bond" + id2 + ";" + id1;
         } else {
-            System.out.println("KEYError: Unknown distance key in pSet: " + id2 + ";" + id1
-                    + " take default bond length: " + DEFAULT_BOND_LENGTH);
+            logger.warn("KEYError: Unknown distance key in pSet: " + id2 + ";" + id1
+                               + " take default bond length: " + DEFAULT_BOND_LENGTH);
             return DEFAULT_BOND_LENGTH;
         }
         return ((Double) (pSet.get(dkey).get(0))).doubleValue();

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateHandler3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateHandler3D.java
@@ -53,6 +53,8 @@ import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
 import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
 import org.openscience.cdk.isomorphism.matchers.QueryAtomContainerCreator;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.RingSetManipulator;
 
 /**
@@ -76,6 +78,8 @@ public class TemplateHandler3D {
     private final List<Pattern>             patterns  = new ArrayList<>();
 
     private static TemplateHandler3D self = null;
+
+    private final ILoggingTool logger = LoggingToolFactory.createLoggingTool(TemplateHandler3D.class);
 
     private UniversalIsomorphismTester universalIsomorphismTester = new UniversalIsomorphismTester();
 
@@ -230,7 +234,7 @@ public class TemplateHandler3D {
             assignCoords(secondBest, secondBestMap);
         }
 
-        System.err.println("WARNING: Maybe RingTemplateError!");
+        logger.warn("Maybe RingTemplateError!");
     }
 
     private void assignCoords(IAtomContainer template,

--- a/tool/builder3dtools/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateExtractor.java
+++ b/tool/builder3dtools/src/main/java/org/openscience/cdk/modeling/builder3d/TemplateExtractor.java
@@ -50,6 +50,7 @@ import org.openscience.cdk.isomorphism.matchers.QueryAtomContainerCreator;
 import org.openscience.cdk.ringsearch.RingPartitioner;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesGenerator;
+import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.RingSetManipulator;
@@ -372,17 +373,18 @@ public class TemplateExtractor {
         //QueryAtomContainer query=null;
         IAtomContainer query = null;
         List<IBitFingerprint> data = new ArrayList<IBitFingerprint>();
+        ILoggingTool logger = LoggingToolFactory.createLoggingTool(getClass());
         try {
-            System.out.print("Read data file in ...");
+            logger.info("Read data file in ...");
             imdl = new IteratingSDFReader(fin, builder);
             // fin.close();
-            System.out.println("ready");
+            logger.info("ready");
         } catch (Exception exc) {
             System.out.println("Could not read Molecules from file" + " due to: " + exc.getMessage());
         }
         int moleculeCounter = 0;
         int fingerprintCounter = 0;
-        System.out.print("Generated Fingerprints: " + fingerprintCounter + "    ");
+        logger.info("Generated Fingerprints: " + fingerprintCounter + "    ");
         while (imdl.hasNext() && (moleculeCounter < limit || limit == -1)) {
             m = (IAtomContainer) imdl.next();
             moleculeCounter++;
@@ -410,7 +412,7 @@ public class TemplateExtractor {
                     timings.put(bin, Integer.valueOf(1));
                 }
             } catch (Exception exc1) {
-                System.out.println("QueryFingerprintError: from molecule:" + moleculeCounter + " due to:"
+                logger.info("QueryFingerprintError: from molecule:" + moleculeCounter + " due to:"
                         + exc1.getMessage());
 
                 // OK, just adds a fingerprint with all ones, so that any
@@ -425,12 +427,12 @@ public class TemplateExtractor {
             }
 
             if (fingerprintCounter % 2 == 0)
-                System.out.print("\b" + "/");
+                logger.info("\b" + "/");
             else
-                System.out.print("\b" + "\\");
+                logger.info("\b" + "\\");
 
             if (fingerprintCounter % 100 == 0)
-                System.out.print("\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b"
+                logger.info("\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b"
                         + "Generated Fingerprints: " + fingerprintCounter + "   \n");
 
         }// while
@@ -439,7 +441,7 @@ public class TemplateExtractor {
         } catch (Exception exc2) {
             exc2.printStackTrace();
         }
-        System.out.print("...ready with:" + moleculeCounter + " molecules\nWrite data...of data vector:" + data.size()
+        logger.info("...ready with:" + moleculeCounter + " molecules\nWrite data...of data vector:" + data.size()
                 + " fingerprintCounter:" + fingerprintCounter);
 
         return data;

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/Electronegativity.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/Electronegativity.java
@@ -20,6 +20,8 @@ package org.openscience.cdk.charges;
 
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
 
 /**
  * Calculation of the electronegativity of orbitals of a molecule
@@ -43,6 +45,8 @@ public class Electronegativity {
     private IAtomContainer                 molSigma;
     private IAtomContainer                 acOldS;
     private double[]                       marsiliFactors;
+
+    private final ILoggingTool logger = LoggingToolFactory.createLoggingTool(Electronegativity.class);
 
     /**
      * Constructor for the PiElectronegativity object.
@@ -111,7 +115,7 @@ public class Electronegativity {
             return electronegativity;
 
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error(e);
         }
 
         return electronegativity;

--- a/tool/charges/src/main/java/org/openscience/cdk/charges/PiElectronegativity.java
+++ b/tool/charges/src/main/java/org/openscience/cdk/charges/PiElectronegativity.java
@@ -22,6 +22,8 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
 
 /**
  * Calculation of the electronegativity of orbitals of a molecule
@@ -46,6 +48,8 @@ public class PiElectronegativity {
     private IAtomContainer                 molPi;
     private IAtomContainer                 acOldP;
     private double[][]                     gasteigerFactors;
+
+    private final ILoggingTool logger = LoggingToolFactory.createLoggingTool(PiElectronegativity.class);
 
     /**
      * Constructor for the PiElectronegativity object.
@@ -120,7 +124,7 @@ public class PiElectronegativity {
                 return ((gasteigerFactors[1][start]) + (q * gasteigerFactors[1][start + 1]) + (gasteigerFactors[1][start + 2] * (q * q)));
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error(e);
         }
 
         return electronegativity;

--- a/tool/forcefield/src/main/java/org/openscience/cdk/modeling/builder3d/MMFF94BasedParameterSetReader.java
+++ b/tool/forcefield/src/main/java/org/openscience/cdk/modeling/builder3d/MMFF94BasedParameterSetReader.java
@@ -448,7 +448,6 @@ public class MMFF94BasedParameterSetReader {
 
         if (ins == null) {
             ClassLoader loader = this.getClass().getClassLoader();
-            System.out.println("loader.getClassName:" + loader.getClass().getName());
             ins = loader.getResourceAsStream(configFile);
         }
         if (ins == null) {


### PR DESCRIPTION
Removes calls to standard out/stack dumps so calling 'mvn test -q' will not report anything unless there is an error.

Only one Im not sue on is the 7d5c798, not really a useful test but think the fix is acceptable. I thought maybe I could set some property of the parser but no luck and always get the error printed: 
"premature end of file"