### PR TITLE
Patch/smartsprep

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
@@ -272,11 +272,12 @@ public class PathTools {
             // now look at bonds
             List<IBond> bonds = atomContainer.getConnectedBondsList(atom);
             for (IBond bond : bonds) {
+                nextAtom = bond.getOther(atom);
                 if (!bond.getFlag(CDKConstants.VISITED)) {
+                    molecule.addAtom(nextAtom);
                     molecule.addBond(bond);
                     bond.setFlag(CDKConstants.VISITED, true);
                 }
-                nextAtom = bond.getOther(atom);
                 if (!nextAtom.getFlag(CDKConstants.VISITED)) {
                     //					logger.debug("wie oft???");
                     newSphere.add(nextAtom);

--- a/base/data/src/main/java/org/openscience/cdk/DefaultChemObjectBuilder.java
+++ b/base/data/src/main/java/org/openscience/cdk/DefaultChemObjectBuilder.java
@@ -118,7 +118,7 @@ public class DefaultChemObjectBuilder implements IChemObjectBuilder {
     }
 
     private static final boolean CDK_LEGACY_AC
-        = getSystemProp("CdkUseLegacyAtomContainer", true);
+        = getSystemProp("CdkUseLegacyAtomContainer", false);
 
     private static volatile IChemObjectBuilder instance = null;
     private static final Object                LOCK     = new Object();

--- a/base/data/src/test/java/org/openscience/cdk/templates/TestMoleculeFactory.java
+++ b/base/data/src/test/java/org/openscience/cdk/templates/TestMoleculeFactory.java
@@ -45,9 +45,13 @@ import org.openscience.cdk.tools.LoggingToolFactory;
 public class TestMoleculeFactory {
 
     private static ILoggingTool logger = LoggingToolFactory.createLoggingTool(TestMoleculeFactory.class);
+    
+    private static IAtomContainer newAtomContainer() {
+        return DefaultChemObjectBuilder.getInstance().newAtomContainer();
+    }
 
     public static IAtomContainer makeAlphaPinene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -84,7 +88,7 @@ public class TestMoleculeFactory {
      * @cdk.created 2003-08-15
      */
     public static IAtomContainer makeAlkane(int chainLength) {
-        IAtomContainer currentChain = new AtomContainer();
+        IAtomContainer currentChain = newAtomContainer();
 
         //Add the initial atom
         currentChain.addAtom(new Atom("C"));
@@ -99,7 +103,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeEthylCyclohexane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -126,7 +130,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C6H10/c1-2-4-6-5-3-1/h1-2H,3-6H2
      */
     public static IAtomContainer makeCyclohexene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -149,7 +153,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C6H12/c1-2-4-6-5-3-1/h1-6H2
      */
     public static IAtomContainer makeCyclohexane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -172,7 +176,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C5H10/c1-2-4-5-3-1/h1-5H2
      */
     public static IAtomContainer makeCyclopentane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -193,7 +197,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H8/c1-2-4-3-1/h1-4H2
      */
     public static IAtomContainer makeCyclobutane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -212,7 +216,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4/c1-2-4-3-1/h1-4H
      */
     public static IAtomContainer makeCyclobutadiene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -226,7 +230,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makePropylCycloPropane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -249,7 +253,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C12H10/c1-3-7-11(8-4-1)12-9-5-2-6-10-12/h1-10H
      */
     public static IAtomContainer makeBiphenyl() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -281,7 +285,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makePhenylEthylBenzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -317,7 +321,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makePhenylAmine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -339,7 +343,7 @@ public class TestMoleculeFactory {
 
     /* build a molecule from 4 condensed triangles */
     public static IAtomContainer make4x3CondensedRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -361,7 +365,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeSpiroRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -388,7 +392,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeBicycloRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -411,7 +415,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeFusedRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -439,7 +443,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeMethylDecaline() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -469,7 +473,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeEthylPropylPhenantren() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -516,7 +520,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeSteran() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -566,7 +570,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C10H8/c1-2-5-9-7-4-8-10(9)6-3-1/h1-8H
      */
     public static IAtomContainer makeAzulene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -599,7 +603,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C8H7N/c1-2-4-8-7(3-1)5-6-9-8/h1-6,9H
      */
     public static IAtomContainer makeIndole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -630,7 +634,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H5N/c1-2-4-5-3-1/h1-5H
      */
     public static IAtomContainer makePyrrole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -652,7 +656,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N/c1-2-4-5-3-1/h1-4H/q-1
      */
     public static IAtomContainer makePyrroleAnion() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         IAtom nitrogenAnion = new Atom("N");
         nitrogenAnion.setFormalCharge(-1);
         mol.addAtom(new Atom("C")); // 0
@@ -676,7 +680,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-5-3-4-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer makeImidazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -698,7 +702,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-4-5-3-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer makePyrazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -720,7 +724,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-4-5-3-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer make124Triazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -742,7 +746,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C2H3N3/c1-2-4-5-3-1/h1-2H,(H,3,4,5)/f/h5H
      */
     public static IAtomContainer make123Triazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -764,7 +768,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/CH2N4/c1-2-4-5-3-1/h1H,(H,2,3,4,5)/f/h4H
      */
     public static IAtomContainer makeTetrazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("N")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -786,7 +790,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-5-3-4-1/h1-3H
      */
     public static IAtomContainer makeOxazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -808,7 +812,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makeIsoxazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -830,7 +834,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NS/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makeIsothiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("S")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -852,7 +856,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C2H2N2S/c1-3-4-2-5-1/h1-2H
      */
     public static IAtomContainer makeThiadiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("S")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -874,7 +878,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C2H2N2O/c1-3-4-2-5-1/h1-2H
      */
     public static IAtomContainer makeOxadiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -896,7 +900,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makePyridine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -920,7 +924,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C5H5NO/c7-6-4-2-1-3-5-6/h1-5H
      */
     public static IAtomContainer makePyridineOxide() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.getAtom(1).setFormalCharge(1);
@@ -948,7 +952,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-5-4-6-3-1/h1-4H
      */
     public static IAtomContainer makePyrimidine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -972,7 +976,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-4-6-5-3-1/h1-4H
      */
     public static IAtomContainer makePyridazine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -996,7 +1000,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-4-6-5-3-1/h1-4H
      */
     public static IAtomContainer makeTriazine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1020,7 +1024,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NS/c1-2-5-3-4-1/h1-3H
      */
     public static IAtomContainer makeThiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1037,7 +1041,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeSingleRing() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1065,7 +1069,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeDiamantane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1104,7 +1108,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeBranchedAliphatic() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1148,7 +1152,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeBenzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1166,7 +1170,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeQuinone() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("O")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1188,7 +1192,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makePiperidine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("N"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -1211,7 +1215,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeTetrahydropyran() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -1234,7 +1238,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C5H5N5/c6-4-3-5(9-1-7-3)10-2-8-4/h1-2H,(H3,6,7,8,9,10)/f/h7H,6H2
      */
     public static IAtomContainer makeAdenine() {
-        IAtomContainer mol = new AtomContainer(); // Adenine
+        IAtomContainer mol = newAtomContainer(); // Adenine
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(21.0223, -17.2946));
         mol.addAtom(a1);

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Pattern.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Pattern.java
@@ -73,7 +73,7 @@ public abstract class Pattern {
      * @param target the container to search for the pattern in
      * @return the mapping from the pattern to the target
      */
-    public final boolean matches(IAtomContainer target) {
+    public boolean matches(IAtomContainer target) {
         return match(target).length > 0;
     }
 

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
@@ -22,6 +22,7 @@ package org.openscience.cdk.isomorphism.matchers;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
+import org.openscience.cdk.AtomRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -734,5 +735,23 @@ public abstract class QueryAtom extends QueryChemObject implements IQueryAtom {
     public IAtom clone() throws CloneNotSupportedException {
         // XXX: clone always dodgy
         return (IAtom) super.clone();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof AtomRef)
+            return super.equals(((AtomRef) obj).deref());
+        return super.equals(obj);
     }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
+import org.openscience.cdk.BondRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -527,4 +528,21 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
         notifyChanged();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BondRef)
+            return super.equals(((BondRef) obj).deref());
+        return super.equals(obj);
+    }
 }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
@@ -113,7 +113,7 @@ public class SilentChemObjectBuilder implements IChemObjectBuilder {
     }
 
     private static final boolean CDK_LEGACY_AC
-        = getSystemProp("CdkUseLegacyAtomContainer", true);
+        = getSystemProp("CdkUseLegacyAtomContainer", false);
 
     private static volatile IChemObjectBuilder instance = null;
     private static final Object                LOCK     = new Object();

--- a/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/AbstractFixedLengthFingerprinterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/AbstractFixedLengthFingerprinterTest.java
@@ -36,6 +36,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.io.MDLV2000Reader;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
@@ -84,15 +85,16 @@ public abstract class AbstractFixedLengthFingerprinterTest extends AbstractFinge
      */
     @Test
     public void testBug853254() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
         String filename = "data/mdl/bug853254-2.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer superstructure = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer superstructure = reader.read(builder.newAtomContainer());
 
         filename = "data/mdl/bug853254-1.mol";
         ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer substructure = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer substructure = reader.read(builder.newAtomContainer());
 
         // these molecules are different resonance forms of the same molecule
         // make sure aromaticity is detected. although some fingerprinters do this
@@ -140,15 +142,16 @@ public abstract class AbstractFixedLengthFingerprinterTest extends AbstractFinge
      */
     @Test
     public void testBug771485() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
         String filename = "data/mdl/bug771485-1.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer structure1 = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer structure1 = (IAtomContainer) reader.read(builder.newAtomContainer());
 
         filename = "data/mdl/bug771485-2.mol";
         ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer structure2 = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer structure2 = (IAtomContainer) reader.read(builder.newAtomContainer());
 
         // these molecules are different resonance forms of the same molecule
         // make sure aromaticity is detected. although some fingerprinters do this
@@ -184,15 +187,16 @@ public abstract class AbstractFixedLengthFingerprinterTest extends AbstractFinge
      */
     @Test
     public void testBug931608() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
         String filename = "data/mdl/bug931608-1.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer structure1 = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer structure1 = reader.read(builder.newAtomContainer());
 
         filename = "data/mdl/bug931608-2.mol";
         ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer structure2 = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer structure2 = reader.read(builder.newAtomContainer());
 
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(structure1);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(structure2);

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/MorganNumbersToolsTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/MorganNumbersToolsTest.java
@@ -51,7 +51,7 @@ public class MorganNumbersToolsTest extends CDKTestCase {
         long[] reference = {28776, 17899, 23549, 34598, 31846, 36393, 9847, 45904, 15669, 15669};
 
         IAtomContainer mol = TestMoleculeFactory.makeAlphaPinene();
-        long[] morganNumbers = MorganNumbersTools.getMorganNumbers((AtomContainer) mol);
+        long[] morganNumbers = MorganNumbersTools.getMorganNumbers(mol);
         Assert.assertEquals(reference.length, morganNumbers.length);
         for (int f = 0; f < morganNumbers.length; f++) {
             //logger.debug(morganNumbers[f]);
@@ -65,7 +65,7 @@ public class MorganNumbersToolsTest extends CDKTestCase {
         String[] reference = {"C-457", "C-428", "C-325", "C-354", "C-325", "C-428", "N-251"};
 
         IAtomContainer mol = TestMoleculeFactory.makePhenylAmine();
-        String[] morganNumbers = MorganNumbersTools.getMorganNumbersWithElementSymbol((AtomContainer) mol);
+        String[] morganNumbers = MorganNumbersTools.getMorganNumbersWithElementSymbol(mol);
         Assert.assertEquals(reference.length, morganNumbers.length);
         for (int f = 0; f < morganNumbers.length; f++) {
             //logger.debug(morganNumbers[f]);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptorTest.java
@@ -99,7 +99,7 @@ public class AcidicGroupCountDescriptorTest extends MolecularDescriptorTest {
      */
     @Test
     public void testTwoGroup() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "O");
         a1.setFormalCharge(0);
         a1.setPoint2d(new Point2d(5.9019, 0.5282));
@@ -173,7 +173,7 @@ public class AcidicGroupCountDescriptorTest extends MolecularDescriptorTest {
      */
     @Test
     public void testCID() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "S");
         a1.setFormalCharge(0);
         a1.setPoint2d(new Point2d(9.4651, 0.25));

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/MolecularDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/MolecularDescriptorTest.java
@@ -338,7 +338,8 @@ public abstract class MolecularDescriptorTest extends DescriptorTest<IMolecularD
     public void testAtomContainerHandling() throws Exception {
         IAtomContainer water1 = someoneBringMeSomeWater(DefaultChemObjectBuilder.getInstance());
         // creates an AtomContainer with the atoms / bonds from water1
-        IAtomContainer water2 = new AtomContainer(water1);
+        IAtomContainer water2 = SilentChemObjectBuilder.getInstance().newAtomContainer();
+        water2.add(water1);
 
         IDescriptorResult v1 = descriptor.calculate(water1).getValue();
         IDescriptorResult v2 = descriptor.calculate(water2).getValue();
@@ -355,7 +356,8 @@ public abstract class MolecularDescriptorTest extends DescriptorTest<IMolecularD
      */
     @Test
     public void testDisconnectedStructureHandling() throws Exception {
-        IAtomContainer disconnected = new AtomContainer();
+        IAtomContainer disconnected = SilentChemObjectBuilder.getInstance()
+                                                             .newAtomContainer();
         IAtom chloride = new Atom("Cl");
         chloride.setFormalCharge(-1);
         disconnected.addAtom(chloride);


### PR DESCRIPTION
Some workup for some incoming patches. Since I added the AtomContainer2 I've been rewriting the SMARTS parser and how query atoms work (using the AtomRef to getTotalHCount for example means we don't need to precompute invariants). This will be explained better in other patches but these commits are required.

The big change here is the final commit where we switch to the new AtomContainer2 by default.