### PR TITLE
Patch/canon aam smiles

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/graph/invariant/Canon.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/invariant/Canon.java
@@ -27,11 +27,14 @@ package org.openscience.cdk.graph.invariant;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IPseudoAtom;
+import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 
 /**
  * An implementation based on the canon algorithm {@cdk.cite WEI89}. The
@@ -120,7 +123,7 @@ public final class Canon {
     /**
      * Compute the canonical labels for the provided structure. The labelling
      * does not consider isomer information or stereochemistry. This method
-     * allows provision of a custom array of initial invariants.
+     * allows provision of a custom array of initial initial.
      *
      * 
      * The current
@@ -131,15 +134,43 @@ public final class Canon {
      *
      * @param container  structure
      * @param g          adjacency list graph representation
-     * @param invariants initial invariants
+     * @param initial    initial seed invariants
      * @return the canonical labelling
      * @see EquivalentClassPartitioner
      * @see InChINumbersTools
      */
-    public static long[] label(IAtomContainer container, int[][] g, long[] invariants) {
-        if (invariants.length != g.length)
-            throw new IllegalArgumentException("number of invariants != number of atoms");
-        return new Canon(g, invariants, terminalHydrogens(container, g), false).labelling;
+    public static long[] label(IAtomContainer container, int[][] g, long[] initial) {
+        if (initial.length != g.length)
+            throw new IllegalArgumentException("number of initial != number of atoms");
+        return new Canon(g, initial, terminalHydrogens(container, g), false).labelling;
+    }
+
+    /**
+     * Compute the canonical labels for the provided structure. The initial
+     * labelling is seed-ed with the provided atom comparator <code>cmp</code>
+     * allowing arbitary properties to be distinguished or ignored.
+     *
+     * @param container  structure
+     * @param g          adjacency list graph representation
+     * @param cmp        comparator to compare atoms
+     * @return the canonical labelling
+     */
+    public static long[] label(IAtomContainer    container,
+                               int[][]           g,
+                               Comparator<IAtom> cmp) {
+        if (g.length == 0)
+            return new long[0];
+        IAtom[] atoms = AtomContainerManipulator.getAtomArray(container);
+        Arrays.sort(atoms, cmp);
+        long[] initial = new long[atoms.length];
+        long   part    = 1;
+        initial[container.indexOf(atoms[0])] = part;
+        for (int i=1; i<atoms.length; i++) {
+            if (cmp.compare(atoms[i], atoms[i-1]) != 0)
+                ++part;
+            initial[container.indexOf(atoms[i])] = part;
+        }
+        return label(container, g, initial);
     }
 
     /**

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmiFlavor.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmiFlavor.java
@@ -165,6 +165,11 @@ public final class SmiFlavor {
     public static final int CxFragmentGroup     = 0x100000;
 
     /**
+     * Renumber AtomAtomMaps during canonical generation
+     */
+    public static final int AtomAtomMapRenumber = Canonical | AtomAtomMap | 0x200000;
+
+    /**
      * Output CXSMILES layers.
      */
     public static final int CxSmiles            = CxAtomLabel | CxAtomValue | CxRadical | CxFragmentGroup | CxMulticenter | CxPolymer;

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesGenerator.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesGenerator.java
@@ -450,6 +450,9 @@ public final class SmilesGenerator {
 
                 g = g.permute(labels);
 
+                if ((flavour & SmiFlavor.AtomAtomMapRenumber) == SmiFlavor.AtomAtomMapRenumber)
+                    g = Functions.renumberAtomMaps(g);
+
                 if (!SmiFlavor.isSet(flavour, SmiFlavor.UseAromaticSymbols))
                     g = g.resonate();
 
@@ -982,7 +985,8 @@ public final class SmilesGenerator {
                     && (cmp = Integer.compare(a.getMassNumber(), b.getMassNumber())) != 0)
                     return cmp;
                 // extra 2) atom map
-                if (SmiFlavor.isSet(flavor, SmiFlavor.AtomAtomMap)) {
+                if (SmiFlavor.isSet(flavor, SmiFlavor.AtomAtomMap) &&
+                    (flavor & SmiFlavor.AtomAtomMapRenumber) != SmiFlavor.AtomAtomMapRenumber) {
                     Integer aMapIdx = a.getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                     Integer bMapIdx = b.getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                     if ((cmp = Integer.compare(unbox(aMapIdx), unbox(bMapIdx))) != 0)

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
@@ -1279,6 +1279,17 @@ public class SmilesGeneratorTest extends CDKTestCase {
                    is("C/C=C=C=C\\C"));
     }
 
+    @Test
+    public void canonAtomMaps() throws CDKException {
+        SmilesParser   smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer mol    = smipar.parseSmiles("[*:2]C(CC[*:3])[*:1]");
+        assertThat(new SmilesGenerator(SmiFlavor.Canonical|SmiFlavor.AtomAtomMap).create(mol),
+                   is("[*:1]C([*:2])CC[*:3]"));
+        IAtomContainer mol2    = smipar.parseSmiles("[*:2]C(CC[*:1])[*:2]");
+        assertThat(new SmilesGenerator(SmiFlavor.Canonical|SmiFlavor.AtomAtomMap).create(mol2),
+                   is("[*:1]CCC([*:2])[*:2]"));
+    }
+
     static ITetrahedralChirality anticlockwise(IAtomContainer container, int central, int a1, int a2, int a3, int a4) {
         return new TetrahedralChirality(container.getAtom(central), new IAtom[]{container.getAtom(a1),
                                                                                 container.getAtom(a2), container.getAtom(a3), container.getAtom(a4)},

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
@@ -1290,6 +1290,17 @@ public class SmilesGeneratorTest extends CDKTestCase {
                    is("[*:1]CCC([*:2])[*:2]"));
     }
 
+    @Test
+    public void canonAtomMapsRenumber() throws CDKException {
+        SmilesParser   smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer mol    = smipar.parseSmiles("[*:2]C(CC[*:3])[*:1]");
+        assertThat(new SmilesGenerator(SmiFlavor.Canonical|SmiFlavor.AtomAtomMapRenumber).create(mol),
+                   is("[*:1]CCC([*:2])[*:3]"));
+        IAtomContainer mol2    = smipar.parseSmiles("[*:3]C(CC[*:1])[*:2]");
+        assertThat(new SmilesGenerator(SmiFlavor.Canonical|SmiFlavor.AtomAtomMapRenumber).create(mol2),
+                   is("[*:1]CCC([*:2])[*:3]"));
+    }
+
     static ITetrahedralChirality anticlockwise(IAtomContainer container, int central, int a1, int a2, int a3, int a4) {
         return new TetrahedralChirality(container.getAtom(central), new IAtom[]{container.getAtom(a1),
                                                                                 container.getAtom(a2), container.getAtom(a3), container.getAtom(a4)},


### PR DESCRIPTION
Resolves #274.

Atom Map Index now affects canonical ordering (if and only if output SMILES has atom maps). In this first example the two inputs (left of reaction) are the same except for their atom map numbering. They get different atom-maps.

```
[*:2]C(CC[*:3])[*:1]>>[*:1]C([*:2])CC[*:3]
[*:2]C(CC[*:1])[*:2]>>[*:1]CCC([*:2])[*:2]
```

The more useful ``SmiFlavor.AtomAtomMapRenumber`` flag takes the same input, canonicalises without atom-atom maps and then renumbers them on output:

```
[*:2]C(CC[*:3])[*:1]>>[*:1]CCC([*:2])[*:3]
[*:1]CCC([*:2])[*:3]>>[*:1]CCC([*:2])[*:3]
```

If desired the caller can track the renumbering by parsing the output inspecting the output ordering array.