### PR TITLE
Patch/exprs

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/PathTools.java
@@ -272,11 +272,12 @@ public class PathTools {
             // now look at bonds
             List<IBond> bonds = atomContainer.getConnectedBondsList(atom);
             for (IBond bond : bonds) {
+                nextAtom = bond.getOther(atom);
                 if (!bond.getFlag(CDKConstants.VISITED)) {
+                    molecule.addAtom(nextAtom);
                     molecule.addBond(bond);
                     bond.setFlag(CDKConstants.VISITED, true);
                 }
-                nextAtom = bond.getOther(atom);
                 if (!nextAtom.getFlag(CDKConstants.VISITED)) {
                     //					logger.debug("wie oft???");
                     newSphere.add(nextAtom);

--- a/base/data/src/main/java/org/openscience/cdk/DefaultChemObjectBuilder.java
+++ b/base/data/src/main/java/org/openscience/cdk/DefaultChemObjectBuilder.java
@@ -118,7 +118,7 @@ public class DefaultChemObjectBuilder implements IChemObjectBuilder {
     }
 
     private static final boolean CDK_LEGACY_AC
-        = getSystemProp("CdkUseLegacyAtomContainer", true);
+        = getSystemProp("CdkUseLegacyAtomContainer", false);
 
     private static volatile IChemObjectBuilder instance = null;
     private static final Object                LOCK     = new Object();

--- a/base/data/src/test/java/org/openscience/cdk/templates/TestMoleculeFactory.java
+++ b/base/data/src/test/java/org/openscience/cdk/templates/TestMoleculeFactory.java
@@ -45,9 +45,13 @@ import org.openscience.cdk.tools.LoggingToolFactory;
 public class TestMoleculeFactory {
 
     private static ILoggingTool logger = LoggingToolFactory.createLoggingTool(TestMoleculeFactory.class);
+    
+    private static IAtomContainer newAtomContainer() {
+        return DefaultChemObjectBuilder.getInstance().newAtomContainer();
+    }
 
     public static IAtomContainer makeAlphaPinene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -84,7 +88,7 @@ public class TestMoleculeFactory {
      * @cdk.created 2003-08-15
      */
     public static IAtomContainer makeAlkane(int chainLength) {
-        IAtomContainer currentChain = new AtomContainer();
+        IAtomContainer currentChain = newAtomContainer();
 
         //Add the initial atom
         currentChain.addAtom(new Atom("C"));
@@ -99,7 +103,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeEthylCyclohexane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -126,7 +130,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C6H10/c1-2-4-6-5-3-1/h1-2H,3-6H2
      */
     public static IAtomContainer makeCyclohexene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -149,7 +153,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C6H12/c1-2-4-6-5-3-1/h1-6H2
      */
     public static IAtomContainer makeCyclohexane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -172,7 +176,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C5H10/c1-2-4-5-3-1/h1-5H2
      */
     public static IAtomContainer makeCyclopentane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -193,7 +197,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H8/c1-2-4-3-1/h1-4H2
      */
     public static IAtomContainer makeCyclobutane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -212,7 +216,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4/c1-2-4-3-1/h1-4H
      */
     public static IAtomContainer makeCyclobutadiene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -226,7 +230,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makePropylCycloPropane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -249,7 +253,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C12H10/c1-3-7-11(8-4-1)12-9-5-2-6-10-12/h1-10H
      */
     public static IAtomContainer makeBiphenyl() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -281,7 +285,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makePhenylEthylBenzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -317,7 +321,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makePhenylAmine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -339,7 +343,7 @@ public class TestMoleculeFactory {
 
     /* build a molecule from 4 condensed triangles */
     public static IAtomContainer make4x3CondensedRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -361,7 +365,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeSpiroRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -388,7 +392,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeBicycloRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -411,7 +415,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeFusedRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -439,7 +443,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeMethylDecaline() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -469,7 +473,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeEthylPropylPhenantren() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -516,7 +520,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeSteran() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -566,7 +570,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C10H8/c1-2-5-9-7-4-8-10(9)6-3-1/h1-8H
      */
     public static IAtomContainer makeAzulene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -599,7 +603,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C8H7N/c1-2-4-8-7(3-1)5-6-9-8/h1-6,9H
      */
     public static IAtomContainer makeIndole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -630,7 +634,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H5N/c1-2-4-5-3-1/h1-5H
      */
     public static IAtomContainer makePyrrole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -652,7 +656,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N/c1-2-4-5-3-1/h1-4H/q-1
      */
     public static IAtomContainer makePyrroleAnion() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         IAtom nitrogenAnion = new Atom("N");
         nitrogenAnion.setFormalCharge(-1);
         mol.addAtom(new Atom("C")); // 0
@@ -676,7 +680,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-5-3-4-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer makeImidazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -698,7 +702,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-4-5-3-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer makePyrazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -720,7 +724,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-4-5-3-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer make124Triazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -742,7 +746,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C2H3N3/c1-2-4-5-3-1/h1-2H,(H,3,4,5)/f/h5H
      */
     public static IAtomContainer make123Triazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -764,7 +768,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/CH2N4/c1-2-4-5-3-1/h1H,(H,2,3,4,5)/f/h4H
      */
     public static IAtomContainer makeTetrazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("N")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -786,7 +790,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-5-3-4-1/h1-3H
      */
     public static IAtomContainer makeOxazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -808,7 +812,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makeIsoxazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -830,7 +834,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NS/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makeIsothiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("S")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -852,7 +856,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C2H2N2S/c1-3-4-2-5-1/h1-2H
      */
     public static IAtomContainer makeThiadiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("S")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -874,7 +878,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C2H2N2O/c1-3-4-2-5-1/h1-2H
      */
     public static IAtomContainer makeOxadiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -896,7 +900,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makePyridine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -920,7 +924,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C5H5NO/c7-6-4-2-1-3-5-6/h1-5H
      */
     public static IAtomContainer makePyridineOxide() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.getAtom(1).setFormalCharge(1);
@@ -948,7 +952,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-5-4-6-3-1/h1-4H
      */
     public static IAtomContainer makePyrimidine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -972,7 +976,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-4-6-5-3-1/h1-4H
      */
     public static IAtomContainer makePyridazine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -996,7 +1000,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-4-6-5-3-1/h1-4H
      */
     public static IAtomContainer makeTriazine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1020,7 +1024,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NS/c1-2-5-3-4-1/h1-3H
      */
     public static IAtomContainer makeThiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1037,7 +1041,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeSingleRing() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1065,7 +1069,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeDiamantane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1104,7 +1108,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeBranchedAliphatic() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1148,7 +1152,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeBenzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1166,7 +1170,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeQuinone() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("O")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1188,7 +1192,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makePiperidine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("N"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -1211,7 +1215,7 @@ public class TestMoleculeFactory {
     }
 
     public static IAtomContainer makeTetrahydropyran() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -1234,7 +1238,7 @@ public class TestMoleculeFactory {
      * @cdk.inchi InChI=1/C5H5N5/c6-4-3-5(9-1-7-3)10-2-8-4/h1-2H,(H3,6,7,8,9,10)/f/h7H,6H2
      */
     public static IAtomContainer makeAdenine() {
-        IAtomContainer mol = new AtomContainer(); // Adenine
+        IAtomContainer mol = newAtomContainer(); // Adenine
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(21.0223, -17.2946));
         mol.addAtom(a1);

--- a/base/interfaces/src/main/java/org/openscience/cdk/isomorphism/matchers/IQueryAtom.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/isomorphism/matchers/IQueryAtom.java
@@ -21,12 +21,11 @@ package org.openscience.cdk.isomorphism.matchers;
 import org.openscience.cdk.interfaces.IAtom;
 
 /**
- * Defines the ability to be matched against {@link IAtom}'s. Most prominent application
- * is in isomorphism and substructure matching in the {@link org.openscience.cdk.isomorphism.UniversalIsomorphismTester}.
+ * Defines the ability to be matched against {@link IAtom}'s.
  *
  * @cdk.module interfaces
  * @cdk.githash
- * @see        org.openscience.cdk.isomorphism.UniversalIsomorphismTester
+ * @see        org.openscience.cdk.isomorphism.Pattern
  */
 public interface IQueryAtom extends IAtom {
 

--- a/base/interfaces/src/main/java/org/openscience/cdk/isomorphism/matchers/IQueryBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/isomorphism/matchers/IQueryBond.java
@@ -21,12 +21,11 @@ package org.openscience.cdk.isomorphism.matchers;
 import org.openscience.cdk.interfaces.IBond;
 
 /**
- * Defines the abililty to be matched against IBond's. Most prominent application
- * is in isomorphism and substructure matching in the UniversalIsomorphismTester.
+ * Defines the abililty to be matched against IBond's.
  *
  * @cdk.module interfaces
  * @cdk.githash
- * @see        org.openscience.cdk.isomorphism.UniversalIsomorphismTester
+ * @see        org.openscience.cdk.isomorphism.Pattern
  */
 public interface IQueryBond extends IBond {
 

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Pattern.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Pattern.java
@@ -73,7 +73,7 @@ public abstract class Pattern {
      * @param target the container to search for the pattern in
      * @return the mapping from the pattern to the target
      */
-    public final boolean matches(IAtomContainer target) {
+    public boolean matches(IAtomContainer target) {
         return match(target).length > 0;
     }
 

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
@@ -1,0 +1,958 @@
+/*
+ * Copyright (c) 2018 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.isomorphism.matchers;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.Weigher;
+import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.ReactionRole;
+import org.openscience.cdk.config.Elements;
+import org.openscience.cdk.graph.Cycles;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IAtomType;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.isomorphism.AtomMatcher;
+import org.openscience.cdk.isomorphism.BondMatcher;
+import org.openscience.cdk.isomorphism.ComponentGrouping;
+import org.openscience.cdk.isomorphism.VentoFoggia;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.*;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Objects;
+
+/**
+ * A expression stores a predicate tree for checking properties of atoms
+ * and bonds.
+ * <pre>
+ * Expr expr = new Expr(ExprType.ELEMENT, 6);
+ * if (expr.matches(atom)) {
+ *   // expression matches if atom is a carbon!
+ * }
+ * </pre>
+ * An expression is composed of an {@link Type}, an optional 'value', and
+ * optionally one or more 'sub-expressions'. Each expr can either be a leaf or
+ * an intermediate (logical) node. The simplest expression trees contain a
+ * single leaf node:
+ * <pre>
+ * new Expr(ExprType.IS_AROMATIC; // matches any aromatic atom
+ * new Expr(ExprType.ELEMENT, 6); // matches any carbon atom (atomic num=6)
+ * new Expr(ExprType.VALENCE, 4); // matches an atom with valence 4
+ * new Expr(ExprType.DEGREE, 1);  // matches a terminal atom, e.g. -OH, =O
+ * new Expr(ExprType.IS_IN_RING); // matches any atom marked as in a ring
+ * new Expr(ExprType.IS_HETERO);  // matches anything other than carbon or nitrogen
+ * new Expr(ExprType.TRUE);       // any atom
+ * </pre>
+ * Logical internal nodes combine one or two sub-expressions with conjunction
+ * (and), disjunction (or), and negation (not).
+ * <br>
+ * Consider the following expression tree, is matches fluorine, chlorine, or
+ * bromine.
+ * <pre>
+ *     OR
+ *    /  \
+ *   F   OR
+ *      /  \
+ *     Cl   Br
+ * </pre>
+ * We can construct this tree as follows:
+ * <pre>
+ * Expr expr = new Expr(ExprType.ELEMENT, 35) // Br
+ *                  .or(new Expr(ExprType.ELEMENT, 17)) // Cl
+ *                  .or(new Expr(ExprType.ELEMENT, 9))  // F</pre>
+ * A more verbose construction could also be used:
+ * <pre>
+ * Expr leafF  = new Expr(ExprType.ELEMENT, 9); // F
+ * Expr leafCl = new Expr(ExprType.ELEMENT, 17); // Cl
+ * Expr leafBr = new Expr(ExprType.ELEMENT, 35);  // Br
+ * Expr node4  = new Expr(ExprType.OR, leaf2, leaf3);
+ * Expr node5  = new Expr(ExprType.OR, leaf1, node4);
+ * </pre>
+ *
+ * Expressions can be used to match bonds. Note some expressions apply to either
+ * atoms or bonds.
+ * <pre>
+ * new Expr(ExprType.TRUE);               // any bond
+ * new Expr(ExprType.IS_IN_RING);         // any ring bond
+ * new Expr(ExprType.ALIPHATIC_ORDER, 2); // double bond
+ * </pre>
+ * See the documentation for {@link Type}s for a detail explanation of
+ * each type.
+ */
+public final class Expr {
+
+    /** Sentinel value for indicating the stereochemistry configuration
+     *  is not yet known. Since stereochemistry depends on the ordering
+     *  of neighbors we can't check this until those neighbors are
+     *  matched. */
+    public static final int UNKNOWN_STEREO = -1;
+
+    // the expression type
+    private Type type;
+    // used for primitive leaf types
+    private int  value;
+    // used for unary and binary types; not, and, or
+    private Expr left, right;
+    // user for recursive expression types
+    private IAtomContainer query;
+
+    /**
+     * Creates an atom expression that will always match ({@link Type#TRUE}).
+     */
+    public Expr() {
+        this(Type.TRUE);
+    }
+
+    /**
+     * Creates an atom expression for the specified primitive.
+     */
+    public Expr(Type op) {
+        setPrimitive(op);
+    }
+
+    /**
+     * Creates an atom expression for the specified primitive and 'value'.
+     */
+    public Expr(Type op, int val) {
+        setPrimitive(op, val);
+    }
+
+    /**
+     * Creates a logical atom expression for the specified.
+     */
+    public Expr(Type op, Expr left, Expr right) {
+        setLogical(op, left, right);
+    }
+
+    /**
+     * Creates a recursive atom expression.
+     */
+    public Expr(Type op, IAtomContainer mol) {
+        setRecursive(op, mol);
+    }
+
+    /**
+     * Copy-constructor, creates a shallow copy of the provided expression.
+     *
+     * @param expr the expre
+     */
+    public Expr(final Expr expr) {
+        set(expr);
+    }
+
+    private static boolean eq(Integer a, int b) {
+        return a != null && a == b;
+    }
+
+    private static int unbox(Integer x) {
+        return x != null ? x : 0;
+    }
+
+    private static boolean isInRingSize(IAtom atom, IBond prev, IAtom beg,
+                                        int size, int req) {
+        atom.setFlag(CDKConstants.VISITED, true);
+        for (IBond bond : atom.bonds()) {
+            if (bond == prev)
+                continue;
+            IAtom nbr = bond.getOther(atom);
+            if (nbr.equals(beg))
+                return size == req;
+            else if (size < req &&
+                     !nbr.getFlag(CDKConstants.VISITED) &&
+                     isInRingSize(nbr, bond, beg, size + 1, req))
+                return true;
+        }
+        atom.setFlag(CDKConstants.VISITED, false);
+        return false;
+    }
+
+    private static boolean isInRingSize(IAtom atom, int size) {
+        for (IAtom a : atom.getContainer().atoms())
+            a.setFlag(CDKConstants.VISITED, false);
+        return isInRingSize(atom, null, atom, 1, size);
+    }
+
+    private static boolean isInSmallRingSize(IAtom atom, int size) {
+        IAtomContainer mol    = atom.getContainer();
+        int[]          distTo = new int[mol.getAtomCount()];
+        Arrays.fill(distTo, 1 + distTo.length);
+        distTo[atom.getIndex()] = 0;
+        Deque<IAtom> queue = new ArrayDeque<>();
+        queue.push(atom);
+        int smallest = 1 + distTo.length;
+        while (!queue.isEmpty()) {
+            IAtom a    = queue.poll();
+            int   dist = 1 + distTo[a.getIndex()];
+            for (IBond b : a.bonds()) {
+                IAtom nbr = b.getOther(a);
+                if (dist < distTo[nbr.getIndex()]) {
+                    distTo[nbr.getIndex()] = dist;
+                    queue.add(nbr);
+                } else if (dist != 2 + distTo[nbr.getIndex()]) {
+                    int tmp = dist + distTo[nbr.getIndex()];
+                    if (tmp < smallest)
+                        smallest = tmp;
+                }
+            }
+            if (2 * dist > 1 + size)
+                break;
+        }
+        return smallest == size;
+    }
+
+    /**
+     * Internal match methods - does not null check.
+     *
+     * @param type the type
+     * @param atom the atom
+     * @return the expression matches
+     */
+    private boolean matches(Type type, IAtom atom, int stereo) {
+        switch (type) {
+            // predicates
+            case TRUE:
+                return true;
+            case FALSE:
+                return false;
+            case IS_AROMATIC:
+                return atom.isAromatic();
+            case IS_ALIPHATIC:
+                return !atom.isAromatic();
+            case IS_IN_RING:
+                return atom.isInRing();
+            case IS_IN_CHAIN:
+                return !atom.isInRing();
+            case IS_HETERO:
+                return !eq(atom.getAtomicNumber(), 6) &&
+                       !eq(atom.getAtomicNumber(), 1);
+            case HAS_IMPLICIT_HYDROGEN:
+                return atom.getImplicitHydrogenCount() != null &&
+                       atom.getImplicitHydrogenCount() > 0;
+            case HAS_ISOTOPE:
+                return atom.getMassNumber() != null;
+            case HAS_UNSPEC_ISOTOPE:
+                return atom.getMassNumber() == null;
+            case UNSATURATED:
+                for (IBond bond : atom.bonds())
+                    if (bond.getOrder() == IBond.Order.DOUBLE)
+                        return true;
+                return false;
+            // value primitives
+            case ELEMENT:
+                return eq(atom.getAtomicNumber(), value);
+            case ALIPHATIC_ELEMENT:
+                return !atom.isAromatic() &&
+                       eq(atom.getAtomicNumber(), value);
+            case AROMATIC_ELEMENT:
+                return atom.isAromatic() &&
+                       eq(atom.getAtomicNumber(), value);
+            case IMPL_H_COUNT:
+                return eq(atom.getImplicitHydrogenCount(), value);
+            case TOTAL_H_COUNT:
+                if (atom.getImplicitHydrogenCount() != null
+                    && atom.getImplicitHydrogenCount() > value)
+                    return false;
+                return getTotalHCount(atom) == value;
+            case DEGREE:
+                return atom.getBondCount() == value;
+            case HEAVY_DEGREE: // XXX: CDK quirk
+                return atom.getBondCount() - (getTotalHCount(atom) - atom.getImplicitHydrogenCount()) == value;
+            case TOTAL_DEGREE:
+                int x = atom.getBondCount() + unbox(atom.getImplicitHydrogenCount());
+                return x == value;
+            case VALENCE:
+                int v = unbox(atom.getImplicitHydrogenCount());
+                if (v > value)
+                    return false;
+                for (IBond bond : atom.bonds()) {
+                    if (bond.getOrder() != null)
+                        v += bond.getOrder().numeric();
+                }
+                return v == value;
+            case ISOTOPE:
+                return eq(atom.getMassNumber(), value);
+            case FORMAL_CHARGE:
+                return eq(atom.getFormalCharge(), value);
+            case RING_BOND_COUNT:
+                if (!atom.isInRing() || atom.getBondCount() < value)
+                    return false;
+                int rbonds = 0;
+                for (IBond bond : atom.bonds())
+                    rbonds += bond.isInRing() ? 1 : 0;
+                return rbonds == value;
+            case RING_COUNT:
+                return atom.isInRing() && getRingCount(atom) == value;
+            case RING_SMALLEST:
+                return atom.isInRing() && isInSmallRingSize(atom, value);
+            case RING_SIZE:
+                return atom.isInRing() && isInRingSize(atom, value);
+            case HETERO_SUBSTITUENT_COUNT:
+                if (atom.getBondCount() < value)
+                    return false;
+                int q = 0;
+                for (IBond bond : atom.bonds())
+                    q += matches(Type.IS_HETERO, bond.getOther(atom), stereo) ? 1 : 0;
+                return q == value;
+            case INSATURATION:
+                int db = 0;
+                for (IBond bond : atom.bonds())
+                    if (bond.getOrder() == IBond.Order.DOUBLE)
+                        db++;
+                return db == value;
+            case HYBRIDISATION_NUMBER:
+                IAtomType.Hybridization hyb = atom.getHybridization();
+                if (hyb == null)
+                    return false;
+                switch (value) {
+                    case 1:
+                        return hyb == IAtomType.Hybridization.SP1;
+                    case 2:
+                        return hyb == IAtomType.Hybridization.SP2;
+                    case 3:
+                        return hyb == IAtomType.Hybridization.SP3;
+                    case 4:
+                        return hyb == IAtomType.Hybridization.SP3D1;
+                    case 5:
+                        return hyb == IAtomType.Hybridization.SP3D2;
+                    case 6:
+                        return hyb == IAtomType.Hybridization.SP3D3;
+                    case 7:
+                        return hyb == IAtomType.Hybridization.SP3D4;
+                    case 8:
+                        return hyb == IAtomType.Hybridization.SP3D5;
+                    default:
+                        return false;
+                }
+            case PERIODIC_GROUP:
+                return atom.getAtomicNumber() != null &&
+                       Elements.ofNumber(atom.getAtomicNumber()).group() == value;
+            case STEREOCHEMISTRY:
+                return stereo == UNKNOWN_STEREO || stereo == value;
+            case REACTION_ROLE:
+                ReactionRole role = atom.getProperty(CDKConstants.REACTION_ROLE);
+                return role != null && role.ordinal() == value;
+            case AND:
+                return left.matches(left.type, atom, stereo) &&
+                       right.matches(right.type, atom, stereo);
+            case OR:
+                return left.matches(left.type, atom, stereo) ||
+                       right.matches(right.type, atom, stereo);
+            case NOT:
+                return !left.matches(left.type, atom, stereo) ||
+                       // XXX: ugly but needed, when matching stereo
+                       (stereo == UNKNOWN_STEREO &&
+                        (left.type == STEREOCHEMISTRY ||
+                         left.type == OR && left.left.type == STEREOCHEMISTRY));
+
+            case RECURSIVE:
+                // TO BE OPTIMIZED
+                for (int[] match : VentoFoggia.findSubstructure(query,
+                                                                AtomMatcher.forQuery(),
+                                                                BondMatcher.forQuery())
+                                              .matchAll(atom.getContainer())
+                                              .filter(new StereoFilter(query, atom.getContainer()))
+                                              .filter(new ComponentGrouping(query, atom.getContainer()))) {
+                    if (match[0] == atom.getIndex())
+                        return true;
+                }
+                return false;
+
+            default:
+                throw new IllegalArgumentException("Cannot match AtomExpr, type=" + type);
+        }
+    }
+
+    public boolean matches(IBond bond, int stereo) {
+        switch (type) {
+            case TRUE:
+                return true;
+            case FALSE:
+                return false;
+            case ALIPHATIC_ORDER:
+                return !bond.isAromatic() &&
+                       bond.getOrder() != null &&
+                       bond.getOrder().numeric() == value;
+            case IS_AROMATIC:
+                return bond.isAromatic();
+            case IS_ALIPHATIC:
+                return !bond.isAromatic();
+            case IS_IN_RING:
+                return bond.isInRing();
+            case IS_IN_CHAIN:
+                return !bond.isInRing();
+            case SINGLE_OR_AROMATIC:
+                return bond.isAromatic() ||
+                       IBond.Order.SINGLE.equals(bond.getOrder());
+            case DOUBLE_OR_AROMATIC:
+                return bond.isAromatic() ||
+                       IBond.Order.DOUBLE.equals(bond.getOrder());
+            case SINGLE_OR_DOUBLE:
+                return IBond.Order.SINGLE.equals(bond.getOrder()) ||
+                       IBond.Order.DOUBLE.equals(bond.getOrder());
+            case STEREOCHEMISTRY:
+                return stereo == UNKNOWN_STEREO || value == stereo;
+            case AND:
+                return left.matches(bond, stereo) && right.matches(bond, stereo);
+            case OR:
+                return left.matches(bond, stereo) || right.matches(bond, stereo);
+            case NOT:
+                return !left.matches(bond, stereo) ||
+                       // XXX: ugly but needed, when matching stereo
+                       (stereo == UNKNOWN_STEREO &&
+                        (left.type == STEREOCHEMISTRY ||
+                         left.type == OR && left.left.type == STEREOCHEMISTRY));
+            default:
+                throw new IllegalArgumentException("Cannot match BondExpr, type=" + type);
+        }
+    }
+
+    public boolean matches(IBond bond) {
+        return matches(bond, UNKNOWN_STEREO);
+    }
+
+    private static int getTotalHCount(IAtom atom) {
+        int h = unbox(atom.getImplicitHydrogenCount());
+        for (IBond bond : atom.bonds())
+            if (eq(bond.getOther(atom).getAtomicNumber(), 1))
+                h++;
+        return h;
+    }
+
+    /**
+     * Test whether this expression matches an atom instance.
+     *
+     * @param atom an atom (nullable)
+     * @return the atom matches
+     */
+    public boolean matches(final IAtom atom) {
+        return atom != null && matches(type, atom, UNKNOWN_STEREO);
+    }
+
+    public boolean matches(final IAtom atom, final int stereo) {
+        return atom != null && matches(type, atom, stereo);
+    }
+
+    /**
+     * Utility, combine this expression with another, using conjunction.
+     * The expression will only match if both conditions are met.
+     *
+     * @param expr the other expression
+     * @return self for chaining
+     */
+    public Expr and(Expr expr) {
+        if (type == Type.TRUE) {
+            set(expr);
+        } else if (expr.type != Type.TRUE) {
+            if (type.isLogical() && !expr.type.isLogical())
+                setLogical(Type.AND, expr, new Expr(this));
+            else
+                setLogical(Type.AND, new Expr(this), expr);
+        }
+        return this;
+    }
+
+    /**
+     * Utility, combine this expression with another, using disjunction.
+     * The expression will match if either conditions is met.
+     * @param expr the other expression
+     * @return self for chaining
+     */
+    public Expr or(Expr expr) {
+        if (type == Type.TRUE ||
+            type == Type.FALSE ||
+            type == NONE) {
+            set(expr);
+        } else if (expr.type != Type.TRUE &&
+                   expr.type != Type.FALSE &&
+                   expr.type != Type.NONE) {
+            if (type.isLogical() && !expr.type.isLogical())
+                setLogical(Type.OR, expr, new Expr(this));
+            else
+                setLogical(Type.OR, new Expr(this), expr);
+        }
+        return this;
+    }
+
+    /**
+     * Negate the expression, the expression will not return true only if
+     * the condition is not met. Some expressions have explicit types
+     * that are more efficient to use, for example:
+     * <code>IS_IN_RING =&gt; NOT(IS_IN_RING) =&gt; IS_IN_CHAIN</code>. This
+     * negation method will use the more efficient type where possible.
+     * <pre>{@code
+     * Expr e = new Expr(ELEMENT, 8); // SMARTS: [#8]
+     * e.negate(); // SMARTS: [!#8]
+     * }</pre>
+     * @return self for chaining
+     */
+    public Expr negate() {
+        switch (type) {
+            case TRUE:
+                type = Type.FALSE;
+                break;
+            case FALSE:
+                type = Type.TRUE;
+                break;
+            case HAS_ISOTOPE:
+                type = Type.HAS_UNSPEC_ISOTOPE;
+                break;
+            case HAS_UNSPEC_ISOTOPE:
+                type = Type.HAS_ISOTOPE;
+                break;
+            case IS_AROMATIC:
+                type = Type.IS_ALIPHATIC;
+                break;
+            case IS_ALIPHATIC:
+                type = Type.IS_AROMATIC;
+                break;
+            case IS_IN_RING:
+                type = Type.IS_IN_CHAIN;
+                break;
+            case IS_IN_CHAIN:
+                type = Type.IS_IN_RING;
+                break;
+            case NOT:
+                set(this.left);
+                break;
+            default:
+                setLogical(Type.NOT, new Expr(this), null);
+                break;
+        }
+        return this;
+    }
+
+    /**
+     * Set the primitive value of this atom expression.
+     *
+     * @param type the type of expression
+     * @param val  the value to check
+     */
+    public void setPrimitive(Type type, int val) {
+        if (type.hasValue()) {
+            this.type = type;
+            this.value = val;
+            this.left = null;
+            this.right = null;
+            this.query = null;
+        } else {
+            throw new IllegalArgumentException("Value provided for non-value "
+                                               + "expression type!");
+        }
+    }
+
+    /**
+     * Set the primitive value of this atom expression.
+     *
+     * @param type the type of expression
+     */
+    public void setPrimitive(Type type) {
+        if (!type.hasValue() && !type.isLogical()) {
+            this.type = type;
+            this.value = -1;
+            this.left = null;
+            this.right = null;
+            this.query = null;
+        } else {
+            throw new IllegalArgumentException("Expression type requires a value!");
+        }
+    }
+
+    /**
+     * Set the logical value of this atom expression.
+     *
+     * @param type  the type of expression
+     * @param left  the left sub-expression
+     * @param right the right sub-expression
+     */
+    public void setLogical(Type type, Expr left, Expr right) {
+        switch (type) {
+            case AND:
+            case OR:
+                this.type = type;
+                this.value = 0;
+                this.left = left;
+                this.right = right;
+                this.query = null;
+                break;
+            case NOT:
+                this.type = type;
+                if (left != null && right == null)
+                    this.left = left;
+                else if (left == null && right != null)
+                    this.left = right;
+                else if (left != null)
+                    throw new IllegalArgumentException("Only one sub-expression"
+                                                       + " should be provided"
+                                                       + " for NOT expressions!");
+                this.query = null;
+                this.value = 0;
+                break;
+            default:
+                throw new IllegalArgumentException("Left/Right sub expressions "
+                                                   + "supplied for "
+                                                   + " non-logical operator!");
+        }
+    }
+
+    /**
+     * Set the recursive value of this atom expression.
+     *
+     * @param type the type of expression
+     * @param mol  the recursive pattern
+     */
+    private void setRecursive(Type type, IAtomContainer mol) {
+        switch (type) {
+            case RECURSIVE:
+                this.type = type;
+                this.value = 0;
+                this.left = null;
+                this.right = null;
+                this.query = mol;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Set this expression to another (shallow copy).
+     *
+     * @param expr the other expression
+     */
+    public void set(Expr expr) {
+        this.type = expr.type;
+        this.value = expr.value;
+        this.left = expr.left;
+        this.right = expr.right;
+        this.query = expr.query;
+    }
+
+    /**
+     * Access the type of the atom expression.
+     *
+     * @return the expression type
+     */
+    public Type type() {
+        return type;
+    }
+
+    /**
+     * Access the value of this atom expression being
+     * tested.
+     *
+     * @return the expression value
+     */
+    public int value() {
+        return value;
+    }
+
+    /**
+     * Access the left sub-expression of this atom expression being
+     * tested.
+     *
+     * @return the expression value
+     */
+    public Expr left() {
+        return left;
+    }
+
+    /**
+     * Access the right sub-expression of this atom expression being
+     * tested.
+     *
+     * @return the expression value
+     */
+    public Expr right() {
+        return right;
+    }
+
+    /* Property Caches */
+    private static LoadingCache<IAtomContainer, int[]> cacheRCounts;
+
+    private static int[] getRingCounts(IAtomContainer mol) {
+        int[] rcounts = new int[mol.getAtomCount()];
+        for (int[] path : Cycles.mcb(mol).paths()) {
+            for (int i = 1; i < path.length; i++) {
+                rcounts[path[i]]++;
+            }
+        }
+        return rcounts;
+    }
+
+    private static int getRingCount(IAtom atom) {
+        final IAtomContainer mol = atom.getContainer();
+        if (cacheRCounts == null) {
+            cacheRCounts = CacheBuilder.newBuilder()
+                                       .maximumWeight(1000) // 4KB
+                                       .weigher(new Weigher<IAtomContainer, int[]>() {
+                                           @Override
+                                           public int weigh(IAtomContainer key,
+                                                            int[] value) {
+                                               return value.length;
+                                           }
+                                       })
+                                       .build(new CacheLoader<IAtomContainer, int[]>() {
+                                           @Override
+                                           public int[] load(IAtomContainer key) throws Exception {
+                                               return getRingCounts(key);
+                                           }
+                                       });
+        }
+        return cacheRCounts.getUnchecked(mol)[atom.getIndex()];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Expr atomExpr = (Expr) o;
+        return type == atomExpr.type &&
+               value == atomExpr.value &&
+               Objects.equals(left, atomExpr.left) && Objects.equals(right, atomExpr.right);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, value, left, right);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(type);
+        if (type.isLogical()) {
+            switch (type) {
+                case NOT:
+                    sb.append('(').append(left).append(')');
+                    break;
+                case OR:
+                case AND:
+                    sb.append('(').append(left).append(',').append(right).append(')');
+                    break;
+            }
+        } else if (type.hasValue()) {
+            sb.append('=').append(value);
+        } else if (type == Type.RECURSIVE) {
+            sb.append("(...)");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Types of expression, for use in the {@link Expr} tree object.
+     */
+    public enum Type {
+        /** Always returns true. */
+        TRUE,
+        /** Always returns false. */
+        FALSE,
+        /** Return true if {@link IAtom#isAromatic} or {@link IBond#isAromatic} is
+         *  true. */
+        IS_AROMATIC,
+        /** Return true if {@link IAtom#isAromatic} or {@link IBond#isAromatic} is
+         *  flase. */
+        IS_ALIPHATIC,
+        /** Return true if {@link IAtom#isInRing()} or {@link IBond#isInRing} is
+         *  true. */
+        IS_IN_RING,
+        /** Return true if {@link IAtom#isInRing()} or {@link IBond#isInRing} is
+         *  false. */
+        IS_IN_CHAIN,
+        /** Return true if {@link IAtom#getAtomicNumber()} is neither 6 (carbon)
+         *  nor 1 (hydrogen). */
+        IS_HETERO,
+        /** Return true if {@link IAtom#getAtomicNumber()} is neither 6 (carbon)
+         *  nor 1 (hydrogen) and the atom is aliphatic. */
+        IS_ALIPHATIC_HETERO,
+        /** True if the hydrogen count ({@link IAtom#getImplicitHydrogenCount()})
+         *  is &gt; 0. */
+        HAS_IMPLICIT_HYDROGEN,
+        /** True if the atom mass ({@link IAtom#getMassNumber()}) is non-null. */
+        HAS_ISOTOPE,
+        /** True if the atom mass ({@link IAtom#getMassNumber()}) is null
+         *  (unspecified). */
+        HAS_UNSPEC_ISOTOPE,
+        /** True if the atom is adjacent to a hetero atom. */
+        HAS_HETERO_SUBSTITUENT,
+        /** True if the atom is adjacent to an aliphatic hetero atom. */
+        HAS_ALIPHATIC_HETERO_SUBSTITUENT,
+        /** True if the atom is unsaturated.
+         *  TODO: check if CACTVS if double bond to non-carbons are counted. */
+        UNSATURATED,
+        /** True if the bond order ({@link IBond#getOrder()}) is single or double. */
+        SINGLE_OR_DOUBLE,
+        /** True if the bond order ({@link IBond#getOrder()}) is single or the bond
+         *  is marked as aromatic ({@link IBond#isAromatic()}). */
+        SINGLE_OR_AROMATIC,
+        /** True if the bond order ({@link IBond#getOrder()}) is double or the bond
+         *  is marked as aromatic ({@link IBond#isAromatic()}). */
+        DOUBLE_OR_AROMATIC,
+
+        /* Expressions that take values */
+
+        /** True if the atomic number ({@link IAtom#getAtomicNumber()} ()})
+         *  of an atom equals the specified 'value'. */
+        ELEMENT,
+        /** True if the atomic number ({@link IAtom#getAtomicNumber()} ()})
+         *  of an atom equals the specified 'value' and {@link IAtom#isAromatic()}
+         *  is false. */
+        ALIPHATIC_ELEMENT,
+        /** True if the atomic number ({@link IAtom#getAtomicNumber()} ()})
+         *  of an atom equals the specified 'value' and {@link IAtom#isAromatic()}
+         *  is true. */
+        AROMATIC_ELEMENT,
+        /** True if the hydrogen count ({@link IAtom#getImplicitHydrogenCount()})
+         *  of an atom equals the specified 'value'. */
+        IMPL_H_COUNT,
+        /** True if the total hydrogen count of an atom equals the specified
+         * 'value'. */
+        TOTAL_H_COUNT,
+        /** True if the degree ({@link IAtom#getBondCount()}) of an atom
+         *  equals the specified 'value'. */
+        DEGREE,
+        /** True if the total degree ({@link IAtom#getBondCount()} +
+         *  {@link IAtom#getImplicitHydrogenCount()}) of an atom equals the
+         *  specified 'value'. */
+        TOTAL_DEGREE,
+        /** True if the degree ({@link IAtom#getBondCount()}) - any hydrogen atoms
+         x*  equals the specified 'value'. */
+        HEAVY_DEGREE,
+        /** True if the valence of an atom equals the specified 'value'. */
+        VALENCE,
+        /** True if the mass ({@link IAtom#getMassNumber()}) of an atom equals the
+         *  specified 'value'. */
+        ISOTOPE,
+        /** True if the formal charge ({@link IAtom#getFormalCharge()}) of an atom
+         *  equals the specified 'value'. */
+        FORMAL_CHARGE,
+        /** True if the ring bond count of an atom equals the specified 'value'. */
+        RING_BOND_COUNT,
+        /** True if the number of rings this atom belongs to matches the specified
+         *  'value'. Here a ring means a member of the Minimum Cycle Basis (MCB)
+         *  (aka Smallest Set of Smallest Rings). Since the MCB is non-unique the
+         *  numbers often don't make sense of bicyclo systems. */
+        RING_COUNT,
+        /** True if the smallest ring this atom belongs to equals the specified
+         *  'value' */
+        RING_SMALLEST,
+        /** True if the this atom belongs to a ring equal to the specified
+         * 'value' */
+        RING_SIZE,
+        /** True if the this atom hybridisation ({@link IAtom#getHybridization()})
+         *  is equal to the specified 'value'. SP1=1, SP2=2, SP3=3, SP3D1=4,
+         *  SP3D2=5, SP3D3=6, SP3D4=7, SP3D5=8. */
+        HYBRIDISATION_NUMBER,
+        /** True if the number hetero atoms (see {@link #IS_HETERO}) this atom is
+         *  next to is equal to the specified value. */
+        HETERO_SUBSTITUENT_COUNT,
+        /** True if the number hetero atoms (see {@link #IS_ALIPHATIC_HETERO}) this atom is
+         *  next to is equal to the specified value. */
+        ALIPHATIC_HETERO_SUBSTITUENT_COUNT,
+        /** True if the periodic table group of this atom is equal to the specified
+         *  value. For example halogens are Group '17'.*/
+        PERIODIC_GROUP,
+        /** True if the number of double bonds equals the specified value.
+         *  TODO: check if CACTVS if double bond to non-carbons are counted. */
+        INSATURATION,
+        /** True if an atom has the specified reaction role. */
+        REACTION_ROLE,
+        /** True if an atom or bond has the specified stereochemistry value, see
+         *  ({@link org.openscience.cdk.interfaces.IStereoElement}) for a list of
+         *  values.*/
+        STEREOCHEMISTRY,
+        /** True if the bond order {@link IBond#getOrder()} equals the specified
+         *  value and the bond is not marked as aromatic
+         *  ({@link IAtom#isAromatic()}). */
+        ALIPHATIC_ORDER,
+
+        /* Binary/unary internal nodes */
+
+        /** True if both the subexpressions are true. */
+        AND,
+        /** True if both either subexpressions are true. */
+        OR,
+        /** True if the subexpression is not true. */
+        NOT,
+
+        /** Recursive query. */
+        RECURSIVE,
+
+        /** Undefined expression type. */
+        NONE;
+
+        boolean isLogical() {
+            switch (this) {
+                case OR:
+                case NOT:
+                case AND:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        boolean hasValue() {
+            switch (this) {
+                case OR:
+                case NOT:
+                case AND:
+                case TRUE:
+                case FALSE:
+                case NONE:
+                case IS_AROMATIC:
+                case IS_ALIPHATIC:
+                case IS_IN_RING:
+                case IS_IN_CHAIN:
+                case IS_HETERO:
+                case IS_ALIPHATIC_HETERO:
+                case HAS_IMPLICIT_HYDROGEN:
+                case HAS_ISOTOPE:
+                case HAS_UNSPEC_ISOTOPE:
+                case HAS_ALIPHATIC_HETERO_SUBSTITUENT:
+                case HAS_HETERO_SUBSTITUENT:
+                case UNSATURATED:
+                case SINGLE_OR_AROMATIC:
+                case SINGLE_OR_DOUBLE:
+                case DOUBLE_OR_AROMATIC:
+                case RECURSIVE:
+                    return false;
+                default:
+                    return true;
+            }
+        }
+    }
+}

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
@@ -371,15 +371,15 @@ public final class Expr {
 
             case RECURSIVE:
                 // TO BE OPTIMIZED
-                for (int[] match : VentoFoggia.findSubstructure(query,
-                                                                AtomMatcher.forQuery(),
-                                                                BondMatcher.forQuery())
-                                              .matchAll(atom.getContainer())
-                                              .filter(new StereoFilter(query, atom.getContainer()))
-                                              .filter(new ComponentGrouping(query, atom.getContainer()))) {
-                    if (match[0] == atom.getIndex())
-                        return true;
-                }
+//                for (int[] match : VentoFoggia.findSubstructure(query,
+//                                                                AtomMatcher.forQuery(),
+//                                                                BondMatcher.forQuery())
+//                                              .matchAll(atom.getContainer())
+//                                              .filter(new StereoFilter(query, atom.getContainer()))
+//                                              .filter(new ComponentGrouping(query, atom.getContainer()))) {
+//                    if (match[0] == atom.getIndex())
+//                        return true;
+//                }
                 return false;
 
             default:

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
@@ -468,10 +468,14 @@ public final class Expr {
         if (type == Type.TRUE) {
             set(expr);
         } else if (expr.type != Type.TRUE) {
-            if (type.isLogical() && !expr.type.isLogical())
-                setLogical(Type.AND, expr, new Expr(this));
-            else
+            if (type.isLogical() && !expr.type.isLogical()) {
+                if (type == AND)
+                    right.and(expr);
+                else
+                    setLogical(Type.AND, expr, new Expr(this));
+            } else {
                 setLogical(Type.AND, new Expr(this), expr);
+            }
         }
         return this;
     }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
@@ -691,6 +691,15 @@ public final class Expr {
         return right;
     }
 
+    /**
+     * Access the sub-query, only applicable to recursive types.
+     * @return the sub-query
+     * @see Type#RECURSIVE
+     */
+    public IAtomContainer subquery() {
+        return query;
+    }
+
     /* Property Caches */
     private static LoadingCache<IAtomContainer, int[]> cacheRCounts;
 

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
@@ -29,13 +29,17 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomType;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
 /**
  * @cdk.module  isomorphism
  * @cdk.githash
  */
-public abstract class QueryAtom extends QueryChemObject implements IQueryAtom {
+public class QueryAtom extends QueryChemObject implements IQueryAtom {
+
+    private static ILoggingTool logger = LoggingToolFactory.createLoggingTool(QueryAtom.class);
 
     /**
      *  The partial charge of the atom.
@@ -131,6 +135,9 @@ public abstract class QueryAtom extends QueryChemObject implements IQueryAtom {
 
     /** The atomic number for this element giving their position in the periodic table. */
     protected Integer                 atomicNumber         = (Integer) CDKConstants.UNSET;
+
+    /** Atom Expression */
+    private Expr expr = new Expr(Expr.Type.TRUE);
 
     public QueryAtom(String symbol, IChemObjectBuilder builder) {
         this(builder);
@@ -729,6 +736,30 @@ public abstract class QueryAtom extends QueryChemObject implements IQueryAtom {
     @Override
     public void setIsInRing(boolean ring) {
         setFlag(CDKConstants.ISINRING, ring);
+    }
+
+    /**
+     * Set the atom-expression predicate for this query atom.
+     * @param expr the expression
+     */
+    public void setExpression(Expr expr) {
+        this.expr = expr;
+    }
+
+    /**
+     * Get the atom-expression predicate for this query atom.
+     * @return the expression
+     */
+    public Expr getExpression() {
+        return expr;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(IAtom atom) {
+        return expr.matches(atom);
     }
 
     @Override

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
@@ -22,6 +22,7 @@ package org.openscience.cdk.isomorphism.matchers;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
+import org.openscience.cdk.AtomRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -734,5 +735,23 @@ public abstract class QueryAtom extends QueryChemObject implements IQueryAtom {
     public IAtom clone() throws CloneNotSupportedException {
         // XXX: clone always dodgy
         return (IAtom) super.clone();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof AtomRef)
+            return super.equals(((AtomRef) obj).deref());
+        return super.equals(obj);
     }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
+import org.openscience.cdk.BondRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -527,4 +528,21 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
         notifyChanged();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BondRef)
+            return super.equals(((BondRef) obj).deref());
+        return super.equals(obj);
+    }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -38,7 +38,7 @@ import org.openscience.cdk.interfaces.IChemObjectBuilder;
  * @cdk.githash
  * @cdk.created 2010-12-16
  */
-public abstract class QueryBond extends QueryChemObject implements IQueryBond {
+public class QueryBond extends QueryChemObject implements IQueryBond {
 
     /**
      * The bond order of this query bond.
@@ -59,6 +59,11 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
      * A descriptor the stereochemical orientation of this query bond.
      */
     protected IQueryBond.Stereo stereo;
+
+    /**
+     * The bond expression.
+     */
+    private Expr expr = new Expr(Expr.Type.TRUE);
 
     /**
      * Constructs an empty query bond.
@@ -544,5 +549,29 @@ public abstract class QueryBond extends QueryChemObject implements IQueryBond {
         if (obj instanceof BondRef)
             return super.equals(((BondRef) obj).deref());
         return super.equals(obj);
+    }
+
+    /**
+     * Access the bond expression predicate associated with this query bond.
+     * @return the bond expression
+     */
+    public Expr getExpression() {
+        return expr;
+    }
+
+    /**
+     * Set the bond expression for this query bond.
+     * @param expr the new bond expression
+     */
+    public void setExpression(Expr expr) {
+        this.expr = expr;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(IBond bond) {
+        return expr.matches(bond);
     }
 }

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ExprTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ExprTest.java
@@ -1090,42 +1090,42 @@ public class ExprTest {
         assertFalse(expr.matches(atom));
     }
 
-    @Ignore("to be added back in later")
-    public void testRecursiveT() {
-        IAtomContainer subexpr = new QueryAtomContainer(null);
-        QueryAtom      qatom   = new QueryAtom(null);
-        qatom.setExpression(new Expr(TRUE));
-        subexpr.addAtom(qatom);
-        Expr           expr = new Expr(RECURSIVE, subexpr);
-        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
-        assertTrue(expr.matches(mol.getAtom(0)));
-    }
-
-    @Ignore("to be added back in later")
-    public void testRecursiveF() {
-        IAtomContainer subexpr = new QueryAtomContainer(null);
-        QueryAtom      qatom   = new QueryAtom(null);
-        qatom.setExpression(new Expr(FALSE));
-        subexpr.addAtom(qatom);
-        Expr           expr = new Expr(RECURSIVE, subexpr);
-        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
-        assertFalse(expr.matches(mol.getAtom(0)));
-    }
-
-    @Ignore("to be added back in later")
-    public void testRecursiveF2() {
-        IAtomContainer subexpr = new QueryAtomContainer(null);
-        QueryAtom      qatom   = new QueryAtom(null);
-        qatom.setExpression(new Expr(ELEMENT, 8));
-        subexpr.addAtom(qatom);
-        Expr           expr = new Expr(RECURSIVE, subexpr);
-        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
-        IAtom          atom = mol.getBuilder().newAtom();
-        atom.setAtomicNumber(8);
-        mol.addAtom(atom);
-        assertFalse(expr.matches(mol.getAtom(0)));
-        assertTrue(expr.matches(mol.getAtom(mol.getAtomCount() - 1)));
-    }
+//    @Ignore("to be added back in later")
+//    public void testRecursiveT() {
+//        IAtomContainer subexpr = new QueryAtomContainer(null);
+//        QueryAtom      qatom   = new QueryAtom(null);
+//        qatom.setExpression(new Expr(TRUE));
+//        subexpr.addAtom(qatom);
+//        Expr           expr = new Expr(RECURSIVE, subexpr);
+//        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+//        assertTrue(expr.matches(mol.getAtom(0)));
+//    }
+//
+//    @Ignore("to be added back in later")
+//    public void testRecursiveF() {
+//        IAtomContainer subexpr = new QueryAtomContainer(null);
+//        QueryAtom      qatom   = new QueryAtom(null);
+//        qatom.setExpression(new Expr(FALSE));
+//        subexpr.addAtom(qatom);
+//        Expr           expr = new Expr(RECURSIVE, subexpr);
+//        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+//        assertFalse(expr.matches(mol.getAtom(0)));
+//    }
+//
+//    @Ignore("to be added back in later")
+//    public void testRecursiveF2() {
+//        IAtomContainer subexpr = new QueryAtomContainer(null);
+//        QueryAtom      qatom   = new QueryAtom(null);
+//        qatom.setExpression(new Expr(ELEMENT, 8));
+//        subexpr.addAtom(qatom);
+//        Expr           expr = new Expr(RECURSIVE, subexpr);
+//        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+//        IAtom          atom = mol.getBuilder().newAtom();
+//        atom.setAtomicNumber(8);
+//        mol.addAtom(atom);
+//        assertFalse(expr.matches(mol.getAtom(0)));
+//        assertTrue(expr.matches(mol.getAtom(mol.getAtomCount() - 1)));
+//    }
 
     /* Bond Exprs */
 

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ExprTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ExprTest.java
@@ -23,6 +23,7 @@
 
 package org.openscience.cdk.isomorphism;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKConstants;
@@ -1089,7 +1090,7 @@ public class ExprTest {
         assertFalse(expr.matches(atom));
     }
 
-    @Test
+    @Ignore("to be added back in later")
     public void testRecursiveT() {
         IAtomContainer subexpr = new QueryAtomContainer(null);
         QueryAtom      qatom   = new QueryAtom(null);
@@ -1100,7 +1101,7 @@ public class ExprTest {
         assertTrue(expr.matches(mol.getAtom(0)));
     }
 
-    @Test
+    @Ignore("to be added back in later")
     public void testRecursiveF() {
         IAtomContainer subexpr = new QueryAtomContainer(null);
         QueryAtom      qatom   = new QueryAtom(null);
@@ -1111,7 +1112,7 @@ public class ExprTest {
         assertFalse(expr.matches(mol.getAtom(0)));
     }
 
-    @Test
+    @Ignore("to be added back in later")
     public void testRecursiveF2() {
         IAtomContainer subexpr = new QueryAtomContainer(null);
         QueryAtom      qatom   = new QueryAtom(null);

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ExprTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ExprTest.java
@@ -1,0 +1,1476 @@
+/*
+ * Copyright (c) 2017 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.junit.Test;
+import org.openscience.cdk.Atom;
+import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.ReactionRole;
+import org.openscience.cdk.config.Elements;
+import org.openscience.cdk.graph.Cycles;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IAtomType;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.isomorphism.matchers.Expr;
+import org.openscience.cdk.isomorphism.matchers.QueryAtom;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
+import org.openscience.cdk.templates.TestMoleculeFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ALIPHATIC_ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ALIPHATIC_ORDER;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.AND;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.AROMATIC_ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.DEGREE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.DOUBLE_OR_AROMATIC;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.FALSE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.FORMAL_CHARGE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HAS_IMPLICIT_HYDROGEN;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HAS_ISOTOPE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HAS_UNSPEC_ISOTOPE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HEAVY_DEGREE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HETERO_SUBSTITUENT_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HYBRIDISATION_NUMBER;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IMPL_H_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.INSATURATION;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ISOTOPE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_ALIPHATIC;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_AROMATIC;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_HETERO;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_IN_CHAIN;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_IN_RING;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.NOT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.OR;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.PERIODIC_GROUP;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.REACTION_ROLE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.RECURSIVE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.RING_BOND_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.RING_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.RING_SIZE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.RING_SMALLEST;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.SINGLE_OR_AROMATIC;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.SINGLE_OR_DOUBLE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.STEREOCHEMISTRY;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TOTAL_DEGREE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TOTAL_H_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TRUE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.UNSATURATED;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.VALENCE;
+
+public class ExprTest {
+
+    @Test
+    public void testT() {
+        Expr  expr = new Expr(TRUE);
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testF() {
+        Expr  expr = new Expr(FALSE);
+        IAtom atom = mock(IAtom.class);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testAndTT() {
+        Expr  expr = new Expr(AND, new Expr(TRUE), new Expr(TRUE));
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testAndTF() {
+        Expr  expr = new Expr(AND, new Expr(TRUE), new Expr(FALSE));
+        IAtom atom = mock(IAtom.class);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testAndFT() {
+        Expr  expr = new Expr(AND, new Expr(FALSE), new Expr(TRUE));
+        IAtom atom = mock(IAtom.class);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testOrTT() {
+        Expr  expr = new Expr(OR, new Expr(TRUE), new Expr(TRUE));
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testOrTF() {
+        Expr  expr = new Expr(OR, new Expr(TRUE), new Expr(FALSE));
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testOrFT() {
+        Expr  expr = new Expr(OR, new Expr(FALSE), new Expr(TRUE));
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testOrFF() {
+        Expr  expr = new Expr(OR, new Expr(FALSE), new Expr(FALSE));
+        IAtom atom = mock(IAtom.class);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testNotF() {
+        Expr  expr = new Expr(NOT, new Expr(FALSE), null);
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testNotT() {
+        Expr  expr = new Expr(NOT, new Expr(TRUE), null);
+        IAtom atom = mock(IAtom.class);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testNotStereo() {
+        Expr  expr = new Expr(NOT, new Expr(STEREOCHEMISTRY, 1), null);
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom));
+        assertTrue(expr.matches(atom, 2));
+        assertFalse(expr.matches(atom, 1));
+    }
+
+    @Test
+    public void testNotStereo3() {
+        Expr  expr = new Expr(NOT, new Expr(STEREOCHEMISTRY, 1).or(new Expr(STEREOCHEMISTRY, 0)), null);
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom));
+        assertTrue(expr.matches(atom, 2));
+        assertFalse(expr.matches(atom, 1));
+    }
+
+    @Test
+    public void testNotStereo4() {
+        Expr  expr = new Expr(NOT, new Expr(OR, new Expr(TRUE), new Expr(TRUE)), null);
+        IAtom atom = mock(IAtom.class);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testStereoT() {
+        Expr  expr = new Expr(STEREOCHEMISTRY, 1);
+        IAtom atom = mock(IAtom.class);
+        assertTrue(expr.matches(atom, 1));
+    }
+
+    @Test
+    public void testStereoF() {
+        Expr  expr = new Expr(STEREOCHEMISTRY, 1);
+        IAtom atom = mock(IAtom.class);
+        assertFalse(expr.matches(atom, 2));
+    }
+
+    @Test
+    public void testIsAromatic() {
+        Expr  expr = new Expr(IS_AROMATIC);
+        IAtom atom = new Atom();
+        atom.setIsAromatic(false);
+        assertFalse(expr.matches(atom));
+        atom.setIsAromatic(true);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testIsAliphaticT() {
+        Expr  expr = new Expr(IS_ALIPHATIC);
+        IAtom atom = new Atom();
+        atom.setIsAromatic(false);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testIsAliphaticF() {
+        Expr  expr = new Expr(IS_ALIPHATIC);
+        IAtom atom = new Atom();
+        atom.setIsAromatic(true);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testIsHetero() {
+        Expr  expr = new Expr(IS_HETERO);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getAtomicNumber()).thenReturn(1);
+        assertFalse(expr.matches(atom));
+        when(atom.getAtomicNumber()).thenReturn(6);
+        assertFalse(expr.matches(atom));
+        when(atom.getAtomicNumber()).thenReturn(8);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHasImplicitHydrogenT() {
+        Expr  expr = new Expr(HAS_IMPLICIT_HYDROGEN);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getImplicitHydrogenCount()).thenReturn(1);
+        assertTrue(expr.matches(atom));
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHasImplicitHydrogenF() {
+        Expr  expr = new Expr(HAS_IMPLICIT_HYDROGEN);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getImplicitHydrogenCount()).thenReturn(0);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHasImplicitHydrogenNull() {
+        Expr  expr = new Expr(HAS_IMPLICIT_HYDROGEN);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getImplicitHydrogenCount()).thenReturn(null);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHasIsotope() {
+        Expr  expr = new Expr(HAS_ISOTOPE);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getMassNumber()).thenReturn(null);
+        assertFalse(expr.matches(atom));
+        when(atom.getMassNumber()).thenReturn(12);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHasUnspecIsotope() {
+        Expr  expr = new Expr(HAS_UNSPEC_ISOTOPE);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getMassNumber()).thenReturn(12);
+        assertFalse(expr.matches(atom));
+        when(atom.getMassNumber()).thenReturn(null);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testIsInRing() {
+        Expr  expr = new Expr(IS_IN_RING);
+        IAtom atom = mock(IAtom.class);
+        when(atom.isInRing()).thenReturn(false);
+        assertFalse(expr.matches(atom));
+        when(atom.isInRing()).thenReturn(true);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testIsInChain() {
+        Expr  expr = new Expr(IS_IN_CHAIN);
+        IAtom atom = mock(IAtom.class);
+        when(atom.isInRing()).thenReturn(false);
+        assertTrue(expr.matches(atom));
+        when(atom.isInRing()).thenReturn(true);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testUnsaturatedT() {
+        Expr  expr = new Expr(UNSATURATED);
+        IAtom atom = mock(IAtom.class);
+        IBond bond = mock(IBond.class);
+        when(bond.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        when(atom.bonds()).thenReturn(Collections.singletonList(bond));
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testUnsaturatedF() {
+        Expr  expr = new Expr(UNSATURATED);
+        IAtom atom = mock(IAtom.class);
+        IBond bond = mock(IBond.class);
+        when(bond.getOrder()).thenReturn(IBond.Order.SINGLE);
+        when(atom.bonds()).thenReturn(Collections.singletonList(bond));
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testElementT() {
+        for (int num = 1; num < 54; ++num) {
+            Expr  expr = new Expr(ELEMENT, num);
+            IAtom atom = mock(IAtom.class);
+            when(atom.getAtomicNumber()).thenReturn(num);
+            assertTrue(expr.matches(atom));
+        }
+    }
+
+    @Test
+    public void testElementF() {
+        for (int num = 1; num < 54; ++num) {
+            Expr  expr = new Expr(ELEMENT, num);
+            IAtom atom = mock(IAtom.class);
+            when(atom.getAtomicNumber()).thenReturn(num + 1);
+            assertFalse(expr.matches(atom));
+        }
+    }
+
+    @Test
+    public void testAliphaticElementT() {
+        for (int num = 1; num < 54; ++num) {
+            Expr  expr = new Expr(ALIPHATIC_ELEMENT, num);
+            IAtom atom = mock(IAtom.class);
+            when(atom.getAtomicNumber()).thenReturn(num);
+            when(atom.isAromatic()).thenReturn(false);
+            assertTrue(expr.matches(atom));
+        }
+    }
+
+    @Test
+    public void testAliphaticElementF() {
+        for (int num = 1; num < 54; ++num) {
+            Expr  expr = new Expr(ALIPHATIC_ELEMENT, num);
+            IAtom atom = mock(IAtom.class);
+            when(atom.getAtomicNumber()).thenReturn(num);
+            when(atom.isAromatic()).thenReturn(true);
+            assertFalse(expr.matches(atom));
+        }
+    }
+
+    @Test
+    public void testAliphaticElementFalse2() {
+        for (int num = 1; num < 54; ++num) {
+            Expr  expr = new Expr(ALIPHATIC_ELEMENT, num);
+            IAtom atom = mock(IAtom.class);
+            when(atom.getAtomicNumber()).thenReturn(num + 1);
+            when(atom.isAromatic()).thenReturn(false);
+            assertFalse(expr.matches(atom));
+        }
+    }
+
+    @Test
+    public void testAromaticElementT() {
+        for (int num = 1; num < 54; ++num) {
+            Expr  expr = new Expr(AROMATIC_ELEMENT, num);
+            IAtom atom = mock(IAtom.class);
+            when(atom.getAtomicNumber()).thenReturn(num);
+            when(atom.isAromatic()).thenReturn(true);
+            assertTrue(expr.matches(atom));
+        }
+    }
+
+    @Test
+    public void testAromaticElementF() {
+        for (int num = 1; num < 54; ++num) {
+            Expr  expr = new Expr(AROMATIC_ELEMENT, num);
+            IAtom atom = mock(IAtom.class);
+            when(atom.getAtomicNumber()).thenReturn(num);
+            when(atom.isAromatic()).thenReturn(false);
+            assertFalse(expr.matches(atom));
+        }
+    }
+
+    @Test
+    public void testAromaticElementFalse2() {
+        for (int num = 1; num < 54; ++num) {
+            Expr  expr = new Expr(AROMATIC_ELEMENT, num);
+            IAtom atom = mock(IAtom.class);
+            when(atom.getAtomicNumber()).thenReturn(num + 1);
+            when(atom.isAromatic()).thenReturn(true);
+            assertFalse(expr.matches(atom));
+        }
+    }
+
+    @Test
+    public void testHCountT() {
+        Expr  expr = new Expr(IMPL_H_COUNT, 1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getImplicitHydrogenCount()).thenReturn(1);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHCountF() {
+        Expr  expr = new Expr(IMPL_H_COUNT, 2);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getImplicitHydrogenCount()).thenReturn(1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testTotalHCountT() {
+        Expr  expr = new Expr(TOTAL_H_COUNT, 3);
+        IAtom atom = mock(IAtom.class);
+        IAtom h    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(b.getOther(atom)).thenReturn(h);
+        when(b.getOther(h)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        when(h.getAtomicNumber()).thenReturn(1);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testTotalHCountF() {
+        Expr  expr = new Expr(TOTAL_H_COUNT, 2);
+        IAtom atom = mock(IAtom.class);
+        IAtom h    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(b.getOther(atom)).thenReturn(h);
+        when(b.getOther(h)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        when(h.getAtomicNumber()).thenReturn(1);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testTotalHCountNullImplT() {
+        Expr  expr = new Expr(TOTAL_H_COUNT, 1);
+        IAtom atom = mock(IAtom.class);
+        IAtom h    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(b.getOther(atom)).thenReturn(h);
+        when(b.getOther(h)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(null);
+        when(h.getAtomicNumber()).thenReturn(1);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testTotalHCountImplF() {
+        Expr  expr = new Expr(TOTAL_H_COUNT, 1);
+        IAtom atom = mock(IAtom.class);
+        IAtom h    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(b.getOther(atom)).thenReturn(h);
+        when(b.getOther(h)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        when(h.getAtomicNumber()).thenReturn(1);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testDegreeT() {
+        Expr  expr = new Expr(DEGREE, 1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getBondCount()).thenReturn(1);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testDegreeF() {
+        Expr  expr = new Expr(DEGREE, 2);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getBondCount()).thenReturn(1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testTotalDegreeT() {
+        Expr  expr = new Expr(TOTAL_DEGREE, 1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getBondCount()).thenReturn(1);
+        when(atom.getImplicitHydrogenCount()).thenReturn(0);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testTotalDegreeF() {
+        Expr  expr = new Expr(TOTAL_DEGREE, 1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getBondCount()).thenReturn(1);
+        when(atom.getImplicitHydrogenCount()).thenReturn(1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHeavyDegreeT() {
+        Expr  expr = new Expr(HEAVY_DEGREE, 0);
+        IAtom atom = mock(IAtom.class);
+        IAtom h    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(atom.getBondCount()).thenReturn(1);
+        when(b.getOther(atom)).thenReturn(h);
+        when(b.getOther(h)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        when(h.getAtomicNumber()).thenReturn(1);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHeavyDegreeF() {
+        Expr  expr = new Expr(HEAVY_DEGREE, 1);
+        IAtom atom = mock(IAtom.class);
+        IAtom h    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(atom.getBondCount()).thenReturn(1);
+        when(b.getOther(atom)).thenReturn(h);
+        when(b.getOther(h)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        when(h.getAtomicNumber()).thenReturn(1);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHeteroSubT() {
+        Expr  expr = new Expr(HETERO_SUBSTITUENT_COUNT, 1);
+        IAtom atom = mock(IAtom.class);
+        IAtom o    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(atom.getBondCount()).thenReturn(1);
+        when(b.getOther(atom)).thenReturn(o);
+        when(b.getOther(o)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        when(o.getAtomicNumber()).thenReturn(8);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHeteroSubFailFastF() {
+        Expr  expr = new Expr(HETERO_SUBSTITUENT_COUNT, 2);
+        IAtom atom = mock(IAtom.class);
+        IAtom o    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(atom.getBondCount()).thenReturn(1);
+        when(b.getOther(atom)).thenReturn(o);
+        when(b.getOther(o)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        when(o.getAtomicNumber()).thenReturn(8);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHeteroSubF() {
+        Expr  expr = new Expr(HETERO_SUBSTITUENT_COUNT, 1);
+        IAtom atom = mock(IAtom.class);
+        IAtom c    = mock(IAtom.class);
+        IBond b    = mock(IBond.class);
+        when(atom.getBondCount()).thenReturn(1);
+        when(b.getOther(atom)).thenReturn(c);
+        when(b.getOther(c)).thenReturn(atom);
+        when(atom.getImplicitHydrogenCount()).thenReturn(2);
+        when(c.getAtomicNumber()).thenReturn(6);
+        when(atom.bonds()).thenReturn(Collections.singletonList(b));
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testValenceT() {
+        Expr  expr = new Expr(VALENCE, 4);
+        IAtom a1   = mock(IAtom.class);
+        IBond b1   = mock(IBond.class);
+        IBond b2   = mock(IBond.class);
+        when(a1.getImplicitHydrogenCount()).thenReturn(1);
+        when(b1.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        when(b2.getOrder()).thenReturn(IBond.Order.SINGLE);
+        when(a1.bonds()).thenReturn(Arrays.asList(b1, b2));
+        assertTrue(expr.matches(a1));
+    }
+
+    @Test
+    public void testValenceF() {
+        Expr  expr = new Expr(VALENCE, 4);
+        IAtom a1   = mock(IAtom.class);
+        IBond b1   = mock(IBond.class);
+        IBond b2   = mock(IBond.class);
+        when(a1.getImplicitHydrogenCount()).thenReturn(1);
+        when(b1.getOrder()).thenReturn(IBond.Order.SINGLE);
+        when(b2.getOrder()).thenReturn(IBond.Order.SINGLE);
+        when(a1.bonds()).thenReturn(Arrays.asList(b1, b2));
+        assertFalse(expr.matches(a1));
+    }
+
+    @Test
+    public void testValenceNullOrderT() {
+        Expr  expr = new Expr(VALENCE, 4);
+        IAtom a1   = mock(IAtom.class);
+        IBond b1   = mock(IBond.class);
+        IBond b2   = mock(IBond.class);
+        when(a1.getImplicitHydrogenCount()).thenReturn(1);
+        when(b1.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        when(b2.getOrder()).thenReturn(null);
+        when(a1.bonds()).thenReturn(Arrays.asList(b1, b2));
+        assertFalse(expr.matches(a1));
+    }
+
+    @Test
+    public void testValenceFailFastF() {
+        Expr  expr = new Expr(VALENCE, 2);
+        IAtom a1   = mock(IAtom.class);
+        when(a1.getImplicitHydrogenCount()).thenReturn(4);
+        assertFalse(expr.matches(a1));
+    }
+
+    @Test
+    public void testIsotopeT() {
+        Expr  expr = new Expr(ISOTOPE, 13);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getMassNumber()).thenReturn(13);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testIsotopeF() {
+        Expr  expr = new Expr(ISOTOPE, 12);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getMassNumber()).thenReturn(13);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testFormalChargeT() {
+        Expr  expr = new Expr(FORMAL_CHARGE, -1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getFormalCharge()).thenReturn(-1);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testFormalChargeF() {
+        Expr  expr = new Expr(FORMAL_CHARGE, -1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getFormalCharge()).thenReturn(0);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testRingBondCountT() {
+        Expr  expr = new Expr(RING_BOND_COUNT, 3);
+        IAtom atom = mock(IAtom.class);
+        IBond b1   = mock(IBond.class);
+        IBond b2   = mock(IBond.class);
+        IBond b3   = mock(IBond.class);
+        when(atom.isInRing()).thenReturn(true);
+        when(atom.getBondCount()).thenReturn(3);
+        when(b1.isInRing()).thenReturn(true);
+        when(b2.isInRing()).thenReturn(true);
+        when(b3.isInRing()).thenReturn(true);
+        when(atom.bonds()).thenReturn(Arrays.asList(b1, b2, b3));
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testRingBondCountF() {
+        Expr  expr = new Expr(RING_BOND_COUNT, 3);
+        IAtom atom = mock(IAtom.class);
+        IBond b1   = mock(IBond.class);
+        IBond b2   = mock(IBond.class);
+        IBond b3   = mock(IBond.class);
+        when(atom.isInRing()).thenReturn(true);
+        when(atom.getBondCount()).thenReturn(3);
+        when(b1.isInRing()).thenReturn(true);
+        when(b2.isInRing()).thenReturn(true);
+        when(b3.isInRing()).thenReturn(false);
+        when(atom.bonds()).thenReturn(Arrays.asList(b1, b2, b3));
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testRingBondCountNonRingF() {
+        Expr  expr = new Expr(RING_BOND_COUNT, 3);
+        IAtom atom = mock(IAtom.class);
+        when(atom.isInRing()).thenReturn(false);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testRingBondCountLessBondsF() {
+        Expr  expr = new Expr(RING_BOND_COUNT, 3);
+        IAtom atom = mock(IAtom.class);
+        when(atom.isInRing()).thenReturn(true);
+        when(atom.getBondCount()).thenReturn(2);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testInsaturationT() {
+        Expr  expr = new Expr(INSATURATION, 2);
+        IAtom atom = mock(IAtom.class);
+        IBond b1   = mock(IBond.class);
+        IBond b2   = mock(IBond.class);
+        when(b1.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        when(b2.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        when(atom.bonds()).thenReturn(Arrays.asList(b1, b2));
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testInsaturationF() {
+        Expr  expr = new Expr(INSATURATION, 2);
+        IAtom atom = mock(IAtom.class);
+        IBond b1   = mock(IBond.class);
+        IBond b2   = mock(IBond.class);
+        when(b1.getOrder()).thenReturn(IBond.Order.SINGLE);
+        when(b2.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        when(atom.bonds()).thenReturn(Arrays.asList(b1, b2));
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testGroupT() {
+        Expr expr = new Expr(PERIODIC_GROUP,
+                             Elements.Chlorine.group());
+        IAtom atom = mock(IAtom.class);
+        when(atom.getAtomicNumber()).thenReturn(9);
+        assertTrue(expr.matches(atom));
+        when(atom.getAtomicNumber()).thenReturn(17);
+        assertTrue(expr.matches(atom));
+        when(atom.getAtomicNumber()).thenReturn(35);
+        assertTrue(expr.matches(atom));
+        when(atom.getAtomicNumber()).thenReturn(53);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testGroupF() {
+        Expr expr = new Expr(PERIODIC_GROUP,
+                             Elements.Chlorine.group());
+        IAtom atom = mock(IAtom.class);
+        when(atom.getAtomicNumber()).thenReturn(8);
+        assertFalse(expr.matches(atom));
+        when(atom.getAtomicNumber()).thenReturn(16);
+        assertFalse(expr.matches(atom));
+        when(atom.getAtomicNumber()).thenReturn(34);
+        assertFalse(expr.matches(atom));
+        when(atom.getAtomicNumber()).thenReturn(52);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testGroupNull() {
+        Expr expr = new Expr(PERIODIC_GROUP,
+                             Elements.Chlorine.group());
+        IAtom atom = mock(IAtom.class);
+        when(atom.getAtomicNumber()).thenReturn(null);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisation0F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             0);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp1T() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp1F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP2);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp2T() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             2);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP2);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp2F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             2);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3T() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             3);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP3);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             3);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d1T() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             4);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP3D1);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d1F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             4);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d2T() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             5);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP3D2);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d2F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             5);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d3T() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             6);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP3D3);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d3F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             6);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d4T() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             7);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP3D4);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d4F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             7);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d5T() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             8);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP3D5);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp1Null() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             1);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(null);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testHybridisationSp3d5F() {
+        Expr expr = new Expr(HYBRIDISATION_NUMBER,
+                             8);
+        IAtom atom = mock(IAtom.class);
+        when(atom.getHybridization()).thenReturn(IAtomType.Hybridization.SP1);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testReactionRoleT() {
+        Expr expr = new Expr(REACTION_ROLE,
+                             ReactionRole.Reactant.ordinal());
+        IAtom atom = mock(IAtom.class);
+        when(atom.getProperty(CDKConstants.REACTION_ROLE)).thenReturn(ReactionRole.Reactant);
+        assertTrue(expr.matches(atom));
+    }
+
+    @Test
+    public void testReactionRoleF() {
+        Expr expr = new Expr(REACTION_ROLE,
+                             ReactionRole.Reactant.ordinal());
+        IAtom atom = mock(IAtom.class);
+        when(atom.getProperty(CDKConstants.REACTION_ROLE)).thenReturn(ReactionRole.Product);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testReactionRoleNull() {
+        Expr expr = new Expr(REACTION_ROLE,
+                             ReactionRole.Reactant.ordinal());
+        IAtom atom = mock(IAtom.class);
+        when(atom.getProperty(CDKConstants.REACTION_ROLE)).thenReturn(null);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testRingSize6() {
+        Expr           expr = new Expr(RING_SIZE, 6);
+        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+        Cycles.markRingAtomsAndBonds(mol);
+        assertTrue(expr.matches(mol.getAtom(0)));
+    }
+
+    @Test
+    public void testRingSize10() {
+        Expr           expr = new Expr(RING_SIZE, 10);
+        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+        Cycles.markRingAtomsAndBonds(mol);
+        assertTrue(expr.matches(mol.getAtom(0)));
+    }
+
+    @Test
+    public void testRingSmallestNonRing() {
+        Expr  expr = new Expr(RING_SMALLEST, 6);
+        IAtom atom = mock(IAtom.class);
+        when(atom.isInRing()).thenReturn(false);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testRingNonRing() {
+        Expr  expr = new Expr(RING_SIZE, 6);
+        IAtom atom = mock(IAtom.class);
+        when(atom.isInRing()).thenReturn(false);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testRingCountNonRing() {
+        Expr  expr = new Expr(RING_COUNT, 6);
+        IAtom atom = mock(IAtom.class);
+        when(atom.isInRing()).thenReturn(false);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testRingSmallestSize6() {
+        Expr           expr = new Expr(RING_SMALLEST, 6);
+        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+        Cycles.markRingAtomsAndBonds(mol);
+        assertTrue(expr.matches(mol.getAtom(0)));
+    }
+
+    @Test
+    public void testRingSmallestSize10() {
+        Expr           expr = new Expr(RING_SMALLEST, 10);
+        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+        Cycles.markRingAtomsAndBonds(mol);
+        assertFalse(expr.matches(mol.getAtom(0)));
+    }
+
+    @Test
+    public void testRingSmallestSize5And6() {
+        Expr           expr5 = new Expr(RING_SMALLEST, 5);
+        Expr           expr6 = new Expr(RING_SMALLEST, 6);
+        IAtomContainer mol   = TestMoleculeFactory.makeIndole();
+        Cycles.markRingAtomsAndBonds(mol);
+        int numSmall5 = 0;
+        int numSmall6 = 0;
+        for (IAtom atom : mol.atoms()) {
+            if (expr5.matches(atom))
+                numSmall5++;
+            if (expr6.matches(atom))
+                numSmall6++;
+        }
+        assertThat(numSmall5, is(5));
+        assertThat(numSmall6, is(4));
+    }
+
+    @Test
+    public void testRingSize5And6() {
+        Expr           expr5 = new Expr(RING_SIZE, 5);
+        Expr           expr6 = new Expr(RING_SIZE, 6);
+        IAtomContainer mol   = TestMoleculeFactory.makeIndole();
+        Cycles.markRingAtomsAndBonds(mol);
+        int numSmall5 = 0;
+        int numSmall6 = 0;
+        for (IAtom atom : mol.atoms()) {
+            if (expr5.matches(atom))
+                numSmall5++;
+            if (expr6.matches(atom))
+                numSmall6++;
+        }
+        assertThat(numSmall5, is(5));
+        assertThat(numSmall6, is(6));
+    }
+
+    @Test
+    public void testRingCount2() {
+        Expr           expr = new Expr(RING_COUNT, 2);
+        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+        Cycles.markRingAtomsAndBonds(mol);
+        int count = 0;
+        for (IAtom atom : mol.atoms()) {
+            if (expr.matches(atom))
+                count++;
+        }
+        assertThat(count, is(2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nonAtomExpr() {
+        Expr  expr = new Expr(ALIPHATIC_ORDER, 2);
+        IAtom atom = mock(IAtom.class);
+        assertFalse(expr.matches(atom));
+    }
+
+    @Test
+    public void testRecursiveT() {
+        IAtomContainer subexpr = new QueryAtomContainer(null);
+        QueryAtom      qatom   = new QueryAtom(null);
+        qatom.setExpression(new Expr(TRUE));
+        subexpr.addAtom(qatom);
+        Expr           expr = new Expr(RECURSIVE, subexpr);
+        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+        assertTrue(expr.matches(mol.getAtom(0)));
+    }
+
+    @Test
+    public void testRecursiveF() {
+        IAtomContainer subexpr = new QueryAtomContainer(null);
+        QueryAtom      qatom   = new QueryAtom(null);
+        qatom.setExpression(new Expr(FALSE));
+        subexpr.addAtom(qatom);
+        Expr           expr = new Expr(RECURSIVE, subexpr);
+        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+        assertFalse(expr.matches(mol.getAtom(0)));
+    }
+
+    @Test
+    public void testRecursiveF2() {
+        IAtomContainer subexpr = new QueryAtomContainer(null);
+        QueryAtom      qatom   = new QueryAtom(null);
+        qatom.setExpression(new Expr(ELEMENT, 8));
+        subexpr.addAtom(qatom);
+        Expr           expr = new Expr(RECURSIVE, subexpr);
+        IAtomContainer mol  = TestMoleculeFactory.makeNaphthalene();
+        IAtom          atom = mol.getBuilder().newAtom();
+        atom.setAtomicNumber(8);
+        mol.addAtom(atom);
+        assertFalse(expr.matches(mol.getAtom(0)));
+        assertTrue(expr.matches(mol.getAtom(mol.getAtomCount() - 1)));
+    }
+
+    /* Bond Exprs */
+
+    @Test
+    public void testBondT() {
+        Expr  expr = new Expr(TRUE);
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondF() {
+        Expr  expr = new Expr(FALSE);
+        IBond bond = mock(IBond.class);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondAndTT() {
+        Expr  expr = new Expr(AND, new Expr(TRUE), new Expr(TRUE));
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondAndTF() {
+        Expr  expr = new Expr(AND, new Expr(TRUE), new Expr(FALSE));
+        IBond bond = mock(IBond.class);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondAndFT() {
+        Expr  expr = new Expr(AND, new Expr(FALSE), new Expr(TRUE));
+        IBond bond = mock(IBond.class);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondOrTT() {
+        Expr  expr = new Expr(OR, new Expr(TRUE), new Expr(TRUE));
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondOrTF() {
+        Expr  expr = new Expr(OR, new Expr(TRUE), new Expr(FALSE));
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondOrFT() {
+        Expr  expr = new Expr(OR, new Expr(FALSE), new Expr(TRUE));
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondOrFF() {
+        Expr  expr = new Expr(OR, new Expr(FALSE), new Expr(FALSE));
+        IBond bond = mock(IBond.class);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondNotF() {
+        Expr  expr = new Expr(NOT, new Expr(FALSE), null);
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondNotT() {
+        Expr  expr = new Expr(NOT, new Expr(TRUE), null);
+        IBond bond = mock(IBond.class);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondNotStereo() {
+        Expr  expr = new Expr(NOT, new Expr(STEREOCHEMISTRY, 1), null);
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond));
+        assertTrue(expr.matches(bond, 2));
+        assertFalse(expr.matches(bond, 1));
+    }
+
+    @Test
+    public void testBondNotStereo3() {
+        Expr  expr = new Expr(NOT, new Expr(STEREOCHEMISTRY, 1).or(new Expr(STEREOCHEMISTRY, 0)), null);
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond));
+        assertTrue(expr.matches(bond, 2));
+        assertFalse(expr.matches(bond, 1));
+    }
+
+    @Test
+    public void testBondNotStereo4() {
+        Expr  expr = new Expr(NOT, new Expr(OR, new Expr(TRUE), new Expr(TRUE)), null);
+        IBond bond = mock(IBond.class);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondStereoT() {
+        Expr  expr = new Expr(STEREOCHEMISTRY, 1);
+        IBond bond = mock(IBond.class);
+        assertTrue(expr.matches(bond, 1));
+    }
+
+    @Test
+    public void testBondStereoF() {
+        Expr  expr = new Expr(STEREOCHEMISTRY, 1);
+        IBond bond = mock(IBond.class);
+        assertFalse(expr.matches(bond, 2));
+    }
+
+    @Test
+    public void testBondIsAromaticT() {
+        Expr  expr = new Expr(IS_AROMATIC);
+        IBond bond = mock(IBond.class);
+        when(bond.isAromatic()).thenReturn(true);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondIsAromaticF() {
+        Expr  expr = new Expr(IS_AROMATIC);
+        IBond bond = mock(IBond.class);
+        when(bond.isAromatic()).thenReturn(false);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondIsAliphaticT() {
+        Expr  expr = new Expr(IS_ALIPHATIC);
+        IBond bond = mock(IBond.class);
+        when(bond.isAromatic()).thenReturn(false);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondIsAliphaticF() {
+        Expr  expr = new Expr(IS_ALIPHATIC);
+        IBond bond = mock(IBond.class);
+        when(bond.isAromatic()).thenReturn(true);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondIsChainT() {
+        Expr  expr = new Expr(IS_IN_CHAIN);
+        IBond bond = mock(IBond.class);
+        when(bond.isInRing()).thenReturn(false);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondIsChainF() {
+        Expr  expr = new Expr(IS_IN_CHAIN);
+        IBond bond = mock(IBond.class);
+        when(bond.isInRing()).thenReturn(true);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondIsRingT() {
+        Expr  expr = new Expr(IS_IN_RING);
+        IBond bond = mock(IBond.class);
+        when(bond.isInRing()).thenReturn(true);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondIsRingF() {
+        Expr  expr = new Expr(IS_IN_RING);
+        IBond bond = mock(IBond.class);
+        when(bond.isInRing()).thenReturn(false);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondOrderT() {
+        Expr  expr = new Expr(ALIPHATIC_ORDER, 2);
+        IBond bond = mock(IBond.class);
+        when(bond.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondOrderF() {
+        Expr  expr = new Expr(ALIPHATIC_ORDER, 2);
+        IBond bond = mock(IBond.class);
+        when(bond.getOrder()).thenReturn(IBond.Order.SINGLE);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondOrderAlipF() {
+        Expr  expr = new Expr(ALIPHATIC_ORDER, 2);
+        IBond bond = mock(IBond.class);
+        when(bond.isAromatic()).thenReturn(true);
+        when(bond.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testBondOrderNullF() {
+        Expr  expr = new Expr(ALIPHATIC_ORDER, 2);
+        IBond bond = mock(IBond.class);
+        when(bond.getOrder()).thenReturn(null);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testSingleOrAromaticT() {
+        Expr  expr = new Expr(SINGLE_OR_AROMATIC);
+        IBond bond = mock(IBond.class);
+        when(bond.isAromatic()).thenReturn(false);
+        when(bond.getOrder()).thenReturn(IBond.Order.SINGLE);
+        assertTrue(expr.matches(bond));
+        when(bond.isAromatic()).thenReturn(true);
+        when(bond.getOrder()).thenReturn(null);
+        assertTrue(expr.matches(bond));
+    }
+
+    @Test
+    public void testSingleOrAromaticF() {
+        Expr  expr = new Expr(SINGLE_OR_AROMATIC);
+        IBond bond = mock(IBond.class);
+        when(bond.isAromatic()).thenReturn(false);
+        when(bond.getOrder()).thenReturn(IBond.Order.TRIPLE);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testDoubleOrAromaticT() {
+        Expr  expr = new Expr(DOUBLE_OR_AROMATIC);
+        IBond bond = mock(IBond.class);
+        when(bond.isAromatic()).thenReturn(true);
+        when(bond.getOrder()).thenReturn(null);
+        assertTrue(expr.matches(bond));
+        when(bond.isAromatic()).thenReturn(false);
+        when(bond.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        assertTrue(expr.matches(bond));
+        when(bond.isAromatic()).thenReturn(false);
+        when(bond.getOrder()).thenReturn(IBond.Order.TRIPLE);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test
+    public void testSingleOrDoubleT() {
+        Expr  expr = new Expr(SINGLE_OR_DOUBLE);
+        IBond bond = mock(IBond.class);
+        when(bond.getOrder()).thenReturn(IBond.Order.SINGLE);
+        assertTrue(expr.matches(bond));
+        when(bond.getOrder()).thenReturn(IBond.Order.DOUBLE);
+        assertTrue(expr.matches(bond));
+        when(bond.getOrder()).thenReturn(IBond.Order.TRIPLE);
+        assertFalse(expr.matches(bond));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNonBondExpr() {
+        Expr  expr = new Expr(RING_COUNT, 1);
+        IBond bond = mock(IBond.class);
+        expr.matches(bond);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(new Expr(TRUE).toString(), is("TRUE"));
+        assertThat(new Expr(ELEMENT, 8).toString(), is("ELEMENT=8"));
+        assertThat(new Expr(ELEMENT, 8).or(new Expr(DEGREE, 3)).toString(), is("OR(ELEMENT=8,DEGREE=3)"));
+        assertThat(new Expr(ELEMENT, 8).and(new Expr(DEGREE, 3)).toString(), is("AND(ELEMENT=8,DEGREE=3)"));
+        assertThat(new Expr(ELEMENT, 8).negate().toString(), is("NOT(ELEMENT=8)"));
+        assertThat(new Expr(RECURSIVE, null).toString(), is("RECURSIVE(...)"));
+    }
+
+    @Test public void testNegationOptimizations() {
+        assertThat(new Expr(TRUE).negate(), is(new Expr(FALSE)));
+        assertThat(new Expr(FALSE).negate(), is(new Expr(TRUE)));
+        assertThat(new Expr(IS_IN_RING).negate(), is(new Expr(IS_IN_CHAIN)));
+        assertThat(new Expr(IS_IN_CHAIN).negate(), is(new Expr(IS_IN_RING)));
+        assertThat(new Expr(IS_ALIPHATIC).negate(), is(new Expr(IS_AROMATIC)));
+        assertThat(new Expr(IS_AROMATIC).negate(), is(new Expr(IS_ALIPHATIC)));
+        assertThat(new Expr(ELEMENT, 8).negate(),
+                   is(new Expr(NOT, new Expr(ELEMENT, 8), null)));
+        assertThat(new Expr(NOT, new Expr(ELEMENT, 8), null).negate(),
+                   is(new Expr(ELEMENT, 8)));
+        assertThat(new Expr(HAS_UNSPEC_ISOTOPE).negate(),
+                   is(new Expr(HAS_ISOTOPE)));
+        assertThat(new Expr(HAS_ISOTOPE).negate(),
+                   is(new Expr(HAS_UNSPEC_ISOTOPE)));
+    }
+
+    @Test public void testLeftBalancedOr1() {
+        Expr expr1 = new Expr(ELEMENT, 9);
+        Expr expr2 = new Expr(ELEMENT, 17).or(new Expr(ELEMENT, 35));
+        expr1.or(expr2);
+        assertThat(expr1.left().type(), is(ELEMENT));
+    }
+
+    @Test public void testLeftBalancedOr2() {
+        Expr expr1 = new Expr(ELEMENT, 9);
+        Expr expr2 = new Expr(ELEMENT, 17).or(new Expr(ELEMENT, 35));
+        expr2.or(expr1);
+        assertThat(expr2.left().type(), is(ELEMENT));
+    }
+
+    @Test public void testLeftBalancedAnd1() {
+        Expr expr1 = new Expr(ELEMENT, 9);
+        Expr expr2 = new Expr(DEGREE, 2).and(new Expr(HAS_IMPLICIT_HYDROGEN));
+        expr1.and(expr2);
+        assertThat(expr1.left().type(), is(ELEMENT));
+    }
+
+    @Test public void testLeftBalancedAnd2() {
+        Expr expr1 = new Expr(ELEMENT, 9);
+        Expr expr2 = new Expr(DEGREE, 2).and(new Expr(HAS_IMPLICIT_HYDROGEN));
+        expr2.and(expr1);
+        assertThat(expr2.left().type(), is(ELEMENT));
+    }
+
+    @Test public void alwaysTrueAnd() {
+        assertThat(new Expr(TRUE).and(new Expr(TRUE)),
+                   is(new Expr(TRUE)));
+    }
+
+    @Test public void alwaysFalseAnd() {
+        assertThat(new Expr(FALSE).and(new Expr(TRUE)),
+                   is(new Expr(FALSE)));
+    }
+
+    @Test public void removeFalseOr() {
+        assertThat(new Expr(DEGREE, 2).or(new Expr(FALSE)),
+                   is(new Expr(DEGREE, 2)));
+        assertThat(new Expr(DEGREE, 2).or(new Expr(TRUE)),
+                   is(new Expr(DEGREE, 2)));
+        assertThat(new Expr(FALSE).or(new Expr(DEGREE, 2)),
+                   is(new Expr(DEGREE, 2)));
+        assertThat(new Expr(TRUE).or(new Expr(DEGREE, 2)),
+                   is(new Expr(DEGREE, 2)));
+    }
+
+
+}

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ExprTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ExprTest.java
@@ -23,7 +23,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKConstants;
@@ -35,8 +34,6 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomType;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.isomorphism.matchers.Expr;
-import org.openscience.cdk.isomorphism.matchers.QueryAtom;
-import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.Arrays;
@@ -1449,7 +1446,10 @@ public class ExprTest {
         Expr expr1 = new Expr(ELEMENT, 9);
         Expr expr2 = new Expr(DEGREE, 2).and(new Expr(HAS_IMPLICIT_HYDROGEN));
         expr2.and(expr1);
-        assertThat(expr2.left().type(), is(ELEMENT));
+        assertThat(expr2.left().type(), is(DEGREE));
+        assertThat(expr2.right().type(), is(AND));
+        assertThat(expr2.right().left().type(), is(HAS_IMPLICIT_HYDROGEN));
+        assertThat(expr2.right().right().type(), is(ELEMENT));
     }
 
     @Test public void alwaysTrueAnd() {

--- a/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
@@ -113,7 +113,7 @@ public class SilentChemObjectBuilder implements IChemObjectBuilder {
     }
 
     private static final boolean CDK_LEGACY_AC
-        = getSystemProp("CdkUseLegacyAtomContainer", true);
+        = getSystemProp("CdkUseLegacyAtomContainer", false);
 
     private static volatile IChemObjectBuilder instance = null;
     private static final Object                LOCK     = new Object();

--- a/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/AbstractFixedLengthFingerprinterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/fingerprint/AbstractFixedLengthFingerprinterTest.java
@@ -36,6 +36,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.io.MDLV2000Reader;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
@@ -84,15 +85,16 @@ public abstract class AbstractFixedLengthFingerprinterTest extends AbstractFinge
      */
     @Test
     public void testBug853254() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
         String filename = "data/mdl/bug853254-2.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer superstructure = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer superstructure = reader.read(builder.newAtomContainer());
 
         filename = "data/mdl/bug853254-1.mol";
         ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer substructure = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer substructure = reader.read(builder.newAtomContainer());
 
         // these molecules are different resonance forms of the same molecule
         // make sure aromaticity is detected. although some fingerprinters do this
@@ -140,15 +142,16 @@ public abstract class AbstractFixedLengthFingerprinterTest extends AbstractFinge
      */
     @Test
     public void testBug771485() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
         String filename = "data/mdl/bug771485-1.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer structure1 = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer structure1 = (IAtomContainer) reader.read(builder.newAtomContainer());
 
         filename = "data/mdl/bug771485-2.mol";
         ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer structure2 = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer structure2 = (IAtomContainer) reader.read(builder.newAtomContainer());
 
         // these molecules are different resonance forms of the same molecule
         // make sure aromaticity is detected. although some fingerprinters do this
@@ -184,15 +187,16 @@ public abstract class AbstractFixedLengthFingerprinterTest extends AbstractFinge
      */
     @Test
     public void testBug931608() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
         String filename = "data/mdl/bug931608-1.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer structure1 = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer structure1 = reader.read(builder.newAtomContainer());
 
         filename = "data/mdl/bug931608-2.mol";
         ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer structure2 = (IAtomContainer) reader.read(new AtomContainer());
+        IAtomContainer structure2 = reader.read(builder.newAtomContainer());
 
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(structure1);
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(structure2);

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/MorganNumbersToolsTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/MorganNumbersToolsTest.java
@@ -51,7 +51,7 @@ public class MorganNumbersToolsTest extends CDKTestCase {
         long[] reference = {28776, 17899, 23549, 34598, 31846, 36393, 9847, 45904, 15669, 15669};
 
         IAtomContainer mol = TestMoleculeFactory.makeAlphaPinene();
-        long[] morganNumbers = MorganNumbersTools.getMorganNumbers((AtomContainer) mol);
+        long[] morganNumbers = MorganNumbersTools.getMorganNumbers(mol);
         Assert.assertEquals(reference.length, morganNumbers.length);
         for (int f = 0; f < morganNumbers.length; f++) {
             //logger.debug(morganNumbers[f]);
@@ -65,7 +65,7 @@ public class MorganNumbersToolsTest extends CDKTestCase {
         String[] reference = {"C-457", "C-428", "C-325", "C-354", "C-325", "C-428", "N-251"};
 
         IAtomContainer mol = TestMoleculeFactory.makePhenylAmine();
-        String[] morganNumbers = MorganNumbersTools.getMorganNumbersWithElementSymbol((AtomContainer) mol);
+        String[] morganNumbers = MorganNumbersTools.getMorganNumbersWithElementSymbol(mol);
         Assert.assertEquals(reference.length, morganNumbers.length);
         for (int f = 0; f < morganNumbers.length; f++) {
             //logger.debug(morganNumbers[f]);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptorTest.java
@@ -99,7 +99,7 @@ public class AcidicGroupCountDescriptorTest extends MolecularDescriptorTest {
      */
     @Test
     public void testTwoGroup() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "O");
         a1.setFormalCharge(0);
         a1.setPoint2d(new Point2d(5.9019, 0.5282));
@@ -173,7 +173,7 @@ public class AcidicGroupCountDescriptorTest extends MolecularDescriptorTest {
      */
     @Test
     public void testCID() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "S");
         a1.setFormalCharge(0);
         a1.setPoint2d(new Point2d(9.4651, 0.25));

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/MolecularDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/MolecularDescriptorTest.java
@@ -338,7 +338,8 @@ public abstract class MolecularDescriptorTest extends DescriptorTest<IMolecularD
     public void testAtomContainerHandling() throws Exception {
         IAtomContainer water1 = someoneBringMeSomeWater(DefaultChemObjectBuilder.getInstance());
         // creates an AtomContainer with the atoms / bonds from water1
-        IAtomContainer water2 = new AtomContainer(water1);
+        IAtomContainer water2 = SilentChemObjectBuilder.getInstance().newAtomContainer();
+        water2.add(water1);
 
         IDescriptorResult v1 = descriptor.calculate(water1).getValue();
         IDescriptorResult v2 = descriptor.calculate(water2).getValue();
@@ -355,7 +356,8 @@ public abstract class MolecularDescriptorTest extends DescriptorTest<IMolecularD
      */
     @Test
     public void testDisconnectedStructureHandling() throws Exception {
-        IAtomContainer disconnected = new AtomContainer();
+        IAtomContainer disconnected = SilentChemObjectBuilder.getInstance()
+                                                             .newAtomContainer();
         IAtom chloride = new Atom("Cl");
         chloride.setFormalCharge(-1);
         disconnected.addAtom(chloride);

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/Smarts.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/Smarts.java
@@ -1,0 +1,2841 @@
+/*
+ * Copyright (c) 2018 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.openscience.cdk.AtomRef;
+import org.openscience.cdk.BondRef;
+import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.ReactionRole;
+import org.openscience.cdk.config.Elements;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObject;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.isomorphism.matchers.Expr;
+import org.openscience.cdk.isomorphism.matchers.QueryAtom;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
+import org.openscience.cdk.isomorphism.matchers.QueryBond;
+import org.openscience.cdk.stereo.DoubleBondStereochemistry;
+import org.openscience.cdk.stereo.TetrahedralChirality;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
+import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ALIPHATIC_ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ALIPHATIC_HETERO_SUBSTITUENT_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ALIPHATIC_ORDER;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.AND;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.AROMATIC_ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.DEGREE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.FORMAL_CHARGE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HAS_ALIPHATIC_HETERO_SUBSTITUENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HAS_HETERO_SUBSTITUENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HEAVY_DEGREE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HETERO_SUBSTITUENT_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.INSATURATION;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_ALIPHATIC;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_AROMATIC;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_IN_CHAIN;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_IN_RING;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.NONE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.PERIODIC_GROUP;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.REACTION_ROLE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.RING_SIZE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.SINGLE_OR_AROMATIC;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.STEREOCHEMISTRY;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TOTAL_DEGREE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TOTAL_H_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TRUE;
+
+public final class Smarts {
+
+    public static final int FLAVOR_LOOSE      = 0x01;
+    public static final int FLAVOR_DAYLIGHT   = 0x02;
+    public static final int FLAVOR_CACTVS     = 0x04;
+    public static final int FLAVOR_MOE        = 0x08;
+    public static final int FLAVOR_OECHEM     = 0x10;
+    public static final int FLAVOR_CDK_LEGACY = 0x20;
+
+    // input flags
+    private static final int BOND_UNSPEC = '?';
+    private static final int BOND_UP     = '/';
+    private static final int BOND_DOWN   = '\\';
+
+    // flags used for generating bond stereo
+    public static final int BSTEREO_ANY             = 0b111;
+    public static final int BSTEREO_INVALID         = 0b000;
+    public static final int BSTEREO_CIS             = 0b100;
+    public static final int BSTEREO_TRANS           = 0b010;
+    public static final int BSTEREO_UNSPEC          = 0b001;
+    public static final int BSTEREO_CIS_OR_TRANS    = 0b110;
+    public static final int BSTEREO_CIS_OR_UNSPEC   = 0b101;
+    public static final int BSTEREO_TRANS_OR_UNSPEC = 0b011;
+
+    // symbols used for encoding bond stereo
+    public static final String BSTEREO_UP      = "/";
+    public static final String BSTEREO_DN      = "\\";
+    public static final String BSTEREO_NEITHER = "!/!\\";
+    public static final String BSTEREO_EITHER  = "/,\\";
+    public static final String BSTEREO_UPU     = "/?";
+    public static final String BSTEREO_DNU     = "\\?";
+
+    private static final class Parser {
+        private String         str;
+        private IAtomContainer mol;
+        private int            flav;
+        private int            pos;
+
+        private IAtom     prev;
+        private QueryBond bond;
+        private Deque<IAtom>            stack   = new ArrayDeque<>();
+        private IBond                   rings[] = new IBond[100];
+        private Map<IAtom, List<IBond>> local   = new HashMap<>();
+        private Set<IAtom>              astereo = new HashSet<>();
+        private Set<IBond>              bstereo = new HashSet<>();
+        private int numRingOpens;
+        private ReactionRole role = ReactionRole.None;
+        private int numComponents;
+        private int curComponentId;
+
+        public Parser(IAtomContainer mol, String str, int flav) {
+            this.str = str;
+            this.mol = mol;
+            this.flav = flav;
+            this.pos = 0;
+        }
+
+        IBond addBond(IAtom atom, IBond bond) {
+            if (atom.equals(bond.getBegin())) {
+                mol.addBond(bond);
+                bond = mol.getBond(mol.getBondCount() - 1);
+            }
+            List<IBond> nbr = local.get(atom);
+            if (nbr == null)
+                local.put(atom, nbr = new ArrayList<>(4));
+            nbr.add(bond);
+            return bond;
+        }
+
+        int nextUnsignedInt() {
+            if (!isDigit(peek()))
+                return -1;
+            int res = next() - '0';
+            while (isDigit(peek()))
+                res = 10 * res + (next() - '0');
+            return res;
+        }
+
+        boolean parseExplicitHydrogen(IAtom atom, Expr dest) {
+            int mark    = pos;
+            int isotope = nextUnsignedInt();
+            if (str.charAt(pos++) != 'H') {
+                pos = mark; // reset
+                return false;
+            }
+            Expr hExpr = isotope < 0 ?
+                         new Expr(Expr.Type.ELEMENT, 1) :
+                         new Expr(Expr.Type.AND,
+                                  new Expr(Expr.Type.ISOTOPE, isotope),
+                                  new Expr(Expr.Type.ELEMENT, 1));
+            if (peek() == '+') {
+                pos++;
+                int num = nextUnsignedInt();
+                if (num < 0) {
+                    num = 1;
+                    while (peek() == '+') {
+                        next();
+                        num++;
+                    }
+                }
+                hExpr.and(new Expr(Expr.Type.FORMAL_CHARGE, +num));
+            } else if (peek() == '-') {
+                pos++;
+                int num = nextUnsignedInt();
+                if (num < 0) {
+                    num = 1;
+                    while (peek() == '-') {
+                        next();
+                        num++;
+                    }
+                }
+                hExpr.and(new Expr(FORMAL_CHARGE, -num));
+            }
+
+            // atom mapping
+            if (peek() == ':') {
+                next();
+                int num = nextUnsignedInt();
+                if (num < 0) {
+                    pos = mark;
+                    return false;
+                }
+                atom.setProperty(CDKConstants.ATOM_ATOM_MAPPING, num);
+            }
+
+            if (peek() == ']') {
+                pos++;
+                dest.set(hExpr);
+                return true;
+            } else {
+                pos = mark;
+                return false;
+            }
+        }
+
+        boolean parseAtomExpr(IAtom atom, Expr dest, char lastOp) {
+            Expr expr = null;
+            int  num;
+            char currOp;
+            while (true) {
+                currOp = '&'; // implicit and
+                switch (next()) {
+                    case '*':
+                        expr = new Expr(TRUE);
+                        break;
+                    case 'A':
+                        switch (next()) {
+                            case 'c': // Ac=Actinium
+                                expr = new Expr(ELEMENT, 89);
+                                break;
+                            case 'g': // Ag=Silver
+                                expr = new Expr(ELEMENT, 47);
+                                break;
+                            case 'l': // Al=Aluminum
+                                expr = new Expr(ALIPHATIC_ELEMENT, 13);
+                                break;
+                            case 'm': // Am=Americium
+                                expr = new Expr(ELEMENT, 95);
+                                break;
+                            case 'r': // Ar=Argon
+                                expr = new Expr(ELEMENT, 18);
+                                break;
+                            case 's': // As=Arsenic
+                                expr = new Expr(ALIPHATIC_ELEMENT, 33);
+                                break;
+                            case 't': // At=Astatine
+                                expr = new Expr(ELEMENT, 85);
+                                break;
+                            case 'u': // Au=Gold
+                                expr = new Expr(ELEMENT, 79);
+                                break;
+                            default:  // A=None
+                                unget();
+                                expr = new Expr(IS_ALIPHATIC);
+                                break;
+                        }
+                        break;
+                    case 'B':
+                        switch (next()) {
+                            case 'a': // Ba=Barium
+                                expr = new Expr(ELEMENT, 56);
+                                break;
+                            case 'e': // Be=Beryllium
+                                expr = new Expr(ELEMENT, 4);
+                                break;
+                            case 'h': // Bh=Bohrium
+                                expr = new Expr(ELEMENT, 107);
+                                break;
+                            case 'i': // Bi=Bismuth
+                                expr = new Expr(ELEMENT, 83);
+                                break;
+                            case 'k': // Bk=Berkelium
+                                expr = new Expr(ELEMENT, 97);
+                                break;
+                            case 'r': // Br=Bromine
+                                expr = new Expr(ELEMENT, 35);
+                                break;
+                            default:  // B=Boron
+                                unget();
+                                expr = new Expr(ALIPHATIC_ELEMENT, 5);
+                                break;
+                        }
+                        break;
+                    case 'C':
+                        switch (next()) {
+                            case 'a': // Ca=Calcium
+                                expr = new Expr(ELEMENT, 20);
+                                break;
+                            case 'd': // Cd=Cadmium
+                                expr = new Expr(ELEMENT, 48);
+                                break;
+                            case 'e': // Ce=Cerium
+                                expr = new Expr(ELEMENT, 58);
+                                break;
+                            case 'f': // Cf=Californium
+                                expr = new Expr(ELEMENT, 98);
+                                break;
+                            case 'l': // Cl=Chlorine
+                                expr = new Expr(ELEMENT, 17);
+                                break;
+                            case 'm': // Cm=Curium
+                                expr = new Expr(ELEMENT, 96);
+                                break;
+                            case 'n': // Cn=Copernicium
+                                expr = new Expr(ELEMENT, 112);
+                                break;
+                            case 'o': // Co=Cobalt
+                                expr = new Expr(ELEMENT, 27);
+                                break;
+                            case 'r': // Cr=Chromium
+                                expr = new Expr(ELEMENT, 24);
+                                break;
+                            case 's': // Cs=Cesium
+                                expr = new Expr(ELEMENT, 55);
+                                break;
+                            case 'u': // Cu=Copper
+                                expr = new Expr(ELEMENT, 29);
+                                break;
+                            default:  // C=Carbon
+                                unget();
+                                expr = new Expr(ALIPHATIC_ELEMENT, 6);
+                                break;
+                        }
+                        break;
+                    case 'D':
+                        switch (next()) {
+                            case 'b': // Db=Dubnium
+                                expr = new Expr(ELEMENT, 105);
+                                break;
+                            case 's': // Ds=Darmstadtium
+                                expr = new Expr(ELEMENT, 110);
+                                break;
+                            case 'y': // Dy=Dysprosium
+                                expr = new Expr(ELEMENT, 66);
+                                break;
+                            default:  // D=Degree
+                                unget();
+                                num = nextUnsignedInt();
+                                if (num < 0) {
+                                    if (isFlavor(FLAVOR_CDK_LEGACY))
+                                        expr = new Expr(HEAVY_DEGREE, 1);
+                                    else
+                                        expr = new Expr(DEGREE, 1);
+                                } else {
+                                    if (isFlavor(FLAVOR_CDK_LEGACY))
+                                        expr = new Expr(HEAVY_DEGREE, num);
+                                    else
+                                        expr = new Expr(DEGREE, num);
+                                }
+                                break;
+                        }
+                        break;
+                    case 'E':
+                        switch (next()) {
+                            case 'r': // Er=Erbium
+                                expr = new Expr(ELEMENT, 68);
+                                break;
+                            case 's': // Es=Einsteinium
+                                expr = new Expr(ELEMENT, 99);
+                                break;
+                            case 'u': // Eu=Europium
+                                expr = new Expr(ELEMENT, 63);
+                                break;
+                            default:  // E=None
+                                return false;
+                        }
+                        break;
+                    case 'F':
+                        switch (next()) {
+                            case 'e': // Fe=Iron
+                                expr = new Expr(ELEMENT, 26);
+                                break;
+                            case 'l': // Fl=Flerovium
+                                expr = new Expr(ELEMENT, 114);
+                                break;
+                            case 'm': // Fm=Fermium
+                                expr = new Expr(ELEMENT, 100);
+                                break;
+                            case 'r': // Fr=Francium
+                                expr = new Expr(ELEMENT, 87);
+                                break;
+                            default:  // F=Fluorine
+                                unget();
+                                expr = new Expr(ELEMENT, 9);
+                                break;
+                        }
+                        break;
+                    case 'G':
+                        switch (next()) {
+                            case 'a': // Ga=Gallium
+                                expr = new Expr(ELEMENT, 31);
+                                break;
+                            case 'd': // Gd=Gadolinium
+                                expr = new Expr(ELEMENT, 64);
+                                break;
+                            case 'e': // Ge=Germanium
+                                expr = new Expr(ALIPHATIC_ELEMENT, 32);
+                                break;
+                            default:  // G=None or Periodic Group or Insaturation
+                                unget();
+                                num = nextUnsignedInt();
+                                if (num <= 0 || num > 18)
+                                    return false;
+                                if (isFlavor(FLAVOR_CDK_LEGACY))
+                                    expr = new Expr(PERIODIC_GROUP, num);
+                                else if (isFlavor(FLAVOR_CACTVS))
+                                    expr = new Expr(INSATURATION, num);
+                                else
+                                    return false;
+                                break;
+                        }
+                        break;
+                    case 'H':
+                        switch (next()) {
+                            case 'e': // He=Helium
+                                expr = new Expr(ELEMENT, 2);
+                                break;
+                            case 'f': // Hf=Hafnium
+                                expr = new Expr(ELEMENT, 72);
+                                break;
+                            case 'g': // Hg=Mercury
+                                expr = new Expr(ELEMENT, 80);
+                                break;
+                            case 'o': // Ho=Holmium
+                                expr = new Expr(ELEMENT, 67);
+                                break;
+                            case 's': // Hs=Hassium
+                                expr = new Expr(ELEMENT, 108);
+                                break;
+                            default:  // H=Hydrogen
+                                unget();
+                                num = nextUnsignedInt();
+                                if (num < 0)
+                                    expr = new Expr(TOTAL_H_COUNT, 1);
+                                else
+                                    expr = new Expr(TOTAL_H_COUNT, num);
+                                break;
+                        }
+                        break;
+                    case 'I':
+                        switch (next()) {
+                            case 'n': // In=Indium
+                                expr = new Expr(ELEMENT, 49);
+                                break;
+                            case 'r': // Ir=Iridium
+                                expr = new Expr(ELEMENT, 77);
+                                break;
+                            default:  // I=Iodine
+                                unget();
+                                expr = new Expr(ELEMENT, 53);
+                                break;
+                        }
+                        break;
+                    case 'J':
+                        return false;
+                    case 'K':
+                        switch (next()) {
+                            case 'r': // Kr=Krypton
+                                expr = new Expr(ELEMENT, 36);
+                                break;
+                            default:  // K=Potassium
+                                unget();
+                                expr = new Expr(ELEMENT, 19);
+                                break;
+                        }
+                        break;
+                    case 'L':
+                        switch (next()) {
+                            case 'a': // La=Lanthanum
+                                expr = new Expr(ELEMENT, 57);
+                                break;
+                            case 'i': // Li=Lithium
+                                expr = new Expr(ELEMENT, 3);
+                                break;
+                            case 'r': // Lr=Lawrencium
+                                expr = new Expr(ELEMENT, 103);
+                                break;
+                            case 'u': // Lu=Lutetium
+                                expr = new Expr(ELEMENT, 71);
+                                break;
+                            case 'v': // Lv=Livermorium
+                                expr = new Expr(ELEMENT, 116);
+                                break;
+                            default:  // L=None
+                                return false;
+                        }
+                        break;
+                    case 'M':
+                        switch (next()) {
+                            case 'c': // Mc=Moscovium
+                                expr = new Expr(ELEMENT, 115);
+                                break;
+                            case 'd': // Md=Mendelevium
+                                expr = new Expr(ELEMENT, 101);
+                                break;
+                            case 'g': // Mg=Magnesium
+                                expr = new Expr(ELEMENT, 12);
+                                break;
+                            case 'n': // Mn=Manganese
+                                expr = new Expr(ELEMENT, 25);
+                                break;
+                            case 'o': // Mo=Molybdenum
+                                expr = new Expr(ELEMENT, 42);
+                                break;
+                            case 't': // Mt=Meitnerium
+                                expr = new Expr(ELEMENT, 109);
+                                break;
+                            default:  // M=None
+                                return false;
+                        }
+                        break;
+                    case 'N':
+                        switch (next()) {
+                            case 'a': // Na=Sodium
+                                expr = new Expr(ELEMENT, 11);
+                                break;
+                            case 'b': // Nb=Niobium
+                                expr = new Expr(ELEMENT, 41);
+                                break;
+                            case 'd': // Nd=Neodymium
+                                expr = new Expr(ELEMENT, 60);
+                                break;
+                            case 'e': // Ne=Neon
+                                expr = new Expr(ELEMENT, 10);
+                                break;
+                            case 'h': // Nh=Nihonium
+                                expr = new Expr(ELEMENT, 113);
+                                break;
+                            case 'i': // Ni=Nickel
+                                expr = new Expr(ELEMENT, 28);
+                                break;
+                            case 'o': // No=Nobelium
+                                expr = new Expr(ELEMENT, 102);
+                                break;
+                            case 'p': // Np=Neptunium
+                                expr = new Expr(ELEMENT, 93);
+                                break;
+                            default:  // N=Nitrogen
+                                unget();
+                                expr = new Expr(ALIPHATIC_ELEMENT, 7);
+                                break;
+                        }
+                        break;
+                    case 'O':
+                        switch (next()) {
+                            case 'g': // Og=Oganesson
+                                expr = new Expr(ELEMENT, 118);
+                                break;
+                            case 's': // Os=Osmium
+                                expr = new Expr(ELEMENT, 76);
+                                break;
+                            default:  // O=Oxygen
+                                unget();
+                                expr = new Expr(ALIPHATIC_ELEMENT, 8);
+                                break;
+                        }
+                        break;
+                    case 'P':
+                        switch (next()) {
+                            case 'a': // Pa=Protactinium
+                                expr = new Expr(ELEMENT, 91);
+                                break;
+                            case 'b': // Pb=Lead
+                                expr = new Expr(ELEMENT, 82);
+                                break;
+                            case 'd': // Pd=Palladium
+                                expr = new Expr(ELEMENT, 46);
+                                break;
+                            case 'm': // Pm=Promethium
+                                expr = new Expr(ELEMENT, 61);
+                                break;
+                            case 'o': // Po=Polonium
+                                expr = new Expr(ELEMENT, 84);
+                                break;
+                            case 'r': // Pr=Praseodymium
+                                expr = new Expr(ELEMENT, 59);
+                                break;
+                            case 't': // Pt=Platinum
+                                expr = new Expr(ELEMENT, 78);
+                                break;
+                            case 'u': // Pu=Plutonium
+                                expr = new Expr(ELEMENT, 94);
+                                break;
+                            default:  // P=Phosphorus
+                                unget();
+                                expr = new Expr(ALIPHATIC_ELEMENT, 15);
+                                break;
+                        }
+                        break;
+                    case 'Q':
+                        return false;
+                    case 'R':
+                        switch (next()) {
+                            case 'a': // Ra=Radium
+                                expr = new Expr(ELEMENT, 88);
+                                break;
+                            case 'b': // Rb=Rubidium
+                                expr = new Expr(ELEMENT, 37);
+                                break;
+                            case 'e': // Re=Rhenium
+                                expr = new Expr(ELEMENT, 75);
+                                break;
+                            case 'f': // Rf=Rutherfordium
+                                expr = new Expr(ELEMENT, 104);
+                                break;
+                            case 'g': // Rg=Roentgenium
+                                expr = new Expr(ELEMENT, 111);
+                                break;
+                            case 'h': // Rh=Rhodium
+                                expr = new Expr(ELEMENT, 45);
+                                break;
+                            case 'n': // Rn=Radon
+                                expr = new Expr(ELEMENT, 86);
+                                break;
+                            case 'u': // Ru=Ruthenium
+                                expr = new Expr(ELEMENT, 44);
+                                break;
+                            default:  // R=Ring Count
+                                unget();
+                                num = nextUnsignedInt();
+                                if (num < 0)
+                                    expr = new Expr(Expr.Type.IS_IN_RING);
+                                else if (num == 0)
+                                    expr = new Expr(Expr.Type.IS_IN_CHAIN);
+                                else if (isFlavor(FLAVOR_OECHEM))
+                                    expr = new Expr(Expr.Type.RING_BOND_COUNT, num);
+                                else
+                                    expr = new Expr(Expr.Type.RING_COUNT, num);
+                                break;
+                        }
+                        break;
+                    case 'S':
+                        switch (next()) {
+                            case 'b': // Sb=Antimony
+                                expr = new Expr(ALIPHATIC_ELEMENT, 51);
+                                break;
+                            case 'c': // Sc=Scandium
+                                expr = new Expr(ELEMENT, 21);
+                                break;
+                            case 'e': // Se=Selenium
+                                expr = new Expr(ALIPHATIC_ELEMENT, 34);
+                                break;
+                            case 'g': // Sg=Seaborgium
+                                expr = new Expr(ELEMENT, 106);
+                                break;
+                            case 'i': // Si=Silicon
+                                expr = new Expr(ALIPHATIC_ELEMENT, 14);
+                                break;
+                            case 'm': // Sm=Samarium
+                                expr = new Expr(ELEMENT, 62);
+                                break;
+                            case 'n': // Sn=Tin
+                                expr = new Expr(ELEMENT, 50);
+                                break;
+                            case 'r': // Sr=Strontium
+                                expr = new Expr(ELEMENT, 38);
+                                break;
+                            default:  // S=Sulfur
+                                unget();
+                                expr = new Expr(ALIPHATIC_ELEMENT, 16);
+                                break;
+                        }
+                        break;
+                    case 'T':
+                        switch (next()) {
+                            case 'a': // Ta=Tantalum
+                                expr = new Expr(ELEMENT, 73);
+                                break;
+                            case 'b': // Tb=Terbium
+                                expr = new Expr(ELEMENT, 65);
+                                break;
+                            case 'c': // Tc=Technetium
+                                expr = new Expr(ELEMENT, 43);
+                                break;
+                            case 'e': // Te=Tellurium
+                                expr = new Expr(ALIPHATIC_ELEMENT, 52);
+                                break;
+                            case 'h': // Th=Thorium
+                                expr = new Expr(ELEMENT, 90);
+                                break;
+                            case 'i': // Ti=Titanium
+                                expr = new Expr(ELEMENT, 22);
+                                break;
+                            case 'l': // Tl=Thallium
+                                expr = new Expr(ELEMENT, 81);
+                                break;
+                            case 'm': // Tm=Thulium
+                                expr = new Expr(ELEMENT, 69);
+                                break;
+                            case 's': // Ts=Tennessine
+                                expr = new Expr(ELEMENT, 117);
+                                break;
+                            default:  // T=None
+                                return false;
+                        }
+                        break;
+                    case 'U':
+                        switch (next()) {
+                            default:  // U=Uranium
+                                unget();
+                                expr = new Expr(ELEMENT, 92);
+                                break;
+                        }
+                        break;
+                    case 'V':
+                        switch (next()) {
+                            default:  // V=Vanadium
+                                unget();
+                                expr = new Expr(ELEMENT, 23);
+                                break;
+                        }
+                        break;
+                    case 'W':
+                        switch (next()) {
+                            default:  // W=Tungsten
+                                unget();
+                                expr = new Expr(ELEMENT, 74);
+                                break;
+                        }
+                        break;
+                    case 'X':
+                        switch (next()) {
+                            case 'e': // Xe=Xenon
+                                expr = new Expr(ELEMENT, 54);
+                                break;
+                            default:  // X=Connectivity
+                                unget();
+                                num = nextUnsignedInt();
+                                if (num < 0)
+                                    expr = new Expr(TOTAL_DEGREE, 1);
+                                else
+                                    expr = new Expr(TOTAL_DEGREE, num);
+                                break;
+                        }
+                        break;
+                    case 'Y':
+                        switch (next()) {
+                            case 'b': // Yb=Ytterbium
+                                expr = new Expr(ELEMENT, 70);
+                                break;
+                            default:  // Y=Yttrium
+                                unget();
+                                expr = new Expr(ELEMENT, 39);
+                                break;
+                        }
+                        break;
+                    case 'Z':
+                        switch (next()) {
+                            case 'n': // Zn=Zinc
+                                expr = new Expr(ELEMENT, 30);
+                                break;
+                            case 'r': // Zr=Zirconium
+                                expr = new Expr(ELEMENT, 40);
+                                break;
+                            default:  // Z=None
+                                unget();
+                                num = nextUnsignedInt();
+                                if (isFlavor(FLAVOR_LOOSE | FLAVOR_DAYLIGHT)) {
+                                    if (num < 0)
+                                        expr = new Expr(IS_IN_RING);
+                                    else if (num == 0)
+                                        expr = new Expr(IS_IN_CHAIN);
+                                    else
+                                        expr = new Expr(RING_SIZE, num);
+                                } else if (isFlavor(FLAVOR_CACTVS)) {
+                                    if (num < 0)
+                                        expr = new Expr(HAS_ALIPHATIC_HETERO_SUBSTITUENT);
+                                    else if (num == 0)
+                                        expr = new Expr(HAS_ALIPHATIC_HETERO_SUBSTITUENT).negate();
+                                    else
+                                        expr = new Expr(ALIPHATIC_HETERO_SUBSTITUENT_COUNT, num);
+                                } else {
+                                    return false;
+                                }
+                                break;
+                        }
+                        break;
+                    case 'a':
+                        switch (next()) {
+                            case 'l': // al=Aluminum (aromatic)
+                                expr = new Expr(AROMATIC_ELEMENT, 13);
+                                break;
+                            case 's': // as=Arsenic (aromatic)
+                                expr = new Expr(AROMATIC_ELEMENT, 33);
+                                break;
+                            default:
+                                unget();
+                                expr = new Expr(IS_AROMATIC);
+                                break;
+                        }
+                        break;
+                    case 'b':
+                        switch (next()) {
+                            default:  // b=Boron (aromatic)
+                                unget();
+                                expr = new Expr(AROMATIC_ELEMENT, 5);
+                                break;
+                        }
+                        break;
+                    case 'c':
+                        expr = new Expr(AROMATIC_ELEMENT, 6);
+                        break;
+                    case 'n':
+                        expr = new Expr(AROMATIC_ELEMENT, 7);
+                        break;
+                    case 'o':
+                        expr = new Expr(AROMATIC_ELEMENT, 8);
+                        break;
+                    case 'p':
+                        expr = new Expr(AROMATIC_ELEMENT, 15);
+                        break;
+                    case 's':
+                        switch (next()) {
+                            case 'b': // sb=Antimony (aromatic)
+                                expr = new Expr(AROMATIC_ELEMENT, 51);
+                                break;
+                            case 'e': // se=Selenium (aromatic)
+                                expr = new Expr(AROMATIC_ELEMENT, 34);
+                                break;
+                            case 'i': // si=Silicon (aromatic)
+                                expr = new Expr(AROMATIC_ELEMENT, 14);
+                                break;
+                            default:  // s=Sulfur (aromatic)
+                                unget();
+                                expr = new Expr(AROMATIC_ELEMENT, 16);
+                                break;
+                        }
+                        break;
+                    case 't':
+                        switch (next()) {
+                            case 'e': // te=Tellurium (aromatic)
+                                expr = new Expr(AROMATIC_ELEMENT, 52);
+                                break;
+                            default:
+                                unget();
+                                return false;
+                        }
+                        break;
+
+
+                    case 'r':
+                        num = nextUnsignedInt();
+                        if (num < 0)
+                            expr = new Expr(Expr.Type.IS_IN_RING);
+                        else if (num == 0)
+                            expr = new Expr(Expr.Type.IS_IN_CHAIN);
+                        else if (num > 2)
+                            expr = new Expr(Expr.Type.RING_SMALLEST, num);
+                        else
+                            return false;
+                        break;
+                    case 'v':
+                        num = nextUnsignedInt();
+                        if (num < 0)
+                            expr = new Expr(Expr.Type.VALENCE, 1);
+                        else
+                            expr = new Expr(Expr.Type.VALENCE, num);
+                        break;
+                    case 'h':
+                        num = nextUnsignedInt();
+                        if (num < 0)
+                            expr = new Expr(Expr.Type.HAS_IMPLICIT_HYDROGEN);
+                        else
+                            expr = new Expr(Expr.Type.IMPL_H_COUNT, num);
+                        break;
+                    case 'x':
+                        num = nextUnsignedInt();
+                        if (num < 0)
+                            expr = new Expr(Expr.Type.IS_IN_RING);
+                        else if (num == 0)
+                            expr = new Expr(Expr.Type.IS_IN_CHAIN);
+                        else if (num > 1)
+                            expr = new Expr(Expr.Type.RING_BOND_COUNT, num);
+                        else
+                            return false;
+                        break;
+                    case '#':
+                        num = nextUnsignedInt();
+                        if (num < 0) {
+                            if (isFlavor(FLAVOR_LOOSE | FLAVOR_CACTVS | FLAVOR_MOE)) {
+                                switch (next()) {
+                                    case 'X':
+                                        expr = new Expr(Expr.Type.IS_HETERO);
+                                        break;
+                                    case 'G':
+                                        num = nextUnsignedInt();
+                                        if (num <= 0 || num > 18)
+                                            return false;
+                                        expr = new Expr(Expr.Type.PERIODIC_GROUP, num);
+                                        break;
+                                    default:
+                                        return false;
+                                }
+
+                            } else {
+                                return false;
+                            }
+                        } else {
+                            expr = new Expr(Expr.Type.ELEMENT, num);
+                        }
+                        break;
+                    case '^':
+                        if (!isFlavor(FLAVOR_LOOSE | FLAVOR_OECHEM | FLAVOR_CDK_LEGACY))
+                            return false;
+                        num = nextUnsignedInt();
+                        if (num <= 0 || num > 8)
+                            return false;
+                        expr = new Expr(Expr.Type.HYBRIDISATION_NUMBER, num);
+                        break;
+                    case 'i':
+                        if (!isFlavor(FLAVOR_MOE | FLAVOR_CACTVS))
+                            return false;
+                        num = nextUnsignedInt();
+                        if (num <= 0 || num > 8)
+                            return false;
+                        expr = new Expr(Expr.Type.INSATURATION, num);
+                        break;
+                    case 'z':
+                        if (!isFlavor(FLAVOR_CACTVS))
+                            return false;
+                        num = nextUnsignedInt();
+                        if (num < 0)
+                            expr = new Expr(HAS_HETERO_SUBSTITUENT);
+                        else if (num == 0)
+                            expr = new Expr(HAS_HETERO_SUBSTITUENT).negate();
+                        else
+                            expr = new Expr(HETERO_SUBSTITUENT_COUNT, num);
+                        break;
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                        unget();
+                        num = nextUnsignedInt();
+                        if (num == 0)
+                            expr = new Expr(Expr.Type.HAS_UNSPEC_ISOTOPE);
+                        else
+                            expr = new Expr(Expr.Type.ISOTOPE, num);
+                        break;
+                    case '-':
+                        num = nextUnsignedInt();
+                        if (num < 0) {
+                            num = 1;
+                            while (peek() == '-') {
+                                num++;
+                                pos++;
+                            }
+                        }
+                        expr = new Expr(Expr.Type.FORMAL_CHARGE, -num);
+                        break;
+                    case '+':
+                        num = nextUnsignedInt();
+                        if (num < 0) {
+                            num = 1;
+                            while (peek() == '+') {
+                                num++;
+                                pos++;
+                            }
+                        }
+                        expr = new Expr(Expr.Type.FORMAL_CHARGE, +num);
+                        break;
+                    case '@':
+                        num = IStereoElement.LEFT;
+                        if (peek() == '@') {
+                            next();
+                            num = IStereoElement.RIGHT;
+                        }
+                        expr = new Expr(Expr.Type.STEREOCHEMISTRY, num);
+                        // "or unspecified"
+                        if (peek() == '?') {
+                            next();
+                            expr.or(new Expr(Expr.Type.STEREOCHEMISTRY, 0));
+                        }
+
+                        // neigbours will be index on 'finish()'
+                        astereo.add(atom);
+                        break;
+
+                    case '&':
+                        if (dest.type() == NONE)
+                            return false;
+                        expr = new Expr(Expr.Type.NONE);
+                        if (!parseAtomExpr(atom, expr, '&'))
+                            return false;
+                        break;
+                    case ';':
+                        if (dest.type() == NONE)
+                            return false;
+                        if (hasPrecedence(lastOp, ';'))
+                            return true;
+                        expr = new Expr(Expr.Type.NONE);
+                        if (!parseAtomExpr(atom, expr, ';'))
+                            return false;
+                        break;
+                    case ',':
+                        if (dest.type() == NONE)
+                            return false;
+                        if (hasPrecedence(lastOp, ','))
+                            return true;
+                        expr = new Expr(Expr.Type.NONE);
+                        if (!parseAtomExpr(atom, expr, ','))
+                            return false;
+                        currOp = ',';
+                        break;
+                    case '!':
+                        expr = new Expr(Expr.Type.NONE);
+                        if (!parseAtomExpr(atom, expr, '!'))
+                            return false;
+                        expr.negate();
+                        break;
+                    case '$':
+                        if (next() != '(')
+                            return false;
+                        int beg = pos;
+                        int end = beg;
+                        int depth = 1;
+                        while (end < str.length()) {
+                            switch (str.charAt(end++)) {
+                                case '(':
+                                    depth++;
+                                    break;
+                                case ')':
+                                    depth--;
+                                    break;
+                            }
+                            if (depth == 0)
+                                break;
+                        }
+                        if (end == str.length())
+                            return false;
+                        IAtomContainer submol = new QueryAtomContainer(mol.getBuilder());
+                        if (!new Parser(submol, str.substring(beg, end - 1), flav).parse())
+                            return false;
+                        if (submol.getAtomCount() == 1) {
+                            expr = ((QueryAtom) submol.getAtom(0)).getExpression();
+                        } else {
+                            expr = new Expr(Expr.Type.RECURSIVE, submol);
+                        }
+                        pos = end;
+                        break;
+                    case ':':
+                        if (expr == null)
+                            return false;
+                        num = nextUnsignedInt();
+                        if (num < 0)
+                            return false;
+                        if (num != 0)
+                            atom.setProperty(CDKConstants.ATOM_ATOM_MAPPING, num);
+                        // should be add end of expr
+                        return next() == ']';
+                    case ']':
+                        if (dest == null || dest.type() == Expr.Type.NONE)
+                            return false;
+                        if (lastOp != 0)
+                            unget();
+                        return true;
+                    default:
+                        return false;
+                }
+
+                if (dest.type() == Expr.Type.NONE) {
+                    dest.set(expr);
+                    // negation is tightest binding
+                    if (lastOp == '!')
+                        return true;
+                } else {
+                    switch (currOp) {
+                        case '&':
+                            dest.and(expr);
+                            break;
+                        case ',':
+                            dest.or(expr);
+                            break;
+                    }
+                }
+            }
+        }
+
+        private boolean isFlavor(int flav) {
+            return (this.flav & flav) != 0;
+        }
+
+        private boolean parseBondExpr(Expr dest, IBond bond, char lastOp) {
+            Expr expr;
+            char currOp;
+            while (true) {
+                currOp = '&';
+                switch (next()) {
+                    case '-':
+                        expr = new Expr(ALIPHATIC_ORDER, 1);
+                        break;
+                    case '=':
+                        expr = new Expr(ALIPHATIC_ORDER, 2);
+                        break;
+                    case '#':
+                        expr = new Expr(ALIPHATIC_ORDER, 3);
+                        break;
+                    case '$':
+                        expr = new Expr(ALIPHATIC_ORDER, 4);
+                        break;
+                    case ':':
+                        expr = new Expr(Expr.Type.IS_AROMATIC);
+                        break;
+                    case '~':
+                        expr = new Expr(Expr.Type.TRUE);
+                        break;
+                    case '@':
+                        expr = new Expr(Expr.Type.IS_IN_RING);
+                        break;
+                    case '&':
+                        if (dest.type() == Expr.Type.NONE)
+                            return false;
+                        expr = new Expr(Expr.Type.NONE);
+                        if (!parseBondExpr(expr, bond, '&'))
+                            return false;
+                        break;
+                    case ';':
+                        if (dest.type() == Expr.Type.NONE)
+                            return false;
+                        if (hasPrecedence(lastOp, ';'))
+                            return true;
+                        expr = new Expr(Expr.Type.NONE);
+                        if (!parseBondExpr(expr, bond, ';'))
+                            return false;
+                        break;
+                    case ',':
+                        if (dest.type() == Expr.Type.NONE)
+                            return false;
+                        if (hasPrecedence(lastOp, ','))
+                            return true;
+                        expr = new Expr(Expr.Type.NONE);
+                        if (!parseBondExpr(expr, bond, ','))
+                            return false;
+                        currOp = ',';
+                        break;
+                    case '!':
+                        expr = new Expr(Expr.Type.NONE);
+                        if (!parseBondExpr(expr, bond, '!'))
+                            return false;
+                        expr.negate();
+                        break;
+                    case '/':
+                        expr = new Expr(Expr.Type.STEREOCHEMISTRY, BOND_UP);
+                        if (peek() == '?') {
+                            next();
+                            expr.or(new Expr(Expr.Type.STEREOCHEMISTRY, BOND_UNSPEC));
+                        }
+                        bstereo.add(bond);
+                        break;
+                    case '\\':
+                        expr = new Expr(Expr.Type.STEREOCHEMISTRY, BOND_DOWN);
+                        if (peek() == '?') {
+                            next();
+                            expr.or(new Expr(Expr.Type.STEREOCHEMISTRY, BOND_UNSPEC));
+                        }
+                        bstereo.add(bond);
+                        break;
+                    default:
+                        pos--;
+                        return dest.type() != Expr.Type.NONE;
+                }
+
+                if (dest.type() == Expr.Type.NONE) {
+                    dest.set(expr);
+                    // negation is tightest binding
+                    if (lastOp == '!')
+                        return true;
+                } else {
+                    switch (currOp) {
+                        case '&':
+                            dest.and(expr);
+                            break;
+                        case ',':
+                            dest.or(expr);
+                            break;
+                    }
+                }
+            }
+        }
+
+        private void unget() {
+            pos--;
+        }
+
+        private boolean hasPrecedence(char lastOp, char currOp) {
+            if (lastOp > 0 && currOp > lastOp) {
+                unget();
+                return true;
+            }
+            return false;
+        }
+
+        private boolean parseAtomExpr() {
+            QueryAtom atom = new QueryAtom(mol.getBuilder());
+            Expr      expr = new Expr(Expr.Type.NONE);
+            atom.setExpression(expr);
+            if (!parseExplicitHydrogen(atom, expr) && !parseAtomExpr(atom, expr, '\0'))
+                return false;
+            append(atom);
+            return true;
+        }
+
+        boolean parseBondExpr() {
+            bond = new QueryBond(mol.getBuilder());
+            bond.setExpression(new Expr(Expr.Type.NONE));
+            return parseBondExpr(bond.getExpression(), bond, '\0');
+        }
+
+        void newFragment() {
+            prev = null;
+        }
+
+        boolean begComponentGroup() {
+            curComponentId = ++numComponents;
+            return true;
+        }
+
+        boolean endComponentGroup() {
+            // closing an unopen component group
+            if (curComponentId == 0)
+                return false;
+            curComponentId = 0;
+            return true;
+        }
+
+        boolean openBranch() {
+            if (prev == null || bond != null)
+                return false;
+            stack.push(prev);
+            return true;
+        }
+
+        boolean closeBranch() {
+            if (stack.isEmpty() || bond != null)
+                return false;
+            prev = stack.pop();
+            return true;
+        }
+
+        boolean openRing(int rnum) {
+            if (bond == null) {
+                bond = new QueryBond(null);
+                bond.setExpression(null);
+            }
+            bond.setAtom(prev, 0);
+            rings[rnum] = addBond(prev, bond);
+            numRingOpens++;
+            bond = null;
+            return true;
+        }
+
+        boolean closeRing(int rnum) {
+            IBond bond = rings[rnum];
+            rings[rnum] = null;
+            numRingOpens--;
+            Expr openExpr = ((QueryBond) BondRef.deref(bond)).getExpression();
+            if (this.bond != null) {
+                Expr closeExpr = ((QueryBond) BondRef.deref(this.bond)).getExpression();
+                if (openExpr == null)
+                    ((QueryBond) BondRef.deref(bond)).setExpression(closeExpr);
+                else if (!openExpr.equals(closeExpr))
+                    return false;
+                this.bond = null;
+            } else if (openExpr == null) {
+                ((QueryBond) BondRef.deref(bond)).setExpression(new Expr(SINGLE_OR_AROMATIC));
+            }
+            bond.setAtom(prev, 1);
+            addBond(prev, bond);
+            return true;
+        }
+
+        boolean ringClosure(int rnum) {
+            if (rings[rnum] == null)
+                return openRing(rnum);
+            else
+                return closeRing(rnum);
+        }
+
+        void swap(Object[] obj, int i, int j) {
+            Object tmp = obj[i];
+            obj[i] = obj[j];
+            obj[j] = tmp;
+        }
+
+        boolean hasAliphaticDoubleBond(Expr expr) {
+            for (; ; ) {
+                switch (expr.type()) {
+                    case NOT:
+                        expr = expr.left();
+                        break;
+                    case AND:
+                    case OR:
+                        if (hasAliphaticDoubleBond(expr.left()))
+                            return true;
+                        expr = expr.right();
+                        break;
+                    case ALIPHATIC_ORDER:
+                        return expr.value() == 2;
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        /**
+         * Traverse an expression tree and flip all the stereo expressions.
+         */
+        void flip(Expr expr) {
+            for (; ; ) {
+                switch (expr.type()) {
+                    case STEREOCHEMISTRY:
+                        if (expr.value() != 0)
+                            expr.setPrimitive(expr.type(),
+                                              expr.value() ^ 0x3);
+                        return;
+                    case AND:
+                    case OR:
+                        flip(expr.left());
+                        expr = expr.right();
+                        break;
+                    case NOT:
+                        expr = expr.left();
+                        break;
+                }
+            }
+        }
+
+        /**
+         * Determines the bond stereo (cis/trans) of a double bond
+         * given the left and right bonds connected to the central bond. For
+         * example:
+         * <pre>{@code
+         *  C/C=C/C    => trans
+         *  C/C=C\C    => cis
+         *  C/C=C\,/C  => cis or trans
+         *  C/C=C/?C   => trans or unspec
+         *  C/C=C!/!\C => unspecified
+         *  C/C=C!/C   => cis or unspec (not trans)
+         *  C/C=C\/C   => cis and trans (always false)
+         * }</prev>
+         *
+         * @param left left directional bond
+         * @param right right directional bond
+         * @return the bond stereo or null if could not be determined
+         */
+        Expr determineBondStereo(Expr left, Expr right) {
+            switch (left.type()) {
+                case AND:
+                case OR:
+                    Expr sub1 = determineBondStereo(left.left(), right);
+                    Expr sub2 = determineBondStereo(left.right(), right);
+                    if (sub1 != null && sub2 != null)
+                        return new Expr(left.type(), sub1, sub2);
+                    else if (sub1 != null)
+                        return sub1;
+                    else if (sub2 != null)
+                        return sub2;
+                    else
+                        return null;
+                case NOT:
+                    sub1 = determineBondStereo(left.left(), right);
+                    if (sub1 != null)
+                        return sub1.negate();
+                    break;
+                case STEREOCHEMISTRY:
+                    switch (right.type()) {
+                        case AND:
+                        case OR:
+                            sub1 = determineBondStereo(left, right.left());
+                            sub2 = determineBondStereo(left, right.right());
+                            if (sub1 != null && sub2 != null)
+                                return new Expr(right.type(), sub1, sub2);
+                            else if (sub1 != null)
+                                return sub1;
+                            else if (sub2 != null)
+                                return sub2;
+                            else
+                                return null;
+                        case NOT:
+                            sub1 = determineBondStereo(left, right.left());
+                            if (sub1 != null)
+                                return sub1.negate();
+                            return null;
+                        case STEREOCHEMISTRY:
+                            if (left.value() == BOND_UNSPEC || right.value() == BOND_UNSPEC)
+                                return new Expr(STEREOCHEMISTRY, 0);
+                            if (left.value() == right.value())
+                                return new Expr(STEREOCHEMISTRY, IStereoElement.TOGETHER);
+                            else
+                                return new Expr(STEREOCHEMISTRY, IStereoElement.OPPOSITE);
+                        default:
+                            return null;
+                    }
+                default:
+                    return null;
+            }
+            return null;
+        }
+
+        // final check
+        boolean finish() {
+            // check for unclosed rings, components, and branches
+            if (numRingOpens != 0 || curComponentId != 0 || !stack.isEmpty())
+                return false;
+            if (role != ReactionRole.None) {
+                if (role != ReactionRole.Agent)
+                    return false;
+                markReactionRoles();
+                for (IAtom atom : mol.atoms()) {
+                    ReactionRole role = atom.getProperty(CDKConstants.REACTION_ROLE);
+                    ((QueryAtom) atom).getExpression().and(
+                        new Expr(Expr.Type.REACTION_ROLE,
+                                 role.ordinal())
+                    );
+                }
+            }
+            // setup data structures for stereo chemistry
+            for (IAtom atom : astereo) {
+                if (local.get(atom) == null)
+                    continue;
+                IAtom[] ligands = new IAtom[4];
+                int     degree  = 0;
+                for (IBond bond : local.get(atom))
+                    ligands[degree++] = bond.getOther(atom);
+                // add implicit neighbor, and move to correct position
+                if (degree == 3) {
+                    ligands[degree++] = atom;
+                    for (int j = 3; j > 0; j--) {
+                        if (mol.indexOf(ligands[j]) > mol.indexOf(ligands[j - 1]))
+                            break;
+                        swap(ligands, j, j - 1);
+                    }
+                }
+                if (degree == 4) {
+                    // Note the left and right is stored in the atom expression, we
+                    // only need the IStereoElement for the local ordering of neighbors
+                    mol.addStereoElement(new TetrahedralChirality(atom, ligands, 0));
+                }
+            }
+            // convert SMARTS up/down bond stereo to something we use to match
+            if (!bstereo.isEmpty()) {
+                for (IBond bond : mol.bonds()) {
+                    Expr expr = ((QueryBond) BondRef.deref(bond)).getExpression();
+                    if (hasAliphaticDoubleBond(expr)) {
+                        IBond left = null, right = null;
+                        List<IBond> bBonds = local.get(bond.getBegin());
+                        List<IBond> eBonds = local.get(bond.getEnd());
+
+                        // not part of this parse
+                        if (bBonds == null || eBonds == null)
+                            continue;
+
+                        for (IBond b : bBonds)
+                            if (bstereo.contains(b))
+                                left = b;
+                        for (IBond b : eBonds)
+                            if (bstereo.contains(b))
+                                right = b;
+                        if (left == null || right == null)
+                            continue;
+                        Expr leftExpr  = ((QueryBond) BondRef.deref(left)).getExpression();
+                        Expr rightExpr = ((QueryBond) BondRef.deref(right)).getExpression();
+                        Expr bexpr     = determineBondStereo(leftExpr, rightExpr);
+                        if (bexpr != null) {
+                            expr.and(bexpr);
+                            // '/' and '\' are directional, correct for this
+                            // relative labelling
+                            // C(/C)=C/C and C\C=C/C are both cis
+                            if (left.getBegin().equals(bond.getBegin()) !=
+                                right.getBegin().equals(bond.getEnd()))
+                                flip(bexpr);
+                            mol.addStereoElement(new DoubleBondStereochemistry(bond,
+                                                                               new IBond[]{
+                                                                                   left,
+                                                                                   right},
+                                                                               0));
+                        }
+                    }
+                }
+                // now strip all '/' and '\' from adjacent double bonds
+                for (IBond bond : bstereo) {
+                    Expr expr = ((QueryBond) BondRef.deref(bond)).getExpression();
+                    expr = strip(expr, Expr.Type.STEREOCHEMISTRY);
+                    if (expr == null)
+                        expr = new Expr(SINGLE_OR_AROMATIC);
+                    else
+                        expr.and(new Expr(SINGLE_OR_AROMATIC));
+                    ((QueryBond) bond).setExpression(expr);
+                }
+            }
+            return true;
+        }
+
+        void append(IAtom atom) {
+            if (curComponentId != 0)
+                atom.setProperty(CDKConstants.REACTION_GROUP, curComponentId);
+            mol.addAtom(atom);
+            if (prev != null) {
+                if (bond == null) {
+                    bond = new QueryBond(mol.getBuilder());
+                    bond.setExpression(new Expr(SINGLE_OR_AROMATIC));
+                }
+                bond.setAtom(prev, 0);
+                bond.setAtom(atom, 1);
+                addBond(prev, bond);
+                addBond(atom, bond);
+            }
+            prev = atom;
+            bond = null;
+        }
+
+        void append(Expr expr) {
+            QueryAtom atom = new QueryAtom(mol.getBuilder());
+            atom.setExpression(expr);
+            append(atom);
+        }
+
+        private char peek() {
+            return pos < str.length() ? str.charAt(pos) : '\0';
+        }
+
+        private char next() {
+            return pos < str.length() ? str.charAt(pos++) : '\0';
+        }
+
+        private static boolean isDigit(char c) {
+            return c >= '0' && c <= '9';
+        }
+
+        public boolean parse() {
+            while (pos < str.length()) {
+                switch (str.charAt(pos++)) {
+                    case '*':
+                        append(new Expr(Expr.Type.TRUE));
+                        break;
+                    case 'A':
+                        append(new Expr(Expr.Type.IS_ALIPHATIC));
+                        break;
+                    case 'B':
+                        if (peek() == 'r') {
+                            next();
+                            append(new Expr(ELEMENT,
+                                            Elements.BROMINE.getAtomicNumber()));
+                        } else {
+                            append(new Expr(ALIPHATIC_ELEMENT,
+                                            Elements.BORON.getAtomicNumber()));
+                        }
+                        break;
+                    case 'C':
+                        if (peek() == 'l') {
+                            next();
+                            append(new Expr(ELEMENT,
+                                            Elements.CHLORINE.getAtomicNumber()));
+                        } else {
+                            append(new Expr(ALIPHATIC_ELEMENT,
+                                            Elements.CARBON.getAtomicNumber()));
+                        }
+                        break;
+                    case 'N':
+                        append(new Expr(ALIPHATIC_ELEMENT,
+                                        Elements.NITROGEN.getAtomicNumber()));
+                        break;
+                    case 'O':
+                        append(new Expr(ALIPHATIC_ELEMENT,
+                                        Elements.OXYGEN.getAtomicNumber()));
+                        break;
+                    case 'P':
+                        append(new Expr(ALIPHATIC_ELEMENT,
+                                        Elements.PHOSPHORUS.getAtomicNumber()));
+                        break;
+                    case 'S':
+                        append(new Expr(ALIPHATIC_ELEMENT,
+                                        Elements.SULFUR.getAtomicNumber()));
+                        break;
+                    case 'F':
+                        append(new Expr(ELEMENT,
+                                        Elements.FLUORINE.getAtomicNumber()));
+                        break;
+                    case 'I':
+                        append(new Expr(ELEMENT,
+                                        Elements.IODINE.getAtomicNumber()));
+                        break;
+
+                    case 'a':
+                        append(new Expr(Expr.Type.IS_AROMATIC));
+                        break;
+                    case 'b':
+                        append(new Expr(AROMATIC_ELEMENT,
+                                        Elements.BORON.getAtomicNumber()));
+                        break;
+                    case 'c':
+                        append(new Expr(AROMATIC_ELEMENT,
+                                        Elements.CARBON.getAtomicNumber()));
+                        break;
+                    case 'n':
+                        append(new Expr(AROMATIC_ELEMENT,
+                                        Elements.NITROGEN.getAtomicNumber()));
+                        break;
+                    case 'o':
+                        append(new Expr(AROMATIC_ELEMENT,
+                                        Elements.OXYGEN.getAtomicNumber()));
+                        break;
+                    case 'p':
+                        append(new Expr(AROMATIC_ELEMENT,
+                                        Elements.PHOSPHORUS.getAtomicNumber()));
+                        break;
+                    case 's':
+                        append(new Expr(AROMATIC_ELEMENT,
+                                        Elements.SULFUR.getAtomicNumber()));
+                        break;
+                    case '[':
+                        if (!parseAtomExpr())
+                            return false;
+                        break;
+
+                    case '.':
+                        newFragment();
+                        break;
+                    case '-':
+                    case '=':
+                    case '#':
+                    case '$':
+                    case ':':
+                    case '@':
+                    case '~':
+                    case '!':
+                    case '/':
+                    case '\\':
+                        unget();
+                        if (!parseBondExpr())
+                            return false;
+                        break;
+
+                    case '(':
+                        if (prev == null) {
+                            if (!begComponentGroup())
+                                return false;
+                        } else {
+                            if (!openBranch())
+                                return false;
+                        }
+                        break;
+                    case ')':
+                        if (stack.isEmpty()) {
+                            if (!endComponentGroup())
+                                return false;
+                        } else {
+                            if (!closeBranch())
+                                return false;
+                        }
+                        break;
+
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                        if (!ringClosure(str.charAt(pos - 1) - '0'))
+                            return false;
+                        break;
+                    case '%':
+                        if (isDigit(peek())) {
+                            int rnum = str.charAt(pos++) - '0';
+                            if (isDigit(peek()))
+                                ringClosure(10 * rnum + (str.charAt(pos++) - '0'));
+                            else
+                                return false;
+                        } else {
+                            return false;
+                        }
+                        break;
+
+                    case '>':
+                        if (!stack.isEmpty())
+                            return false;
+                        if (!markReactionRoles())
+                            return false;
+                        prev = null;
+                        break;
+
+                    case ' ':
+                    case '\t':
+                        while (true) {
+                            if (isTerminalChar(next()))
+                                break;
+                        }
+                        mol.setTitle(str.substring(pos - 1));
+                        break;
+                    case '\r':
+                    case '\n':
+                    case '\0':
+                        return finish();
+
+                    default:
+                        return false;
+                }
+            }
+            return finish();
+        }
+
+        private boolean markReactionRoles() {
+            if (role == ReactionRole.None)
+                role = ReactionRole.Reactant;
+            else if (role == ReactionRole.Reactant)
+                role = ReactionRole.Agent;
+            else if (role == ReactionRole.Agent)
+                role = ReactionRole.Product;
+            else
+                return false;
+            int idx = mol.getAtomCount() - 1;
+            while (idx >= 0) {
+                IAtom atom = mol.getAtom(idx--);
+                if (atom.getProperty(CDKConstants.REACTION_ROLE) != null)
+                    break;
+                atom.setProperty(CDKConstants.REACTION_ROLE, role);
+            }
+            return true;
+        }
+
+        private boolean isTerminalChar(char c) {
+            switch (c) {
+                case '\0':
+                case '\n':
+                case '\r':
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    private static boolean hasOr(Expr expr) {
+        for (; ; ) {
+            switch (expr.type()) {
+                case AND:
+                    if (hasOr(expr.left()))
+                        return true;
+                    expr = expr.right();
+                    break;
+                case OR:
+                    return expr.left().type() != STEREOCHEMISTRY ||
+                           expr.right().type() != STEREOCHEMISTRY ||
+                           expr.right().value() != 0;
+                case SINGLE_OR_AROMATIC:
+                case SINGLE_OR_DOUBLE:
+                case DOUBLE_OR_AROMATIC:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    private static boolean isUpper(char c) {
+        return c >= 'A' && c <= 'Z';
+    }
+
+    private static boolean isLower(char c) {
+        return c >= 'a' && c <= 'z';
+    }
+
+    private static boolean isDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private static boolean generateBond(StringBuilder sb, Expr expr) {
+        switch (expr.type()) {
+            case TRUE:
+                sb.append('~');
+                break;
+            case FALSE:
+                sb.append("!~");
+                break;
+            case IS_AROMATIC:
+                sb.append(":");
+                break;
+            case IS_ALIPHATIC:
+                sb.append("!:");
+                break;
+            case IS_IN_RING:
+                sb.append("@");
+                break;
+            case IS_IN_CHAIN:
+                sb.append("!@");
+                break;
+            case SINGLE_OR_AROMATIC:
+                sb.append("-,:");
+                break;
+            case DOUBLE_OR_AROMATIC:
+                sb.append("=,:");
+                break;
+            case SINGLE_OR_DOUBLE:
+                sb.append("-,=");
+                break;
+            case ALIPHATIC_ORDER:
+                switch (expr.value()) {
+                    case 1:
+                        sb.append('-');
+                        break;
+                    case 2:
+                        sb.append('=');
+                        break;
+                    case 3:
+                        sb.append('#');
+                        break;
+                    case 4:
+                        sb.append('$');
+                        break;
+                    default:
+                        throw new IllegalArgumentException();
+                }
+                break;
+            case NOT:
+                sb.append('!');
+                if (!generateBond(sb, expr.left())) {
+                    sb.setLength(sb.length() - 1);
+                    return false;
+                }
+                break;
+            case OR:
+                if (generateBond(sb, expr.left())) {
+                    sb.append(',');
+                    if (!generateBond(sb, expr.right()))
+                        sb.setLength(sb.length() - 1);
+                    return true;
+                } else if (generateBond(sb, expr.right()))
+                    return true;
+                else
+                    return false;
+            case AND:
+                boolean lowPrec = hasOr(expr.left()) || hasOr(expr.right());
+                if (generateBond(sb, expr.left())) {
+                    if (lowPrec)
+                        sb.append(';');
+                    if (!generateBond(sb, expr.right()) && lowPrec)
+                        sb.setLength(sb.length() - 1);
+                    return true;
+                } else if (generateBond(sb, expr.right()))
+                    return true;
+                else
+                    return false;
+            case STEREOCHEMISTRY:
+                // bond stereo is encoded with directional / \ bonds we determine
+                // what these are separately and store them in 'bdirs'
+                return false;
+            default:
+                throw new IllegalArgumentException("Can not generate SMARTS for bond "
+                                                   + "expression: " + expr.type());
+        }
+        return true;
+    }
+
+    public static String generateAtom(Expr expr) {
+        return new Generator(null).generateAtom(null, expr);
+    }
+
+    public static String generateBond(Expr expr) {
+        // default bond type
+        if (expr.type() == SINGLE_OR_AROMATIC)
+            return "";
+        StringBuilder sb = new StringBuilder();
+        generateBond(sb, expr);
+        return sb.toString();
+    }
+
+    public static boolean parse(IAtomContainer mol, String smarts, int flavor) {
+        Parser state = new Parser(mol, smarts, flavor);
+        return state.parse();
+    }
+
+    public static boolean parse(IAtomContainer mol, String smarts) {
+        return parse(mol, smarts, FLAVOR_LOOSE);
+    }
+
+    private static final class Generator {
+
+        private final IAtomContainer          mol;
+        private final Map<IAtom, List<IBond>> nbrs;
+        // visit array
+        private final Set<IAtom>          avisit = new HashSet<>();
+        // ring bonds
+        private final Set<IBond>          rbonds = new HashSet<>();
+        // used ring numbers
+        private final boolean[]           rvisit = new boolean[100];
+        // open ring bonds and their number
+        private final Map<IBond, Integer> rnums  = new HashMap<>();
+        // bond direction (up/down) for stereo
+        private final Map<IBond, String>  bdirs  = new HashMap<>();
+        // logger
+        private final ILoggingTool logger = LoggingToolFactory.createLoggingTool(Generator.class);
+
+        /* fields only used for assign double bond stereo */
+        // stereo element cache
+        private Map<IChemObject,IStereoElement> ses;
+        // marks atoms that are in double bonds with stereo
+        private Set<IAtom>                      adjToDb;
+        // marks stereo bonds we've visited
+        private Set<IBond>                      bvisit;
+
+        public Generator(IAtomContainer mol) {
+            this.mol = mol;
+            this.nbrs = new HashMap<>();
+        }
+
+        private int nextRingNum() {
+            int rnum = 1;
+            while (rnum < rvisit.length && rvisit[rnum]) {
+                rnum++;
+            }
+            if (rnum < rvisit.length) {
+                rvisit[rnum] = true;
+                return rnum;
+            }
+            throw new IllegalStateException("Not enough ring numbers!");
+        }
+
+        private void markRings(IAtom atom, IBond prev) {
+            avisit.add(atom);
+            List<IBond> bonds = mol.getConnectedBondsList(atom);
+            nbrs.put(atom, bonds);
+            for (IBond bond : bonds) {
+                if (bond == prev) continue;
+                IAtom other = bond.getOther(atom);
+                if (avisit.contains(other))
+                    rbonds.add(bond);
+                else
+                    markRings(other, bond);
+            }
+        }
+
+        // select a bond we will put the directional '/' '\' labels  on
+        private IBond chooseBondToDir(IAtom atom, IBond db, Set<IAtom> adjToDb) {
+            IBond choice = null;
+            for (IBond bond : nbrs.get(atom)) {
+                if (bond == db)
+                    continue;
+                if (adjToDb.contains(bond.getOther(atom)))
+                    return bond;
+                else
+                    choice = bond;
+            }
+            return choice;
+        }
+
+        private void setBondDir(IAtom beg, IBond bond, String dir) {
+            if (bond.getEnd().equals(beg)) {
+                bdirs.put(bond, dir);
+            } else if (bond.getBegin().equals(beg)) {
+                if (dir.equals(BSTEREO_UP))
+                    dir = BSTEREO_DN;
+                else if (dir.equals(BSTEREO_DN))
+                    dir = BSTEREO_UP;
+                else if (dir.equals(BSTEREO_UPU))
+                    dir = BSTEREO_DNU;
+                else if (dir.equals(BSTEREO_DNU))
+                    dir = BSTEREO_UPU;
+                bdirs.put(bond, dir);
+            } else
+                throw new IllegalArgumentException();
+        }
+
+        private void setBondDirs(IAtomContainer mol) {
+
+            adjToDb = new HashSet<>();
+            ses = new HashMap<>();
+            bvisit = new HashSet<>();
+
+            for (IStereoElement se : mol.stereoElements()) {
+                if (se.getConfigClass() == IStereoElement.CisTrans) {
+                    ses.put(se.getFocus(), se);
+                }
+            }
+
+            for (IBond bond : mol.bonds()) {
+                Expr expr = ((QueryBond) BondRef.deref(bond)).getExpression();
+                int  flags = getBondStereoFlag(expr);
+                if (flags != BSTEREO_ANY) {
+                    adjToDb.add(bond.getBegin());
+                    adjToDb.add(bond.getEnd());
+                }
+            }
+
+            // first we set and propagate
+            for (IBond bond : mol.bonds()) {
+                if (!bvisit.contains(bond))
+                    propagateBondStereo(bond, false);
+            }
+            // now set the complex ones
+            for (IBond bond : mol.bonds()) {
+                if (!bvisit.contains(bond))
+                    propagateBondStereo(bond, true);
+            }
+        }
+
+        private void propagateBondStereo(IBond bond, boolean all) {
+            Expr expr  = ((QueryBond) BondRef.deref(bond)).getExpression();
+            int  flags = getBondStereoFlag(expr);
+            if (flags != BSTEREO_ANY) {
+
+                // first pass only handle CIS and TRANS bond stereo, ignoring
+                // cis/upspec, trans/unspec, cis/trans, etc.
+                if (!all && flags != BSTEREO_CIS && flags != BSTEREO_TRANS)
+                    return;
+
+                bvisit.add(bond);
+                final IAtom beg = bond.getBegin();
+                final IAtom end = bond.getEnd();
+
+                final IBond bBond = chooseBondToDir(beg, bond, adjToDb);
+                final IBond eBond = chooseBondToDir(end, bond, adjToDb);
+
+                if (bBond == null || eBond == null) {
+                    logger.warn("Too few bonds to encode bond stereochemistry in SMARTS");
+                    return;
+                }
+
+                // if a stereo element is specified it may have extra
+                // information about which bonds are the 'reference', only
+                // matters if either neighbor is deg > 2
+                IStereoElement se = ses.get(bond);
+                if (se != null) {
+                    if (se.getCarriers().contains(bBond) != se.getCarriers().contains(eBond)) {
+                        switch (flags) {
+                            case BSTEREO_CIS:
+                                flags = BSTEREO_TRANS;
+                                break;
+                            case BSTEREO_TRANS:
+                                flags = BSTEREO_CIS;
+                                break;
+                            case BSTEREO_CIS_OR_UNSPEC:
+                                flags = BSTEREO_TRANS_OR_UNSPEC;
+                                break;
+                            case BSTEREO_TRANS_OR_UNSPEC:
+                                flags = BSTEREO_CIS_OR_UNSPEC;
+                                break;
+                        }
+                    }
+                }
+
+                // current begin and end directions
+                String bDir = bdirs.get(bBond);
+                String eDir = bdirs.get(eBond);
+
+                // trivial case no conflict possible
+                if (bDir == null && eDir == null) {
+                    switch (flags) {
+                        case BSTEREO_CIS:
+                            setBondDir(beg, bBond, BSTEREO_UP);
+                            setBondDir(end, eBond, BSTEREO_UP);
+                            break;
+                        case BSTEREO_TRANS:
+                            setBondDir(beg, bBond, BSTEREO_UP);
+                            setBondDir(end, eBond, BSTEREO_DN);
+                            break;
+                        case BSTEREO_CIS_OR_TRANS:
+                            setBondDir(beg, bBond, BSTEREO_UP);
+                            setBondDir(end, eBond, BSTEREO_EITHER);
+                            break;
+                        case BSTEREO_CIS_OR_UNSPEC:
+                            setBondDir(beg, bBond, BSTEREO_UP);
+                            setBondDir(end, eBond, BSTEREO_UPU);
+                            break;
+                        case BSTEREO_TRANS_OR_UNSPEC:
+                            setBondDir(beg, bBond, BSTEREO_UP);
+                            setBondDir(end, eBond, BSTEREO_DNU);
+                            break;
+                        case BSTEREO_UNSPEC:
+                            setBondDir(beg, bBond, BSTEREO_UP);
+                            setBondDir(end, eBond, BSTEREO_NEITHER);
+                            break;
+                    }
+                }
+                // set relative to the beg direction
+                else if (eDir == null) {
+                    switch (flags) {
+                        case BSTEREO_CIS:
+                            if (bDir.equals(BSTEREO_UP))
+                                setBondDir(end, eBond, BSTEREO_UP);
+                            else if (bDir.equals(BSTEREO_DN))
+                                setBondDir(end, eBond, BSTEREO_DN);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_TRANS:
+                            if (bDir.equals(BSTEREO_UP))
+                                setBondDir(end, eBond, BSTEREO_DN);
+                            else if (bDir.equals(BSTEREO_DN))
+                                setBondDir(end, eBond, BSTEREO_UP);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_CIS_OR_TRANS:
+                            if (bDir.equals(BSTEREO_UP) || bDir.equals(BSTEREO_DN))
+                                setBondDir(end, eBond, BSTEREO_EITHER);
+                            else if (!bDir.equals(BSTEREO_NEITHER))
+                                setBondDir(end, bBond, BSTEREO_UP);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_CIS_OR_UNSPEC:
+                            if (bDir.equals(BSTEREO_UP))
+                                setBondDir(end, eBond, BSTEREO_UPU);
+                            else if (bDir.equals(BSTEREO_DN))
+                                setBondDir(end, eBond, BSTEREO_DNU);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_TRANS_OR_UNSPEC:
+                            if (bDir.equals(BSTEREO_UP))
+                                setBondDir(end, eBond, BSTEREO_DNU);
+                            else if (bDir.equals(BSTEREO_DN))
+                                setBondDir(end, eBond, BSTEREO_UPU);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_UNSPEC:
+                            if (bDir.equals(BSTEREO_NEITHER))
+                                setBondDir(end, eBond, BSTEREO_UP);
+                            else
+                                setBondDir(end, eBond, BSTEREO_NEITHER);
+                            break;
+                    }
+                }
+                // set relative to the end direction
+                else if (bDir == null) {
+                    switch (flags) {
+                        case BSTEREO_CIS:
+                            if (eDir.equals(BSTEREO_UP))
+                                setBondDir(beg, bBond, BSTEREO_UP);
+                            else if (eDir.equals(BSTEREO_DN))
+                                setBondDir(beg, bBond, BSTEREO_DN);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_TRANS:
+                            if (eDir.equals(BSTEREO_UP))
+                                setBondDir(beg, bBond, BSTEREO_DN);
+                            else if (eDir.equals(BSTEREO_DN))
+                                setBondDir(beg, bBond, BSTEREO_UP);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_CIS_OR_TRANS:
+                            if (eDir.equals(BSTEREO_UP) || eDir.equals(BSTEREO_DN))
+                                setBondDir(beg, bBond, BSTEREO_EITHER);
+                            else if (!eDir.equals(BSTEREO_NEITHER))
+                                setBondDir(beg, bBond, BSTEREO_UP);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_CIS_OR_UNSPEC:
+                            if (eDir.equals(BSTEREO_UP))
+                                setBondDir(beg, bBond, BSTEREO_UPU);
+                            else if (eDir.equals(BSTEREO_DN))
+                                setBondDir(beg, bBond, BSTEREO_DNU);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_TRANS_OR_UNSPEC:
+                            if (eDir.equals(BSTEREO_UP))
+                                setBondDir(beg, bBond, BSTEREO_DNU);
+                            else if (eDir.equals(BSTEREO_DN))
+                                setBondDir(beg, bBond, BSTEREO_UPU);
+                            else
+                                logger.warn("Could not encode bond stereochemistry");
+                            break;
+                        case BSTEREO_UNSPEC:
+                            if (eDir.equals(BSTEREO_NEITHER))
+                                setBondDir(beg, bBond, BSTEREO_UP);
+                            else
+                                setBondDir(beg, bBond, BSTEREO_NEITHER);
+                            break;
+                    }
+                } else {
+                    logger.warn("Bond stereochemistry may be incorrect");
+                }
+
+                // propagate bond decision
+                for (IBond bOther : nbrs.get(bBond.getOther(beg)))
+                    if (!bvisit.contains(bOther))
+                        propagateBondStereo(bOther, all);
+                for (IBond bOther : nbrs.get(eBond.getOther(end)))
+                    if (!bvisit.contains(bOther))
+                        propagateBondStereo(bOther, all);
+            }
+        }
+
+        private boolean isRingOpen(IBond bond) {
+            return rbonds.contains(bond);
+        }
+
+        private boolean isRingClose(IBond bond) {
+            return rnums.containsKey(bond);
+        }
+
+        private void sort(List<IBond> bonds, final IBond prev) {
+            Collections.sort(bonds,
+                             new Comparator<IBond>() {
+                                 @Override
+                                 public int compare(IBond a, IBond b) {
+                                     if (a == prev)
+                                         return -1;
+                                     if (b == prev)
+                                         return +1;
+                                     if (isRingClose(a) && !isRingClose(b))
+                                         return -1;
+                                     if (!isRingClose(a) && isRingClose(b))
+                                         return +1;
+                                     if (isRingOpen(a) && !isRingOpen(b))
+                                         return -1;
+                                     if (!isRingOpen(a) && isRingOpen(b))
+                                         return +1;
+                                     return 0;
+                                 }
+                             });
+        }
+
+        private void generateRecurAtom(StringBuilder sb,
+                                       IAtom atom,
+                                       Expr expr) {
+            sb.append("$([");
+            generateAtom(sb, atom, expr, false);
+            sb.append("])");
+        }
+
+        private void generateAtom(StringBuilder sb,
+                                  IAtom atom,
+                                  Expr expr,
+                                  boolean withDisjunction) {
+            switch (expr.type()) {
+                case TRUE:
+                    sb.append('*');
+                    break;
+                case FALSE:
+                    sb.append("!*");
+                    break;
+                case IS_AROMATIC:
+                    sb.append('a');
+                    break;
+                case IS_ALIPHATIC:
+                    sb.append('A');
+                    break;
+                case IS_IN_RING:
+                    sb.append('R');
+                    break;
+                case IS_IN_CHAIN:
+                    sb.append("!R");
+                    break;
+                case DEGREE:
+                    sb.append('D');
+                    if (expr.value() != 1)
+                        sb.append(expr.value());
+                    break;
+                case TOTAL_H_COUNT:
+                    sb.append('H');
+                    sb.append(expr.value());
+                    break;
+                case HAS_IMPLICIT_HYDROGEN:
+                    sb.append('h');
+                    break;
+                case IMPL_H_COUNT:
+                    sb.append('h').append(expr.value());
+                    break;
+                case VALENCE:
+                    sb.append('v');
+                    if (expr.value() != 1)
+                        sb.append(expr.value());
+                    break;
+                case TOTAL_DEGREE:
+                    sb.append('X');
+                    if (expr.value() != 1)
+                        sb.append(expr.value());
+                    break;
+                case FORMAL_CHARGE:
+                    if (expr.value() == -1)
+                        sb.append('-');
+                    else if (expr.value() == +1)
+                        sb.append('+');
+                    else if (expr.value() == 0)
+                        sb.append('+').append('0');
+                    else if (expr.value() < 0)
+                        sb.append(expr.value());
+                    else
+                        sb.append('+').append(expr.value());
+                    break;
+                case RING_BOND_COUNT:
+                    sb.append('x').append(expr.value());
+                    break;
+                case RING_COUNT:
+                    sb.append('R').append(expr.value());
+                    break;
+                case RING_SMALLEST:
+                    sb.append('r').append(expr.value());
+                    break;
+                case HAS_ISOTOPE:
+                    sb.append("!0");
+                    break;
+                case HAS_UNSPEC_ISOTOPE:
+                    sb.append("0");
+                    break;
+                case ISOTOPE:
+                    sb.append(expr.value());
+                    break;
+                case ELEMENT:
+                    switch (expr.value()) {
+                        case 0:
+                            sb.append("#0");
+                            break;
+                        case 1:
+                            sb.append("#1");
+                            break;
+                        case 5: // B
+                        case 6: // C
+                        case 7: //
+                        case 8:
+                        case 13:
+                        case 14:
+                        case 15:
+                        case 16:
+                        case 33:
+                        case 34:
+                        case 51:
+                        case 52:
+                            sb.append('#').append(expr.value());
+                            break;
+                        default:
+                            // can't be aromatic, just emit the symbol
+                            Elements elem = Elements.ofNumber(expr.value());
+                            if (elem == Elements.Unknown)
+                                throw new IllegalArgumentException("No element with atomic number: " + expr.value());
+                            if (expr.value() > Elements.RADON.getAtomicNumber())
+                                sb.append('#').append(expr.value());
+                            else
+                                sb.append(elem.symbol());
+                            break;
+                    }
+                    break;
+                case ALIPHATIC_ELEMENT:
+                    Elements elem = Elements.ofNumber(expr.value());
+                    if (elem == Elements.Unknown)
+                        throw new IllegalArgumentException("No element with atomic number: " + expr.value());
+                    if (expr.value() > Elements.RADON.getAtomicNumber())
+                        sb.append('#').append(expr.value()).append('A');
+                    else
+                        sb.append(elem.symbol());
+                    break;
+                case AROMATIC_ELEMENT:
+                    // could restrict
+                    elem = Elements.ofNumber(expr.value());
+                    if (elem == Elements.Unknown)
+                        throw new IllegalArgumentException("No element with atomic number: " + expr.value());
+                    sb.append(elem.symbol().toLowerCase(Locale.ROOT));
+                    break;
+                case AND:
+
+                    if (expr.left().type() == REACTION_ROLE) {
+                        generateAtom(sb, atom, expr.right(), withDisjunction);
+                        return;
+                    } else if (expr.right().type() == REACTION_ROLE) {
+                        generateAtom(sb, atom, expr.left(), withDisjunction);
+                        return;
+                    }
+
+                    boolean disjuncBelow = hasOr(expr.left()) || hasOr(expr.right());
+                    if (disjuncBelow) {
+                        // if we're below and above a disjunction we must use
+                        // recursive SMARTS to group the terms correctly
+                        if (withDisjunction) {
+                            if (hasOr(expr.left()))
+                                generateRecurAtom(sb, atom, expr.left());
+                            else
+                                generateAtom(sb, atom, expr.left(), true);
+                            int mark = sb.length();
+                            if (hasOr(expr.right()))
+                                generateRecurAtom(sb, atom, expr.right());
+                            else
+                                generateAtom(sb, atom, expr.right(), true);
+                            maybeExplAnd(sb, mark);
+                        } else {
+                            generateAtom(sb, atom, expr.left(), false);
+                            sb.append(';');
+                            generateAtom(sb, atom, expr.right(), false);
+                        }
+                    } else {
+                        generateAtom(sb, atom, expr.left(), withDisjunction);
+                        int mark = sb.length();
+                        generateAtom(sb, atom, expr.right(), withDisjunction);
+                        maybeExplAnd(sb, mark);
+                    }
+                    break;
+                case OR:
+                    if (expr.left().type() == STEREOCHEMISTRY &&
+                        expr.right().type() == STEREOCHEMISTRY &&
+                        expr.right().value() == 0) {
+                        generateAtom(sb, atom, expr.left(), true);
+                        sb.append('?');
+                    } else {
+                        generateAtom(sb, atom, expr.left(), true);
+                        sb.append(',');
+                        generateAtom(sb, atom, expr.right(), true);
+                    }
+                    break;
+                case NOT:
+                    sb.append('!');
+                    switch (expr.left().type()) {
+                        case AND:
+                        case OR:
+                            generateRecurAtom(sb, atom, expr.left());
+                            break;
+                        default:
+                            generateAtom(sb, atom, expr.left(), withDisjunction);
+                            break;
+                    }
+                    break;
+                case RECURSIVE:
+                    sb.append("$(").append(Smarts.generate(expr.subquery())).append(")");
+                    break;
+                case STEREOCHEMISTRY:
+                    int order = expr.value();
+                    // stereo depends on output order, if within writePart
+                    // we have this stored in 'nbrs'
+                    if (atom != null && flipStereo(atom))
+                        order ^= (IStereoElement.LEFT | IStereoElement.RIGHT);
+                    if (order == IStereoElement.LEFT)
+                        sb.append('@');
+                    else if (order == IStereoElement.RIGHT)
+                        sb.append("@@");
+                    else
+                        throw new IllegalArgumentException();
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+        }
+
+        static int parity4(IAtom[] b1, IAtom[] b2) {
+            // auto generated
+            if (b1[0] == b2[0]) {
+                if (b1[1] == b2[1]) {
+                    // a,b,c,d -> a,b,c,d
+                    if (b1[2] == b2[2] && b1[3] == b2[3]) return 2;
+                    // a,b,c,d -> a,b,d,c
+                    if (b1[2] == b2[3] && b1[3] == b2[2]) return 1;
+                } else if (b1[1] == b2[2]) {
+                    // a,b,c,d -> a,c,b,d
+                    if (b1[2] == b2[1] && b1[3] == b2[3]) return 1;
+                    // a,b,c,d -> a,c,d,b
+                    if (b1[2] == b2[3] && b1[3] == b2[1]) return 2;
+                } else if (b1[1] == b2[3]) {
+                    // a,b,c,d -> a,d,c,b
+                    if (b1[2] == b2[2] && b1[3] == b2[1]) return 1;
+                    // a,b,c,d -> a,d,b,c
+                    if (b1[2] == b2[1] && b1[3] == b2[2]) return 2;
+                }
+            } else if (b1[0] == b2[1]) {
+                if (b1[1] == b2[0]) {
+                    // a,b,c,d -> b,a,c,d
+                    if (b1[2] == b2[2] && b1[3] == b2[3]) return 1;
+                    // a,b,c,d -> b,a,d,c
+                    if (b1[2] == b2[3] && b1[3] == b2[2]) return 2;
+                } else if (b1[1] == b2[2]) {
+                    // a,b,c,d -> b,c,a,d
+                    if (b1[2] == b2[0] && b1[3] == b2[3]) return 2;
+                    // a,b,c,d -> b,c,d,a
+                    if (b1[2] == b2[3] && b1[3] == b2[0]) return 1;
+                } else if (b1[1] == b2[3]) {
+                    // a,b,c,d -> b,d,c,a
+                    if (b1[2] == b2[2] && b1[3] == b2[0]) return 2;
+                    // a,b,c,d -> b,d,a,c
+                    if (b1[2] == b2[0] && b1[3] == b2[2]) return 1;
+                }
+            } else if (b1[0] == b2[2]) {
+                if (b1[1] == b2[1]) {
+                    // a,b,c,d -> c,b,a,d
+                    if (b1[2] == b2[0] && b1[3] == b2[3]) return 1;
+                    // a,b,c,d -> c,b,d,a
+                    if (b1[2] == b2[3] && b1[3] == b2[0]) return 2;
+                } else if (b1[1] == b2[0]) {
+                    // a,b,c,d -> c,a,b,d
+                    if (b1[2] == b2[1] && b1[3] == b2[3]) return 2;
+                    // a,b,c,d -> c,a,d,b
+                    if (b1[2] == b2[3] && b1[3] == b2[1]) return 1;
+                } else if (b1[1] == b2[3]) {
+                    // a,b,c,d -> c,d,a,b
+                    if (b1[2] == b2[0] && b1[3] == b2[1]) return 2;
+                    // a,b,c,d -> c,d,b,a
+                    if (b1[2] == b2[1] && b1[3] == b2[0]) return 1;
+                }
+            } else if (b1[0] == b2[3]) {
+                if (b1[1] == b2[1]) {
+                    // a,b,c,d -> d,b,c,a
+                    if (b1[2] == b2[2] && b1[3] == b2[0]) return 1;
+                    // a,b,c,d -> d,b,a,c
+                    if (b1[2] == b2[0] && b1[3] == b2[2]) return 2;
+                } else if (b1[1] == b2[2]) {
+                    // a,b,c,d -> d,c,b,a
+                    if (b1[2] == b2[1] && b1[3] == b2[0]) return 2;
+                    // a,b,c,d -> d,c,a,b
+                    if (b1[2] == b2[0] && b1[3] == b2[1]) return 1;
+                } else if (b1[1] == b2[0]) {
+                    // a,b,c,d -> d,a,c,b
+                    if (b1[2] == b2[2] && b1[3] == b2[1]) return 2;
+                    // a,b,c,d -> d,a,b,c
+                    if (b1[2] == b2[1] && b1[3] == b2[2]) return 1;
+                }
+            }
+            return 0;
+        }
+
+        public String generate(IAtom end, QueryBond bond) {
+            String bexpr = generateBond(bond.getExpression());
+            if (bdirs.containsKey(bond)) {
+                String bdir = bdirs.get(bond);
+                if (bond.getBegin().equals(end)) {
+                    switch (bdir) {
+                        case BSTEREO_DN:  bdir = BSTEREO_UP; break;
+                        case BSTEREO_UP:  bdir = BSTEREO_DN; break;
+                        case BSTEREO_DNU: bdir = BSTEREO_UPU; break;
+                        case BSTEREO_UPU: bdir = BSTEREO_DNU; break;
+                    }
+                }
+                if (bexpr.isEmpty())
+                    bexpr = bdir;
+                else
+                    bexpr += ';' + bdir;
+            }
+            return bexpr;
+        }
+
+        private boolean flipStereo(IAtom atom) {
+            List<IBond> bonds = nbrs.get(atom);
+            for (IStereoElement se : mol.stereoElements()) {
+                if (se.getConfigClass() == IStereoElement.TH &&
+                    se.getFocus().equals(atom)) {
+                    @SuppressWarnings("unchecked")
+                    List<IAtom> src = (List<IAtom>) se.getCarriers();
+                    List<IAtom> dst = new ArrayList<>();
+                    for (IBond bond : bonds)
+                        dst.add(bond.getOther(atom));
+                    if (dst.size() == 3) {
+                        if (avisit.contains(dst.get(0)))
+                            dst.add(1, atom);
+                        else
+                            dst.add(0, atom);
+                    }
+                    return parity4(src.toArray(new IAtom[4]),
+                                   dst.toArray(new IAtom[4])) == 1;
+                }
+            }
+            // no enough info
+            return false;
+        }
+
+        private static void maybeExplAnd(StringBuilder sb, int mark) {
+            if (isDigit(sb.charAt(mark)) ||
+                isUpper(sb.charAt(mark - 1)) && isLower(sb.charAt(mark)))
+                sb.insert(mark, '&');
+        }
+
+        String generateAtom(IAtom atom, Expr expr) {
+
+            if (expr.type() == AND) {
+                if (expr.left().type() == Expr.Type.REACTION_ROLE)
+                    return generateAtom(atom, expr.right());
+                if (expr.right().type() == Expr.Type.REACTION_ROLE)
+                    return generateAtom(atom, expr.left());
+            }
+
+            int mapidx = atom != null ? mapidx(atom) : 0;
+            if (mapidx == 0) {
+                switch (expr.type()) {
+                    case TRUE:
+                        return "*";
+                    case ELEMENT:
+                        switch (expr.value()) {
+                            case 9:
+                                return "F";
+                            case 17:
+                                return "Cl";
+                            case 35:
+                                return "Br";
+                            case 53:
+                                return "I";
+                        }
+                        break;
+                    case AROMATIC_ELEMENT:
+                        switch (expr.value()) {
+                            case 5:
+                                return "b";
+                            case 6:
+                                return "c";
+                            case 7:
+                                return "n";
+                            case 8:
+                                return "o";
+                            case 15:
+                                return "p";
+                            case 16:
+                                return "s";
+                        }
+                        break;
+                    case ALIPHATIC_ELEMENT:
+                        switch (expr.value()) {
+                            case 5:
+                                return "B";
+                            case 6:
+                                return "C";
+                            case 7:
+                                return "N";
+                            case 8:
+                                return "O";
+                            case 9:
+                                return "F";
+                            case 15:
+                                return "P";
+                            case 16:
+                                return "S";
+                            case 17:
+                                return "Cl";
+                            case 35:
+                                return "Br";
+                            case 53:
+                                return "I";
+                        }
+                        break;
+                }
+            }
+            StringBuilder sb = new StringBuilder();
+            sb.append('[');
+            generateAtom(sb, atom, expr, false);
+            if (mapidx != 0)
+                sb.append(':').append(mapidx);
+            sb.append(']');
+            return sb.toString();
+        }
+
+        private void writePart(StringBuilder sb, IAtom atom, IBond prev) {
+            final List<IBond> bonds  = nbrs.get(atom);
+            int               remain = bonds.size();
+            sort(bonds, prev);
+            if (prev != null) {
+                remain--;
+                sb.append(generate(atom, ((QueryBond) BondRef.deref(prev))));
+            }
+            sb.append(generateAtom(atom, ((QueryAtom) AtomRef.deref(atom)).getExpression()));
+            avisit.add(atom);
+
+            for (IBond bond : bonds) {
+                if (bond == prev)
+                    continue;
+                // ring close
+                if (isRingClose(bond)) {
+                    Integer rnum = rnums.get(bond);
+                    sb.append(generate(bond.getOther(atom), ((QueryBond) BondRef.deref(bond))));
+                    sb.append(rnum);
+                    rvisit[rnum] = false;
+                    rnums.remove(bond);
+                    remain--;
+                }
+                // ring open
+                else if (isRingOpen(bond)) {
+                    int rnum = nextRingNum();
+                    sb.append(rnum);
+                    rnums.put(bond, rnum);
+                    rbonds.remove(bond);
+                    remain--;
+                }
+                // branch
+                else {
+                    IAtom other = bond.getOther(atom);
+                    remain--;
+                    if (remain != 0)
+                        sb.append('(');
+                    writePart(sb, other, bond);
+                    if (remain != 0)
+                        sb.append(')');
+                }
+            }
+        }
+
+        private void writeParts(IAtom[] atoms, StringBuilder sb,
+                                ReactionRole role) {
+            boolean first    = true;
+            int     prevComp = 0;
+            for (IAtom atom : atoms) {
+                if (role != null && role(atom) != role)
+                    continue;
+                if (avisit.contains(atom))
+                    continue;
+                int currComp = compGroup(atom);
+                if (prevComp != currComp && prevComp != 0)
+                    sb.append(')');
+                if (!first)
+                    sb.append('.');
+                if (currComp != prevComp && currComp != 0)
+                    sb.append('(');
+                writePart(sb, atom, null);
+                first = false;
+                prevComp = currComp;
+            }
+            if (prevComp != 0)
+                sb.append(')');
+        }
+
+        public String generate() {
+
+            IAtom[] atoms = AtomContainerManipulator.getAtomArray(mol);
+            sortAtoms(atoms);
+
+            // mark ring closures
+            for (IAtom atom : atoms)
+                if (!avisit.contains(atom))
+                    markRings(atom, null);
+            avisit.clear();
+
+            setBondDirs(mol);
+
+            boolean       isRxn = role(atoms[atoms.length - 1]) != ReactionRole.None;
+            StringBuilder sb    = new StringBuilder();
+            if (isRxn) {
+                writeParts(atoms, sb, ReactionRole.Reactant);
+                sb.append('>');
+                writeParts(atoms, sb, ReactionRole.Agent);
+                sb.append('>');
+                writeParts(atoms, sb, ReactionRole.Product);
+            } else {
+                writeParts(atoms, sb, null);
+            }
+            return sb.toString();
+        }
+
+
+        private void sortAtoms(IAtom[] atoms) {
+            Arrays.sort(atoms,
+                        new Comparator<IAtom>() {
+                            @Override
+                            public int compare(IAtom a, IAtom b) {
+                                int cmp = role(a).compareTo(role(b));
+                                if (cmp != 0)
+                                    return cmp;
+                                return Integer.compare(compGroup(a), compGroup(b));
+                            }
+                        });
+        }
+    }
+
+    public static String generate(IAtomContainer mol) {
+        return new Generator(mol).generate();
+    }
+
+    private static int compGroup(IAtom atom) {
+        Integer id = atom.getProperty(CDKConstants.REACTION_GROUP);
+        return id != null ? id : 0;
+    }
+
+    private static ReactionRole role(IAtom atom) {
+        ReactionRole role = atom.getProperty(CDKConstants.REACTION_ROLE);
+        return role != null ? role : ReactionRole.None;
+    }
+
+    private static int mapidx(IAtom atom) {
+        Integer mapidx = atom.getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+        return mapidx != null ? mapidx : 0;
+    }
+
+    private static int getBondStereoFlag(Expr expr) {
+        switch (expr.type()) {
+            case STEREOCHEMISTRY:
+                switch (expr.value()) {
+                    case 0:
+                        return BSTEREO_UNSPEC;
+                    case IStereoElement.TOGETHER:
+                        return BSTEREO_CIS;
+                    case IStereoElement.OPPOSITE:
+                        return BSTEREO_TRANS;
+                    default:
+                        throw new IllegalArgumentException();
+                }
+            case OR:
+                return getBondStereoFlag(expr.left()) |
+                       getBondStereoFlag(expr.right());
+            case AND:
+                return getBondStereoFlag(expr.left()) &
+                       getBondStereoFlag(expr.right());
+            case NOT:
+                return ~getBondStereoFlag(expr.left());
+            default:
+                return BSTEREO_ANY;
+        }
+    }
+
+    /**
+     * Traverse and expression and remove all expressions of a given type.
+     *
+     * @param expr the expression tree
+     * @param type remove expressions of this type
+     * @return the stripped expression, possibly null
+     */
+    private static Expr strip(Expr expr, Expr.Type type) {
+        switch (expr.type()) {
+            case AND:
+            case OR:
+                Expr left = strip(expr.left(), type);
+                Expr right = strip(expr.right(), type);
+                if (left != null && right != null)
+                    expr.setLogical(expr.type(), left, right);
+                else if (left != null)
+                    return left;
+                else if (right != null)
+                    return right;
+                else
+                    return null;
+            case NOT:
+                Expr sub = strip(expr.left(), type);
+                if (sub != null) {
+                    expr.setLogical(expr.type(), sub, null);
+                    return expr;
+                } else {
+                    return null;
+                }
+            default:
+                return expr.type() == type ? null : expr;
+        }
+    }
+}

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/Smarts.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/Smarts.java
@@ -100,7 +100,7 @@ import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TRUE;
  * }
  * }
  * </pre>
- * When parsing SMARTS several flavors are available. The flavors effect how
+ * When parsing SMARTS several flavors are available. The flavors affect how
  * queries are interpreted. The following flavors are available:
  * <ul>
  *     <li>{@link #FLAVOR_LOOSE} - allows all unambiguous extensions.</li>

--- a/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/Smarts.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/isomorphism/Smarts.java
@@ -2704,6 +2704,10 @@ public final class Smarts {
                 switch (expr.type()) {
                     case TRUE:
                         return "*";
+                    case IS_AROMATIC:
+                        return "a";
+                    case IS_ALIPHATIC:
+                        return "A";
                     case ELEMENT:
                         switch (expr.value()) {
                             case 9:

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/ParserTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/ParserTest.java
@@ -1,0 +1,1494 @@
+/* Copyright (C) 2004-2007  Egon Willighagen <egonw@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.openscience.cdk.isomorphism;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openscience.cdk.CDKTestCase;
+import org.openscience.cdk.DefaultChemObjectBuilder;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
+import org.openscience.cdk.isomorphism.matchers.smarts.AnyOrderQueryBond;
+import org.openscience.cdk.isomorphism.matchers.smarts.AromaticQueryBond;
+import org.openscience.cdk.isomorphism.matchers.smarts.OrderQueryBond;
+import org.openscience.cdk.isomorphism.matchers.smarts.SMARTSAtom;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+
+/**
+ * JUnit test routines for the SMARTS parser.
+ *
+ * @author Egon Willighagen
+ * @cdk.module test-smarts
+ * @cdk.require ant1.6
+ */
+public class ParserTest extends CDKTestCase {
+
+    private void parse(String smarts, int flav) throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
+        if (!Smarts.parse(builder.newAtomContainer(), smarts, flav))
+            throw new Exception("Invalid SMARTS!");
+    }
+
+    private void parse(String smarts) throws Exception {
+        parse(smarts, Smarts.FLAVOR_LOOSE);
+    }
+
+    @Test
+    public void testQueryAtomCreation() throws Exception {
+        parse("*");
+    }
+
+    @Test
+    public void testAliphaticAtom() throws Exception {
+        parse("A");
+    }
+
+    @Test
+    public void testAromaticAtom() throws Exception {
+        parse("a");
+    }
+
+    @Test
+    public void testDegree() throws Exception {
+        parse("[D2]");
+    }
+
+    @Test
+    public void testImplicitHCount() throws Exception {
+        parse("[h3]");
+    }
+
+    @Test
+    public void testTotalHCount() throws Exception {
+        parse("[H2]");
+    }
+
+    /**
+     * @cdk.bug 1760967
+     */
+    @Test
+    public void testSingleBond() throws Exception {
+        parse("C-C");
+    }
+
+    @Test
+    public void testDoubleBond() throws Exception {
+        parse("C=C");
+    }
+
+    @Test
+    public void testTripleBond() throws Exception {
+        parse("C#C");
+    }
+
+    @Test
+    public void testAromaticBond() throws Exception {
+        parse("C:C");
+    }
+
+    @Test
+    public void testAnyOrderBond() throws Exception {
+        parse("C~C");
+    }
+
+    /**
+     * @cdk.bug 2786624
+     */
+    @Test
+    public void test2LetterSMARTS() throws Exception {
+        parse("Sc1ccccc1");
+    }
+
+    @Test
+    public void testPattern1() throws Exception {
+        parse("[CX4]");
+    }
+
+    @Test
+    public void testPattern2() throws Exception {
+        parse("[$([CX2](=C)=C)]");
+    }
+
+    @Test
+    public void testPattern3() throws Exception {
+        parse("[$([CX3]=[CX3])]");
+    }
+
+    @Test
+    public void testPattern4() throws Exception {
+        parse("[$([CX2]#C)]");
+    }
+
+    @Test
+    public void testPattern5() throws Exception {
+        parse("[CX3]=[OX1]");
+    }
+
+    @Test
+    public void testPattern6() throws Exception {
+        parse("[$([CX3]=[OX1]),$([CX3+]-[OX1-])]");
+    }
+
+    @Test
+    public void testPattern7() throws Exception {
+        parse("[CX3](=[OX1])C");
+    }
+
+    @Test
+    public void testPattern8() throws Exception {
+        parse("[OX1]=CN");
+    }
+
+    @Test
+    public void testPattern9() throws Exception {
+        parse("[CX3](=[OX1])O");
+    }
+
+    @Test
+    public void testPattern10() throws Exception {
+        parse("[CX3](=[OX1])[F,Cl,Br,I]");
+    }
+
+    @Test
+    public void testPattern11() throws Exception {
+        parse("[CX3H1](=O)[#6]");
+    }
+
+    @Test
+    public void testPattern12() throws Exception {
+        parse("[CX3](=[OX1])[OX2][CX3](=[OX1])");
+    }
+
+    @Test
+    public void testPattern13() throws Exception {
+        parse("[NX3][CX3](=[OX1])[#6]");
+    }
+
+    @Test
+    public void testPattern14() throws Exception {
+        parse("[NX3][CX3]=[NX3+]");
+    }
+
+    @Test
+    public void testPattern15() throws Exception {
+        parse("[NX3,NX4+][CX3](=[OX1])[OX2,OX1-]");
+    }
+
+    @Test
+    public void testPattern16() throws Exception {
+        parse("[NX3][CX3](=[OX1])[OX2H0]");
+    }
+
+    @Test
+    public void testPattern17() throws Exception {
+        parse("[NX3,NX4+][CX3](=[OX1])[OX2H,OX1-]");
+    }
+
+    @Test
+    public void testPattern18() throws Exception {
+        parse("[CX3](=O)[O-]");
+    }
+
+    @Test
+    public void testPattern19() throws Exception {
+        parse("[CX3](=[OX1])(O)O");
+    }
+
+    @Test
+    public void testPattern20() throws Exception {
+        parse("[CX3](=[OX1])([OX2])[OX2H,OX1H0-1]");
+    }
+
+    @Test
+    public void testPattern21() throws Exception {
+        parse("[CX3](=O)[OX2H1]");
+    }
+
+    @Test
+    public void testPattern22() throws Exception {
+        parse("[CX3](=O)[OX1H0-,OX2H1]");
+    }
+
+    @Test
+    public void testPattern23() throws Exception {
+        parse("[NX3][CX2]#[NX1]");
+    }
+
+    @Test
+    public void testPattern24() throws Exception {
+        parse("[#6][CX3](=O)[OX2H0][#6]");
+    }
+
+    @Test
+    public void testPattern25() throws Exception {
+        parse("[#6][CX3](=O)[#6]");
+    }
+
+    @Test
+    public void testPattern26() throws Exception {
+        parse("[OD2]([#6])[#6]");
+    }
+
+    @Test
+    public void testPattern27() throws Exception {
+        parse("[H]");
+    }
+
+    @Test
+    public void testPattern28() throws Exception {
+        parse("[!#1]");
+    }
+
+    @Test
+    public void testPattern29() throws Exception {
+        parse("[H+]");
+    }
+
+    @Test
+    public void testPattern30() throws Exception {
+        parse("[+H]");
+    }
+
+    @Test
+    public void testPattern31() throws Exception {
+        parse("[NX3;H2,H1;!$(NC=O)]");
+    }
+
+    @Test
+    public void testPattern32() throws Exception {
+        parse("[NX3][CX3]=[CX3]");
+    }
+
+    @Test
+    public void testPattern33() throws Exception {
+        parse("[NX3;H2,H1;!$(NC=O)].[NX3;H2,H1;!$(NC=O)]");
+    }
+
+    @Test
+    public void testPattern34() throws Exception {
+        parse("[NX3][$(C=C),$(cc)]");
+    }
+
+    @Test
+    public void testPattern35() throws Exception {
+        parse("[NX3,NX4+][CX4H]([*])[CX3](=[OX1])[O,N]");
+    }
+
+    @Test
+    public void testPattern36() throws Exception {
+        parse("[NX3H2,NH3X4+][CX4H]([*])[CX3](=[OX1])[NX3,NX4+][CX4H]([*])[CX3](=[OX1])[OX2H,OX1-]");
+    }
+
+    @Test
+    public void testPattern37() throws Exception {
+        parse("[$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H]([*])[CX3](=[OX1])[OX2H,OX1-,N]");
+    }
+
+    @Test
+    public void testPattern38() throws Exception {
+        parse("[CH3X4]");
+    }
+
+    @Test
+    public void testPattern39() throws Exception {
+        parse("[CH2X4][CH2X4][CH2X4][NHX3][CH0X3](=[NH2X3+,NHX2+0])[NH2X3]");
+    }
+
+    @Test
+    public void testPattern40() throws Exception {
+        parse("[CH2X4][CX3](=[OX1])[NX3H2]");
+    }
+
+    @Test
+    public void testPattern41() throws Exception {
+        parse("[CH2X4][CX3](=[OX1])[OH0-,OH]");
+    }
+
+    @Test
+    public void testPattern42() throws Exception {
+        parse("[CH2X4][SX2H,SX1H0-]");
+    }
+
+    @Test
+    public void testPattern43() throws Exception {
+        parse("[CH2X4][CH2X4][CX3](=[OX1])[OH0-,OH]");
+    }
+
+    @Test
+    public void testPattern44() throws Exception {
+        parse("[$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H2][CX3](=[OX1])[OX2H,OX1-,N])]");
+    }
+
+    @Test
+    public void testPattern45() throws Exception {
+        parse("[CH2X4][#6X3]1:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:[#6X3H]:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:[#6X3H]1");
+    }
+
+    @Test
+    public void testPattern47() throws Exception {
+        parse("[CHX4]([CH3X4])[CH2X4][CH3X4]");
+    }
+
+    @Test
+    public void testPattern48() throws Exception {
+        parse("[CH2X4][CHX4]([CH3X4])[CH3X4]");
+    }
+
+    @Test
+    public void testPattern49() throws Exception {
+        parse("[CH2X4][CH2X4][CH2X4][CH2X4][NX4+,NX3+0]");
+    }
+
+    @Test
+    public void testPattern50() throws Exception {
+        parse("[CH2X4][CH2X4][SX2][CH3X4]");
+    }
+
+    @Test
+    public void testPattern51() throws Exception {
+        parse("[CH2X4][cX3]1[cX3H][cX3H][cX3H][cX3H][cX3H]1");
+    }
+
+    @Test
+    public void testPattern52() throws Exception {
+        parse("[$([NX3H,NX4H2+]),$([NX3](C)(C)(C))]1[CX4H]([CH2][CH2][CH2]1)[CX3](=[OX1])[OX2H,OX1-,N]");
+    }
+
+    @Test
+    public void testPattern53() throws Exception {
+        parse("[CH2X4][OX2H]");
+    }
+
+    @Test
+    public void testPattern54() throws Exception {
+        parse("[NX3][CX3]=[SX1]");
+    }
+
+    @Test
+    public void testPattern55() throws Exception {
+        parse("[CHX4]([CH3X4])[OX2H]");
+    }
+
+    @Test
+    public void testPattern56() throws Exception {
+        parse("[CH2X4][cX3]1[cX3H][nX3H][cX3]2[cX3H][cX3H][cX3H][cX3H][cX3]12");
+    }
+
+    @Test
+    public void testPattern57() throws Exception {
+        parse("[CH2X4][cX3]1[cX3H][cX3H][cX3]([OHX2,OH0X1-])[cX3H][cX3H]1");
+    }
+
+    @Test
+    public void testPattern58() throws Exception {
+        parse("[CHX4]([CH3X4])[CH3X4]");
+    }
+
+    @Test
+    public void testPattern59() throws Exception {
+        parse("[CH3X4]");
+    }
+
+    @Test
+    public void testPattern60() throws Exception {
+        parse("[CH2X4][CH2X4][CH2X4][NHX3][CH0X3](=[NH2X3+,NHX2+0])[NH2X3]");
+    }
+
+    @Test
+    public void testPattern61() throws Exception {
+        parse("[CH2X4][CX3](=[OX1])[NX3H2]");
+    }
+
+    @Test
+    public void testPattern62() throws Exception {
+        parse("[CH2X4][CX3](=[OX1])[OH0-,OH]");
+    }
+
+    @Test
+    public void testPattern63() throws Exception {
+        parse("[CH2X4][SX2H,SX1H0-]");
+    }
+
+    @Test
+    public void testPattern64() throws Exception {
+        parse("[CH2X4][CH2X4][CX3](=[OX1])[OH0-,OH]");
+    }
+
+    @Test
+    public void testPattern65() throws Exception {
+        parse("[CH2X4][#6X3]1:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:[#6X3H]:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:[#6X3H]1");
+    }
+
+    @Test
+    public void testPattern67() throws Exception {
+        parse("[CHX4]([CH3X4])[CH2X4][CH3X4]");
+    }
+
+    @Test
+    public void testPattern68() throws Exception {
+        parse("[CH2X4][CHX4]([CH3X4])[CH3X4]");
+    }
+
+    @Test
+    public void testPattern69() throws Exception {
+        parse("[CH2X4][CH2X4][CH2X4][CH2X4][NX4+,NX3+0]");
+    }
+
+    @Test
+    public void testPattern70() throws Exception {
+        parse("[CH2X4][CH2X4][SX2][CH3X4]");
+    }
+
+    @Test
+    public void testPattern71() throws Exception {
+        parse("[CH2X4][cX3]1[cX3H][cX3H][cX3H][cX3H][cX3H]1");
+    }
+
+    @Test
+    public void testPattern72() throws Exception {
+        parse("[CH2X4][OX2H]");
+    }
+
+    @Test
+    public void testPattern73() throws Exception {
+        parse("[CHX4]([CH3X4])[OX2H]");
+    }
+
+    @Test
+    public void testPattern74() throws Exception {
+        parse("[CH2X4][cX3]1[cX3H][nX3H][cX3]2[cX3H][cX3H][cX3H][cX3H][cX3]12");
+    }
+
+    @Test
+    public void testPattern75() throws Exception {
+        parse("[CH2X4][cX3]1[cX3H][cX3H][cX3]([OHX2,OH0X1-])[cX3H][cX3H]1");
+    }
+
+    @Test
+    public void testPattern76() throws Exception {
+        parse("[CHX4]([CH3X4])[CH3X4]");
+    }
+
+    @Test
+    public void testPattern77() throws Exception {
+        parse("[$(*-[NX2-]-[NX2+]#[NX1]),$(*-[NX2]=[NX2+]=[NX1-])]");
+    }
+
+    @Test
+    public void testPattern78() throws Exception {
+        parse("[$([NX1-]=[NX2+]=[NX1-]),$([NX1]#[NX2+]-[NX1-2])]");
+    }
+
+    @Test
+    public void testPattern79() throws Exception {
+        parse("[#7]");
+    }
+
+    @Test
+    public void testPattern80() throws Exception {
+        parse("[NX2]=N");
+    }
+
+    @Test
+    public void testPattern81() throws Exception {
+        parse("[NX2]=[NX2]");
+    }
+
+    @Test
+    public void testPattern82() throws Exception {
+        parse("[$([NX2]=[NX3+]([O-])[#6]),$([NX2]=[NX3+0](=[O])[#6])]");
+    }
+
+    @Test
+    public void testPattern83() throws Exception {
+        parse("[$([#6]=[N+]=[N-]),$([#6-]-[N+]#[N])]");
+    }
+
+    @Test
+    public void testPattern84() throws Exception {
+        parse("[$([nr5]:[nr5,or5,sr5]),$([nr5]:[cr5]:[nr5,or5,sr5])]");
+    }
+
+    @Test
+    public void testPattern85() throws Exception {
+        parse("[NX3][NX3]");
+    }
+
+    @Test
+    public void testPattern86() throws Exception {
+        parse("[NX3][NX2]=[*]");
+    }
+
+    @Test
+    public void testPattern87() throws Exception {
+        parse("[CX3;$([C]([#6])[#6]),$([CH][#6])]=[NX2][#6]");
+    }
+
+    @Test
+    public void testPattern88() throws Exception {
+        parse("[$([CX3]([#6])[#6]),$([CX3H][#6])]=[$([NX2][#6]),$([NX2H])]");
+    }
+
+    @Test
+    public void testPattern89() throws Exception {
+        parse("[NX3+]=[CX3]");
+    }
+
+    @Test
+    public void testPattern90() throws Exception {
+        parse("[CX3](=[OX1])[NX3H][CX3](=[OX1])");
+    }
+
+    @Test
+    public void testPattern91() throws Exception {
+        parse("[CX3](=[OX1])[NX3H0]([#6])[CX3](=[OX1])");
+    }
+
+    @Test
+    public void testPattern92() throws Exception {
+        parse("[CX3](=[OX1])[NX3H0]([NX3H0]([CX3](=[OX1]))[CX3](=[OX1]))[CX3](=[OX1])");
+    }
+
+    @Test
+    public void testPattern93() throws Exception {
+        parse("[$([NX3](=[OX1])(=[OX1])O),$([NX3+]([OX1-])(=[OX1])O)]");
+    }
+
+    @Test
+    public void testPattern94() throws Exception {
+        parse("[$([OX1]=[NX3](=[OX1])[OX1-]),$([OX1]=[NX3+]([OX1-])[OX1-])]");
+    }
+
+    @Test
+    public void testPattern95() throws Exception {
+        parse("[NX1]#[CX2]");
+    }
+
+    @Test
+    public void testPattern96() throws Exception {
+        parse("[CX1-]#[NX2+]");
+    }
+
+    @Test
+    public void testPattern97() throws Exception {
+        parse("[$([NX3](=O)=O),$([NX3+](=O)[O-])][!#8]");
+    }
+
+    @Test
+    public void testPattern98() throws Exception {
+        parse("[$([NX3](=O)=O),$([NX3+](=O)[O-])][!#8].[$([NX3](=O)=O),$([NX3+](=O)[O-])][!#8]");
+    }
+
+    @Test
+    public void testPattern99() throws Exception {
+        parse("[NX2]=[OX1]");
+    }
+
+    @Test
+    public void testPattern101() throws Exception {
+        parse("[$([#7+][OX1-]),$([#7v5]=[OX1]);!$([#7](~[O])~[O]);!$([#7]=[#7])]");
+    }
+
+    @Test
+    public void testPattern102() throws Exception {
+        parse("[OX2H]");
+    }
+
+    @Test
+    public void testPattern103() throws Exception {
+        parse("[#6][OX2H]");
+    }
+
+    @Test
+    public void testPattern104() throws Exception {
+        parse("[OX2H][CX3]=[OX1]");
+    }
+
+    @Test
+    public void testPattern105() throws Exception {
+        parse("[OX2H]P");
+    }
+
+    @Test
+    public void testPattern106() throws Exception {
+        parse("[OX2H][#6X3]=[#6]");
+    }
+
+    @Test
+    public void testPattern107() throws Exception {
+        parse("[OX2H][cX3]:[c]");
+    }
+
+    @Test
+    public void testPattern108() throws Exception {
+        parse("[OX2H][$(C=C),$(cc)]");
+    }
+
+    @Test
+    public void testPattern109() throws Exception {
+        parse("[$([OH]-*=[!#6])]");
+    }
+
+    @Test
+    public void testPattern110() throws Exception {
+        parse("[OX2,OX1-][OX2,OX1-]");
+    }
+
+    @Test
+    public void testPattern111() throws Exception { // Phosphoric_acid groups.
+        parse("[$(P(=[OX1])([$([OX2H]),$([OX1-]),$([OX2]P)])([$([OX2H]),$([OX1-]),$([OX2]P)])[$([OX2H]),$([OX1-]),$([OX2]P)]),$([P+]([OX1-])([$([OX"
+                + "2H]),$([OX1-]),$([OX2]P)])([$([OX2H]),$([OX1-]),$([OX2]P)])[$([OX2H]),$([OX1-]),$([OX2]P)])]");
+    }
+
+    @Test
+    public void testPattern112() throws Exception { // Phosphoric_ester groups.
+        parse("[$(P(=[OX1])([OX2][#6])([$([OX2H]),$([OX1-]),$([OX2][#6])])[$([OX2H]),$([OX1-]),$([OX2][#6]),$([OX2]P)]),$([P+]([OX1-])([OX2][#6])(["
+                + "$([OX2H]),$([OX1-]),$([OX2][#6])])[$([OX2H]),$([OX1-]),$([OX2][#6]),$([OX2]P)])]");
+    }
+
+    @Test
+    public void testPattern113() throws Exception {
+        parse("[S-][CX3](=S)[#6]");
+    }
+
+    @Test
+    public void testPattern114() throws Exception {
+        parse("[#6X3](=[SX1])([!N])[!N]");
+    }
+
+    @Test
+    public void testPattern115() throws Exception {
+        parse("[SX2]");
+    }
+
+    @Test
+    public void testPattern116() throws Exception {
+        parse("[#16X2H]");
+    }
+
+    @Test
+    public void testPattern117() throws Exception {
+        parse("[#16!H0]");
+    }
+
+    @Test
+    public void testPattern118() throws Exception {
+        parse("[NX3][CX3]=[SX1]");
+    }
+
+    @Test
+    public void testPattern119() throws Exception {
+        parse("[#16X2H0]");
+    }
+
+    @Test
+    public void testPattern120() throws Exception {
+        parse("[#16X2H0][!#16]");
+    }
+
+    @Test
+    public void testPattern121() throws Exception {
+        parse("[#16X2H0][#16X2H0]");
+    }
+
+    @Test
+    public void testPattern122() throws Exception {
+        parse("[#16X2H0][!#16].[#16X2H0][!#16]");
+    }
+
+    @Test
+    public void testPattern123() throws Exception {
+        parse("[$([#16X3](=[OX1])[OX2H0]),$([#16X3+]([OX1-])[OX2H0])]");
+    }
+
+    @Test
+    public void testPattern124() throws Exception {
+        parse("[$([#16X3](=[OX1])[OX2H,OX1H0-]),$([#16X3+]([OX1-])[OX2H,OX1H0-])]");
+    }
+
+    @Test
+    public void testPattern125() throws Exception {
+        parse("[$([#16X4](=[OX1])=[OX1]),$([#16X4+2]([OX1-])[OX1-])]");
+    }
+
+    @Test
+    public void testPattern126() throws Exception {
+        parse("[$([#16X4](=[OX1])(=[OX1])([#6])[#6]),$([#16X4+2]([OX1-])([OX1-])([#6])[#6])]");
+    }
+
+    @Test
+    public void testPattern127() throws Exception {
+        parse("[$([#16X4](=[OX1])(=[OX1])([#6])[OX2H,OX1H0-]),$([#16X4+2]([OX1-])([OX1-])([#6])[OX2H,OX1H0-])]");
+    }
+
+    @Test
+    public void testPattern128() throws Exception {
+        parse("[$([#16X4](=[OX1])(=[OX1])([#6])[OX2H0]),$([#16X4+2]([OX1-])([OX1-])([#6])[OX2H0])]");
+    }
+
+    @Test
+    public void testPattern129() throws Exception {
+        parse("[$([#16X4]([NX3])(=[OX1])(=[OX1])[#6]),$([#16X4+2]([NX3])([OX1-])([OX1-])[#6])]");
+    }
+
+    @Test
+    public void testPattern130() throws Exception {
+        parse("[SX4](C)(C)(=O)=N");
+    }
+
+    @Test
+    public void testPattern131() throws Exception {
+        parse("[$([SX4](=[OX1])(=[OX1])([!O])[NX3]),$([SX4+2]([OX1-])([OX1-])([!O])[NX3])]");
+    }
+
+    @Test
+    public void testPattern132() throws Exception {
+        parse("[$([#16X3]=[OX1]),$([#16X3+][OX1-])]");
+    }
+
+    @Test
+    public void testPattern133() throws Exception {
+        parse("[$([#16X3](=[OX1])([#6])[#6]),$([#16X3+]([OX1-])([#6])[#6])]");
+    }
+
+    @Test
+    public void testPattern134() throws Exception {
+        parse("[$([#16X4](=[OX1])(=[OX1])([OX2H,OX1H0-])[OX2][#6]),$([#16X4+2]([OX1-])([OX1-])([OX2H,OX1H0-])[OX2][#6])]");
+    }
+
+    @Test
+    public void testPattern135() throws Exception {
+        parse("[$([SX4](=O)(=O)(O)O),$([SX4+2]([O-])([O-])(O)O)]");
+    }
+
+    @Test
+    public void testPattern136() throws Exception {
+        parse("[$([#16X4](=[OX1])(=[OX1])([OX2][#6])[OX2][#6]),$([#16X4](=[OX1])(=[OX1])([OX2][#6])[OX2][#6])]");
+    }
+
+    @Test
+    public void testPattern137() throws Exception {
+        parse("[$([#16X4]([NX3])(=[OX1])(=[OX1])[OX2][#6]),$([#16X4+2]([NX3])([OX1-])([OX1-])[OX2][#6])]");
+    }
+
+    @Test
+    public void testPattern138() throws Exception {
+        parse("[$([#16X4]([NX3])(=[OX1])(=[OX1])[OX2H,OX1H0-]),$([#16X4+2]([NX3])([OX1-])([OX1-])[OX2H,OX1H0-])]");
+    }
+
+    @Test
+    public void testPattern139() throws Exception {
+        parse("[#16X2][OX2H,OX1H0-]");
+    }
+
+    @Test
+    public void testPattern140() throws Exception {
+        parse("[#16X2][OX2H0]");
+    }
+
+    @Test
+    public void testPattern141() throws Exception {
+        parse("[#6][F,Cl,Br,I]");
+    }
+
+    @Test
+    public void testPattern142() throws Exception {
+        parse("[F,Cl,Br,I]");
+    }
+
+    @Test
+    public void testPattern143() throws Exception {
+        parse("[F,Cl,Br,I].[F,Cl,Br,I].[F,Cl,Br,I]");
+    }
+
+    @Test
+    public void testPattern144() throws Exception {
+        parse("[CX3](=[OX1])[F,Cl,Br,I]");
+    }
+
+    @Test
+    public void testPattern145() throws Exception {
+        parse("[$([#6X4@](*)(*)(*)*),$([#6X4@H](*)(*)*)]");
+    }
+
+    @Test
+    public void testPattern146() throws Exception {
+        parse("[$([cX2+](:*):*)]");
+    }
+
+    @Test
+    public void testPattern147() throws Exception {
+        parse("[$([cX3](:*):*),$([cX2+](:*):*)]");
+    }
+
+    @Test
+    public void testPattern148() throws Exception {
+        parse("[$([cX3](:*):*),$([cX2+](:*):*),$([CX3]=*),$([CX2+]=*)]");
+    }
+
+    @Test
+    public void testPattern149() throws Exception {
+        parse("[$([nX3](:*):*),$([nX2](:*):*),$([#7X2]=*),$([NX3](=*)=*),$([#7X3+](-*)=*),$([#7X3+H]=*)]");
+    }
+
+    @Test
+    public void testPattern150() throws Exception {
+        parse("[$([#1X1][$([nX3](:*):*),$([nX2](:*):*),$([#7X2]=*),$([NX3](=*)=*),$([#7X3+](-*)=*),$([#7X3+H]=*)])]");
+    }
+
+    @Test
+    public void testPattern151() throws Exception {
+        parse("[$([NX4+]),$([NX3]);!$(*=*)&!$(*:*)]");
+    }
+
+    @Test
+    public void testPattern152() throws Exception {
+        parse("[$([#1X1][$([NX4+]),$([NX3]);!$(*=*)&!$(*:*)])]");
+    }
+
+    @Test
+    public void testPattern153() throws Exception {
+        parse("[$([$([NX3]=O),$([NX3+][O-])])]");
+    }
+
+    @Test
+    public void testPattern154() throws Exception {
+        parse("[$([$([NX4]=O),$([NX4+][O-])])]");
+    }
+
+    @Test
+    public void testPattern155() throws Exception {
+        parse("[$([$([NX4]=O),$([NX4+][O-,#0])])]");
+    }
+
+    @Test
+    public void testPattern156() throws Exception {
+        parse("[$([NX4+]),$([NX4]=*)]");
+    }
+
+    @Test
+    public void testPattern157() throws Exception {
+        parse("[$([SX3]=N)]");
+    }
+
+    @Test
+    public void testPattern158() throws Exception {
+        parse("[$([SX1]=[#6])]");
+    }
+
+    @Test
+    public void testPattern159() throws Exception {
+        parse("[$([NX1]#*)]");
+    }
+
+    @Test
+    public void testPattern160() throws Exception {
+        parse("[$([OX2])]");
+    }
+
+    @Test
+    public void testPattern161() throws Exception {
+        parse("[R0;D2][R0;D2][R0;D2][R0;D2]");
+    }
+
+    @Test
+    public void testPattern162() throws Exception {
+        parse("[R0;D2]~[R0;D2]~[R0;D2]~[R0;D2]");
+    }
+
+    @Test
+    public void testPattern163() throws Exception {
+        parse("[AR0]~[AR0]~[AR0]~[AR0]~[AR0]~[AR0]~[AR0]~[AR0]");
+    }
+
+    @Test
+    public void testPattern164() throws Exception {
+        parse("[!$([#6+0]);!$(C(F)(F)F);!$(c(:[!c]):[!c])!$([#6]=,#[!#6])]");
+    }
+
+    @Test
+    public void testPattern165() throws Exception {
+        parse("[$([#6+0]);!$(C(F)(F)F);!$(c(:[!c]):[!c])!$([#6]=,#[!#6])]");
+    }
+
+    @Test
+    public void testPattern166() throws Exception {
+        parse("[$([SX1]~P)]");
+    }
+
+    @Test
+    public void testPattern167() throws Exception {
+        parse("[$([NX3]C=N)]");
+    }
+
+    @Test
+    public void testPattern168() throws Exception {
+        parse("[$([NX3]N=C)]");
+    }
+
+    @Test
+    public void testPattern169() throws Exception {
+        parse("[$([NX3]N=N)]");
+    }
+
+    @Test
+    public void testPattern170() throws Exception {
+        parse("[$([OX2]C=N)]");
+    }
+
+    @Test
+    public void testPattern171() throws Exception {
+        parse("[!$(*#*)&!D1]-!@[!$(*#*)&!D1]");
+    }
+
+    @Test
+    public void testPattern172() throws Exception {
+        parse("[$([*R2]([*R])([*R])([*R]))].[$([*R2]([*R])([*R])([*R]))]");
+    }
+
+    @Test
+    public void testPattern173() throws Exception {
+        parse("*-!:aa-!:*");
+    }
+
+    @Test
+    public void testPattern174() throws Exception {
+        parse("*-!:aaa-!:*");
+    }
+
+    @Test
+    public void testPattern175() throws Exception {
+        parse("*-!:aaaa-!:*");
+    }
+
+    @Test
+    public void testPattern176() throws Exception {
+        parse("*-!@*");
+    }
+
+    @Test
+    public void testPattern177() throws Exception { // CIS or TRANS double or aromatic bond in a ring
+        parse("*/,\\[R]=,:;@[R]/,\\*");
+    }
+
+    @Test
+    public void testPattern178() throws Exception { // Fused benzene rings
+        parse("c12ccccc1cccc2");
+    }
+
+    @Test
+    public void testPattern179() throws Exception {
+        parse("[r;!r3;!r4;!r5;!r6;!r7]");
+    }
+
+    @Test
+    public void testPattern180() throws Exception {
+        parse("[sX2r5]");
+    }
+
+    @Test
+    public void testPattern181() throws Exception {
+        parse("[oX2r5]");
+    }
+
+    @Test
+    public void testPattern182() throws Exception { // Unfused benzene ring
+        parse("[cR1]1[cR1][cR1][cR1][cR1][cR1]1");
+    }
+
+    @Test
+    public void testPattern183() throws Exception { // Multiple non-fused benzene rings
+        parse("[cR1]1[cR1][cR1][cR1][cR1][cR1]1.[cR1]1[cR1][cR1][cR1][cR1][cR1]1");
+    }
+
+    @Test
+    public void testPattern184() throws Exception { // Generic amino acid: low specificity.
+        parse("[NX3,NX4+][CX4H]([*])[CX3](=[OX1])[O,N]");
+    }
+
+    @Test
+    public void testPattern185() throws Exception { //Template for 20 standard a.a.s
+        parse("[$([$([NX3H,NX4H2+]),$([NX3](C)(C)(C))]1[CX4H]([CH2][CH2][CH2]1)[CX3](=[OX1])[OX2H,OX1-,N]),"
+                + "$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX"
+                + "4H2][CX3](=[OX1])[OX2H,OX1-,N]),$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H]([*])[CX3](=[OX1])[OX2H,OX1-,N])]");
+    }
+
+    @Test
+    public void testPattern186() throws Exception { // Proline
+        parse("[$([NX3H,NX4H2+]),$([NX3](C)(C)(C))]1[CX4H]([CH2][CH2][CH2]1)[CX3](=[OX1])[OX2H,OX1-,N]");
+    }
+
+    @Test
+    public void testPattern187() throws Exception { // Glycine
+        parse("[$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H2][CX3](=[OX1])[OX2H,OX1-,N])]");
+    }
+
+    @Test
+    public void testPattern188() throws Exception { // Alanine
+        parse("[$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H]([CH3X4])[CX3](=[OX1])[OX2H,OX1-,N]");
+    }
+
+    @Test
+    public void testPattern189() throws Exception { //18_standard_aa_side_chains.
+        parse("([$([CH3X4]),$([CH2X4][CH2X4][CH2X4][NHX3][CH0X3](=[NH2X3+,NHX2+0])[NH2X3]),"
+                + "$([CH2X4][CX3](=[OX1])[NX3H2]),$([CH2X4][CX3](=[OX1])[OH0-,OH]),"
+                + "$([CH2X4][SX2H,SX1H0-]),$([CH2X4][CH2X4][CX3](=[OX1])[OH0-,OH]),"
+                + "$([CH2X4][#6X3]1:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:"
+                + "[#6X3H]:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:[#6X3H]1),"
+                + "$([CHX4]([CH3X4])[CH2X4][CH3X4]),$([CH2X4][CHX4]([CH3X4])[CH3X4]),"
+                + "$([CH2X4][CH2X4][CH2X4][CH2X4][NX4+,NX3+0]),$([CH2X4][CH2X4][SX2][CH3X4]),"
+                + "$([CH2X4][cX3]1[cX3H][cX3H][cX3H][cX3H][cX3H]1),$([CH2X4][OX2H]),"
+                + "$([CHX4]([CH3X4])[OX2H]),$([CH2X4][cX3]1[cX3H][nX3H][cX3]2[cX3H][cX3H][cX3H][cX3H][cX3]12),"
+                + "$([CH2X4][cX3]1[cX3H][cX3H][cX3]([OHX2,OH0X1-])[cX3H][cX3H]1),$([CHX4]([CH3X4])[CH3X4])])");
+    }
+
+    @Test
+    public void testPattern190() throws Exception { // N in Any_standard_amino_acid.
+        parse("[$([$([NX3H,NX4H2+]),$([NX3](C)(C)(C))]1[CX4H]([CH2][CH2][CH2]1)[CX3]"
+                + "(=[OX1])[OX2H,OX1-,N]),$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H2][CX3]"
+                + "(=[OX1])[OX2H,OX1-,N]),$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H]([$([CH3X4]),"
+                + "$([CH2X4][CH2X4][CH2X4][NHX3][CH0X3](=[NH2X3+,NHX2+0])[NH2X3]),$"
+                + "([CH2X4][CX3](=[OX1])[NX3H2]),$([CH2X4][CX3](=[OX1])[OH0-,OH]),"
+                + "$([CH2X4][SX2H,SX1H0-]),$([CH2X4][CH2X4][CX3](=[OX1])[OH0-,OH]),"
+                + "$([CH2X4][#6X3]1:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:"
+                + "[#6X3H]:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:[#6X3H]1),"
+                + "$([CHX4]([CH3X4])[CH2X4][CH3X4]),$([CH2X4][CHX4]([CH3X4])[CH3X4]),"
+                + "$([CH2X4][CH2X4][CH2X4][CH2X4][NX4+,NX3+0]),$([CH2X4][CH2X4][SX2][CH3X4]),"
+                + "$([CH2X4][cX3]1[cX3H][cX3H][cX3H][cX3H][cX3H]1),$([CH2X4][OX2H]),"
+                + "$([CHX4]([CH3X4])[OX2H]),$([CH2X4][cX3]1[cX3H][nX3H][cX3]2[cX3H][cX3H][cX3H][cX3H][cX3]12),"
+                + "$([CH2X4][cX3]1[cX3H][cX3H][cX3]([OHX2,OH0X1-])[cX3H][cX3H]1),"
+                + "$([CHX4]([CH3X4])[CH3X4])])[CX3](=[OX1])[OX2H,OX1-,N])]");
+    }
+
+    @Test
+    public void testPattern191() throws Exception { // Non-standard amino acid.
+        parse("[$([NX3,NX4+][CX4H]([*])[CX3](=[OX1])[O,N]);!$([$([$([NX3H,NX4H2+]),"
+                + "$([NX3](C)(C)(C))]1[CX4H]([CH2][CH2][CH2]1)[CX3](=[OX1])[OX2H,OX1-,N]),"
+                + "$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H2][CX3](=[OX1])[OX2H,OX1-,N]),"
+                + "$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H]([$([CH3X4]),$([CH2X4][CH2X4][CH2X4][NHX3][CH0X3]"
+                + "(=[NH2X3+,NHX2+0])[NH2X3]),$([CH2X4][CX3](=[OX1])[NX3H2]),$([CH2X4][CX3](=[OX1])[OH0-,OH]),"
+                + "$([CH2X4][SX2H,SX1H0-]),$([CH2X4][CH2X4][CX3](=[OX1])[OH0-,OH]),$([CH2X4][#6X3]1:"
+                + "[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),$([#7X3H])]:"
+                + "[#6X3H]:[$([#7X3H+,#7X2H0+0]:[#6X3H]:[#7X3H]),"
+                + "$([#7X3H])]:[#6X3H]1),$([CHX4]([CH3X4])[CH2X4][CH3X4]),$([CH2X4][CHX4]([CH3X4])[CH3X4]),"
+                + "$([CH2X4][CH2X4][CH2X4][CH2X4][NX4+,NX3+0]),$([CH2X4][CH2X4][SX2][CH3X4]),"
+                + "$([CH2X4][cX3]1[cX3H][cX3H][cX3H][cX3H][cX3H]1),$([CH2X4][OX2H]),$([CHX4]([CH3X4])[OX2H]),"
+                + "$([CH2X4][cX3]1[cX3H][nX3H][cX3]2[cX3H][cX3H][cX3H][cX3H][cX3]12),"
+                + "$([CH2X4][cX3]1[cX3H][cX3H][cX3]([OHX2,OH0X1-])[cX3H][cX3H]1),"
+                + "$([CHX4]([CH3X4])[CH3X4])])[CX3](=[OX1])[OX2H,OX1-,N])])]");
+    }
+
+    @Test
+    public void testPattern192() throws Exception { //Azide group
+        parse("[$(*-[NX2-]-[NX2+]#[NX1]),$(*-[NX2]=[NX2+]=[NX1-])]");
+    }
+
+    @Test
+    public void testPattern193() throws Exception { // Azide ion
+        parse("[$([NX1-]=[NX2+]=[NX1-]),$([NX1]#[NX2+]-[NX1-2])]");
+    }
+
+    @Test
+    public void testPattern194() throws Exception { //Azide or azide ion
+        parse("[$([$(*-[NX2-]-[NX2+]#[NX1]),$(*-[NX2]=[NX2+]=[NX1-])]),$([$([NX1-]=[NX2+]=[NX1-]),$([NX1]#[NX2+]-[NX1-2])])]");
+    }
+
+    @Test
+    public void testPattern195() throws Exception { // Sulfide
+        parse("[#16X2H0]");
+    }
+
+    @Test
+    public void testPattern196() throws Exception { // Mono-sulfide
+        parse("[#16X2H0][!#16]");
+    }
+
+    @Test
+    public void testPattern197() throws Exception { // Di-sulfide
+        parse("[#16X2H0][#16X2H0]");
+    }
+
+    @Test
+    public void testPattern198() throws Exception { // Two sulfides
+        parse("[#16X2H0][!#16].[#16X2H0][!#16]");
+    }
+
+    @Test
+    public void testPattern199() throws Exception { // Acid/conj-base
+        parse("[OX2H,OX1H0-]");
+    }
+
+    @Test
+    public void testPattern200() throws Exception { // Non-acid Oxygen
+        parse("[OX2H0]");
+    }
+
+    @Test
+    public void testPattern201() throws Exception { // Acid/base
+        parse("[H1,H0-]");
+    }
+
+    @Test
+    public void testPattern202() throws Exception {
+        parse("([Cl!$(Cl~c)].[c!$(c~Cl)])");
+    }
+
+    @Test
+    public void testPattern203() throws Exception {
+        parse("([Cl]).([c])");
+    }
+
+    @Test
+    public void testPattern204() throws Exception {
+        parse("([Cl].[c])");
+    }
+
+    @Test
+    public void testPattern205() throws Exception {
+        parse("[NX3;H2,H1;!$(NC=O)].[NX3;H2,H1;!$(NC=O)]");
+    }
+
+    @Test
+    public void testPattern206() throws Exception {
+        parse("[#0]");
+    }
+
+    @Test
+    public void testPattern207() throws Exception {
+        parse("[*!H0,#1]");
+    }
+
+    @Test
+    public void testPattern208() throws Exception {
+        parse("[#6!H0,#1]");
+    }
+
+    @Test
+    public void testPattern209() throws Exception {
+        parse("[H,#1]");
+    }
+
+    @Test
+    public void testPattern210() throws Exception {
+        parse("[!H0;F,Cl,Br,I,N+,$([OH]-*=[!#6]),+]");
+    }
+
+    @Test
+    public void testPattern211() throws Exception {
+        parse("[CX3](=O)[OX2H1]");
+    }
+
+    @Test
+    public void testPattern212() throws Exception {
+        parse("[CX3](=O)[OX1H0-,OX2H1]");
+    }
+
+    @Test
+    public void testPattern213() throws Exception {
+        parse("[$([OH]-*=[!#6])]");
+    }
+
+    @Test
+    public void testPattern214() throws Exception { // Phosphoric_Acid
+        parse("[$(P(=[OX1])([$([OX2H]),$([OX1-]),$([OX2]P)])([$([OX2H]),$([OX1-]),$([OX2]P)])[$([OX2H]),$([OX1-]),$([OX2]P)]),$([P+]([OX1-])([$([OX"
+                + "2H]),$([OX1-]),$([OX2]P)])([$([OX2H]),$([OX1-]),$([OX2]P)])[$([OX2H]),$([OX1-]),$([OX2]P)])]");
+    }
+
+    @Test
+    public void testPattern215() throws Exception { // Sulfonic Acid. High specificity.
+        parse("[$([#16X4](=[OX1])(=[OX1])([#6])[OX2H,OX1H0-]),$([#16X4+2]([OX1-])([OX1-])([#6])[OX2H,OX1H0-])]");
+    }
+
+    @Test
+    public void testPattern216() throws Exception { // Acyl Halide
+        parse("[CX3](=[OX1])[F,Cl,Br,I]");
+    }
+
+    @Test
+    public void testPattern217() throws Exception {
+        parse("[NX2-]");
+    }
+
+    @Test
+    public void testPattern218() throws Exception {
+        parse("[OX2H+]=*");
+    }
+
+    @Test
+    public void testPattern219() throws Exception {
+        parse("[OX3H2+]");
+    }
+
+    @Test
+    public void testPattern220() throws Exception {
+        parse("[#6+]");
+    }
+
+    @Test
+    public void testPattern221() throws Exception {
+        parse("[$([cX2+](:*):*)]");
+    }
+
+    @Test
+    public void testPattern222() throws Exception {
+        parse("[$([NX1-]=[NX2+]=[NX1-]),$([NX1]#[NX2+]-[NX1-2])]");
+    }
+
+    @Test
+    public void testPattern223() throws Exception {
+        parse("[+1]~*~*~[-1]");
+    }
+
+    @Test
+    public void testPattern224() throws Exception {
+        parse("[$([!-0!-1!-2!-3!-4]~*~[!+0!+1!+2!+3!+4]),$([!-0!-1!-2!-3!-4]~*~*~[!+0!+1!+2!+3!+4]),$([!-0!-1!-2!-3!-4]~*~*~*~[!+0!+1!+2!+3!+4]),$([!-0!-1!-2!-3!-4]~*~*~*~*~[!+0!+1!+2!+3!+4]),$([!-0!-1!-2!-3!-4]~*~*~*~*~*~[!+0!+1!+2!+3!+4]),$([!-0!-1!-2!-3!-4]~*~*~*~*~*~*~[!+0!+1!+2!+3!+4]),$([!-0!-1!-2!-3!-4]~*~*~*~*~*~*~*~[!+0!+1!+2!+3!+4]),$([!-0!-1!-2!-3!-4]~*~*~*~*~*~*~*~*~[!+0!+1!+2!+3!+4]),$([!-0!-1!-2!-3!-4]~*~*~*~*~*~*~*~*~*~[!+0!+1!+2!+3!+4])]");
+    }
+
+    @Test
+    public void testPattern225() throws Exception {
+        parse("([!-0!-1!-2!-3!-4].[!+0!+1!+2!+3!+4])");
+    }
+
+    @Test
+    public void testPattern226() throws Exception { // Hydrogen-bond acceptor, Only hits carbonyl and nitroso
+        parse("[#6,#7;R0]=[#8]");
+    }
+
+    @Test
+    public void testPattern227() throws Exception { // Hydrogen-bond acceptor
+        parse("[!$([#6,F,Cl,Br,I,o,s,nX3,#7v5,#15v5,#16v4,#16v6,*+1,*+2,*+3])]");
+    }
+
+    @Test
+    public void testPattern228() throws Exception {
+        parse("[!$([#6,H0,-,-2,-3])]");
+    }
+
+    @Test
+    public void testPattern229() throws Exception {
+        parse("[!H0;#7,#8,#9]");
+    }
+
+    @Test
+    public void testPattern230() throws Exception {
+        parse("[O,N;!H0]-*~*-*=[$([C,N;R0]=O)]");
+    }
+
+    @Test
+    public void testPattern231() throws Exception {
+        parse("[#6;X3v3+0]");
+    }
+
+    @Test
+    public void testPattern232() throws Exception {
+        parse("[#7;X2v4+0]");
+    }
+
+    @Test
+    public void testPattern233() throws Exception { // Amino Acid
+        parse("[$([$([NX3H,NX4H2+]),$([NX3](C)(C)(C))]1[CX4H]([CH2][CH2][CH2]1)[CX3](=[OX1])[OX2H,OX1-,N]),$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H2]["
+                + "CX3](=[OX1])[OX2H,OX1-,N]),$([$([NX3H2,NX4H3+]),$([NX3H](C)(C))][CX4H]([*])[CX3](=[OX1])[OX2H,OX1-,N])]");
+    }
+
+    @Test
+    public void testPattern234() throws Exception {
+        parse("[#6][CX3](=O)[$([OX2H0]([#6])[#6]),$([#7])]");
+    }
+
+    @Test
+    public void testPattern235() throws Exception {
+        parse("[#8]=[C,N]-aaa[F,Cl,Br,I]");
+    }
+
+    @Test
+    public void testPattern236() throws Exception {
+        parse("[O,N;!H0;R0]");
+    }
+
+    @Test
+    public void testPattern237() throws Exception {
+        parse("[#8]=[C,N]");
+    }
+
+    @Test
+    public void testPattern238() throws Exception { // PCB
+        parse("[$(c:cCl),$(c:c:cCl),$(c:c:c:cCl)]-[$(c:cCl),$(c:c:cCl),$(c:c:c:cCl)]");
+    }
+
+    @Test
+    public void testPattern239() throws Exception { // Imidazolium Nitrogen
+        parse("[nX3r5+]:c:n");
+    }
+
+    @Test
+    public void testPattern240() throws Exception { // 1-methyl-2-hydroxy benzene with either a Cl or H at the 5 position.
+        parse("Cc1:c(O):c:c:[$(cCl),$([cH])]:c1");
+    }
+
+    @Test
+    public void testPattern241() throws Exception { // Nonstandard atom groups.
+        parse("[!#1;!#2;!#3;!#5;!#6;!#7;!#8;!#9;!#11;!#12;!#15;!#16;!#17;!#19;!#20;!#35;!#53]");
+    }
+
+    @Test
+    public void testRing() throws Exception {
+        parse("[$([C;#12]=1CCCCC1)]");
+    }
+
+    @Test
+    public void testHydrogen() throws Exception {
+        parse("[H]");
+    }
+
+    @Test
+    public void testHybridizationNumber1() throws Exception {
+        parse("[^1]");
+    }
+
+    @Test
+    public void testHybridizationNumber2() throws Exception {
+        parse("[^1&N]");
+    }
+
+    @Test
+    public void testHybridizationNumber3() throws Exception {
+        parse("[^1&N,^2&C]");
+    }
+
+    @Test(expected = Exception.class)
+    public void testHybridizationNumber4() throws Exception {
+        parse("[^]");
+    }
+
+    @Test(expected = Exception.class)
+    public void testHybridizationNumber5() throws Exception {
+        parse("[^X]");
+    }
+
+    @Test(expected = Exception.class)
+    public void testHybridizationNumber6() throws Exception {
+        parse("[^0]");
+    }
+
+    @Test(expected = Exception.class)
+    public void testHybridizationNumber7() throws Exception {
+        parse("[^9]");
+    }
+
+    @Test
+    public void testNonCHHeavyAtom1() throws Exception {
+        parse("[#X]");
+    }
+
+    @Test
+    public void testNonCHHeavyAtom2() throws Exception {
+        parse("C#[#X]");
+    }
+
+    @Test
+    public void testPeriodicGroupNumber1() throws Exception {
+        parse("[G14]", Smarts.FLAVOR_CDK_LEGACY);
+    }
+
+    @Test
+    public void testPeriodicGroupNumber2() throws Exception {
+        parse("[G14,G15]", Smarts.FLAVOR_CDK_LEGACY);
+    }
+
+    @Test(expected = Exception.class)
+    public void testPeriodicGroupNumber3() throws Exception {
+        parse("[G19]", Smarts.FLAVOR_CDK_LEGACY);
+    }
+
+    @Test(expected = Exception.class)
+    public void testPeriodicGroupNumber4() throws Exception {
+        parse("[G0]", Smarts.FLAVOR_CDK_LEGACY);
+    }
+
+    @Test(expected = Exception.class)
+    public void testPeriodicGroupNumber5() throws Exception {
+        parse("[G345]", Smarts.FLAVOR_CDK_LEGACY);
+    }
+
+    @Test(expected = Exception.class)
+    public void testPeriodicGroupNumber6() throws Exception {
+        parse("[G]", Smarts.FLAVOR_CDK_LEGACY);
+    }
+
+    @Test(expected = Exception.class)
+    public void testPeriodicGroupNumber7() throws Exception {
+        parse("[GA]");
+    }
+
+    @Test
+    public void testGroup5Elements() throws Exception {
+        parse("[V,Cr,Mn,Nb,Mo,Tc,Ta,W,Re]");
+    }
+    
+    @Test public void endOnSpace() throws Exception {
+        parse("C ");
+    }
+
+    @Test public void endOnTab() throws Exception {
+        parse("C\t");
+    }
+
+    @Test public void endOnNewline() throws Exception {
+        parse("C\n");
+    }
+
+    @Test public void endOnCarriageReturn() throws Exception {
+        parse("C\r");
+    }
+
+    @Test(expected = Exception.class)
+    public void badReaction1() throws Exception {
+        parse("C>");
+    }
+
+    @Test(expected = Exception.class)
+    public void badReaction2() throws Exception {
+        parse(">");
+    }
+
+    @Test(expected = Exception.class)
+    public void badReaction3() throws Exception {
+        parse(">C");
+    }
+
+    @Test(expected = Exception.class)
+    public void badReaction4() throws Exception {
+        parse("CC(C>C)C>CC");
+    }
+
+    @Test
+    public void emptyReaction() throws Exception {
+        parse(">>");
+    }
+
+    /**
+     * @cdk.bug 909
+     */
+    @Test public void bug909() throws Exception {
+        parse("O=C1NCCSc2ccccc12");
+    }
+
+}

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/SmartsExprReadTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/SmartsExprReadTest.java
@@ -1,0 +1,901 @@
+/*
+ * Copyright (c) 2018 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.junit.Test;
+import org.openscience.cdk.AtomRef;
+import org.openscience.cdk.BondRef;
+import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.config.Elements;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.isomorphism.matchers.Expr;
+import org.openscience.cdk.isomorphism.matchers.QueryAtom;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
+import org.openscience.cdk.isomorphism.matchers.QueryBond;
+import org.openscience.cdk.silent.AtomContainer;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.*;
+
+public class SmartsExprReadTest {
+
+    static Expr expr(Expr.Type type) {
+        return new Expr(type);
+    }
+
+    static Expr expr(Expr.Type type, int val) {
+        return new Expr(type, val);
+    }
+
+    static Expr and(Expr a, Expr b) {
+        return new Expr(AND, a, b);
+    }
+
+    static Expr or(Expr a, Expr b) {
+        return new Expr(OR, a, b);
+    }
+
+    private static Expr getAtomExpr(IAtom atom) {
+        return ((QueryAtom) AtomRef.deref(atom)).getExpression();
+    }
+
+    private static Expr getBondExpr(IBond bond) {
+        return ((QueryBond) BondRef.deref(bond)).getExpression();
+    }
+
+    static Expr getAtomExpr(String sma, int flav) {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, sma, flav));
+        return getAtomExpr(mol.getAtom(0));
+    }
+
+    static Expr getAtomExpr(String sma) {
+        return getAtomExpr(sma, Smarts.FLAVOR_LOOSE);
+    }
+
+    static Expr getBondExpr(String sma, int flav) {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, sma, flav));
+        return getBondExpr(mol.getBond(0));
+    }
+
+    static Expr getBondExpr(String sma) {
+        return getBondExpr(sma, Smarts.FLAVOR_LOOSE);
+    }
+
+    @Test
+    public void trailingOperator() {
+        IAtomContainer mol = new AtomContainer();
+        assertFalse(Smarts.parse(mol, "[a#6,]"));
+        assertFalse(Smarts.parse(mol, "[a#6;]"));
+        assertFalse(Smarts.parse(mol, "[a#6&]"));
+        assertFalse(Smarts.parse(mol, "[a#6!]"));
+    }
+
+    @Test
+    public void leadingOperator() {
+        IAtomContainer mol = new AtomContainer();
+        assertFalse(Smarts.parse(mol, "[,a#6]"));
+        assertFalse(Smarts.parse(mol, "[;a#6]"));
+        assertFalse(Smarts.parse(mol, "[&a#6]"));
+        assertTrue(Smarts.parse(mol, "[!a#6]"));
+    }
+
+    @Test
+    public void trailingBondOperator() {
+        IAtomContainer mol = new AtomContainer();
+        assertFalse(Smarts.parse(mol, "*-,*"));
+        assertFalse(Smarts.parse(mol, "*-;*"));
+        assertFalse(Smarts.parse(mol, "*-&*"));
+        assertFalse(Smarts.parse(mol, "*-!*"));
+    }
+
+    @Test
+    public void leadingBondOperator() {
+        IAtomContainer mol = new AtomContainer();
+        assertFalse(Smarts.parse(mol, "*,-*"));
+        assertFalse(Smarts.parse(mol, "*;-*"));
+        assertFalse(Smarts.parse(mol, "*&-*"));
+        assertTrue(Smarts.parse(mol, "*!-*"));
+    }
+
+    @Test
+    public void opPrecedence1() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[a#6,a#7]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = or(and(expr(IS_AROMATIC), expr(ELEMENT, 6)),
+                           and(expr(IS_AROMATIC), expr(ELEMENT, 7)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void opPrecedence2() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[a;#6,#7]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = and(expr(IS_AROMATIC),
+                            or(expr(ELEMENT, 6), expr(ELEMENT, 7)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void opPrecedence3() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[#6,#7;a]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = and(expr(IS_AROMATIC),
+                            or(expr(ELEMENT, 6), expr(ELEMENT, 7)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void opPrecedence4() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[#6,#7a]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = or(expr(ELEMENT, 6),
+                           and(expr(ELEMENT, 7), expr(IS_AROMATIC)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void opPrecedence5() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[#6&a,#7]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = or(expr(ELEMENT, 7),
+                           and(expr(ELEMENT, 6), expr(IS_AROMATIC)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void orList() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[F,Cl,Br,I]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = or(expr(ELEMENT, 9),
+                           or(expr(ELEMENT, 17),
+                              or(expr(ELEMENT, 35),
+                                 expr(ELEMENT, 53))));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void explicitHydrogen() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[2H+]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = and(expr(ISOTOPE, 2),
+                            and(expr(ELEMENT, 1), expr(FORMAL_CHARGE, 1)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void explicitHydrogenNeg() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[H-]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = and(expr(ELEMENT, 1),
+                            expr(FORMAL_CHARGE, -1));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void explicitHydrogenWithAtomMap() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[2H+:2]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = and(expr(ISOTOPE, 2),
+                            and(expr(ELEMENT, 1),
+                                expr(FORMAL_CHARGE, 1)));
+        assertThat(mol.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING,
+                                              Integer.class),
+                   is(2));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void explicitHydrogenWithBadAtomMap() {
+        IAtomContainer mol = new AtomContainer();
+        assertFalse(Smarts.parse(mol, "[2H+:]"));
+    }
+
+    @Test
+    public void nonExplicitHydrogen() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[2&H+]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = and(expr(ISOTOPE, 2),
+                            and(expr(TOTAL_H_COUNT, 1),
+                                expr(FORMAL_CHARGE, +1)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void nonExplicitHydrogen2() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[2,H+]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = or(expr(ISOTOPE, 2),
+                           and(expr(TOTAL_H_COUNT, 1),
+                               expr(FORMAL_CHARGE, +1)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void nonExplicitHydrogen3() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[2H1+]"));
+        Expr actual = getAtomExpr(mol.getAtom(0));
+        Expr expected = and(expr(ISOTOPE, 2),
+                            and(expr(TOTAL_H_COUNT, 1),
+                                expr(FORMAL_CHARGE, 1)));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void specifiedIsotope() {
+        Expr actual   = getAtomExpr("[!0]");
+        Expr expected = expr(HAS_ISOTOPE);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void unspecifiedIsotope() {
+        Expr actual   = getAtomExpr("[0]");
+        Expr expected = expr(HAS_UNSPEC_ISOTOPE);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringMembership() {
+        Expr actual   = getAtomExpr("[R]");
+        Expr expected = expr(IS_IN_RING);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringMembership2() {
+        Expr actual   = getAtomExpr("[!R0]");
+        Expr expected = expr(IS_IN_RING);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void chainMembership() {
+        Expr actual   = getAtomExpr("[R0]");
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void chainMembership2() {
+        Expr actual   = getAtomExpr("[!R]");
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void chainMembership3() {
+        Expr actual   = getAtomExpr("[r0]");
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void chainMembership4() {
+        Expr actual   = getAtomExpr("[x0]");
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void aromatic() {
+        Expr actual   = getAtomExpr("[a]");
+        Expr expected = expr(IS_AROMATIC);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void aromatic2() {
+        Expr actual   = getAtomExpr("[!A]");
+        Expr expected = expr(IS_AROMATIC);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void aliphatic() {
+        Expr actual   = getAtomExpr("[A]");
+        Expr expected = expr(IS_ALIPHATIC);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void aliphatic2() {
+        Expr actual   = getAtomExpr("[!a]");
+        Expr expected = expr(IS_ALIPHATIC);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void notTrue() {
+        Expr actual   = getAtomExpr("[!*]");
+        Expr expected = expr(FALSE);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void notNotTrue() {
+        Expr actual   = getAtomExpr("[!!*]");
+        Expr expected = expr(TRUE);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringCountDefault() {
+        Expr actual   = getAtomExpr("[R]");
+        Expr expected = expr(IS_IN_RING);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringCount0() {
+        Expr actual   = getAtomExpr("[R0]");
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringCount() {
+        Expr actual   = getAtomExpr("[R1]");
+        Expr expected = expr(RING_COUNT, 1);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringCountOEChem() {
+        Expr actual   = getAtomExpr("[R2]", Smarts.FLAVOR_OECHEM);
+        Expr expected = expr(RING_BOND_COUNT, 2);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringSmallest() {
+        Expr actual   = getAtomExpr("[r5]");
+        Expr expected = expr(RING_SMALLEST, 5);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringSmallestDefault() {
+        Expr actual   = getAtomExpr("[r]");
+        Expr expected = expr(IS_IN_RING);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringSmallestInvalid() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[r0]")); // not in ring
+        assertFalse(Smarts.parse(mol, "[r1]"));
+        assertFalse(Smarts.parse(mol, "[r2]"));
+        assertTrue(Smarts.parse(mol, "[r3]"));
+    }
+
+    // make sure not read as C & r
+    @Test
+    public void chromium() {
+        Expr actual   = getAtomExpr("[Cr]");
+        Expr expected = expr(ELEMENT, Elements.Chromium.number());
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void hetero() {
+        Expr actual   = getAtomExpr("[#X]");
+        Expr expected = expr(IS_HETERO);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringSize() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[Z8]", Smarts.FLAVOR_LOOSE));
+        Expr actual   = getAtomExpr(mol.getAtom(0));
+        Expr expected = expr(RING_SIZE, 8);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringSize0() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[Z0]", Smarts.FLAVOR_LOOSE));
+        Expr actual   = getAtomExpr(mol.getAtom(0));
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringSizeDefault() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[Z]", Smarts.FLAVOR_LOOSE));
+        Expr actual   = getAtomExpr(mol.getAtom(0));
+        Expr expected = expr(IS_IN_RING);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void adjacentHeteroCount() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[Z2]", Smarts.FLAVOR_CACTVS));
+        Expr actual   = getAtomExpr(mol.getAtom(0));
+        Expr expected = expr(ALIPHATIC_HETERO_SUBSTITUENT_COUNT, 2);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void adjacentHetero() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[Z]", Smarts.FLAVOR_CACTVS));
+        Expr actual   = getAtomExpr(mol.getAtom(0));
+        Expr expected = expr(HAS_ALIPHATIC_HETERO_SUBSTITUENT);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void adjacentHetero0() {
+        IAtomContainer mol = new AtomContainer();
+        assertTrue(Smarts.parse(mol, "[Z0]", Smarts.FLAVOR_CACTVS));
+        Expr actual   = getAtomExpr(mol.getAtom(0));
+        Expr expected = expr(HAS_ALIPHATIC_HETERO_SUBSTITUENT).negate();
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void valence() {
+        Expr actual   = getAtomExpr("[v4]");
+        Expr expected = expr(VALENCE, 4);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void valenceDefault() {
+        Expr actual   = getAtomExpr("[v]");
+        Expr expected = expr(VALENCE, 1);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void degree() {
+        Expr actual   = getAtomExpr("[D4]");
+        Expr expected = expr(DEGREE, 4);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void degreeDefault() {
+        Expr actual   = getAtomExpr("[D]");
+        Expr expected = expr(DEGREE, 1);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void degreeCDKLegacy() {
+        Expr actual   = getAtomExpr("[D4]", Smarts.FLAVOR_CDK_LEGACY);
+        Expr expected = expr(HEAVY_DEGREE, 4);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void degreeCDKLegacyDefault() {
+        Expr actual   = getAtomExpr("[D]", Smarts.FLAVOR_CDK_LEGACY);
+        Expr expected = expr(HEAVY_DEGREE, 1);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void connectivity() {
+        Expr actual   = getAtomExpr("[X4]");
+        Expr expected = expr(TOTAL_DEGREE, 4);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void connectivityDefault() {
+        Expr actual   = getAtomExpr("[X]");
+        Expr expected = expr(TOTAL_DEGREE, 1);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void totalHCount() {
+        Expr actual   = getAtomExpr("[H2]");
+        Expr expected = expr(TOTAL_H_COUNT, 2);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void implHCount() {
+        Expr actual   = getAtomExpr("[h2]");
+        Expr expected = expr(IMPL_H_COUNT, 2);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void hasImplHCount() {
+        Expr actual   = getAtomExpr("[h]");
+        Expr expected = expr(HAS_IMPLICIT_HYDROGEN);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringBondCount() {
+        Expr actual   = getAtomExpr("[x2]");
+        Expr expected = expr(RING_BOND_COUNT, 2);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringBondCount0() {
+        Expr actual   = getAtomExpr("[x0]");
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void ringBondCount1() {
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[x1]"));
+    }
+
+    @Test
+    public void ringBondCountDefault() {
+        Expr actual   = getAtomExpr("[x]");
+        Expr expected = expr(IS_IN_RING);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void formalChargeNeg() {
+        Expr actual   = getAtomExpr("[-1]");
+        Expr expected = expr(FORMAL_CHARGE, -1);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void formalChargeNegNeg() {
+        Expr actual   = getAtomExpr("[--]");
+        Expr expected = expr(FORMAL_CHARGE, -2);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void formalChargePos() {
+        Expr actual   = getAtomExpr("[+]");
+        Expr expected = expr(FORMAL_CHARGE, +1);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void formalChargePosPos() {
+        Expr actual   = getAtomExpr("[++]");
+        Expr expected = expr(FORMAL_CHARGE, +2);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void atomMaps() {
+        IAtomContainer mol = new QueryAtomContainer(null);
+        assertFalse(Smarts.parse(mol, "[:10]"));
+        assertTrue(Smarts.parse(mol, "[*:10]"));
+        assertThat(mol.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING, Integer.class),
+                   is(10));
+    }
+
+    @Test
+    public void periodicTableGroup() {
+        Expr actual   = getAtomExpr("[#G16]", Smarts.FLAVOR_MOE);
+        Expr expected = expr(PERIODIC_GROUP, 16);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void periodicTableGroupCDKLegacy() {
+        Expr actual   = getAtomExpr("[G16]", Smarts.FLAVOR_CDK_LEGACY);
+        Expr expected = expr(PERIODIC_GROUP, 16);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void insaturationCactvs() {
+        Expr actual   = getAtomExpr("[G1]", Smarts.FLAVOR_CACTVS);
+        Expr expected = expr(INSATURATION, 1);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void insaturationCactvsOrMoe() {
+        assertThat(getAtomExpr("[i1]", Smarts.FLAVOR_CACTVS),
+                   is(expr(INSATURATION, 1)));
+        assertThat(getAtomExpr("[i1]", Smarts.FLAVOR_MOE),
+                   is(expr(INSATURATION, 1)));
+    }
+
+    @Test
+    public void heteroSubCountCactvs() {
+        assertThat(getAtomExpr("[z]", Smarts.FLAVOR_CACTVS),
+                   is(expr(HAS_HETERO_SUBSTITUENT)));
+        assertThat(getAtomExpr("[z1]", Smarts.FLAVOR_CACTVS),
+                   is(expr(HETERO_SUBSTITUENT_COUNT, 1)));
+    }
+
+    @Test
+    public void hybridisationNumber() {
+        Expr actual   = getAtomExpr("[^2]", Smarts.FLAVOR_OECHEM);
+        Expr expected = expr(HYBRIDISATION_NUMBER, 2);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void hybridisationNumberDaylight() {
+        assertFalse(Smarts.parse(new QueryAtomContainer(null),
+                                 "[^2]",
+                                 Smarts.FLAVOR_DAYLIGHT));
+    }
+
+    @Test
+    public void atomStereoLeft() {
+        Expr actual   = getAtomExpr("[@]");
+        Expr expected = expr(STEREOCHEMISTRY, IStereoElement.LEFT);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void atomStereoRight() {
+        Expr actual   = getAtomExpr("[@@]");
+        Expr expected = expr(STEREOCHEMISTRY, IStereoElement.RIGHT);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void atomStereoLeftOrUnspec() {
+        Expr actual   = getAtomExpr("[@?]");
+        Expr expected = or(expr(STEREOCHEMISTRY, IStereoElement.LEFT),
+                           expr(STEREOCHEMISTRY, 0));
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void atomStereoSimpleLeft() {
+        Expr actual   = getAtomExpr("[C@H]");
+        System.out.println(actual);
+    }
+
+    @Test
+    public void badExprs() {
+        IAtomContainer mol = new AtomContainer();
+        assertFalse(Smarts.parse(mol, "*-,*"));
+        assertFalse(Smarts.parse(mol, "*-;*"));
+        assertFalse(Smarts.parse(mol, "*-!*"));
+        assertFalse(Smarts.parse(mol, "*-&*"));
+        assertFalse(Smarts.parse(mol, "*!*"));
+        assertFalse(Smarts.parse(mol, "*,*"));
+        assertFalse(Smarts.parse(mol, "*;*"));
+        assertFalse(Smarts.parse(mol, "*&*"));
+        assertFalse(Smarts.parse(mol, "*,-*"));
+    }
+
+    @Test
+    public void singleOrAromatic() {
+        Expr actual   = getBondExpr("**");
+        Expr expected = expr(SINGLE_OR_AROMATIC);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void singleBond() {
+        Expr actual   = getBondExpr("*-*");
+        Expr expected = expr(ALIPHATIC_ORDER, 1);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void doubleBond() {
+        Expr actual   = getBondExpr("*=*");
+        Expr expected = expr(ALIPHATIC_ORDER, 2);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void tripleBond() {
+        Expr actual   = getBondExpr("*#*");
+        Expr expected = expr(ALIPHATIC_ORDER, 3);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void quadBond() {
+        Expr actual   = getBondExpr("*$*");
+        Expr expected = expr(ALIPHATIC_ORDER, 4);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void aromaticBond() {
+        Expr actual   = getBondExpr("*:*");
+        Expr expected = expr(IS_AROMATIC);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void aliphaticBond() {
+        Expr actual   = getBondExpr("*!:*");
+        Expr expected = expr(IS_ALIPHATIC);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void chainBond() {
+        Expr actual   = getBondExpr("*!@*");
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void anyBond() {
+        Expr actual   = getBondExpr("*~*");
+        Expr expected = expr(TRUE);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void singleOrDouble() {
+        Expr actual = getBondExpr("*-,=*");
+        Expr expected = or(expr(ALIPHATIC_ORDER, 1),
+                           expr(ALIPHATIC_ORDER, 2));
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void operatorPrecedence() {
+        Expr actual = getBondExpr("*@;-,=*");
+        Expr expected = and(expr(IS_IN_RING),
+                            or(expr(ALIPHATIC_ORDER, 1),
+                               expr(ALIPHATIC_ORDER, 2)));
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void notInRing() {
+        Expr actual   = getBondExpr("*!@*");
+        Expr expected = expr(IS_IN_CHAIN);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void notAromatic() {
+        Expr actual   = getBondExpr("*!:*");
+        Expr expected = expr(IS_ALIPHATIC);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void notNotWildcard() {
+        Expr actual   = getBondExpr("*!!~*");
+        Expr expected = expr(TRUE);
+        assertThat(expected, is(actual));
+    }
+
+    @Test
+    public void testAliphaticSymbols() {
+        for (Elements e : Elements.values()) {
+            int len = e.symbol().length();
+            if (len == 1 || len == 2) {
+                String             smarts = "[" + e.symbol() + "]";
+                QueryAtomContainer mol    = new QueryAtomContainer(null);
+                assertTrue(smarts, Smarts.parse(mol, smarts));
+                Expr expr = getAtomExpr(mol.getAtom(0));
+                assertThat(expr, anyOf(is(new Expr(ELEMENT, e.number())),
+                                       is(new Expr(ALIPHATIC_ELEMENT, e.number()))));
+            }
+        }
+    }
+
+    @Test
+    public void testAromaticSymbols() {
+        assertThat(getAtomExpr("[b]"), is(new Expr(AROMATIC_ELEMENT, 5)));
+        assertThat(getAtomExpr("[c]"), is(new Expr(AROMATIC_ELEMENT, 6)));
+        assertThat(getAtomExpr("[n]"), is(new Expr(AROMATIC_ELEMENT, 7)));
+        assertThat(getAtomExpr("[o]"), is(new Expr(AROMATIC_ELEMENT, 8)));
+        assertThat(getAtomExpr("[al]"), is(new Expr(AROMATIC_ELEMENT, 13)));
+        assertThat(getAtomExpr("[si]"), is(new Expr(AROMATIC_ELEMENT, 14)));
+        assertThat(getAtomExpr("[p]"), is(new Expr(AROMATIC_ELEMENT, 15)));
+        assertThat(getAtomExpr("[s]"), is(new Expr(AROMATIC_ELEMENT, 16)));
+        assertThat(getAtomExpr("[as]"), is(new Expr(AROMATIC_ELEMENT, 33)));
+        assertThat(getAtomExpr("[se]"), is(new Expr(AROMATIC_ELEMENT, 34)));
+        assertThat(getAtomExpr("[sb]"), is(new Expr(AROMATIC_ELEMENT, 51)));
+        assertThat(getAtomExpr("[te]"), is(new Expr(AROMATIC_ELEMENT, 52)));
+    }
+
+    @Test
+    public void testBadSymbols() {
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[L]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[J]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[Q]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[G]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[T]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[M]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[E]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[t]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[?]"));
+    }
+
+    @Test
+    public void testRecursive() {
+        assertTrue(Smarts.parse(new QueryAtomContainer(null), "[$(*OC)]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[$*OC)]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[$(*OC]"));
+        assertTrue(Smarts.parse(new QueryAtomContainer(null), "[$((*[O-].[Na+]))]"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "[$([J])]"));
+    }
+
+    // recursive SMARTS with single atoms should be 'lifted' up to a single
+    // non-recursive expression
+    @Test
+    public void testTrivialRecursive() {
+        Expr expr = getAtomExpr("[$(F),$(Cl),$(Br)]");
+        assertThat(expr, is(or(expr(ELEMENT, 9),
+                               or(expr(ELEMENT, 17),
+                                  expr(ELEMENT, 35)))));
+    }
+
+    // must always be read/written in SMARTS as recursive but we can lift
+    // the expression up to the top level
+    @Test
+    public void testTrivialRecursive2() {
+        Expr expr = getAtomExpr("[!$([F,Cl,Br])]");
+        assertThat(expr, is(or(expr(ELEMENT, 9),
+                                or(expr(ELEMENT, 17),
+                                  expr(ELEMENT, 35))).negate()));
+    }
+
+    @Test
+    public void ringOpenCloseInconsistency() {
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "C=1CC-,=1"));
+        assertFalse(Smarts.parse(new QueryAtomContainer(null), "C=1CC-1"));;
+    }
+
+    @Test
+    public void ringOpenCloseConsistency() {
+        assertTrue(Smarts.parse(new QueryAtomContainer(null), "C-,=1CC-,=1"));
+        assertTrue(Smarts.parse(new QueryAtomContainer(null), "C!~1CC!~1"));
+    }
+}

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/SmartsExprWriteTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/SmartsExprWriteTest.java
@@ -1,0 +1,478 @@
+/*
+ * Copyright (c) 2018 John Mayfield <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.junit.Test;
+import org.openscience.cdk.config.Elements;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.isomorphism.matchers.Expr;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
+import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ALIPHATIC_ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ALIPHATIC_ORDER;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.AND;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.AROMATIC_ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.DEGREE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ELEMENT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.FORMAL_CHARGE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HAS_IMPLICIT_HYDROGEN;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HAS_ISOTOPE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.HAS_UNSPEC_ISOTOPE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.ISOTOPE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_AROMATIC;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_IN_CHAIN;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.IS_IN_RING;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.OR;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.RING_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.RING_SMALLEST;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.SINGLE_OR_DOUBLE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TOTAL_DEGREE;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.TOTAL_H_COUNT;
+import static org.openscience.cdk.isomorphism.matchers.Expr.Type.VALENCE;
+
+public class SmartsExprWriteTest {
+
+    static Expr expr(Expr.Type type) {
+        return new Expr(type);
+    }
+
+    static Expr expr(Expr.Type type, int val) {
+        return new Expr(type, val);
+    }
+
+    static Expr and(Expr a, Expr b) {
+        return new Expr(AND, a, b);
+    }
+
+    static Expr or(Expr a, Expr b) {
+        return new Expr(OR, a, b);
+    }
+
+    // C&r6 not Cr
+    @Test public void useExplAnd1() {
+        Expr expr = new Expr(ALIPHATIC_ELEMENT, 6).and(
+            new Expr(RING_SMALLEST, 6)
+        );
+        assertThat(Smarts.generateAtom(expr), is("[C&r6]"));
+    }
+
+    // D&2 not D2
+    @Test public void useExplAnd2() {
+        Expr expr = new Expr(DEGREE, 1).and(
+            new Expr(ISOTOPE, 2)
+        );
+        assertThat(Smarts.generateAtom(expr), is("[D&2]"));
+    }
+
+    // aromatic or aliphatic
+    @Test public void carbon() {
+        Expr expr = new Expr(ELEMENT, 6);
+        assertThat(Smarts.generateAtom(expr), is("[#6]"));
+    }
+
+    // helium can't be aromatic so we can always use the symbol
+    @Test public void helium() {
+        Expr expr = new Expr(ELEMENT, 2);
+        assertThat(Smarts.generateAtom(expr), is("[He]"));
+    }
+
+    @Test public void degree() {
+        assertThat(Smarts.generateAtom(expr(DEGREE, 1)), is("[D]"));
+        assertThat(Smarts.generateAtom(expr(DEGREE, 2)), is("[D2]"));
+    }
+
+    // can sometimes write just 'H' but a lot of effort to figure out when
+    @Test public void totalHCount() {
+        assertThat(Smarts.generateAtom(expr(TOTAL_H_COUNT, 1)), is("[H1]"));
+        assertThat(Smarts.generateAtom(expr(TOTAL_H_COUNT, 2)), is("[H2]"));
+    }
+
+    @Test public void connectivity() {
+        assertThat(Smarts.generateAtom(expr(TOTAL_DEGREE, 1)), is("[X]"));
+        assertThat(Smarts.generateAtom(expr(TOTAL_DEGREE, 2)), is("[X2]"));
+    }
+
+    @Test public void ringMembership() {
+        assertThat(Smarts.generateAtom(expr(IS_IN_RING)), is("[R]"));
+        assertThat(Smarts.generateAtom(expr(IS_IN_CHAIN)), is("[!R]"));
+    }
+
+    @Test public void ringCount() {
+        assertThat(Smarts.generateAtom(expr(RING_COUNT, 2)), is("[R2]"));
+    }
+
+    @Test public void ringSmallest() {
+        assertThat(Smarts.generateAtom(expr(RING_SMALLEST, 4)), is("[r4]"));
+    }
+
+    @Test public void isotopes() {
+        assertThat(Smarts.generateAtom(expr(ISOTOPE, 13)), is("[13]"));
+        assertThat(Smarts.generateAtom(expr(HAS_UNSPEC_ISOTOPE)), is("[0]"));
+        assertThat(Smarts.generateAtom(expr(HAS_ISOTOPE)), is("[!0]"));
+    }
+
+    @Test public void formalCharges() {
+        assertThat(Smarts.generateAtom(expr(FORMAL_CHARGE, -2)), is("[-2]"));
+        assertThat(Smarts.generateAtom(expr(FORMAL_CHARGE, -1)), is("[-]"));
+        assertThat(Smarts.generateAtom(expr(FORMAL_CHARGE, 0)), is("[+0]"));
+        assertThat(Smarts.generateAtom(expr(FORMAL_CHARGE, 1)), is("[+]"));
+        assertThat(Smarts.generateAtom(expr(FORMAL_CHARGE, 2)), is("[+2]"));
+    }
+
+    @Test public void valence() {
+        assertThat(Smarts.generateAtom(expr(VALENCE, 1)), is("[v]"));
+        assertThat(Smarts.generateAtom(expr(VALENCE, 2)), is("[v2]"));
+    }
+
+    @Test public void atomicNum() {
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 0)), is("[#0]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 1)), is("[#1]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 2)), is("[He]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 3)), is("[Li]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 6)), is("[#6]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 7)), is("[#7]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 8)), is("[#8]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 9)), is("F"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 10)), is("[Ne]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 11)), is("[Na]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, 12)), is("[Mg]"));
+        // Ds, Ts and Nh etc write as #<num>
+        assertThat(Smarts.generateAtom(expr(ELEMENT, Elements.Darmstadtium.number())),
+                   is("[#110]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, Elements.Tennessine.number())),
+                   is("[#117]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, Elements.Nihonium.number())),
+                   is("[#113]"));
+    }
+
+    // Ds, Ts and Nh etc can be ambiguous - we write anything above radon as
+    // '#<num>'
+    @Test public void atomicNumHighWeightElements() {
+        assertThat(Smarts.generateAtom(expr(ELEMENT, Elements.Darmstadtium.number())),
+                   is("[#110]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, Elements.Tennessine.number())),
+                   is("[#117]"));
+        assertThat(Smarts.generateAtom(expr(ELEMENT, Elements.Nihonium.number())),
+                   is("[#113]"));
+        assertThat(Smarts.generateAtom(expr(ALIPHATIC_ELEMENT, Elements.Darmstadtium.number())),
+                   is("[#110A]"));
+        assertThat(Smarts.generateAtom(expr(ALIPHATIC_ELEMENT, Elements.Tennessine.number())),
+                   is("[#117A]"));
+        assertThat(Smarts.generateAtom(expr(ALIPHATIC_ELEMENT, Elements.Nihonium.number())),
+                   is("[#113A]"));
+    }
+
+    @Test public void aromaticElement() {
+        assertThat(Smarts.generateAtom(expr(AROMATIC_ELEMENT, 6)), is("c"));
+        assertThat(Smarts.generateAtom(expr(AROMATIC_ELEMENT, 7)), is("n"));
+    }
+
+    @Test public void useLowPrecedenceAnd() {
+        Expr expr = new Expr(ELEMENT, 8).and(
+            new Expr(DEGREE, 2).or(
+                new Expr(DEGREE, 1)));
+        assertThat(Smarts.generateAtom(expr), is("[#8;D2,D]"));
+    }
+
+    @Test public void useImplAnd() {
+        Expr expr = new Expr(AROMATIC_ELEMENT, 7).and(
+            new Expr(DEGREE, 2).and(
+                new Expr(HAS_IMPLICIT_HYDROGEN)));
+        assertThat(Smarts.generateAtom(expr), is("[nD2h]"));
+    }
+
+    // logical under a negate needs to be recursive
+    @Test public void usrRecrNot() {
+        Expr expr = new Expr(ELEMENT, 9)
+            .or(new Expr(ELEMENT, 17))
+            .or(new Expr(ELEMENT, 35))
+            .negate();
+        assertThat(Smarts.generateAtom(expr), is("[!$([Br,F,Cl])]"));
+    }
+
+    // or -> and -> or needs to be recursive
+    @Test public void usrRecrOr() {
+        Expr expr = or(and(or(expr(ELEMENT, 6),
+                              expr(ELEMENT, 7)),
+                           expr(IS_IN_RING)),
+                       expr(IS_AROMATIC));
+        assertThat(Smarts.generateAtom(expr),
+                          is("[$([#6,#7])R,a]"));
+    }
+
+    @Test public void singleOrDouble() {
+        Expr expr = new Expr(ALIPHATIC_ORDER, 1)
+            .or(new Expr(ALIPHATIC_ORDER, 2));
+        assertThat(Smarts.generateBond(expr), is("-,="));
+    }
+
+    @Test public void singleOrDoubleInRing() {
+        Expr expr = new Expr(IS_IN_RING)
+            .and(new Expr(ALIPHATIC_ORDER, 1)
+                      .or(new Expr(ALIPHATIC_ORDER, 2)));
+        assertThat(Smarts.generateBond(expr), is("@;-,="));
+    }
+
+    @Test public void singleOrDoubleInRing2() {
+        Expr expr = new Expr(IS_IN_RING)
+            .and(new Expr(SINGLE_OR_DOUBLE));
+        assertThat(Smarts.generateBond(expr), is("@;-,="));
+    }
+
+    @Test public void indoleRoundTrip() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "n1ccc2c1cccc2"));
+        // CDK choice of data structures lose local arrangement but
+        // output is still indole
+        assertThat(Smarts.generate(mol), is("n1c2c(cc1)cccc2"));
+    }
+
+    @Test public void indoleWithExprRoundTrip() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "[n;$(*C),$(*OC)]1ccc2c1cccc2"));
+        // CDK choice of data structures lose local arrangement but
+        // output is still indole
+        assertThat(Smarts.generate(mol), is("[n;$(*C),$(*OC)]1c2c(cc1)cccc2"));
+    }
+
+    @Test public void bondTrue() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C~C~N(~O)~O"));
+        assertThat(Smarts.generate(mol), is("C~C~N(~O)~O"));
+    }
+
+    @Test public void bondFalse() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C!~C"));
+        assertThat(Smarts.generate(mol), is("C!~C"));
+    }
+
+    @Test public void bondInChain() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C!@C"));
+        assertThat(Smarts.generate(mol), is("C!@C"));
+    }
+
+    @Test public void bondInRing() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C@C"));
+        assertThat(Smarts.generate(mol), is("C@C"));
+    }
+
+    @Test public void tripleBond() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C#C"));
+        assertThat(Smarts.generate(mol), is("C#C"));
+    }
+
+    @Test public void notTripleBond() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C!#C"));
+        assertThat(Smarts.generate(mol), is("C!#C"));
+    }
+
+    @Test public void aromaticBond() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "[#6]:[#6]"));
+        assertThat(Smarts.generate(mol), is("[#6]:[#6]"));
+    }
+
+    @Test public void ringClosureExprs() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C1CCCC-,=1"));
+        assertThat(Smarts.generate(mol), is("C1-,=CCCC1"));
+    }
+
+    @Test public void ringClosureExprs2() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C-,=1CCCC1"));
+        assertThat(Smarts.generate(mol), is("C1-,=CCCC1"));
+    }
+
+    @Test public void ringClosureExprs3() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C1-,=CCCC1"));
+        assertThat(Smarts.generate(mol), is("C1CCCC-,=1"));
+    }
+
+    @Test public void reaction() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "c1ccccc1[NH2]>>c1ccccc1N(~O)~O"));
+        assertThat(Smarts.generate(mol), is("c1c(cccc1)[NH2]>>c1c(cccc1)N(~O)~O"));
+    }
+
+    @Test public void reactionWithMaps() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "c1cccc[c:1]1[NH2:2]>>c1cccc[c:1]1[N:2](~O)~O"));
+        assertThat(Smarts.generate(mol), is("c1[c:1](cccc1)[NH2:2]>>c1[c:1](cccc1)[N:2](~O)~O"));
+    }
+
+    @Test public void compGrouping() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "([Na+].[Cl-]).c1ccccc1"));
+        assertThat(Smarts.generate(mol), is("c1ccccc1.([Na+].[Cl-])"));
+    }
+
+    @Test public void compGroupingOnAgent() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, ">(c1ccccc1[O-].[Na+])>"));
+        assertThat(Smarts.generate(mol), is(">(c1c(cccc1)[O-].[Na+])>"));
+    }
+
+    @Test public void atomStereo() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C[C@H](O)CC"));
+        assertThat(Smarts.generate(mol), is("C[C@H1](O)CC"));
+    }
+
+    private static void swap(Object[] a, int i, int j) {
+        Object tmp = a[i];
+        a[i] = a[j];
+        a[j] = tmp;
+    }
+
+    @Test public void atomStereoReordered() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C[C@H](O)CC"));
+        IBond[] bonds = AtomContainerManipulator.getBondArray(mol);
+        swap(bonds, 1, 2);
+        mol.setBonds(bonds);
+        assertThat(Smarts.generate(mol), is("C[C@@H1](CC)O"));
+    }
+
+    @Test public void atomStereoReordered2() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C[C@H](O)CC"));
+        IAtom[] atoms = AtomContainerManipulator.getAtomArray(mol);
+        swap(atoms, 0, 1);
+        mol.setAtoms(atoms);
+        assertThat(Smarts.generate(mol), is("[C@@H1](C)(O)CC"));
+    }
+
+    @Test public void atomStereoReordered3() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "[C@H](C)(O)CC"));
+        IAtom[] atoms = AtomContainerManipulator.getAtomArray(mol);
+        swap(atoms, 0, 1);
+        mol.setAtoms(atoms);
+        assertThat(Smarts.generate(mol), is("C[C@@H1](O)CC"));
+    }
+
+    @Test public void atomStereoOrUnspec() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C[C@?H](O)CC"));
+        assertThat(Smarts.generate(mol), is("C[CH1@?](O)CC"));
+    }
+
+    @Test public void bondStereoTrans() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/C=C/C"));
+        assertThat(Smarts.generate(mol), is("C/C=C/C"));
+        IAtom[] atoms = AtomContainerManipulator.getAtomArray(mol);
+        swap(atoms, 0, 1);
+        mol.setAtoms(atoms);
+        assertThat(Smarts.generate(mol), is("C(\\C)=C/C"));
+    }
+
+    @Test public void bondStereoCisTrans() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/C=C/,\\C"));
+        assertThat(Smarts.generate(mol), is("C/C=C/,\\C"));
+    }
+
+    @Test public void bondStereoCisUnspec() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/C=C\\?C"));
+        assertThat(Smarts.generate(mol), is("C/C=C\\?C"));
+        // not trans same as cis/unspec
+        mol.removeAllElements();
+        assertTrue(Smarts.parse(mol, "C/C=C!/C"));
+        assertThat(Smarts.generate(mol), is("C/C=C\\?C"));
+    }
+
+    @Test public void bondStereoTransUnspec() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/?C=C/C"));
+        assertThat(Smarts.generate(mol), is("C/C=C/?C"));
+        // not cis same as trans/unspec
+        mol.removeAllElements();
+        assertTrue(Smarts.parse(mol, "C/C=C!\\C"));
+        assertThat(Smarts.generate(mol), is("C/C=C/?C"));
+    }
+
+    // unspecified db can be written as either /?\\? or !/!\\
+    @Test public void bondStereoUnspec() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/C=C/?\\?C"));
+        assertThat(Smarts.generate(mol), is("C/C=C!/!\\C"));
+    }
+
+    // here we have one bond symbol shared between two stereo
+    // bonds, changing it's affects both stereos
+    @Test public void bondStereoCisThenTrans() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/C=C\\C=C\\C"));
+        assertThat(Smarts.generate(mol), is("C/C=C\\C=C\\C"));
+    }
+
+    // make sure we set the bond direction on the correct neighbor
+    @Test public void bondStereoCisThenTransWithNbr() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/C=C(C)\\C=C\\C"));
+        assertThat(Smarts.generate(mol), is("C/C=C(C)\\C=C\\C"));
+    }
+
+    @Test public void bondStereoCisThenTransUnspecWithNbr() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/C=C(C)\\C=C\\?O"));
+        assertThat(Smarts.generate(mol), is("C/C=C(C)\\C=C\\?O"));
+        IAtom[] atoms = AtomContainerManipulator.getAtomArray(mol);
+        swap(atoms, 0, atoms.length-1);
+        mol.setAtoms(atoms);
+        assertThat(Smarts.generate(mol), is("O/?C=C/C(=C\\C)C"));
+    }
+
+    // this case is tricky, we need to set the non-query bond stereo
+    // first then the 'or unspecified' one otherwise we would initially
+    // set 'C/C=C(C)/?C=CO' and there is no way to set the other bond
+    @Test public void bondStereoCisThenTransUnspecWithNbrComplex() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/?C=C(C)\\C=C\\O"));
+        assertThat(Smarts.generate(mol), is("C/?C=C(C)/C=C/O"));
+    }
+
+    // multiple calls to parse should set the stereo correctly and
+    // put the queries in a single atom container
+    @Test public void multipleReads() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(mol, "C/C=C/C"));
+        assertTrue(Smarts.parse(mol, "C/C=C\\C"));
+        assertThat(Smarts.generate(mol), is("C/C=C/C.C/C=C\\C"));
+    }
+}


### PR DESCRIPTION
**Final two commits only**

More compact representation of binary expression trees. The existing scheme of polymorphic/inheritaned QueryAtoms/QueryBonds is fine for matching but makes it very difficult to a) generate a SMARTS or b) inspect/optimise patterns.

Ultimately this will deprecate almost ~100 class in the public API (all the QueryAtoms specific to SMARTS primitives, all the AST primitives used in the javacc SMARTS parser, also parts like the CTQueryBond ect). Because of the current virtual dispatches (how inheritance works) there may be a small improvement in performance, certainly not having to pre-compute all invariants like total H count, ring bond count, valence, etc will be a big win. The matching can be done completely outside of the Expr.matches() by inspecting the left/right/value properties.

I've actually run a few commits ahead and re-written the SMARTS reading and tested all our existing SMARTS queries to make sure things will work correctly. Realised I had to reverse the recursive bits here which depends on uncommitted parts downstream of this. Have also made sure using jacoco the tests hit all the 627 instructions in the matching of properties.

![image](https://user-images.githubusercontent.com/983232/36933643-acbc030c-1ed4-11e8-8f9b-4f241b8481d9.png)
