### PR TITLE
ShortestPaths.isPrecedingPathTo(-1) throws exception

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/graph/ShortestPaths.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/ShortestPaths.java
@@ -342,7 +342,7 @@ public final class ShortestPaths {
      *         preceding the <i>start</i>
      */
     public boolean isPrecedingPathTo(int end) {
-        return (end >= 0 || end < routeTo.length) && precedes[end];
+        return (end >= 0 && end < routeTo.length) && precedes[end];
     }
 
     /**

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/ShortestPathsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/ShortestPathsTest.java
@@ -163,11 +163,12 @@ public class ShortestPathsTest {
         //   5 - 4
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testIsPrecedingPathTo_OutOfBounds() {
         IAtomContainer benzene = TestMoleculeFactory.makeBenzene();
         ShortestPaths paths = new ShortestPaths(benzene, benzene.getAtom(0));
         assertFalse(paths.isPrecedingPathTo(-1));
+        assertFalse(paths.isPrecedingPathTo(10));
     }
 
     /**


### PR DESCRIPTION
ShortestPaths.isPrecedingPathTo(int) throws exception when the parameter is out of the bounds but don't throw exception by design.

