### PR TITLE
Patch/regressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: java
-script: mvn test -fn -q
+install: true
+script: mvn clean test -q

--- a/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
+++ b/base/core/src/main/java/org/openscience/cdk/tools/SystemOutLoggingTool.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.Locale;
 
 /**
  * Implementation of the {@link ILoggingTool} interface that sends output to
@@ -52,6 +53,28 @@ public class SystemOutLoggingTool implements ILoggingTool {
         if (System.getProperty("cdk.debugging", "false").equals("true")
                 || System.getProperty("cdk.debug.stdout", "false").equals("true")) {
             level = DEBUG;
+        }
+        // change logging level from system prop
+        String val = System.getProperty("cdk.logging.level", "warn");
+        switch (val.toLowerCase(Locale.ROOT)) {
+            case "trace":
+                level = ILoggingTool.TRACE;
+                break;
+            case "debug":
+                level = ILoggingTool.DEBUG;
+                break;
+            case "info":
+                level = ILoggingTool.INFO;
+                break;
+            case "warn":
+                level = ILoggingTool.WARN;
+                break;
+            case "error":
+                level = ILoggingTool.ERROR;
+                break;
+            case "fatal":
+                level = ILoggingTool.FATAL;
+                break;
         }
     }
 

--- a/base/data/src/main/java/org/openscience/cdk/DefaultChemObjectBuilder.java
+++ b/base/data/src/main/java/org/openscience/cdk/DefaultChemObjectBuilder.java
@@ -146,6 +146,7 @@ public class DefaultChemObjectBuilder implements IChemObjectBuilder {
 
         // atom containers
         if (CDK_LEGACY_AC) {
+            System.err.println("[WARN] Using the old AtomContainer implementation.");
             factory.register(IAtomContainer.class, AtomContainer.class);
         } else {
             factory.register(IAtomContainer.class, AtomContainer2.class);

--- a/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
@@ -141,9 +141,9 @@ public class SilentChemObjectBuilder implements IChemObjectBuilder {
 
         // atom containers
         if (CDK_LEGACY_AC) {
+            System.err.println("[WARN] Using the old AtomContainer implementation.");
             factory.register(IAtomContainer.class, AtomContainer.class);
         } else {
-            System.err.println("[INFO] Using the new AtomContainer implementation.");
             factory.register(IAtomContainer.class, AtomContainer2.class);
         }
 

--- a/base/test-core/src/test/java/org/openscience/cdk/config/AtomTypeFactoryTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/config/AtomTypeFactoryTest.java
@@ -332,33 +332,18 @@ public class AtomTypeFactoryTest extends CDKTestCase {
                 + tmpCMLSchema.getAbsolutePath());
         Assert.assertNotNull("Could not find the atom type list CML source", ins);
 
-        if (System.getProperty("java.version").indexOf("1.6") != -1
-            || System.getProperty("java.version").indexOf("1.7") != -1
-            || System.getProperty("java.version").indexOf("1.8") != -1) {
+        InputStream cmlSchema = new FileInputStream(tmpCMLSchema);
+        Assert.assertNotNull("Could not find the CML schema", cmlSchema);
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setValidating(true);
+        factory.setAttribute(JAXP_SCHEMA_LANGUAGE, W3C_XML_SCHEMA);
+        factory.setAttribute(JAXP_SCHEMA_LANGUAGE, cmlSchema);
+        factory.setFeature("http://apache.org/xml/features/validation/schema", true);
 
-            InputStream cmlSchema = new FileInputStream(tmpCMLSchema);
-            Assert.assertNotNull("Could not find the CML schema", cmlSchema);
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setValidating(true);
-            factory.setAttribute(JAXP_SCHEMA_LANGUAGE, W3C_XML_SCHEMA);
-            factory.setAttribute(JAXP_SCHEMA_LANGUAGE, cmlSchema);
-            factory.setFeature("http://apache.org/xml/features/validation/schema", true);
-
-            DocumentBuilder parser = factory.newDocumentBuilder();
-            parser.setErrorHandler(new SAXValidityErrorHandler(shortcut));
-            parser.parse(new FileInputStream(tmpInput));
-        } else if (System.getProperty("java.version").indexOf("1.5") != -1) {
-            DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-            Document document = parser.parse(tmpInput);
-            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-            Source schemaFile = new StreamSource(tmpCMLSchema);
-            Schema schema = factory.newSchema(schemaFile);
-            Validator validator = schema.newValidator();
-            validator.validate(new DOMSource(document));
-        } else {
-            Assert.fail("Don't know how to validate with Java version: " + System.getProperty("java.version"));
-        }
+        DocumentBuilder parser = factory.newDocumentBuilder();
+        parser.setErrorHandler(new SAXValidityErrorHandler(shortcut));
+        parser.parse(new FileInputStream(tmpInput));
     }
 
     /**

--- a/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibMCSHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibMCSHandler.java
@@ -312,8 +312,8 @@ public class VFlibMCSHandler extends AbstractMCSAlgorithm implements IMCSBase {
                 } else {
                     tAtom = query.getAtom(mapping.getKey());
                     qAtom = mapping.getValue();
-                    qIndex = getProductMol().indexOf(qAtom);
-                    tIndex = getReactantMol().indexOf(tAtom);
+                    tIndex = getProductMol().indexOf(qAtom);
+                    qIndex = getReactantMol().indexOf(tAtom);
                 }
 
                 if (qIndex != -1 && tIndex != -1) {

--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
                 <configuration>
                     <!-- prevent the annoying ForkedBooter process from stealing
                          window focus on Mac OS -->
-                    <argLine>-Djava.awt.headless=true</argLine>
+                    <argLine>-Djava.awt.headless=true -Dcdk.logging.level=ERROR</argLine>
                     <excludes>
                         <!-- not a test class -->
                         <exclude>**/TestMoleculeFactory.java</exclude>

