### PR TITLE
Fix skipping commands in MDLV3000Reader

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -165,7 +165,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                 foundEND = true;
             } else if ("BEGIN CTAB".equals(command)) {
                 // that's fine
-            } else if ("COUNTS".equals(command)) {
+            } else if (command.startsWith("COUNTS ")) {
                 // don't think I need to parse this
             } else if ("BEGIN ATOM".equals(command)) {
                 readAtomBlock(readData);


### PR DESCRIPTION
"COUNTS" in MDL Molfile V3000 should be followed by space and digits. This suppresses count line warnings.