### PR TITLE
Implementing output of EPS (and also PS) vector formats.

### DIFF
--- a/app/depict/pom.xml
+++ b/app/depict/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>freehep-graphicsio-pdf</artifactId>
             <version>2.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.freehep</groupId>
+            <artifactId>freehep-graphicsio-ps</artifactId>
+            <version>2.4</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
@@ -227,6 +227,8 @@ public abstract class Depiction {
         formats.add(SVG_FMT.toUpperCase(Locale.ROOT));
         formats.add(PS_FMT);
         formats.add(PS_FMT.toUpperCase(Locale.ROOT));
+        formats.add(EPS_FMT);
+        formats.add(EPS_FMT.toUpperCase(Locale.ROOT));
         formats.add(PDF_FMT);
         formats.add(PDF_FMT.toUpperCase(Locale.ROOT));
         formats.addAll(Arrays.asList(ImageIO.getWriterFormatNames()));

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
@@ -73,7 +73,7 @@ public abstract class Depiction {
     public static final String PS_FMT = "ps";
 
     /**
-     * Encapsulated PostScript (PS) format key.
+     * Encapsulated PostScript (EPS) format key.
      */
     public static final String EPS_FMT = "eps";
 

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
@@ -73,6 +73,11 @@ public abstract class Depiction {
     public static final String PS_FMT = "ps";
 
     /**
+     * Encapsulated PostScript (PS) format key.
+     */
+    public static final String EPS_FMT = "eps";
+
+    /**
      * Portable Document Format (PDF) format key.
      */
     public static final String PDF_FMT = "pdf";
@@ -146,12 +151,22 @@ public abstract class Depiction {
     }
 
     /**
-     * Render the image to an EPS format string.
+     * Render the image to an PS (PostScript) format string.
      *
-     * @return eps content
+     * @return PS content
+     */
+    public final String toPsStr() {
+        return toVecStr(PS_FMT, UNITS_MM);
+    }
+
+    /**
+     * Render the image to an EPS (ncapsulated PostScript) format
+     * string.
+     *
+     * @return EPS content
      */
     public final String toEpsStr() {
-        return toVecStr(PS_FMT, UNITS_MM);
+        return toVecStr(EPS_FMT, UNITS_MM);
     }
 
     /**

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
@@ -160,7 +160,7 @@ public abstract class Depiction {
     }
 
     /**
-     * Render the image to an EPS (ncapsulated PostScript) format
+     * Render the image to an EPS (Encapsulated PostScript) format
      * string.
      *
      * @return EPS content

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -134,8 +134,8 @@ final class FreeHepWrapper {
             // We should determine new-line separator (nl) not from OS type, but from the line-endings
             // in the actual EPS outpu; there is nothing that would prevent us from generating Unix-style
             // file in Windows :)
-            if( result.contains("\n\r")) {
-                nl = "\n\r";
+            if( result.contains("\r\n")) {
+                nl = "\r\n";
             } else if( result.contains("\r")) {
                 nl = "\r";
             } else {

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -117,15 +117,16 @@ final class FreeHepWrapper {
             result = result.replaceAll("\"([-+0-9.]+)px\"", "\"$1mm\"");
         }
         if (fmt.equals(Depiction.PS_FMT)) {
-            String split[] = result.split("\\n",2);
+            String nl = System.getProperty("line.separator");
+            String split[] = result.split(nl,2);
             if( split.length > 1 && split[0].startsWith("%!PS-") ) {
                 String boundingBox = "%%BoundingBox: ";
                 if( this.dim != null ) {
                     boundingBox += "0 0 " + dim.width + " " + dim.height + "\n";
                 }
 
-                result = split[0] + "\n" +
-                    "%%BoundingBox: (atend)\n" +
+                result = split[0] + nl +
+                    "%%BoundingBox: (atend)" + nl +
                     split[1].
                     replaceFirst("(\\d+ ){4}setmargins",
                                "0 0 0 0 setmargins").

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -126,8 +126,7 @@ final class FreeHepWrapper {
         // we want SVG in mm not pixels!
         if (fmt.equals(Depiction.SVG_FMT)) {
             result = result.replaceAll("\"([-+0-9.]+)px\"", "\"$1mm\"");
-        }
-        if (fmt.equals(Depiction.EPS_FMT)) {
+        } else if (fmt.equals(Depiction.EPS_FMT)) {
             String nl;
             // We should determine new-line separator (nl) not from OS type, but from the line-endings
             // in the actual EPS outpu; there is nothing that would prevent us from generating Unix-style

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -127,9 +127,9 @@ final class FreeHepWrapper {
                 result = split[0] + "\n" +
                     "%%BoundingBox: (atend)\n" +
                     split[1].
-                    replaceAll("(\\d+ ){4}setmargins",
+                    replaceFirst("(\\d+ ){4}setmargins",
                                "0 0 0 0 setmargins").
-                    replaceAll("(\\d+ ){2}setpagesize",
+                    replaceFirst("(\\d+ ){2}setpagesize",
                                dim.width + " " + dim.height +
                                " setpagesize") +
                     boundingBox;

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -81,6 +81,9 @@ final class FreeHepWrapper {
                 // For EPS (Encapsulated PostScript) page size has no
                 // meaning since this image is supposed to be included
                 // in another page.
+                Properties eps_props = new Properties();
+                eps_props.setProperty(PDFGraphics2D.FIT_TO_PAGE, "false");
+                eps.setProperties(eps_props);
                 eps.writeHeader();
                 return eps;
             case Depiction.PS_FMT:

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -76,16 +76,20 @@ final class FreeHepWrapper {
                 pdf.setProperties(props);
                 pdf.writeHeader();
                 return pdf;
-            case Depiction.PS_FMT:
+            case Depiction.EPS_FMT:
                 PSGraphics2D eps = new PSGraphics2D(out, dim);
                 // For EPS (Encapsulated PostScript) page size has no
                 // meaning since this image is supposed to be included
                 // in another page.
-                Properties eps_props = new Properties();
-                eps_props.setProperty(PDFGraphics2D.FIT_TO_PAGE, "false");
-                eps.setProperties(eps_props);
                 eps.writeHeader();
                 return eps;
+            case Depiction.PS_FMT:
+                PSGraphics2D ps = new PSGraphics2D(out, dim);
+                Properties ps_props = new Properties();
+                ps_props.setProperty(PDFGraphics2D.FIT_TO_PAGE, "true");
+                ps.setProperties(ps_props);
+                ps.writeHeader();
+                return ps;
             default:
                 throw new IOException("Unsupported vector format, " + fmt);
         }
@@ -120,7 +124,7 @@ final class FreeHepWrapper {
         if (fmt.equals(Depiction.SVG_FMT)) {
             result = result.replaceAll("\"([-+0-9.]+)px\"", "\"$1mm\"");
         }
-        if (fmt.equals(Depiction.PS_FMT)) {
+        if (fmt.equals(Depiction.EPS_FMT)) {
             String nl = System.getProperty("line.separator");
             String split[] = result.split(nl,2);
             if( split.length > 1 && split[0].startsWith("%!PS-") ) {

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -41,7 +41,10 @@ import java.util.Properties;
  * @see <a href="http://java.freehep.org/">java.freehep.org</a>
  *
  * @cdk.cite The toString() method cites the following documents:
+ *
  * [PLDS92] PostScript Language Document Structuring Conventions Specification, Version 3.0, 25 September 1992
+ * @see <a href="https://www.adobe.com/content/dam/acom/en/devnet/actionscript/articles/5001.DSC_Spec.pdf">5001.DSC_Spec</a>
+ *
  * [EGFF96] J.D.Murray & W. vanPyper, Encyclopedia of Graphics File Formats 2nd ed., O'Reilly & Assoc., 1996
  */
 final class FreeHepWrapper {

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -128,7 +128,17 @@ final class FreeHepWrapper {
             result = result.replaceAll("\"([-+0-9.]+)px\"", "\"$1mm\"");
         }
         if (fmt.equals(Depiction.EPS_FMT)) {
-            String nl = System.getProperty("line.separator");
+            String nl;
+            // We should determine new-line separator (nl) not from OS type, but from the line-endings
+            // in the actual EPS outpu; there is nothing that would prevent us from generating Unix-style
+            // file in Windows :)
+            if( result.contains("\n\r")) {
+                nl = "\n\r";
+            } else if( result.contains("\r")) {
+                nl = "\r";
+            } else {
+                nl = "\n";
+            }
             String split[] = result.split(nl,2);
             if( split.length > 1 && split[0].startsWith("%!PS-") ) {
                 String boundingBox;

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -120,20 +120,22 @@ final class FreeHepWrapper {
             String nl = System.getProperty("line.separator");
             String split[] = result.split(nl,2);
             if( split.length > 1 && split[0].startsWith("%!PS-") ) {
-                String boundingBox = "%%BoundingBox: ";
+                String boundingBox;
                 if( this.dim != null ) {
-                    boundingBox += "0 0 " + dim.width + " " + dim.height + "\n";
+                    boundingBox = "%%BoundingBox: 0 0 " +
+                        dim.width + " " + dim.height + nl;
+                } else {
+                    boundingBox = "";
                 }
 
                 result = split[0] + nl +
-                    "%%BoundingBox: (atend)" + nl +
+                    boundingBox +
                     split[1].
                     replaceFirst("(\\d+ ){4}setmargins",
-                               "0 0 0 0 setmargins").
+                                 "0 0 0 0 setmargins").
                     replaceFirst("(\\d+ ){2}setpagesize",
-                               dim.width + " " + dim.height +
-                               " setpagesize") +
-                    boundingBox;
+                                 dim.width + " " + dim.height +
+                                 " setpagesize");
             }
         }
         return result;

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -42,9 +42,9 @@ import java.util.Properties;
  *
  * The toString() method cites the following documents:
  *
- * [PLDS92]  {@cdk.cite Adobe1992}
- * [PLDS92a] {@cdk.cite Adobe1992a}
- * [EGFF96]  {@cdk.cite Murray1996}
+ * [PLDS92] {@cdk.cite Adobe1992}
+ * [EPSF92] {@cdk.cite Adobe1992a}
+ * [EGFF96] {@cdk.cite Murray1996}
  */
 final class FreeHepWrapper {
 
@@ -164,7 +164,7 @@ final class FreeHepWrapper {
                 // appear in any order."
                 //
                 // Thus, I infer that the "%%BoundingBox:" comment may be added immediately after the
-                // "%!PS-..." header line. This is also given as a valid example in PLDS92a, p. 4.
+                // "%!PS-..." header line. This is also given as a valid example in EPSF92, p. 4.
 
                 result = split[0] + nl +
                     boundingBox +

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -109,6 +109,10 @@ final class FreeHepWrapper {
         g2.dispose();
     }
 
+    // Documents cited below:
+    // [PLDS92] PostScript Language Document Structuring Conventions Specification, Version 3.0, 25 September 1992
+    // [EGFF96] J.D.Murray & W. vanPyper, Encyclopedia of Graphics File Formats 2nd ed., O'Reilly & Assoc., 1996
+
     @Override
     public String toString() {
         String result = new String(bout.toByteArray(), StandardCharsets.UTF_8);
@@ -127,6 +131,22 @@ final class FreeHepWrapper {
                 } else {
                     boundingBox = "";
                 }
+                if(!split[0].contains("EPS") && !boundingBox.equals("")) {
+                    split[0] += " EPSF-3.0";
+                }
+                // EGFF96 (p. 379):
+                // "Both the %%PS-Adobe- [sic] and the %%BoundingBox: lines must appear in every EPS file.
+                // Ordinary PostScript files may formally be changed into EPS files by adding these two lines
+                // to the PostScript header."
+
+                // PLDS92 (p. 29):
+                // "The order of some comments in the document is significant, but in a
+                // section of the document they may appear in any order. For example, in the
+                // header section, %%DocumentResources:, %%Title:, and %%Creator: may
+                // appear in any order."
+                //
+                // Thus, the "%%BoundingBox:" comment may be added immediately after the
+                // "%!PS-..." header line.
 
                 result = split[0] + nl +
                     boundingBox +

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -79,7 +79,7 @@ final class FreeHepWrapper {
             case Depiction.PS_FMT:
                 PSGraphics2D eps = new PSGraphics2D(out, dim);
                 // For EPS (Encapsulated PostScript) page size has no
-                // meaning since this image is supposed to b eincluded
+                // meaning since this image is supposed to be included
                 // in another page.
                 Properties eps_props = new Properties();
                 eps_props.setProperty(PDFGraphics2D.FIT_TO_PAGE, "false");

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -123,16 +123,17 @@ final class FreeHepWrapper {
                 if( this.dim != null ) {
                     boundingBox += "0 0 " + dim.width + " " + dim.height + "\n";
                 }
+
                 result = split[0] + "\n" +
                     "%%BoundingBox: (atend)\n" +
-                    split[1] + boundingBox;
+                    split[1].
+                    replaceAll("(\\d+ ){4}setmargins",
+                               "0 0 0 0 setmargins").
+                    replaceAll("(\\d+ ){2}setpagesize",
+                               dim.width + " " + dim.height +
+                               " setpagesize") +
+                    boundingBox;
 
-                result = result.replaceAll("(\\d+ ){4}setmargins",
-                                           "0 0 0 0 setmargins");
-
-                result = result.replaceAll("(\\d+ ){2}setpagesize",
-                                           dim.width + " " + dim.height +
-                                           " setpagesize");
             }
         }
         return result;

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -133,7 +133,6 @@ final class FreeHepWrapper {
                                dim.width + " " + dim.height +
                                " setpagesize") +
                     boundingBox;
-
             }
         }
         return result;

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -126,6 +126,13 @@ final class FreeHepWrapper {
                 result = split[0] + "\n" +
                     "%%BoundingBox: (atend)\n" +
                     split[1] + boundingBox;
+
+                result = result.replaceAll("(\\d+ ){4}setmargins",
+                                           "0 0 0 0 setmargins");
+
+                result = result.replaceAll("(\\d+ ){2}setpagesize",
+                                           dim.width + " " + dim.height +
+                                           " setpagesize");
             }
         }
         return result;

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -145,8 +145,8 @@ final class FreeHepWrapper {
                 // header section, %%DocumentResources:, %%Title:, and %%Creator: may
                 // appear in any order."
                 //
-                // Thus, the "%%BoundingBox:" comment may be added immediately after the
-                // "%!PS-..." header line.
+                // Thus, I infer that the "%%BoundingBox:" comment may be added immediately after the
+                // "%!PS-..." header line (S.G.).
 
                 result = split[0] + nl +
                     boundingBox +

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -39,6 +39,10 @@ import java.util.Properties;
  * Internal - wrapper around the FreeHEP vector graphics output that makes things consistent
  * in terms of writing the required headers and footers.
  * @see <a href="http://java.freehep.org/">java.freehep.org</a>
+ *
+ * @cdk.cite The toString() method cites the following documents:
+ * [PLDS92] PostScript Language Document Structuring Conventions Specification, Version 3.0, 25 September 1992
+ * [EGFF96] J.D.Murray & W. vanPyper, Encyclopedia of Graphics File Formats 2nd ed., O'Reilly & Assoc., 1996
  */
 final class FreeHepWrapper {
 
@@ -115,10 +119,6 @@ final class FreeHepWrapper {
         }
         g2.dispose();
     }
-
-    // Documents cited below:
-    // [PLDS92] PostScript Language Document Structuring Conventions Specification, Version 3.0, 25 September 1992
-    // [EGFF96] J.D.Murray & W. vanPyper, Encyclopedia of Graphics File Formats 2nd ed., O'Reilly & Assoc., 1996
 
     @Override
     public String toString() {

--- a/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/FreeHepWrapper.java
@@ -40,12 +40,11 @@ import java.util.Properties;
  * in terms of writing the required headers and footers.
  * @see <a href="http://java.freehep.org/">java.freehep.org</a>
  *
- * @cdk.cite The toString() method cites the following documents:
+ * The toString() method cites the following documents:
  *
- * [PLDS92] PostScript Language Document Structuring Conventions Specification, Version 3.0, 25 September 1992
- * @see <a href="https://www.adobe.com/content/dam/acom/en/devnet/actionscript/articles/5001.DSC_Spec.pdf">5001.DSC_Spec</a>
- *
- * [EGFF96] J.D.Murray & W. vanPyper, Encyclopedia of Graphics File Formats 2nd ed., O'Reilly & Assoc., 1996
+ * [PLDS92]  {@cdk.cite Adobe1992}
+ * [PLDS92a] {@cdk.cite Adobe1992a}
+ * [EGFF96]  {@cdk.cite Murray1996}
  */
 final class FreeHepWrapper {
 
@@ -165,7 +164,7 @@ final class FreeHepWrapper {
                 // appear in any order."
                 //
                 // Thus, I infer that the "%%BoundingBox:" comment may be added immediately after the
-                // "%!PS-..." header line (S.G.).
+                // "%!PS-..." header line. This is also given as a valid example in PLDS92a, p. 4.
 
                 result = split[0] + nl +
                     boundingBox +

--- a/app/depict/src/main/java/org/openscience/cdk/depict/MolGridDepiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/MolGridDepiction.java
@@ -156,7 +156,7 @@ final class MolGridDepiction extends Depiction {
         Dimensions targetDim = dimensions;
 
         // PDF and PS are in point to we need to account for that
-        if (PDF_FMT.equals(fmt) || PS_FMT.equals(fmt))
+        if (PDF_FMT.equals(fmt) || PS_FMT.equals(fmt) || EPS_FMT.equals(fmt))
             targetDim = targetDim.scale(MM_TO_POINT);
 
         targetDim = targetDim.add(-2 * margin, -2 * margin)
@@ -174,7 +174,7 @@ final class MolGridDepiction extends Depiction {
                            .add((nCol - 1) * padding, (nRow - 1) * padding);
         } else {
             // we want all vector graphics dims in MM
-            if (PDF_FMT.equals(fmt) || PS_FMT.equals(fmt))
+            if (PDF_FMT.equals(fmt) || PS_FMT.equals(fmt) || EPS_FMT.equals(fmt))
                 return dimensions.scale(MM_TO_POINT);
             else
                 return dimensions;
@@ -199,7 +199,7 @@ final class MolGridDepiction extends Depiction {
             zoom *= rescaleForBondLength(Depiction.ACS_1996_BOND_LENGTH_MM);
 
         // PDF and PS units are in Points (1/72 inch) in FreeHEP so need to adjust for that
-        if (fmt.equals(PDF_FMT) || fmt.equals(PS_FMT)) {
+        if (fmt.equals(PDF_FMT) || fmt.equals(PS_FMT) || fmt.equals(EPS_FMT)) {
             zoom    *= MM_TO_POINT;
             margin  *= MM_TO_POINT;
             padding *= MM_TO_POINT;

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -1,14 +1,12 @@
 package org.openscience.cdk.depict;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class DepictionTest {
 

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -1,12 +1,14 @@
 package org.openscience.cdk.depict;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
 
 public class DepictionTest {
 
@@ -15,8 +17,7 @@ public class DepictionTest {
         DepictionGenerator dg = new DepictionGenerator();
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer ac = sp.parseSmiles("[nH]1cccc1");
-        Depiction d = dg.depict(ac);
-        String eps = d.toPsStr();
+        String eps = dg.depict(ac).toPsStr();
         String nl = System.getProperty("line.separator");
         String lines[] = eps.split(nl,3);
         assertEquals("%!PS-Adobe-3.0", lines[0]);
@@ -28,8 +29,7 @@ public class DepictionTest {
         DepictionGenerator dg = new DepictionGenerator();
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer ac = sp.parseSmiles("[nH]1cccc1");
-        Depiction d = dg.depict(ac);
-        String eps = d.toEpsStr();
+        String eps = dg.depict(ac).toEpsStr();
         String nl = System.getProperty("line.separator");
         String lines[] = eps.split(nl,3);
         assertEquals("%!PS-Adobe-3.0 EPSF-3.0", lines[0]);
@@ -41,8 +41,7 @@ public class DepictionTest {
         DepictionGenerator dg = new DepictionGenerator();
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer ac = sp.parseSmiles("C1CCCCC1CCCCC");
-        Depiction d = dg.depict(ac);
-        String eps = d.toEpsStr();
+        String eps = dg.depict(ac).toEpsStr();
         String nl = System.getProperty("line.separator");
         String lines[] = eps.split(nl,3);
         assertEquals("%!PS-Adobe-3.0 EPSF-3.0", lines[0]);

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -1,0 +1,25 @@
+package org.openscience.cdk.depict;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class DepictionTest {
+
+    @Test
+    public void depictAsEps() throws CDKException {
+        DepictionGenerator dg = new DepictionGenerator();
+        SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer ac = sp.parseSmiles("[nH]1cccc1");
+        Depiction d = dg.depict(ac);
+        String eps = d.toEpsStr();
+        assertTrue(eps.startsWith("%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 28 35\n"));
+    }
+
+}

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 John May <jwmay@users.sf.net>
+ * Copyright (c) 2018 Saulius Gražulis <grazulis@ibt.lt>
  *
  * Contact: cdk-devel@lists.sourceforge.net
  *

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -25,6 +25,7 @@ public class DepictionTest {
         assertEquals("%%Creator: FreeHEP Graphics2D Driver", lines[1]);
     }
 
+    @Test
     public void depictAsEps() throws CDKException {
         DepictionGenerator dg = new DepictionGenerator();
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -1,13 +1,11 @@
 package org.openscience.cdk.depict;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 public class DepictionTest {

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -38,4 +38,17 @@ public class DepictionTest {
         assertEquals("%%BoundingBox: 0 0 28 35", lines[1]);
     }
 
+    @Test
+    public void depictAsEps2() throws CDKException {
+        DepictionGenerator dg = new DepictionGenerator();
+        SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer ac = sp.parseSmiles("C1CCCCC1CCCCC");
+        Depiction d = dg.depict(ac);
+        String eps = d.toEpsStr();
+        String nl = System.getProperty("line.separator");
+        String lines[] = eps.split(nl,3);
+        assertEquals("%!PS-Adobe-3.0 EPSF-3.0", lines[0]);
+        assertEquals("%%BoundingBox: 0 0 92 33", lines[1]);
+    }
+
 }

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -13,13 +13,28 @@ import static org.junit.Assert.*;
 public class DepictionTest {
 
     @Test
+    public void depictAsPs() throws CDKException {
+        DepictionGenerator dg = new DepictionGenerator();
+        SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer ac = sp.parseSmiles("[nH]1cccc1");
+        Depiction d = dg.depict(ac);
+        String eps = d.toPsStr();
+        String nl = System.getProperty("line.separator");
+        String lines[] = eps.split(nl,3);
+        assertEquals("%!PS-Adobe-3.0", lines[0]);
+        assertEquals("%%Creator: FreeHEP Graphics2D Driver", lines[1]);
+    }
+
     public void depictAsEps() throws CDKException {
         DepictionGenerator dg = new DepictionGenerator();
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer ac = sp.parseSmiles("[nH]1cccc1");
         Depiction d = dg.depict(ac);
         String eps = d.toEpsStr();
-        assertTrue(eps.startsWith("%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 28 35\n"));
+        String nl = System.getProperty("line.separator");
+        String lines[] = eps.split(nl,3);
+        assertEquals("%!PS-Adobe-3.0 EPSF-3.0", lines[0]);
+        assertEquals("%%BoundingBox: 0 0 28 35", lines[1]);
     }
 
 }

--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 John May <jwmay@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 U
+ */
+
 package org.openscience.cdk.depict;
 
 import org.junit.Test;

--- a/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
@@ -143,7 +143,7 @@ public class SilentChemObjectBuilder implements IChemObjectBuilder {
         if (CDK_LEGACY_AC) {
             factory.register(IAtomContainer.class, AtomContainer.class);
         } else {
-            // System.err.println("[INFO] Using the new AtomContainer implementation.");
+            System.err.println("[INFO] Using the new AtomContainer implementation.");
             factory.register(IAtomContainer.class, AtomContainer2.class);
         }
 

--- a/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
@@ -143,7 +143,7 @@ public class SilentChemObjectBuilder implements IChemObjectBuilder {
         if (CDK_LEGACY_AC) {
             factory.register(IAtomContainer.class, AtomContainer.class);
         } else {
-            System.err.println("[INFO] Using the new AtomContainer implementation.");
+            // System.err.println("[INFO] Using the new AtomContainer implementation.");
             factory.register(IAtomContainer.class, AtomContainer2.class);
         }
 


### PR DESCRIPTION
As of current CDK tip, requesting PS output from Depiction (toEpsStr()) would trigger exception, which is confusing since PS is listed among supported format.
This PR implements output in PostScript (PS) and Encapsulated PostScript (EPS) formats; EPS output contains %%BoundingBox: as required by EPS specification. Such files are handy when including into larger documents, e.g. into LaTeX (PS workflow) generated files.