### PR TITLE
use new, secure DOI resolver

### DIFF
--- a/base/testdata/src/test/resources/data/asn/pubchem/taxols.xml
+++ b/base/testdata/src/test/resources/data/asn/pubchem/taxols.xml
@@ -33926,7 +33926,7 @@
         <PC-XRefData_dburl>http://www.nature.com/nchembio/</PC-XRefData_dburl>
       </PC-XRefData>
       <PC-XRefData>
-        <PC-XRefData_sburl>http://dx.doi.org/10.1038/nchembio.2007.34</PC-XRefData_sburl>
+        <PC-XRefData_sburl>https://doi.org/10.1038/nchembio.2007.34</PC-XRefData_sburl>
       </PC-XRefData>
     </PC-Substance_xref>
     <PC-Substance_compound>

--- a/doc/dict/data/react/bibtexml2xhtml.xsl
+++ b/doc/dict/data/react/bibtexml2xhtml.xsl
@@ -313,7 +313,7 @@
 
 <xsl:template match="bibxml:doi">
 	<xsl:if test=". != ''">	
-		<a href="http://dx.doi.org/{.}">
+		<a href="https://doi.org/{.}">
 		<xsl:value-of select="."/>	
 		</a>
 	</xsl:if>

--- a/doc/refs/cheminf.bibx
+++ b/doc/refs/cheminf.bibx
@@ -504,7 +504,7 @@
       <bibtex:volume>3</bibtex:volume>
       <bibtex:pages>1&#x2013;14</bibtex:pages>
       <bibtex:number>1</bibtex:number>
-      <bibtex:url>http://dx.doi.org/10.1186/1758&#45;2946&#45;3&#45;3</bibtex:url>
+      <bibtex:url>https://doi.org/10.1186/1758&#45;2946&#45;3&#45;3</bibtex:url>
       <bibtex:doi>10.1186/1758&#45;2946&#45;3&#45;3</bibtex:doi>
     </bibtex:article>
   </bibtex:entry>

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/SybylDescriptorFormat.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/formats/SybylDescriptorFormat.java
@@ -21,7 +21,7 @@ package org.openscience.cdk.io.formats;
 import org.openscience.cdk.tools.DataFeatures;
 
 /**
- * See <a href="http://dx.doi.org/10.1021/ci034207y">here</a>.
+ * See <a href="https://doi.org/10.1021/ci034207y">here</a>.
  *
  * @cdk.module ioformats
  * @cdk.githash


### PR DESCRIPTION
Hello!

The DOI foundation [prefers `https://doi.org`](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR updates both included DOIs and the XSL accordingly.

Cheers :-)