### PR TITLE
Updates to molecular formula string generation

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
+++ b/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
@@ -220,7 +220,7 @@ public final class RingSearch {
      * @return whether the atom is in a ring
      * @throws NoSuchAtomException the atom was not found
      */
-    public boolean cyclic(IAtom atom) throws NoSuchAtomException {
+    public boolean cyclic(IAtom atom) {
         int i = container.indexOf(atom);
         if (i < 0) throw new NoSuchAtomException("no such atom");
         return cyclic(i);

--- a/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
+++ b/base/core/src/main/java/org/openscience/cdk/ringsearch/RingSearch.java
@@ -220,7 +220,7 @@ public final class RingSearch {
      * @return whether the atom is in a ring
      * @throws NoSuchAtomException the atom was not found
      */
-    public boolean cyclic(IAtom atom) {
+    public boolean cyclic(IAtom atom) throws NoSuchAtomException {
         int i = container.indexOf(atom);
         if (i < 0) throw new NoSuchAtomException("no such atom");
         return cyclic(i);

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -200,9 +200,9 @@ public class MolecularFormulaManipulator {
     private static void appendElement(StringBuilder sb, Integer mass, int elem, int count) {
         if (mass != null)
             sb.append('[')
-              .append(mass)
-              .append(Elements.ofNumber(elem).symbol())
-              .append(']');
+                    .append(mass)
+                    .append(']')
+                    .append(Elements.ofNumber(elem).symbol());
         else
             sb.append(Elements.ofNumber(elem).symbol());
         if (count != 0)
@@ -229,6 +229,12 @@ public class MolecularFormulaManipulator {
                                    boolean setOne, boolean setMassNumber) {
         StringBuilder  stringMF     = new StringBuilder();
         List<IIsotope> isotopesList = putInOrder(orderElements, formula);
+        IsotopeFactory ifac = null;
+        try {
+            ifac = Isotopes.getInstance();
+        } catch (IOException e) {
+            throw new RuntimeException("IsotopeFactory could not be loaded");
+        }
 
         if (!setMassNumber) {
             int count = 0;
@@ -251,9 +257,13 @@ public class MolecularFormulaManipulator {
         } else {
             for (IIsotope isotope : isotopesList) {
                 int count = formula.getIsotopeCount(isotope);
+                Integer massNumber = isotope.getMassNumber();
+                if (massNumber != null && massNumber.equals(ifac.getMajorIsotope(isotope.getAtomicNumber()).getMassNumber()))
+                    massNumber = null;
                 appendElement(stringMF,
-                              isotope.getMassNumber(), isotope.getAtomicNumber(),
-                              setOne || count != 1 ? count : 0);
+                        massNumber,
+                        isotope.getAtomicNumber(),
+                        setOne || count != 1 ? count : 0);
             }
         }
 

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -1324,7 +1324,6 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
 
     @Test public void testMassNumberDisplay() throws Exception {
         IsotopeFactory ifac = Isotopes.getInstance();
-        IIsotope br81 = ifac.getIsotope("Br", 81);
 
         IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
         IMolecularFormula mf = bldr.newInstance(IMolecularFormula.class);
@@ -1336,7 +1335,23 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         mf.addIsotope(ifac.getIsotope("Br", 81), 1);
 
         assertThat(MolecularFormulaManipulator.getString(mf, false, false), is("C7H3Br2O3"));
-        assertThat(MolecularFormulaManipulator.getString(mf, false, true), is("C7H3[81Br]BrO3"));
+        assertThat(MolecularFormulaManipulator.getString(mf, false, true), is("C7H3[81]BrBrO3"));
+    }
+
+    @Test public void testMassNumberDisplayWithDefinedIsotopes() throws Exception {
+        IsotopeFactory ifac = Isotopes.getInstance();
+
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IMolecularFormula mf = bldr.newInstance(IMolecularFormula.class);
+
+        mf.addIsotope(ifac.getMajorIsotope("C"), 7);
+        mf.addIsotope(ifac.getMajorIsotope("O"), 3);
+        mf.addIsotope(ifac.getMajorIsotope("H"), 3);
+        mf.addIsotope(ifac.getMajorIsotope("Br"), 1);
+        mf.addIsotope(ifac.getIsotope("Br", 81), 1);
+
+        assertThat(MolecularFormulaManipulator.getString(mf, false, false), is("C7H3Br2O3"));
+        assertThat(MolecularFormulaManipulator.getString(mf, false, true), is("C7H3[81]BrBrO3"));
     }
 
 }


### PR DESCRIPTION
Based on discussions at https://github.com/rajarshi/cdkr/issues/65, the usage of these formula is such that when no mass number is specified it is assumed to be the major isotope (whose definition seems to be in a bit of flux), and as a result, when displaying mass numbers, only elements with non-major isotopes should have their mass number displayed

In addition, it appears that for compatibility reasons, display of mass number should be `[##]Ee` rather than `[##Ee]`. The latter is the SMILES approach; but given molecular formula is not SMILES, and the former convention is used by other mass spec tools, going with `[##]Ee` seems to be correct