### PR TITLE
CXSMILES relative stereo can omit the component ids.

### DIFF
--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesParser.java
@@ -442,10 +442,13 @@ final class CxSmilesParser {
                     }
                     break;
                 case 'r': // relative stereochemistry ignored
-                    if (!iter.nextIf(':'))
-                        return -1;
-                    if (!skipIntList(iter, COMMA_SEPARATOR))
-                        return -1;
+                    if (iter.nextIf(':')) {
+                        if (!skipIntList(iter, COMMA_SEPARATOR))
+                            return -1;
+                    } else {
+                        if (!iter.nextIf(',') && iter.curr() != '|')
+                            return -1;
+                    }
                     break;
                 case 'l': // lone pairs ignored
                     if (!iter.nextIf("p:"))

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesParserTest.java
@@ -199,6 +199,19 @@ public class CxSmilesParserTest {
         assertThat(CxSmilesParser.unescape("&#9;"), is("\t")); // TAB
     }
 
+    @Test public void relativeStereoMolecule() {
+        CxSmilesState state = new CxSmilesState();
+        assertThat(CxSmilesParser.processCx("|r|", state), is(not(-1)));
+        assertThat(CxSmilesParser.processCx("|r,$_R1$|", state), is(not(-1)));
+        assertThat(CxSmilesParser.processCx("|$_R1$,r|", state), is(not(-1)));
+    }
+
+
+    @Test public void relativeStereoReaction() {
+        CxSmilesState state = new CxSmilesState();
+        assertThat(CxSmilesParser.processCx("|r:2,4,5|", state), is(not(-1)));
+    }
+
     /**
      * Custom matcher for checking an array of doubles closely matches (epsilon=0.01)
      * an expected value.


### PR DESCRIPTION
Fixes #423.