### PR TITLE
Patch/fast murcko scaffolds

### DIFF
--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/MurckoFragmenter.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/MurckoFragmenter.java
@@ -36,13 +36,16 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.ringsearch.AllRingsFinder;
+import org.openscience.cdk.ringsearch.RingSearch;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -84,6 +87,7 @@ public class MurckoFragmenter implements IFragmenter {
     Map<Long, IAtomContainer>   ringMap              = new HashMap<Long, IAtomContainer>();
 
     boolean                     singleFrameworkOnly  = false;
+    boolean                     ringFramgnets        = true;
     int                         minimumFragmentSize  = 5;
 
     /**
@@ -127,6 +131,15 @@ public class MurckoFragmenter implements IFragmenter {
     }
 
     /**
+     * Sets whether to calculate ring fragments (true by default).
+     *
+     * @param val true/false
+     */
+    public void setComputeRingFragments(boolean val) {
+        this.ringFramgnets = val;
+    }
+
+    /**
      * Perform the fragmentation procedure.
      *
      * @param atomContainer The input molecule
@@ -140,7 +153,93 @@ public class MurckoFragmenter implements IFragmenter {
         run(atomContainer, fragmentSet);
     }
 
+    /**
+     * Computes the Murcko Scaffold for the provided molecule in linear time.
+     * Note the return value contains the same atoms/bonds as in the input
+     * and an additional clone and valence adjustments may be required.
+     *
+     * @param mol the molecule
+     * @return the atoms and bonds in the scaffold
+     */
+    public static IAtomContainer scaffold(final IAtomContainer mol) {
+
+        // Old AtomContainer IMPL, cannot work with this
+        if (!mol.isEmpty() && mol.getAtom(0).getContainer() == null)
+            return null;
+
+        Deque<IAtom> queue = new ArrayDeque<>();
+        int[] bcount = new int[mol.getAtomCount()];
+
+        // Step 1. Mark and queue all terminal (degree 1) atoms
+        for (IAtom atom : mol.atoms()) {
+            int numBonds = atom.getBondCount();
+            bcount[atom.getIndex()] = numBonds;
+            if (numBonds == 1)
+                queue.add(atom);
+        }
+
+        // Step 2. Iteratively remove terminal atoms queuing new atoms
+        //         as they become terminal
+        while (!queue.isEmpty()) {
+            IAtom atom = queue.poll();
+            if (atom == null)
+                continue;
+            bcount[atom.getIndex()] = 0;
+            for (IBond bond : atom.bonds()) {
+                IAtom nbr = bond.getOther(atom);
+                bcount[nbr.getIndex()]--;
+                if (bcount[nbr.getIndex()] == 1)
+                    queue.add(nbr);
+            }
+        }
+
+        // Step 3. Copy out the atoms/bonds that are part of the Murcko
+        //         scaffold
+        IAtomContainer scaffold = mol.getBuilder().newAtomContainer();
+        for (int i = 0; i < mol.getAtomCount(); i++) {
+            IAtom atom = mol.getAtom(i);
+            if (bcount[i] > 0)
+                scaffold.addAtom(atom);
+        }
+        for (int i = 0; i < mol.getBondCount(); i++) {
+            IBond bond = mol.getBond(i);
+            if (bcount[bond.getBegin().getIndex()] > 0 &&
+                bcount[bond.getEnd().getIndex()] > 0)
+                scaffold.addBond(bond);
+        }
+        return scaffold;
+    }
+
+    private void addRingFragment(IAtomContainer mol) {
+        if (mol.getAtomCount() < minimumFragmentSize)
+            return;
+        long hash = generator.generate(mol);
+        ringMap.put(hash, mol);
+    }
+
     private void run(IAtomContainer atomContainer, Set<Long> fragmentSet) throws CDKException {
+
+        if (singleFrameworkOnly) {
+            IAtomContainer scaffold = scaffold(atomContainer);
+            if (scaffold != null) {
+                try {
+                    scaffold = scaffold.clone();
+                } catch (CloneNotSupportedException e) {
+                    throw new IllegalStateException("Clone not supported!");
+                }
+                if (scaffold.getAtomCount() >= minimumFragmentSize)
+                    frameMap.put(0L, scaffold);
+                if (ringFramgnets) {
+                    RingSearch rs = new RingSearch(scaffold);
+                    for (IAtomContainer rset : rs.fusedRingFragments())
+                        addRingFragment(rset);
+                    for (IAtomContainer rset : rs.isolatedRingFragments())
+                        addRingFragment(rset);
+                }
+                return;
+            }
+        }
+
         Long hash;
 
         // identify rings

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/MurckoFragmenter.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/MurckoFragmenter.java
@@ -87,7 +87,7 @@ public class MurckoFragmenter implements IFragmenter {
     Map<Long, IAtomContainer>   ringMap              = new HashMap<Long, IAtomContainer>();
 
     boolean                     singleFrameworkOnly  = false;
-    boolean                     ringFramgnets        = true;
+    boolean                     ringFragments        = true;
     int                         minimumFragmentSize  = 5;
 
     /**
@@ -97,7 +97,7 @@ public class MurckoFragmenter implements IFragmenter {
      * frameworks if available.
      */
     public MurckoFragmenter() {
-        this(false, 5, null);
+        this(true, 5, null);
     }
 
     /**
@@ -136,7 +136,7 @@ public class MurckoFragmenter implements IFragmenter {
      * @param val true/false
      */
     public void setComputeRingFragments(boolean val) {
-        this.ringFramgnets = val;
+        this.ringFragments = val;
     }
 
     /**
@@ -229,7 +229,7 @@ public class MurckoFragmenter implements IFragmenter {
                 }
                 if (scaffold.getAtomCount() >= minimumFragmentSize)
                     frameMap.put(0L, scaffold);
-                if (ringFramgnets) {
+                if (ringFragments) {
                     RingSearch rs = new RingSearch(scaffold);
                     for (IAtomContainer rset : rs.fusedRingFragments())
                         addRingFragment(rset);

--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/MurckoFragmenterTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/MurckoFragmenterTest.java
@@ -19,6 +19,7 @@
  */
 package org.openscience.cdk.fragment;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import org.openscience.cdk.SlowTest;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.templates.TestMoleculeFactory;
@@ -332,5 +334,18 @@ public class MurckoFragmenterTest extends CDKTestCase {
         assertThat(rs.length, is(2));
         String[] fs = fragmenter.getFragments();
         assertThat(fs.length, is(3));
+    }
+
+    /**
+     * @see <a href="https://github.com/cdk/cdk/issues/263">GitHub Issue #263</a>
+     */
+    @Test
+    public void testCHEMBL529226() throws CDKException {
+        String smiles = "CC1=CN([C@@H]2O[C@@]3(COP(=S)(O)O[C@H]4[C@H]5OC[C@]4(COP(=S)(O)O[C@H]6C[C@@H](O[C@@H]6COP(=S)(O)O[C@H]7[C@@H](O)[C@@H](O[C@@H]7COP(=S)(O)O[C@H]8[C@@H](O)[C@@H](O[C@@H]8COP(=S)(O)O[C@H]9[C@@H](O)[C@@H](O[C@@H]9COP(=S)(O)O[C@H]%10[C@@H](O)[C@@H](O[C@@H]%10COP(=S)(O)O[C@H]%11[C@@H](O)[C@@H](O[C@@H]%11COP(=S)(O)O[C@H]%12[C@@H](O)[C@@H](O[C@@H]%12COP(=S)(O)O[C@H]%13[C@@H](O)[C@@H](O[C@@H]%13COP(=S)(O)O[C@H]%14[C@@H](O)[C@@H](O[C@@H]%14COP(=S)(O)O[C@H]%15[C@@H](O)[C@@H](O[C@@H]%15COP(=S)(O)O[C@H]%16[C@H]%17OC[C@]%16(COP(=S)(O)O[C@H]%18[C@H]%19OC[C@]%18(CO)O[C@H]%19N%20C=C(C)C(=O)NC%20=O)O[C@H]%17N%21C=C(C)C(=NC%21=O)N)N%22C=CC(=NC%22=O)N)n%23cnc%24C(=O)NC(=Nc%23%24)N)n%25cnc%26C(=O)NC(=Nc%25%26)N)N%27C=C(C)C(=O)NC%27=O)N%28C=CC(=NC%28=O)N)n%29cnc%30c(N)ncnc%29%30)N%31C=CC(=NC%31=O)N)n%32cnc%33C(=O)NC(=Nc%32%33)N)n%34cnc%35C(N)NC=Nc%34%35)N%36C=C(C)C(=O)NC%36=O)O[C@H]5N%37C=C(C)C(=O)NC%37=O)CO[C@@H]2[C@@H]3O)C(=O)N=C1N";
+        SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer mol = smipar.parseSmiles(smiles);
+        MurckoFragmenter fragmenter = new MurckoFragmenter(true, 6);
+        fragmenter.generateFragments(mol);
+        assertThat(fragmenter.getFrameworks().length, CoreMatchers.is(1));
     }
 }

--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/MurckoFragmenterTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/MurckoFragmenterTest.java
@@ -56,7 +56,7 @@ public class MurckoFragmenterTest extends CDKTestCase {
 
     @BeforeClass
     public static void setup() {
-        fragmenter = new MurckoFragmenter();
+        fragmenter = new MurckoFragmenter(false, 5);
         smilesParser = new SmilesParser(DefaultChemObjectBuilder.getInstance());
     }
 


### PR DESCRIPTION
Adds much faster Murcko scaffold generation to the ``MurckoFragmenter`` when run in ``singleFrameworkOnly`` mode, Unfortunately this isn't the default but I'm pretty sure this is the more common use case. I would therefore propose changing the default constructor, any thoughts @rajarshi? 

Although it is possible to make the entire framework generation much faster I'm less convinced of the applicability. I also added a flag to disable the ring fragment generation, we can compute these much faster elsewhere and not really "Murcko" specific.

This resolves #263, previously reported as being 17 hours (but that could be the frameworks, unclear) now runs in ~2 ms on my laptop. Running with the old method in singleFragmentOnly mode I gave up running after 5 mins.

![image](https://user-images.githubusercontent.com/983232/41989730-2efaa8f0-7a38-11e8-981d-1663eeb3ab00.png)
