### PR TITLE
Added support to generate molecular formula that includes mass number…

### DIFF
--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -184,17 +184,33 @@ public class MolecularFormulaManipulator {
      * @param formula       The IMolecularFormula Object
      * @param orderElements The order of Elements
      * @param setOne        True, when must be set the value 1 for elements with
-     * 					    one atom
-     * @param setMassNumber If the formula contains an isotope of an element that is the
-     *                      non-major isotope, the element is represented as <code>[XE]</code> where
-     *                      <code>X</code> is the mass number and <code>E</code> is the element symbol
-     * @return              A String containing the molecular formula
-     *
+     *                      one atom
+     * @return A String containing the molecular formula
      * @see #getHTML(IMolecularFormula)
      * @see #generateOrderEle()
      * @see #generateOrderEle_Hill_NoCarbons()
      * @see #generateOrderEle_Hill_WithCarbons()
+     */
+    public static String getString(IMolecularFormula formula, String[] orderElements,
+                                   boolean setOne) {
+        return getString(formula, orderElements, setOne, true);
+    }
+
+    /**
+     * Returns the string representation of the molecule formula.
      *
+     * @param formula       The IMolecularFormula Object
+     * @param orderElements The order of Elements
+     * @param setOne        True, when must be set the value 1 for elements with
+     *                      one atom
+     * @param setMassNumber If the formula contains an isotope of an element that is the
+     *                      non-major isotope, the element is represented as <code>[XE]</code> where
+     *                      <code>X</code> is the mass number and <code>E</code> is the element symbol
+     * @return A String containing the molecular formula
+     * @see #getHTML(IMolecularFormula)
+     * @see #generateOrderEle()
+     * @see #generateOrderEle_Hill_NoCarbons()
+     * @see #generateOrderEle_Hill_WithCarbons()
      */
     public static String getString(IMolecularFormula formula, String[] orderElements,
                                    boolean setOne, boolean setMassNumber) {
@@ -223,8 +239,7 @@ public class MolecularFormulaManipulator {
                 int count = formula.getIsotopeCount(isotope);
                 try {
                     IIsotope major = Isotopes.getInstance().getMajorIsotope(isotope.getSymbol());
-                    if (isotope.getMassNumber() == null ||
-                            Objects.equals(isotope.getMassNumber(), major.getMassNumber()))
+                    if (isotope.getMassNumber() == null)
                         stringMF.append(isotope.getSymbol());
                     else
                         stringMF.append("[")

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -223,10 +223,14 @@ public class MolecularFormulaManipulator {
                 int count = formula.getIsotopeCount(isotope);
                 try {
                     IIsotope major = Isotopes.getInstance().getMajorIsotope(isotope.getSymbol());
-                    if (Objects.equals(isotope.getMassNumber(), major.getMassNumber()))
+                    if (isotope.getMassNumber() == null ||
+                            Objects.equals(isotope.getMassNumber(), major.getMassNumber()))
                         stringMF.append(isotope.getSymbol());
                     else
-                        stringMF.append("["+isotope.getMassNumber()+isotope.getSymbol()+"]");
+                        stringMF.append("[")
+                                .append(isotope.getMassNumber())
+                                .append(isotope.getSymbol())
+                                .append("]");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -176,7 +176,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         newOrder[0] = "H";
         newOrder[1] = "C";
 
-        Assert.assertEquals("H2C2", MolecularFormulaManipulator.getString(formula, newOrder, true));
+        Assert.assertEquals("H2C2", MolecularFormulaManipulator.getString(formula, newOrder, true, false));
 
     }
 
@@ -1321,4 +1321,26 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         assertThat(mf.getIsotopeCount(deuterium), is(1));
         assertThat(mf.getIsotopeCount(hydrogen), is(5));
     }
+
+    @Test public void testMassNumberDisplay() throws Exception {
+        IsotopeFactory ifac = Isotopes.getInstance();
+        IIsotope c = ifac.getMajorIsotope("C");
+        IIsotope h = ifac.getMajorIsotope("H");
+        IIsotope o = ifac.getMajorIsotope("O");
+        IIsotope br79 = ifac.getMajorIsotope("Br");
+        IIsotope br81 = ifac.getIsotope("Br", 81);
+
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IMolecularFormula mf = bldr.newInstance(IMolecularFormula.class);
+
+        mf.addIsotope(c,7);
+        mf.addIsotope(o, 3);
+        mf.addIsotope(h, 3);
+        mf.addIsotope(br79, 1);
+        mf.addIsotope(br81, 1);
+
+        assertThat(MolecularFormulaManipulator.getString(mf, false, false), is("C7H3Br2O3"));
+        assertThat(MolecularFormulaManipulator.getString(mf, false, true), is("C7H3Br[81Br]O3"));
+    }
+
 }

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -176,7 +176,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         newOrder[0] = "H";
         newOrder[1] = "C";
 
-        Assert.assertEquals("H2C2", MolecularFormulaManipulator.getString(formula, newOrder, true, false));
+        Assert.assertEquals("H2C2", MolecularFormulaManipulator.getString(formula, newOrder, true));
 
     }
 
@@ -1324,23 +1324,19 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
 
     @Test public void testMassNumberDisplay() throws Exception {
         IsotopeFactory ifac = Isotopes.getInstance();
-        IIsotope c = ifac.getMajorIsotope("C");
-        IIsotope h = ifac.getMajorIsotope("H");
-        IIsotope o = ifac.getMajorIsotope("O");
-        IIsotope br79 = ifac.getMajorIsotope("Br");
         IIsotope br81 = ifac.getIsotope("Br", 81);
 
         IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
         IMolecularFormula mf = bldr.newInstance(IMolecularFormula.class);
 
-        mf.addIsotope(c,7);
-        mf.addIsotope(o, 3);
-        mf.addIsotope(h, 3);
-        mf.addIsotope(br79, 1);
-        mf.addIsotope(br81, 1);
+        mf.addIsotope(new Atom("C"), 7);
+        mf.addIsotope(new Atom("O"), 3);
+        mf.addIsotope(new Atom("H"), 3);
+        mf.addIsotope(new Atom("Br"), 1);
+        mf.addIsotope(ifac.getIsotope("Br", 81), 1);
 
         assertThat(MolecularFormulaManipulator.getString(mf, false, false), is("C7H3Br2O3"));
-        assertThat(MolecularFormulaManipulator.getString(mf, false, true), is("C7H3Br[81Br]O3"));
+        assertThat(MolecularFormulaManipulator.getString(mf, false, true), is("C7H3[81Br]BrO3"));
     }
 
 }


### PR DESCRIPTION
… of non-major isotopes are present. This can be useful in formula generation, such as when a compound contains say two isotopes of an element in which case the formula could be written as 
`C7H3[81Br]BrO3` as opposed to the traditional way of `C7H3Br2O3`