### PR TITLE
Remove assertion to fail

### DIFF
--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -771,7 +771,6 @@ final class StandardBondGenerator {
     private IRenderingElement generateOffsetDoubleBond(IBond bond, IAtom atom1, IAtom atom2, IBond atom1Bond,
             List<IBond> atom2Bonds, boolean invert, boolean dashed) {
 
-        assert !hasDisplayedSymbol(atom1);
         assert atom1Bond != null;
 
         final Point2d atom1Point = atom1.getPoint2d();


### PR DESCRIPTION
Assertion in StandardBondGenerator.generateOffsetDoubleBond method is removed. 
It fails by #403.