--- a/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
+++ b/storage/pdb/src/main/java/org/openscience/cdk/io/PDBReader.java
@@ -241,11 +241,7 @@ public class PDBReader extends DefaultChemObjectReader {
                 logger.debug("Read line: ", cRead);
                 if (cRead != null) {
                     lineLength = cRead.length();
-
-                    if (lineLength < 80) {
-                        logger.warn("Line is not of the expected length 80!");
-                    }
-
+                    
                     // make sure the record name is 6 characters long
                     if (lineLength < 6) {
                         cRead = cRead + "      ";

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -338,6 +338,20 @@ public class MolecularFormulaManipulator {
             IElement element = formula.getBuilder().newInstance(IElement.class, orderElement);
             if (containsElement(formula, element)) {
                 List<IIsotope> isotopes = getIsotopes(formula, element);
+                Collections.sort(isotopes,
+                                 new Comparator<IIsotope>() {
+                                     @Override
+                                     public int compare(IIsotope a,
+                                                        IIsotope b) {
+                                         Integer aMass = a.getMassNumber();
+                                         Integer bMass = b.getMassNumber();
+                                         if (aMass == null)
+                                             return -1;
+                                         if (bMass == null)
+                                             return +1;
+                                         return aMass.compareTo(bMass);
+                                     }
+                                 });
                 isotopesList.addAll(isotopes);
             }
         }

--- a/tool/formula/src/test/java/org/openscience/cdk/formula/rules/FormulaRuleTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/formula/rules/FormulaRuleTest.java
@@ -65,28 +65,6 @@ public abstract class FormulaRuleTest extends CDKTestCase {
     }
 
     @Test
-    public void testGetParameters() {
-        Object[] params = rule.getParameters();
-        //		FIXME: the next would be nice, but not currently agreed-upon policy
-        //		assertNotNull(
-        //			"The method getParameters() must return a non-null value, possible a zero length Object[] array",
-        //			paramNames
-        //		);
-        //		FIXME: so instead:
-        if (params == null) params = new Object[0];
-        for (int i = 0; i < params.length; i++) {
-            Assert.assertNotNull("A parameter default must not be null.", params[i]);
-        }
-    }
-
-    @Test
-    public void testSetParameters_arrayObject() throws Exception {
-        IRule rule = getRule();
-        Object[] defaultParams = rule.getParameters();
-        rule.setParameters(defaultParams);
-    }
-
-    @Test
     public void testValidate_IMolecularFormula() throws Exception {
         IRule rule = getRule();
     	
@@ -98,5 +76,4 @@ public abstract class FormulaRuleTest extends CDKTestCase {
         // can it handle an empty MF?
         rule.validate(new MolecularFormula());
     }
-
 }

--- a/tool/formula/src/test/java/org/openscience/cdk/formula/rules/IsotopePatternRuleTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/formula/rules/IsotopePatternRuleTest.java
@@ -131,7 +131,7 @@ public class IsotopePatternRuleTest extends FormulaRuleTest {
      * @return    The test suite
      */
     @Test
-    public void testDefaultValidTrue() throws Exception {
+    public void testValidate_IMolecularFormula() throws Exception {
 
         IMolecularFormula formula = new MolecularFormula();
         formula.addIsotope(ifac.getMajorIsotope("C"), 5);

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -1336,7 +1336,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         mf.addIsotope(ifac.getIsotope("Br", 81), 1);
 
         assertThat(MolecularFormulaManipulator.getString(mf, false, false), is("C7H3Br2O3"));
-        assertThat(MolecularFormulaManipulator.getString(mf, false, true), is("C7H3[81]BrBrO3"));
+        assertThat(MolecularFormulaManipulator.getString(mf, false, true), is("C7H3Br[81]BrO3"));
     }
 
     @Test


### PR DESCRIPTION
Fixing some regressions with some other cleanup:

1 - Formula's use a map and so the ordering of items was coming out in different ways
2 - The FormulaRuleTest had some basic tests for parameters that were not true now the testing was stateless (see #459). Since these tests were minor and in a rare part of the code it seem most appropriate simply to remove them. Normal usage is not affected.
3 - SMSD, I got the right idea in this [patch](https://github.com/cdk/cdk/commit/422d77858dc7f7f530f0b457262460b9b48c99bb) but also had to swap the qIndex and tIndex. Now correct