### PR TITLE
Patch/betterlogging

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
+++ b/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
@@ -35,9 +35,6 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** The logging level, default anything above warnings. */
     private int level = ILoggingTool.FATAL;
 
-    /** Logger used to report internal problems. */
-    private static ILoggingTool logger;
-
     /** Name of the class for which this {@link ILoggingTool} is reporting. */
     private String              classname;
 
@@ -137,7 +134,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
             } catch (Exception ioException) {
                 error("Serious error in LoggingTool while printing exception " + "stack trace: ",
                         ioException.getMessage());
-                logger.debug(ioException);
+                ioException.printStackTrace();
             }
             Throwable cause = problem.getCause();
             if (cause != null) {

--- a/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
+++ b/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
@@ -32,8 +32,8 @@ import java.io.StringWriter;
  */
 public class SystemOutLoggingTool implements ILoggingTool {
 
-    /** Boolean which is true when debug messages are send to System.out. */
-    private boolean             doDebug = false;
+    /** The logging level, default anything above warnings. */
+    private int level = ILoggingTool.FATAL;
 
     /** Logger used to report internal problems. */
     private static ILoggingTool logger;
@@ -52,10 +52,9 @@ public class SystemOutLoggingTool implements ILoggingTool {
      */
     public SystemOutLoggingTool(Class<?> classInst) {
         this.classname = classInst.getName();
-        doDebug = false;
         if (System.getProperty("cdk.debugging", "false").equals("true")
                 || System.getProperty("cdk.debug.stdout", "false").equals("true")) {
-            doDebug = true;
+            level = DEBUG;
         }
     }
 
@@ -84,7 +83,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void debug(Object object) {
-        if (doDebug) {
+        if (level <= DEBUG) {
             if (object instanceof Throwable) {
                 debugThrowable((Throwable) object);
             } else {
@@ -100,7 +99,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void debug(Object object, Object... objects) {
-        if (doDebug) {
+        if (level <= DEBUG) {
             StringBuilder result = new StringBuilder();
             result.append(object.toString());
             for (Object obj : objects) {
@@ -151,7 +150,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void error(Object object) {
-        if (doDebug) {
+        if (level <= ERROR) {
             errorString("" + object);
         }
     }
@@ -159,7 +158,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void error(Object object, Object... objects) {
-        if (doDebug) {
+        if (level <= ERROR) {
             StringBuilder result = new StringBuilder();
             result.append(object.toString());
             for (Object obj : objects) {
@@ -176,7 +175,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void fatal(Object object) {
-        if (doDebug) {
+        if (level <= FATAL) {
             printToSTDOUT("FATAL", object.toString());
         }
     }
@@ -184,7 +183,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void info(Object object) {
-        if (doDebug) {
+        if (level <= INFO) {
             infoString("" + object);
         }
     }
@@ -192,7 +191,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void info(Object object, Object... objects) {
-        if (doDebug) {
+        if (level <= INFO) {
             StringBuilder result = new StringBuilder();
             result.append(object.toString());
             for (Object obj : objects) {
@@ -209,7 +208,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void warn(Object object) {
-        if (doDebug) {
+        if (level <= WARN) {
             warnString("" + object);
         }
     }
@@ -221,7 +220,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public void warn(Object object, Object... objects) {
-        if (doDebug) {
+        if (level <= WARN) {
             StringBuilder result = new StringBuilder();
             result.append(object.toString());
             for (Object obj : objects) {
@@ -234,7 +233,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     /** {@inheritDoc} */
     @Override
     public boolean isDebugEnabled() {
-        return doDebug;
+        return level <= DEBUG;
     }
 
     private void printToSTDOUT(String level, String message) {
@@ -257,9 +256,29 @@ public class SystemOutLoggingTool implements ILoggingTool {
 
     /**
      * Protected method which must not be used, except for testing purposes.
+     * @deprecated use {@link #setLevel(int)}
      */
+    @Deprecated
     protected void setDebugEnabled(boolean enabled) {
-        doDebug = enabled;
+        if (enabled)
+            setLevel(DEBUG);
+        else
+            setLevel(FATAL);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getLevel() {
+        return level;
+    }
 }

--- a/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
+++ b/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
@@ -25,7 +25,7 @@ import java.io.StringWriter;
 
 /**
  * Implementation of the {@link ILoggingTool} interface that sends output to
- * the {@link System}.out channel.
+ * the {@link System#err} channel.
  *
  * @cdk.module core
  * @cdk.githash
@@ -90,7 +90,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     }
 
     private void debugString(String string) {
-        printToSTDOUT("DEBUG", string);
+        printToStderr("DEBUG", string);
     }
 
     /** {@inheritDoc} */
@@ -166,14 +166,14 @@ public class SystemOutLoggingTool implements ILoggingTool {
     }
 
     private void errorString(String string) {
-        printToSTDOUT("ERROR", string);
+        printToStderr("ERROR", string);
     }
 
     /** {@inheritDoc} */
     @Override
     public void fatal(Object object) {
         if (level <= FATAL) {
-            printToSTDOUT("FATAL", object.toString());
+            printToStderr("FATAL", object.toString());
         }
     }
 
@@ -199,7 +199,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     }
 
     private void infoString(String string) {
-        printToSTDOUT("INFO", string);
+        printToStderr("INFO", string);
     }
 
     /** {@inheritDoc} */
@@ -211,7 +211,7 @@ public class SystemOutLoggingTool implements ILoggingTool {
     }
 
     private void warnString(String string) {
-        printToSTDOUT("WARN", string);
+        printToStderr("WARN", string);
     }
 
     /** {@inheritDoc} */
@@ -233,12 +233,12 @@ public class SystemOutLoggingTool implements ILoggingTool {
         return level <= DEBUG;
     }
 
-    private void printToSTDOUT(String level, String message) {
-        System.out.print(classname);
-        System.out.print(" ");
-        System.out.print(level);
-        System.out.print(": ");
-        System.out.println(message);
+    private void printToStderr(String level, String message) {
+        System.err.print(classname);
+        System.err.print(" ");
+        System.err.print(level);
+        System.err.print(": ");
+        System.err.println(message);
     }
 
     /**

--- a/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
+++ b/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
@@ -98,13 +98,9 @@ public class SystemOutLoggingTool implements ILoggingTool {
     public void debug(Object object, Object... objects) {
         if (level <= DEBUG) {
             StringBuilder result = new StringBuilder();
-            result.append(object.toString());
+            result.append(object);
             for (Object obj : objects) {
-                if (obj == null) {
-                    result.append("null");
-                } else {
-                    result.append(obj.toString());
-                }
+                result.append(obj);
             }
             debugString(result.toString());
         }
@@ -157,9 +153,9 @@ public class SystemOutLoggingTool implements ILoggingTool {
     public void error(Object object, Object... objects) {
         if (level <= ERROR) {
             StringBuilder result = new StringBuilder();
-            result.append(object.toString());
+            result.append(object);
             for (Object obj : objects) {
-                result.append(obj.toString());
+                result.append(obj);
             }
             errorString(result.toString());
         }
@@ -190,9 +186,9 @@ public class SystemOutLoggingTool implements ILoggingTool {
     public void info(Object object, Object... objects) {
         if (level <= INFO) {
             StringBuilder result = new StringBuilder();
-            result.append(object.toString());
+            result.append(object);
             for (Object obj : objects) {
-                result.append(obj.toString());
+                result.append(obj);
             }
             infoString(result.toString());
         }
@@ -219,9 +215,9 @@ public class SystemOutLoggingTool implements ILoggingTool {
     public void warn(Object object, Object... objects) {
         if (level <= WARN) {
             StringBuilder result = new StringBuilder();
-            result.append(object.toString());
+            result.append(object);
             for (Object obj : objects) {
-                result.append(obj.toString());
+                result.append(obj);
             }
             warnString(result.toString());
         }

--- a/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
+++ b/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
@@ -33,7 +33,7 @@ import java.io.StringWriter;
 public class SystemOutLoggingTool implements ILoggingTool {
 
     /** The logging level, default anything above warnings. */
-    private int level = ILoggingTool.FATAL;
+    private int level = ILoggingTool.WARN;
 
     /** Name of the class for which this {@link ILoggingTool} is reporting. */
     private String              classname;

--- a/base/interfaces/src/main/java/org/openscience/cdk/tools/ILoggingTool.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/tools/ILoggingTool.java
@@ -91,17 +91,30 @@ package org.openscience.cdk.tools;
  */
 public interface ILoggingTool {
 
+    /** Trace, Debug, Info, Warn, Error, and Fatal messages will be emitted. */
+    int TRACE = 0;
+    /** Debug, Info, Warn, Error, and Fatal messages will be emitted. */
+    int DEBUG = 1;
+    /** Info, Warn, Error, and Fatal messages will be emitted. */
+    int INFO  = 2;
+    /** Warn, Error, and Fatal messages will be emitted. */
+    int WARN  = 3;
+    /** Error, and Fatal messages will be emitted. */
+    int ERROR = 4;
+    /** Only Fatal messages will be emitted. */
+    int FATAL = 5;
+
     /**
      * Default number of StackTraceElements to be printed by debug(Exception).
      */
-    public final int DEFAULT_STACK_LENGTH = 5;
+    int DEFAULT_STACK_LENGTH = 5;
 
     /**
      * Outputs system properties for the operating system and the java
      * version. More specifically: os.name, os.version, os.arch, java.version
      * and java.vendor.
      */
-    public void dumpSystemProperties();
+    void dumpSystemProperties();
 
     /**
      * Sets the number of StackTraceElements to be printed in DEBUG mode when
@@ -112,12 +125,12 @@ public interface ILoggingTool {
      *
      * @see #DEFAULT_STACK_LENGTH
      */
-    public void setStackLength(int length);
+    void setStackLength(int length);
 
     /**
      * Outputs the system property for java.class.path.
      */
-    public void dumpClasspath();
+    void dumpClasspath();
 
     /**
      * Shows DEBUG output for the Object. If the object is an instanceof
@@ -126,7 +139,7 @@ public interface ILoggingTool {
      *
      * @param object Object to apply toString() too and output
      */
-    public void debug(Object object);
+    void debug(Object object);
 
     /**
      * Shows DEBUG output for the given Object's. It uses the
@@ -135,14 +148,14 @@ public interface ILoggingTool {
      * @param object  Object to apply toString() too and output
      * @param objects Object... to apply toString() too and output
      */
-    public void debug(Object object, Object... objects);
+    void debug(Object object, Object... objects);
 
     /**
      * Shows ERROR output for the Object. It uses the toString() method.
      *
      * @param object Object to apply toString() too and output
      */
-    public void error(Object object);
+    void error(Object object);
 
     /**
      * Shows ERROR output for the given Object's. It uses the
@@ -151,21 +164,21 @@ public interface ILoggingTool {
      * @param object  Object to apply toString() too and output
      * @param objects Object... to apply toString() too and output
      */
-    public void error(Object object, Object... objects);
+    void error(Object object, Object... objects);
 
     /**
      * Shows FATAL output for the Object. It uses the toString() method.
      *
      * @param object Object to apply toString() too and output
      */
-    public void fatal(Object object);
+    void fatal(Object object);
 
     /**
      * Shows INFO output for the Object. It uses the toString() method.
      *
      * @param object Object to apply toString() too and output
      */
-    public void info(Object object);
+    void info(Object object);
 
     /**
      * Shows INFO output for the given Object's. It uses the
@@ -174,14 +187,14 @@ public interface ILoggingTool {
      * @param object  Object to apply toString() too and output
      * @param objects Object... to apply toString() too and output
      */
-    public void info(Object object, Object... objects);
+    void info(Object object, Object... objects);
 
     /**
      * Shows WARN output for the Object. It uses the toString() method.
      *
      * @param object Object to apply toString() too and output
      */
-    public void warn(Object object);
+    void warn(Object object);
 
     /**
      * Shows WARN output for the given Object's. It uses the
@@ -190,7 +203,7 @@ public interface ILoggingTool {
      * @param object Object to apply toString() too and output
      * @param objects Object... to apply toString() too and output
      */
-    public void warn(Object object, Object... objects);
+    void warn(Object object, Object... objects);
 
     /**
      * Use this method for computational demanding debug info.
@@ -204,5 +217,23 @@ public interface ILoggingTool {
      *
      * @return true, if debug is enabled
      */
-    public boolean isDebugEnabled();
+    boolean isDebugEnabled();
+
+    /**
+     * Set the level of this logger. The level is provided in one of the
+     * constants: {@link #TRACE}, {@link #DEBUG}, {@link #INFO}, {@link #WARN}
+     * , {@link #ERROR}, {@link #FATAL}. After setting the level only messages
+     * above the specified level will be emitted.
+     *
+     * @param level the level
+     */
+    void setLevel(int level);
+
+    /**
+     * Get the current level of this logger. The level is provided in one of the
+     * constants: {@link #TRACE}, {@link #DEBUG}, {@link #INFO}, {@link #WARN}
+     * , {@link #ERROR}, {@link #FATAL}.
+     * @return the current level
+     */
+    int getLevel();
 }

--- a/base/test-core/src/test/java/org/openscience/cdk/tools/LoggingToolFactoryTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/tools/LoggingToolFactoryTest.java
@@ -109,5 +109,15 @@ public class LoggingToolFactoryTest {
 
         @Override
         public void warn(Object object, Object... objects) {}
+
+        @Override
+        public void setLevel(int level) {
+
+        }
+
+        @Override
+        public int getLevel() {
+            return 0;
+        }
     }
 }

--- a/base/test-core/src/test/java/org/openscience/cdk/tools/SystemOutLoggingToolTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/tools/SystemOutLoggingToolTest.java
@@ -41,7 +41,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -51,7 +51,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -70,7 +70,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -79,7 +79,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -90,7 +90,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("1"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -99,7 +99,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -110,7 +110,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("1.0"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -130,7 +130,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("true"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -139,7 +139,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -149,7 +149,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -168,7 +168,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -177,7 +177,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -187,7 +187,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -196,7 +196,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -206,7 +206,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -215,7 +215,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -225,7 +225,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -234,7 +234,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -245,7 +245,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("1"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -254,7 +254,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -265,7 +265,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("1.0"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -274,7 +274,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -285,7 +285,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("true"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -294,7 +294,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -304,7 +304,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -313,7 +313,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -323,7 +323,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -332,7 +332,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -342,7 +342,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -351,7 +351,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -361,7 +361,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -370,7 +370,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -380,7 +380,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -389,7 +389,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -400,7 +400,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("1"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -409,7 +409,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -420,7 +420,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("1.0"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -429,7 +429,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -440,7 +440,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("true"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -449,7 +449,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -459,7 +459,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -468,7 +468,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -478,7 +478,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -487,7 +487,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -497,7 +497,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -506,7 +506,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -516,7 +516,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -525,7 +525,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -535,7 +535,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -544,7 +544,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -555,7 +555,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("1"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -564,7 +564,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -575,7 +575,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("1.0"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -584,7 +584,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -595,7 +595,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("true"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -604,7 +604,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -614,7 +614,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -623,7 +623,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -633,7 +633,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -642,7 +642,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -652,7 +652,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -661,7 +661,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -671,7 +671,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains(this.getClass().getName()));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -687,7 +687,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -698,7 +698,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("java.class.path"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test
@@ -707,7 +707,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         // set up things such that we can test the actual output
         PrintStream stdout = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(out));
 
         // do the testing
         SystemOutLoggingTool logger = new SystemOutLoggingTool(this.getClass());
@@ -722,7 +722,7 @@ public class SystemOutLoggingToolTest extends AbstractLoggingToolTest {
         Assert.assertTrue(out.toString().contains("java.vendor"));
 
         // reset the STDOUT
-        System.setOut(stdout);
+        System.setErr(stdout);
     }
 
     @Test

--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
@@ -317,13 +317,14 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void error(Object object, Object... objects) {
-        StringBuilder result = new StringBuilder();
-        result.append(object.toString());
-        for (Object obj : objects) {
-            result.append(obj.toString());
+        if (getLevel() <= ERROR) {
+            StringBuilder result = new StringBuilder();
+            result.append(object.toString());
+            for (Object obj : objects) {
+                result.append(obj.toString());
+            }
+            errorString(result.toString());
         }
-        errorString(result.toString());
-
     }
 
     private void errorString(String string) {
@@ -367,12 +368,14 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void info(Object object, Object... objects) {
-        StringBuilder result = new StringBuilder();
-        result.append(object.toString());
-        for (Object obj : objects) {
-            result.append(obj.toString());
+        if (getLevel() <= INFO) {
+            StringBuilder result = new StringBuilder();
+            result.append(object.toString());
+            for (Object obj : objects) {
+                result.append(obj.toString());
+            }
+            infoString(result.toString());
         }
-        infoString(result.toString());
     }
 
     private void infoString(String string) {
@@ -410,12 +413,14 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void warn(Object object, Object... objects) {
-        StringBuilder result = new StringBuilder();
-        result.append(object.toString());
-        for (Object obj : objects) {
-            result.append(obj.toString());
+        if (getLevel() <= WARN) {
+            StringBuilder result = new StringBuilder();
+            result.append(object.toString());
+            for (Object obj : objects) {
+                result.append(obj.toString());
+            }
+            warnString(result.toString());
         }
-        warnString(result.toString());
     }
 
     /**

--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.io.StringReader;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 /**
@@ -85,7 +86,6 @@ import org.apache.log4j.Logger;
  */
 public class LoggingTool implements ILoggingTool {
 
-    private boolean             doDebug              = false;
     private boolean             toSTDOUT             = false;
 
     private Logger              log4jLogger;
@@ -142,7 +142,6 @@ public class LoggingTool implements ILoggingTool {
          * exception handler. So we are going to check the JVM version first
          * **************************************************************
          */
-        doDebug = false;
         String strJvmVersion = System.getProperty("java.version");
         if (strJvmVersion.compareTo("1.2") >= 0) {
             // Use a try {} to catch SecurityExceptions when used in applets
@@ -150,7 +149,7 @@ public class LoggingTool implements ILoggingTool {
                 // by default debugging is set off, but it can be turned on
                 // with starting java like "java -Dcdk.debugging=true"
                 if (System.getProperty("cdk.debugging", "false").equals("true")) {
-                    doDebug = true;
+                    log4jLogger.setLevel(Level.DEBUG);
                 }
                 if (System.getProperty("cdk.debug.stdout", "false").equals("true")) {
                     toSTDOUT = true;
@@ -226,7 +225,7 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void debug(Object object) {
-        if (doDebug) {
+        if (isDebugEnabled()) {
             if (object instanceof Throwable) {
                 debugThrowable((Throwable) object);
             } else {
@@ -252,7 +251,7 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void debug(Object object, Object... objects) {
-        if (doDebug) {
+        if (isDebugEnabled()) {
             StringBuilder result = new StringBuilder();
             result.append(object.toString());
             for (Object obj : objects) {
@@ -306,9 +305,7 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void error(Object object) {
-        if (doDebug) {
-            errorString("" + object);
-        }
+        errorString("" + object);
     }
 
     /**
@@ -320,14 +317,13 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void error(Object object, Object... objects) {
-        if (doDebug) {
-            StringBuilder result = new StringBuilder();
-            result.append(object.toString());
-            for (Object obj : objects) {
-                result.append(obj.toString());
-            }
-            errorString(result.toString());
+        StringBuilder result = new StringBuilder();
+        result.append(object.toString());
+        for (Object obj : objects) {
+            result.append(obj.toString());
         }
+        errorString(result.toString());
+
     }
 
     private void errorString(String string) {
@@ -345,12 +341,10 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void fatal(Object object) {
-        if (doDebug) {
-            if (toSTDOUT) {
-                printToSTDOUT("FATAL", object.toString());
-            } else {
-                log4jLogger.fatal("" + object.toString());
-            }
+        if (toSTDOUT) {
+            printToSTDOUT("FATAL", object.toString());
+        } else {
+            log4jLogger.fatal("" + object.toString());
         }
     }
 
@@ -361,9 +355,7 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void info(Object object) {
-        if (doDebug) {
-            infoString("" + object);
-        }
+        infoString("" + object);
     }
 
     /**
@@ -375,14 +367,12 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void info(Object object, Object... objects) {
-        if (doDebug) {
-            StringBuilder result = new StringBuilder();
-            result.append(object.toString());
-            for (Object obj : objects) {
-                result.append(obj.toString());
-            }
-            infoString(result.toString());
+        StringBuilder result = new StringBuilder();
+        result.append(object.toString());
+        for (Object obj : objects) {
+            result.append(obj.toString());
         }
+        infoString(result.toString());
     }
 
     private void infoString(String string) {
@@ -400,9 +390,7 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void warn(Object object) {
-        if (doDebug) {
-            warnString("" + object);
-        }
+        warnString("" + object);
     }
 
     private void warnString(String string) {
@@ -422,14 +410,12 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public void warn(Object object, Object... objects) {
-        if (doDebug) {
-            StringBuilder result = new StringBuilder();
-            result.append(object.toString());
-            for (Object obj : objects) {
-                result.append(obj.toString());
-            }
-            warnString(result.toString());
+        StringBuilder result = new StringBuilder();
+        result.append(object.toString());
+        for (Object obj : objects) {
+            result.append(obj.toString());
         }
+        warnString(result.toString());
     }
 
     /**
@@ -446,7 +432,7 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public boolean isDebugEnabled() {
-        return doDebug;
+        return log4jLogger.isDebugEnabled();
     }
 
     private void printToSTDOUT(String level, String message) {
@@ -467,4 +453,55 @@ public class LoggingTool implements ILoggingTool {
         return new LoggingTool(sourceClass);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setLevel(int level) {
+        switch (level) {
+            case TRACE:
+                log4jLogger.setLevel(Level.TRACE);
+                break;
+            case DEBUG:
+                log4jLogger.setLevel(Level.DEBUG);
+                break;
+            case INFO:
+                log4jLogger.setLevel(Level.INFO);
+                break;
+            case WARN:
+                log4jLogger.setLevel(Level.WARN);
+                break;
+            case ERROR:
+                log4jLogger.setLevel(Level.ERROR);
+                break;
+            case FATAL:
+                log4jLogger.setLevel(Level.FATAL);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid log level: " + level);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getLevel() {
+        switch (log4jLogger.getLevel().toInt()) {
+            case Level.TRACE_INT:
+                return TRACE;
+            case Level.DEBUG_INT:
+                return DEBUG;
+            case Level.INFO_INT:
+                return INFO;
+            case Level.WARN_INT:
+                return WARN;
+            case Level.ERROR_INT:
+                return ERROR;
+            case Level.FATAL_INT:
+                return FATAL;
+            default:
+                throw new IllegalArgumentException("Unsupported log4j level: " + log4jLogger.getLevel());
+        }
+    }
 }

--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
@@ -492,7 +492,10 @@ public class LoggingTool implements ILoggingTool {
      */
     @Override
     public int getLevel() {
-        switch (log4jLogger.getLevel().toInt()) {
+        Level level = log4jLogger.getLevel();
+        if (level == null)
+            level = Logger.getRootLogger().getLevel();
+        switch (level.toInt()) {
             case Level.TRACE_INT:
                 return TRACE;
             case Level.DEBUG_INT:
@@ -506,7 +509,7 @@ public class LoggingTool implements ILoggingTool {
             case Level.FATAL_INT:
                 return FATAL;
             default:
-                throw new IllegalArgumentException("Unsupported log4j level: " + log4jLogger.getLevel());
+                throw new IllegalArgumentException("Unsupported log4j level: " + level);
         }
     }
 }

--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
@@ -79,7 +79,7 @@ import org.apache.log4j.Logger;
  * }
  * </pre>
  *
- * <p>The class uses log4j as a backend if available, and System.out otherwise.
+ * <p>The class uses log4j as a backend if available, and {@link System#err} otherwise.
  *
  * @cdk.module log4j
  * @cdk.githash
@@ -236,7 +236,7 @@ public class LoggingTool implements ILoggingTool {
 
     private void debugString(String string) {
         if (toSTDOUT) {
-            printToSTDOUT("DEBUG", string);
+            printToStderr("DEBUG", string);
         } else {
             log4jLogger.debug(string);
         }
@@ -328,7 +328,7 @@ public class LoggingTool implements ILoggingTool {
 
     private void errorString(String string) {
         if (toSTDOUT) {
-            printToSTDOUT("ERROR", string);
+            printToStderr("ERROR", string);
         } else {
             log4jLogger.error(string);
         }
@@ -342,7 +342,7 @@ public class LoggingTool implements ILoggingTool {
     @Override
     public void fatal(Object object) {
         if (toSTDOUT) {
-            printToSTDOUT("FATAL", object.toString());
+            printToStderr("FATAL", object.toString());
         } else {
             log4jLogger.fatal("" + object.toString());
         }
@@ -377,7 +377,7 @@ public class LoggingTool implements ILoggingTool {
 
     private void infoString(String string) {
         if (toSTDOUT) {
-            printToSTDOUT("INFO", string);
+            printToStderr("INFO", string);
         } else {
             log4jLogger.info(string);
         }
@@ -395,7 +395,7 @@ public class LoggingTool implements ILoggingTool {
 
     private void warnString(String string) {
         if (toSTDOUT) {
-            printToSTDOUT("WARN", string);
+            printToStderr("WARN", string);
         } else {
             log4jLogger.warn(string);
         }
@@ -435,12 +435,12 @@ public class LoggingTool implements ILoggingTool {
         return log4jLogger.isDebugEnabled();
     }
 
-    private void printToSTDOUT(String level, String message) {
-        System.out.print(classname);
-        System.out.print(" ");
-        System.out.print(level);
-        System.out.print(": ");
-        System.out.println(message);
+    private void printToStderr(String level, String message) {
+        System.err.print(classname);
+        System.err.print(" ");
+        System.err.print(level);
+        System.err.print(": ");
+        System.err.println(message);
     }
 
     /**

--- a/misc/log4j/src/test/java/org/openscience/cdk/tools/LoggingToolTest.java
+++ b/misc/log4j/src/test/java/org/openscience/cdk/tools/LoggingToolTest.java
@@ -19,13 +19,20 @@
  */
 package org.openscience.cdk.tools;
 
+import org.apache.log4j.BasicConfigurator;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  * @cdk.module test-log4j
  */
 public class LoggingToolTest extends AbstractLoggingToolTest {
+
+    @BeforeClass
+    public static void ensureLog4JConfigured() {
+        BasicConfigurator.configure();
+    }
 
     @Override
     public LoggingTool getLoggingTool() {


### PR DESCRIPTION
Addresses problems encountered by Chris in #430 and cleans up the API considerably. The current behaviour was actually a little backwards having both a 'doDebug' and 'level' for Log4J. Hence even if you had log4j configure it would not show warnings/errors.

I've cleaned up behaviour of the default logger too and now by default it will log anything that is a warning or more serious. There are lots of warnings/errors from our tests that were being missed!

Possible big patch but switching to SL4J and it handle things could be better.