### PR TITLE
Added a method to enable debugging output.

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
+++ b/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
@@ -256,9 +256,12 @@ public class SystemOutLoggingTool implements ILoggingTool {
     }
 
     /**
-     * Protected method which must not be used, except for testing purposes.
+     * Enables debugging output. 
+     * Use this method for computational demanding debug info.
+     * 
+     * @see isDebugEnabled()
      */
-    protected void setDebugEnabled(boolean enabled) {
+    public void setDebugEnabled(boolean enabled) {
         doDebug = enabled;
     }
 

--- a/base/interfaces/src/main/java/org/openscience/cdk/tools/ILoggingTool.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/tools/ILoggingTool.java
@@ -205,4 +205,12 @@ public interface ILoggingTool {
      * @return true, if debug is enabled
      */
     public boolean isDebugEnabled();
+    
+    /**
+     * Enables debugging output. 
+     * Use this method for computational demanding debug info.
+     * 
+     * @see isDebugEnabled()
+     */
+    public void setDebugEnabled(boolean enabled);
 }

--- a/base/test-core/src/test/java/org/openscience/cdk/tools/LoggingToolFactoryTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/tools/LoggingToolFactoryTest.java
@@ -100,6 +100,9 @@ public class LoggingToolFactoryTest {
         public boolean isDebugEnabled() {
             return true;
         }
+        
+        @Override
+        public void setDebugEnabled(boolean enabled) {}
 
         @Override
         public void setStackLength(int length) {}

--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
@@ -448,6 +448,17 @@ public class LoggingTool implements ILoggingTool {
     public boolean isDebugEnabled() {
         return doDebug;
     }
+    
+    /**
+     * Enables debugging output. 
+     * Use this method for computational demanding debug info.
+     * 
+     * @see isDebugEnabled()
+     */
+    @Override
+    public void setDebugEnabled(boolean enabled) {
+        doDebug = enabled;
+    }
 
     private void printToSTDOUT(String level, String message) {
         System.out.print(classname);
@@ -466,5 +477,7 @@ public class LoggingTool implements ILoggingTool {
     public static ILoggingTool create(Class<?> sourceClass) {
         return new LoggingTool(sourceClass);
     }
+    
+    
 
 }


### PR DESCRIPTION
SystemOutLoggingTool is supposed to log to System.out without the help of log4j. Its ability to output relies on debugEnabled being true. There was, however, no method setDebugEnabled() to switch this on. Now added.