### PR TITLE
Corrected JavaDoc

### DIFF
--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -94,7 +94,7 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
      * SymbolVisibility}.
      *
      * <pre>{@code
-     * atom.setProperty(CDKConstants.HIGHLIGHT_COLOR, Color.RED);
+     * atom.setProperty(StandardGenerator.HIGHLIGHT_COLOR, Color.RED);
      * }</pre>
      */
     public final static String          HIGHLIGHT_COLOR       = "stdgen.highlight.color";


### PR DESCRIPTION
In the JavaDoc `CDKConstrants.HIGHLIGHT_COLOR` was referenced but no such field exists. Corrected it to point to the `StandardGenerator.HIGHLIGHT_COLOR` instead (which exists and is fulfilling the purpose).