### PR TITLE
Fix formula rule class and its tests

### DIFF
--- a/tool/formula/src/main/java/org/openscience/cdk/formula/rules/ElementRule.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/rules/ElementRule.java
@@ -78,7 +78,7 @@ public class ElementRule implements IRule {
     public void setParameters(Object[] params) throws CDKException {
         if (params.length != 1) throw new CDKException("ElementRule expects one parameters");
 
-        if (!(params[0] instanceof MolecularFormulaRange))
+        if (!(params[0] == null || params[0] instanceof MolecularFormulaRange))
             throw new CDKException("The parameter must be of type MolecularFormulaExpand");
 
         mfRange = (MolecularFormulaRange) params[0];

--- a/tool/formula/src/test/java/org/openscience/cdk/formula/rules/FormulaRuleTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/formula/rules/FormulaRuleTest.java
@@ -34,15 +34,15 @@ import org.openscience.cdk.interfaces.IMolecularFormula;
 public abstract class FormulaRuleTest extends CDKTestCase {
 
     protected static IRule rule;
+    private static Class<? extends IRule> ruleClass;
 
-    public static void setRule(Class ruleClass) throws Exception {
-        if (FormulaRuleTest.rule == null) {
-            Object rule = (Object) ruleClass.newInstance();
-            if (!(rule instanceof IRule)) {
-                throw new CDKException("The passed rule class must be a IRule");
-            }
-            FormulaRuleTest.rule = (IRule) rule;
-        }
+    public static void setRule(Class<? extends IRule> ruleClass) throws Exception {
+        FormulaRuleTest.ruleClass = ruleClass;
+        FormulaRuleTest.rule = getRule();
+    }
+    
+    private static IRule getRule() throws Exception {
+        return ruleClass.newInstance();
     }
 
     /**
@@ -81,12 +81,15 @@ public abstract class FormulaRuleTest extends CDKTestCase {
 
     @Test
     public void testSetParameters_arrayObject() throws Exception {
+        IRule rule = getRule();
         Object[] defaultParams = rule.getParameters();
         rule.setParameters(defaultParams);
     }
 
     @Test
     public void testValidate_IMolecularFormula() throws Exception {
+        IRule rule = getRule();
+    	
         IMolecularFormula mf = new MolecularFormula();
         mf.addIsotope(new Isotope("C", 13));
         mf.addIsotope(new Isotope("H", 2), 4);

--- a/tool/formula/src/test/java/org/openscience/cdk/formula/rules/NitrogenRuleTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/formula/rules/NitrogenRuleTest.java
@@ -40,7 +40,7 @@ public class NitrogenRuleTest extends FormulaRuleTest {
     @BeforeClass
     public static void setUp() throws Exception {
         builder = DefaultChemObjectBuilder.getInstance();
-        setRule(ChargeRule.class);
+        setRule(NitrogenRule.class);
     }
 
     /**

--- a/tool/formula/src/test/java/org/openscience/cdk/formula/rules/RDBERuleTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/formula/rules/RDBERuleTest.java
@@ -42,7 +42,7 @@ public class RDBERuleTest extends FormulaRuleTest {
     @BeforeClass
     public static void setUp() throws Exception {
         builder = DefaultChemObjectBuilder.getInstance();
-        setRule(ChargeRule.class);
+        setRule(RDBERule.class);
     }
 
     /**


### PR DESCRIPTION
- Fix wrong class names in setUp() method of NitrogenRuleTest and  RDBERuleTest.
- Fix ElementRule because its Parameters[0] can be null.
- Create rule instance in each method in FormulaRuleTest because some implementations of IRule, e.g. ElementRule, are not stateless.
