### PR TITLE
Cif reader fix (fixes issue #426)

### DIFF
--- a/storage/io/src/main/java/org/openscience/cdk/io/CIFReader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/CIFReader.java
@@ -23,29 +23,18 @@
  */
 package org.openscience.cdk.io;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.StringTokenizer;
-
-import javax.vecmath.Point3d;
-import javax.vecmath.Vector3d;
-
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.CrystalGeometryTools;
-import org.openscience.cdk.interfaces.IAtom;
-import org.openscience.cdk.interfaces.IChemFile;
-import org.openscience.cdk.interfaces.IChemModel;
-import org.openscience.cdk.interfaces.IChemObject;
-import org.openscience.cdk.interfaces.IChemSequence;
-import org.openscience.cdk.interfaces.ICrystal;
+import org.openscience.cdk.interfaces.*;
 import org.openscience.cdk.io.formats.CIFFormat;
 import org.openscience.cdk.io.formats.IResourceFormat;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
+
+import javax.vecmath.Point3d;
+import javax.vecmath.Vector3d;
+import java.io.*;
+import java.util.StringTokenizer;
 
 /**
  * This is not a reader for the CIF and mmCIF crystallographic formats.
@@ -267,7 +256,26 @@ public class CIFReader extends DefaultChemObjectReader {
             processAtomLoopBlock(line);
         } else {
             logger.warn("Skipping loop block");
-            skipUntilEmptyOrCommentLine(line);
+            skipLoopBody(line);
+        }
+    }
+
+    private void skipLoopBody(String line) throws IOException {
+        // skip everything until the end of the loop body
+    	if (line != null) line = line.trim();
+    	// First, skip the loop_ data name list:
+        while (line != null && line.length() > 0 && line.charAt(0) == '_') {
+            line = input.readLine();
+            if (line != null) line = line.trim();
+        }
+        // Then, skip every line that looks like starting with a CIF value:
+        while (line != null && line.length() > 0 &&
+        		line.charAt(0) != '#' &&
+        		line.charAt(0) != '_' &&
+        		!line.startsWith("loop_") &&
+        		!line.startsWith("data_")) {
+            line = input.readLine();
+            if (line != null) line = line.trim();
         }
     }
 

--- a/storage/io/src/main/java/org/openscience/cdk/io/CIFReader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/CIFReader.java
@@ -257,7 +257,6 @@ public class CIFReader extends DefaultChemObjectReader {
             return processAtomLoopBlock(line);
         } else {
             logger.warn("Skipping loop block");
-            //skipUntilEmptyOrCommentLine(line);
             return skipLoop(line);
         }
     }
@@ -284,14 +283,6 @@ public class CIFReader extends DefaultChemObjectReader {
             if (line != null) line = line.trim();
         }
         return line;
-    }
-
-    private void skipUntilEmptyOrCommentLine(String line) throws IOException {
-        // skip everything until empty line, or comment line
-        while (line != null && line.length() > 0 && line.charAt(0) != '#') {
-            line = input.readLine();
-            if (line != null) line = line.trim();
-        }
     }
 
     private String processAtomLoopBlock(String firstLine) throws IOException {

--- a/storage/io/src/test/java/org/openscience/cdk/io/CIFReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/CIFReaderTest.java
@@ -33,6 +33,8 @@ import org.openscience.cdk.silent.ChemFile;
 import java.io.IOException;
 import java.io.InputStream;
 
+import javax.vecmath.Vector3d;
+
 import static org.hamcrest.CoreMatchers.is;
 
 /**
@@ -66,14 +68,32 @@ public class CIFReaderTest extends ChemObjectIOTest {
     }
 
     @Test()
-    public void cod1100784Cell() throws IOException, CDKException {
+    public void cod1100784CellLengths() throws IOException, CDKException {
         InputStream in = getClass().getResourceAsStream("1100784.cif");
         CIFReader cifReader = new CIFReader(in);
         IChemFile chemFile = cifReader.read(new ChemFile());
         ICrystal crystal = chemFile.getChemSequence(0).getChemModel(0).getCrystal();
         Assert.assertTrue( java.lang.Math.abs(crystal.getA().length() - 10.9754) < 1E-5 );
         Assert.assertTrue( java.lang.Math.abs(crystal.getB().length() - 11.4045) < 1E-5 );
-        Assert.assertTrue( java.lang.Math.abs(crystal.getC().length() - 10.9754) < 1E-5 );
+        Assert.assertTrue( java.lang.Math.abs(crystal.getC().length() - 12.9314) < 1E-5 );
+        cifReader.close();
+    }
+
+    @Test()
+    public void cod1100784CellAngles() throws IOException, CDKException {
+        InputStream in = getClass().getResourceAsStream("1100784.cif");
+        CIFReader cifReader = new CIFReader(in);
+        IChemFile chemFile = cifReader.read(new ChemFile());
+        ICrystal crystal = chemFile.getChemSequence(0).getChemModel(0).getCrystal();
+        Vector3d a = crystal.getA();
+        Vector3d b = crystal.getB();
+        Vector3d c = crystal.getC();
+        double alpha = java.lang.Math.acos(b.dot(c)/(b.length()*c.length()))*180/java.lang.Math.PI;
+        double beta  = java.lang.Math.acos(c.dot(a)/(c.length()*a.length()))*180/java.lang.Math.PI;
+        double gamma = java.lang.Math.acos(a.dot(b)/(a.length()*b.length()))*180/java.lang.Math.PI;
+        Assert.assertTrue( java.lang.Math.abs(alpha - 109.1080) < 1E-5 );
+        Assert.assertTrue( java.lang.Math.abs(beta  -  98.4090) < 1E-5 );
+        Assert.assertTrue( java.lang.Math.abs(gamma - 102.7470) < 1E-5 );
         cifReader.close();
     }
 

--- a/storage/io/src/test/java/org/openscience/cdk/io/CIFReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/CIFReaderTest.java
@@ -67,6 +67,16 @@ public class CIFReaderTest extends ChemObjectIOTest {
         //        }
     }
 
+    @Test
+    public void cod1100784AtomCount() throws IOException, CDKException {
+        InputStream in = getClass().getResourceAsStream("1100784.cif");
+        CIFReader cifReader = new CIFReader(in);
+        IChemFile chemFile = cifReader.read(new ChemFile());
+        ICrystal crystal = chemFile.getChemSequence(0).getChemModel(0).getCrystal();
+        Assert.assertEquals(72, crystal.getAtomCount());
+        cifReader.close();
+    }
+
     @Test()
     public void cod1100784CellLengths() throws IOException, CDKException {
         InputStream in = getClass().getResourceAsStream("1100784.cif");

--- a/storage/io/src/test/java/org/openscience/cdk/io/CIFReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/CIFReaderTest.java
@@ -27,6 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IChemFile;
+import org.openscience.cdk.interfaces.ICrystal;
 import org.openscience.cdk.silent.ChemFile;
 
 import java.io.IOException;
@@ -62,6 +63,18 @@ public class CIFReaderTest extends ChemObjectIOTest {
         //        } finally {
         cifReader.close();
         //        }
+    }
+
+    @Test()
+    public void cod1100784Cell() throws IOException, CDKException {
+        InputStream in = getClass().getResourceAsStream("1100784.cif");
+        CIFReader cifReader = new CIFReader(in);
+        IChemFile chemFile = cifReader.read(new ChemFile());
+        ICrystal crystal = chemFile.getChemSequence(0).getChemModel(0).getCrystal();
+        Assert.assertTrue( java.lang.Math.abs(crystal.getA().length() - 10.9754) < 1E-5 );
+        Assert.assertTrue( java.lang.Math.abs(crystal.getB().length() - 11.4045) < 1E-5 );
+        Assert.assertTrue( java.lang.Math.abs(crystal.getC().length() - 10.9754) < 1E-5 );
+        cifReader.close();
     }
 
 }


### PR DESCRIPTION
While the the CIFReader class was not converted to a full CIF parser, the suggested modifications make it possible to read in unit cell parameters and fractional atomic coordinates from COD CIFs. An automated test is provided; no other tests are broken ;). It restores the desired CIFReader behaviour as described in the issue #426.