### PR TITLE
Revert "Add a new method atom::getBond(), that allows testing as to whether t…"

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/AtomRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/AtomRef.java
@@ -406,14 +406,6 @@ public class AtomRef extends ChemObjectRef implements IAtom {
      * {@inheritDoc}
      */
     @Override
-    public IBond getBond(IAtom atom) {
-        return this.atom.getBond(atom);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean isAromatic() {
         return atom.isAromatic();
     }

--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -270,14 +270,6 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public IBond getBond(IAtom atom) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      *  Sets the partial charge of this atom.
      *
      * @param  charge  The partial charge

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
@@ -621,8 +621,15 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
      */
     @Override
     public IBond getBond(IAtom beg, IAtom end) {
-        final AtomRef begref = getAtomRefUnsafe(beg);
-        return begref != null ? begref.getBond(end) : null;
+        AtomRef begref = getAtomRefUnsafe(beg);
+        AtomRef endref = getAtomRefUnsafe(end);
+        if (begref != null && endref != null) {
+            for (IBond bond : begref.bonds()) {
+                if (bond.getOther(begref) == endref)
+                    return bond;
+            }
+        }
+        return null;
     }
 
     /**
@@ -1651,16 +1658,6 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
         @Override
         public final Iterable<IBond> bonds() {
             return bonds;
-        }
-
-        @Override
-        public IBond getBond(IAtom atom) {
-            for (IBond bond : bonds) {
-                if (bond.getBegin().equals(atom) ||
-                    bond.getEnd().equals(atom))
-                    return bond;
-            }
-            return null;
         }
 
         @Override

--- a/base/data/src/test/java/org/openscience/cdk/AtomContainer2Test.java
+++ b/base/data/src/test/java/org/openscience/cdk/AtomContainer2Test.java
@@ -33,10 +33,6 @@ import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.ILonePair;
 import org.openscience.cdk.interfaces.ITestObjectBuilder;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-
 /**
  * Checks the functionality of the AtomContainer.
  *
@@ -114,26 +110,5 @@ public class AtomContainer2Test extends AbstractAtomContainerTest {
         IAtomContainer container = new AtomContainer(acetone);
         Assert.assertEquals(4, container.getAtomCount());
         Assert.assertEquals(3, container.getBondCount());
-    }
-
-    @Test
-    public void testAtomGetBond() {
-        IAtomContainer mol = (IAtomContainer) newChemObject();
-        IAtom          a1 = mol.getBuilder().newAtom();
-        IAtom          a2 = mol.getBuilder().newAtom();
-        IAtom          a3 = mol.getBuilder().newAtom();
-        a1.setSymbol("CH3");
-        a2.setSymbol("CH2");
-        a3.setSymbol("OH");
-        mol.addAtom(a1);
-        mol.addAtom(a2);
-        mol.addAtom(a3);
-        mol.addBond(0, 1, IBond.Order.SINGLE);
-        mol.addBond(1, 2, IBond.Order.SINGLE);
-        assertThat(mol.getBond(0),
-                   is(mol.getAtom(0).getBond(mol.getAtom(1))));
-        assertThat(mol.getBond(1),
-                   is(mol.getAtom(1).getBond(mol.getAtom(2))));
-        assertNull(mol.getAtom(0).getBond(mol.getAtom(2)));
     }
 }

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
@@ -204,20 +204,7 @@ public interface IAtom extends IAtomType {
      */
     Iterable<IBond> bonds();
 
-    /**
-     * Get the number of explicit bonds connected to this atom.
-     * @return the total bond count
-     */
     int getBondCount();
-
-    /**
-     * Returns the bond connecting 'this' atom to the provided atom. If the
-     * atoms are not bonded, null is return
-     * @param atom the other atom
-     * @return the bond connecting the atoms
-     * @throws UnsupportedOperationException thrown if the bonds are not known
-     */
-    IBond getBond(IAtom atom);
 
     /**
      * Access whether this atom has been marked as aromatic. The default

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -272,14 +272,6 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public IBond getBond(IAtom atom) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      *  Sets the partial charge of this atom.
      *
      * @param  charge  The partial charge

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer2.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer2.java
@@ -609,8 +609,15 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
      */
     @Override
     public IBond getBond(IAtom beg, IAtom end) {
-        final AtomRef begref = getAtomRefUnsafe(beg);
-        return begref != null ? begref.getBond(end) : null;
+        AtomRef begref = getAtomRefUnsafe(beg);
+        AtomRef endref = getAtomRefUnsafe(end);
+        if (begref != null && endref != null) {
+            for (IBond bond : begref.bonds()) {
+                if (bond.getOther(begref) == endref)
+                    return bond;
+            }
+        }
+        return null;
     }
 
     /**
@@ -1613,16 +1620,6 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
         @Override
         public final Iterable<IBond> bonds() {
             return bonds;
-        }
-
-        @Override
-        public IBond getBond(IAtom atom) {
-            for (IBond bond : bonds) {
-                if (bond.getBegin().equals(atom) ||
-                    bond.getEnd().equals(atom))
-                    return bond;
-            }
-            return null;
         }
 
         @Override

--- a/base/silent/src/test/java/org/openscience/cdk/silent/AtomContainer2Test.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/AtomContainer2Test.java
@@ -35,7 +35,6 @@ import org.openscience.cdk.interfaces.ILonePair;
 import org.openscience.cdk.interfaces.ITestObjectBuilder;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -214,26 +213,5 @@ public class AtomContainer2Test extends AbstractAtomContainerTest {
         org.clone();
         assertThat(org.getAtom(0).getBondCount(), is(1));
         assertThat(org.getAtom(1).getBondCount(), is(1));
-    }
-
-    @Test
-    public void testAtomGetBond() {
-        IAtomContainer mol = (IAtomContainer) newChemObject();
-        IAtom          a1 = mol.getBuilder().newAtom();
-        IAtom          a2 = mol.getBuilder().newAtom();
-        IAtom          a3 = mol.getBuilder().newAtom();
-        a1.setSymbol("CH3");
-        a2.setSymbol("CH2");
-        a3.setSymbol("OH");
-        mol.addAtom(a1);
-        mol.addAtom(a2);
-        mol.addAtom(a3);
-        mol.addBond(0, 1, IBond.Order.SINGLE);
-        mol.addBond(1, 2, IBond.Order.SINGLE);
-        assertThat(mol.getBond(0),
-                   is(mol.getAtom(0).getBond(mol.getAtom(1))));
-        assertThat(mol.getBond(1),
-                   is(mol.getAtom(1).getBond(mol.getAtom(2))));
-        assertNull(mol.getAtom(0).getBond(mol.getAtom(2)));
     }
 }


### PR DESCRIPTION
Sorry... I did not take the Travis warning seriously, but the patch actually has compile errors.