### PR TITLE
behavior of new Atom(String) 

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -565,7 +565,7 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
 
         int mass = -1;
         int anum = 0;
-        int hcnt = 0;
+        int hcnt = -1;
         int chg = 0;
         String symbol = null;
         boolean flag = false;
@@ -613,6 +613,7 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
                         case 'H':
                             pos++;
                             if (pos < len && isDigit(str.charAt(pos))) {
+                            	hcnt = 0;
                                 while (pos < len && isDigit(str.charAt(pos)))
                                     hcnt = 10 * hcnt + (str.charAt(pos++) - '0');
                             } else {
@@ -660,12 +661,13 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             atom.setMassNumber(mass);
         atom.setAtomicNumber(anum);
         atom.setSymbol(symbol);
-        atom.setImplicitHydrogenCount(hcnt);
+        if (hcnt >= 0)
+        	atom.setImplicitHydrogenCount(hcnt);
         atom.setFormalCharge(chg);
 
         return true;
     }
-
+    
     /**
      * {@inheritDoc}
      */

--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -176,13 +176,12 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             throw new IllegalArgumentException("Cannot pass atom symbol: " + symbol);
     }
 
-
     /**
-         * Constructs an Atom from an Element and a Point3d.
-         *
-         * @param   elementSymbol   The symbol of the atom
-         * @param   point3d         The 3D coordinates of the atom
-         */
+     * Constructs an Atom from an Element and a Point3d.
+     *
+     * @param   elementSymbol   The symbol of the atom
+     * @param   point3d         The 3D coordinates of the atom
+     */
     public Atom(String elementSymbol, Point3d point3d) {
         this(elementSymbol);
         this.point3d = point3d;
@@ -548,7 +547,6 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         return (IAtom) clone;
     }
 
-
     private static boolean isUpper(char c) {
         return c >= 'A' && c <= 'Z';
     }
@@ -569,6 +567,8 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         int anum = 0;
         int hcnt = 0;
         int chg = 0;
+        String symbol = null;
+        boolean flag = false;
 
         // optional mass
         if (pos < len && isDigit(str.charAt(pos))) {
@@ -576,87 +576,94 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             while (pos < len && isDigit(str.charAt(pos)))
                 mass = 10 * mass + (str.charAt(pos++) - '0');
         } else if ("R".equals(str)) {
-            atom.setAtomicNumber(0);
-            atom.setSymbol("R");
-            return true;
+            anum = 0;
+            symbol = "R";
+            flag = true;
         } else if ("*".equals(str)) {
-            atom.setAtomicNumber(0);
-            atom.setSymbol("*");
-            return true;
+            anum = 0;
+            symbol = "*";
+            flag = true;
         } else if ("D".equals(str)) {
-            atom.setAtomicNumber(1);
-            atom.setMassNumber(2);
-            atom.setSymbol("H");
-            return true;
+            anum = 1;
+            mass = 2;
+            symbol = "H";
+            flag = true;
         } else if ("T".equals(str)) {
-            atom.setAtomicNumber(1);
-            atom.setMassNumber(3);
-            atom.setSymbol("H");
-            return true;
+            anum = 1;
+            mass = 3;
+            symbol = "H";
+            flag = true;
         }
 
-        // atom symbol
-        if (pos < len && isUpper(str.charAt(pos))) {
-            int beg = pos;
-            pos++;
-            while (pos < len && isLower(str.charAt(pos)))
+        if (flag == false) {
+            // atom symbol
+            if (pos < len && isUpper(str.charAt(pos))) {
+                int beg = pos;
                 pos++;
-            Elements elem = Elements.ofString(str.substring(beg, pos));
-            if (elem == Elements.Unknown)
-                return false;
-            anum = elem.number();
-
-            // optional fields after atom symbol
-            while (pos < len) {
-                switch (str.charAt(pos)) {
-                    case 'H':
-                        pos++;
-                        if (pos < len && isDigit(str.charAt(pos))) {
-                            while (pos < len && isDigit(str.charAt(pos)))
-                                hcnt = 10 * hcnt + (str.charAt(pos++) - '0');
-                        } else {
-                            hcnt = 1;
-                        }
-                        break;
-                    case '+':
-                        pos++;
-                        if (pos < len && isDigit(str.charAt(pos))) {
-                            chg = (str.charAt(pos++) - '0');
-                            while (pos < len && isDigit(str.charAt(pos)))
-                                chg = 10 * chg + (str.charAt(pos++) - '0');
-                        } else {
-                            chg = +1;
-                        }
-                        break;
-                    case '-':
-                        pos++;
-                        if (pos < len && isDigit(str.charAt(pos))) {
-                            chg = (str.charAt(pos++) - '0');
-                            while (pos < len && isDigit(str.charAt(pos)))
-                                chg = 10 * chg + (str.charAt(pos++) - '0');
-                            chg *= -1;
-                        } else {
-                            chg = -1;
-                        }
-                        break;
-                    default:
-                        return false;
+                while (pos < len && isLower(str.charAt(pos)))
+                    pos++;
+                Elements elem = Elements.ofString(str.substring(beg, pos));
+                if (elem == Elements.Unknown)
+                    return false;
+                anum = elem.number();
+    
+                // optional fields after atom symbol
+                while (pos < len) {
+                    switch (str.charAt(pos)) {
+                        case 'H':
+                            pos++;
+                            if (pos < len && isDigit(str.charAt(pos))) {
+                                while (pos < len && isDigit(str.charAt(pos)))
+                                    hcnt = 10 * hcnt + (str.charAt(pos++) - '0');
+                            } else {
+                                hcnt = 1;
+                            }
+                            break;
+                        case '+':
+                            pos++;
+                            if (pos < len && isDigit(str.charAt(pos))) {
+                                chg = (str.charAt(pos++) - '0');
+                                while (pos < len && isDigit(str.charAt(pos)))
+                                    chg = 10 * chg + (str.charAt(pos++) - '0');
+                            } else {
+                                chg = +1;
+                            }
+                            break;
+                        case '-':
+                            pos++;
+                            if (pos < len && isDigit(str.charAt(pos))) {
+                                chg = (str.charAt(pos++) - '0');
+                                while (pos < len && isDigit(str.charAt(pos)))
+                                    chg = 10 * chg + (str.charAt(pos++) - '0');
+                                chg *= -1;
+                            } else {
+                                chg = -1;
+                            }
+                            break;
+                        default:
+                            return false;
+                    }
                 }
+            } else {
+                return false;
             }
-        } else {
-            return false;
+            flag = pos == len && len > 0;
+            symbol = Elements.ofNumber(anum).symbol();
         }
+        
+        if (!flag)
+            return false;
 
         if (mass < 0)
             atom.setMassNumber(null);
         else
             atom.setMassNumber(mass);
         atom.setAtomicNumber(anum);
-        atom.setSymbol(Elements.ofNumber(anum).symbol());
+        atom.setSymbol(symbol);
         atom.setImplicitHydrogenCount(hcnt);
         atom.setFormalCharge(chg);
 
-        return pos == len && len > 0;
+        return true;
     }
 
     /**

--- a/base/data/src/test/java/org/openscience/cdk/AtomTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/AtomTest.java
@@ -130,7 +130,7 @@ public class AtomTest extends AbstractAtomTest {
         IAtom a = new Atom("O-");
         Assert.assertEquals("O", a.getSymbol());
         Assert.assertEquals((Integer) 8, a.getAtomicNumber());
-        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals(null, a.getImplicitHydrogenCount());
         Assert.assertEquals(Integer.valueOf(-1), a.getFormalCharge());
         Assert.assertNull(a.getPoint2d());
         Assert.assertNull(a.getPoint3d());
@@ -142,7 +142,7 @@ public class AtomTest extends AbstractAtomTest {
         IAtom a = new Atom("Ca+2");
         Assert.assertEquals("Ca", a.getSymbol());
         Assert.assertEquals((Integer) 20, a.getAtomicNumber());
-        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals(null, a.getImplicitHydrogenCount());
         Assert.assertEquals(Integer.valueOf(+2), a.getFormalCharge());
         Assert.assertNull(a.getPoint2d());
         Assert.assertNull(a.getPoint3d());
@@ -209,10 +209,10 @@ public class AtomTest extends AbstractAtomTest {
 
     @Test
     public void testNewAtomImplicitHydrogenCount() {
-        Assert.assertNotNull(new Atom("C").getImplicitHydrogenCount());
-        Assert.assertNotNull(new Atom("*").getImplicitHydrogenCount());
-        Assert.assertNotNull(new Atom("H").getImplicitHydrogenCount());
-        Assert.assertNotNull(new Atom("D").getImplicitHydrogenCount());
-        Assert.assertNotNull(new Atom("T").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("C").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("*").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("H").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("D").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("T").getImplicitHydrogenCount());
     }
 }

--- a/base/data/src/test/java/org/openscience/cdk/AtomTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/AtomTest.java
@@ -207,4 +207,12 @@ public class AtomTest extends AbstractAtomTest {
         }
     }
 
+    @Test
+    public void testNewAtomImplicitHydrogenCount() {
+        Assert.assertNotNull(new Atom("C").getImplicitHydrogenCount());
+        Assert.assertNotNull(new Atom("*").getImplicitHydrogenCount());
+        Assert.assertNotNull(new Atom("H").getImplicitHydrogenCount());
+        Assert.assertNotNull(new Atom("D").getImplicitHydrogenCount());
+        Assert.assertNotNull(new Atom("T").getImplicitHydrogenCount());
+    }
 }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -561,7 +561,7 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
 
         int mass = -1;
         int anum = 0;
-        int hcnt = 0;
+        int hcnt = -1;
         int chg = 0;
         String symbol = null;
         boolean flag = false;
@@ -609,6 +609,7 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
                         case 'H':
                             pos++;
                             if (pos < len && isDigit(str.charAt(pos))) {
+                            	hcnt = 0;
                                 while (pos < len && isDigit(str.charAt(pos)))
                                     hcnt = 10 * hcnt + (str.charAt(pos++) - '0');
                             } else {
@@ -656,7 +657,8 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
             atom.setMassNumber(mass);
         atom.setAtomicNumber(anum);
         atom.setSymbol(symbol);
-        atom.setImplicitHydrogenCount(hcnt);
+        if (hcnt >= 0)
+        	atom.setImplicitHydrogenCount(hcnt);
         atom.setFormalCharge(chg);
 
         return true;

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -208,7 +208,7 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
      * and covalent radii, formal charge, hybridization, electron
      * valency, formal neighbour count and atom type name from the
      * given IAtomType. It does not copy the listeners and
-     * properties. If the element is an instanceof
+     * properties. If the element is an instance of
      * IAtom, then the 2D, 3D and fractional coordinates, partial
      * atomic charge, hydrogen count and stereo parity are copied
      * too.
@@ -556,31 +556,6 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
     }
 
     private static boolean parseAtomSymbol(IAtom atom, String str) {
-        Elements elem = Elements.ofString(str);
-        if (elem != Elements.Unknown) {
-            atom.setAtomicNumber(elem.number());
-            atom.setSymbol(elem.symbol());
-            return true;
-        } else if ("R".equals(str)) {
-            atom.setAtomicNumber(0);
-            atom.setSymbol("R");
-            return true;
-        } else if ("*".equals(str)) {
-            atom.setAtomicNumber(0);
-            atom.setSymbol("*");
-            return true;
-        } else if ("D".equals(str)) {
-            atom.setAtomicNumber(1);
-            atom.setMassNumber(2);
-            atom.setSymbol("H");
-            return true;
-        } else if ("T".equals(str)) {
-            atom.setAtomicNumber(1);
-            atom.setMassNumber(3);
-            atom.setSymbol("H");
-            return true;
-        }
-
         final int len = str.length();
         int pos = 0;
 
@@ -588,76 +563,103 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         int anum = 0;
         int hcnt = 0;
         int chg = 0;
+        String symbol = null;
+        boolean flag = false;
 
         // optional mass
         if (pos < len && isDigit(str.charAt(pos))) {
             mass = (str.charAt(pos++) - '0');
             while (pos < len && isDigit(str.charAt(pos)))
                 mass = 10 * mass + (str.charAt(pos++) - '0');
+        } else if ("R".equals(str)) {
+            anum = 0;
+            symbol = "R";
+            flag = true;
+        } else if ("*".equals(str)) {
+            anum = 0;
+            symbol = "*";
+            flag = true;
+        } else if ("D".equals(str)) {
+            anum = 1;
+            mass = 2;
+            symbol = "H";
+            flag = true;
+        } else if ("T".equals(str)) {
+            anum = 1;
+            mass = 3;
+            symbol = "H";
+            flag = true;
         }
 
-        // atom symbol
-        if (pos < len && isUpper(str.charAt(pos))) {
-            int beg = pos;
-            pos++;
-            while (pos < len && isLower(str.charAt(pos)))
+        if (flag == false) {
+            // atom symbol
+            if (pos < len && isUpper(str.charAt(pos))) {
+                int beg = pos;
                 pos++;
-            elem = Elements.ofString(str.substring(beg, pos));
-            if (elem == Elements.Unknown)
-                return false;
-            anum = elem.number();
-
-            // optional fields after atom symbol
-            while (pos < len) {
-                switch (str.charAt(pos)) {
-                    case 'H':
-                        pos++;
-                        if (pos < len && isDigit(str.charAt(pos))) {
-                            while (pos < len && isDigit(str.charAt(pos)))
-                                hcnt = 10 * hcnt + (str.charAt(pos++) - '0');
-                        } else {
-                            hcnt = 1;
-                        }
-                        break;
-                    case '+':
-                        pos++;
-                        if (pos < len && isDigit(str.charAt(pos))) {
-                            chg = (str.charAt(pos++) - '0');
-                            while (pos < len && isDigit(str.charAt(pos)))
-                                chg = 10 * chg + (str.charAt(pos++) - '0');
-                        } else {
-                            chg = +1;
-                        }
-                        break;
-                    case '-':
-                        pos++;
-                        if (pos < len && isDigit(str.charAt(pos))) {
-                            chg = (str.charAt(pos++) - '0');
-                            while (pos < len && isDigit(str.charAt(pos)))
-                                chg = 10 * chg + (str.charAt(pos++) - '0');
-                            chg *= -1;
-                        } else {
-                            chg = -1;
-                        }
-                        break;
-                    default:
-                        return false;
+                while (pos < len && isLower(str.charAt(pos)))
+                    pos++;
+                Elements elem = Elements.ofString(str.substring(beg, pos));
+                if (elem == Elements.Unknown)
+                    return false;
+                anum = elem.number();
+    
+                // optional fields after atom symbol
+                while (pos < len) {
+                    switch (str.charAt(pos)) {
+                        case 'H':
+                            pos++;
+                            if (pos < len && isDigit(str.charAt(pos))) {
+                                while (pos < len && isDigit(str.charAt(pos)))
+                                    hcnt = 10 * hcnt + (str.charAt(pos++) - '0');
+                            } else {
+                                hcnt = 1;
+                            }
+                            break;
+                        case '+':
+                            pos++;
+                            if (pos < len && isDigit(str.charAt(pos))) {
+                                chg = (str.charAt(pos++) - '0');
+                                while (pos < len && isDigit(str.charAt(pos)))
+                                    chg = 10 * chg + (str.charAt(pos++) - '0');
+                            } else {
+                                chg = +1;
+                            }
+                            break;
+                        case '-':
+                            pos++;
+                            if (pos < len && isDigit(str.charAt(pos))) {
+                                chg = (str.charAt(pos++) - '0');
+                                while (pos < len && isDigit(str.charAt(pos)))
+                                    chg = 10 * chg + (str.charAt(pos++) - '0');
+                                chg *= -1;
+                            } else {
+                                chg = -1;
+                            }
+                            break;
+                        default:
+                            return false;
+                    }
                 }
+            } else {
+                return false;
             }
-        } else {
-            return false;
+            flag = pos == len && len > 0;
+            symbol = Elements.ofNumber(anum).symbol();
         }
+        
+        if (!flag)
+            return false;
 
         if (mass < 0)
             atom.setMassNumber(null);
         else
             atom.setMassNumber(mass);
         atom.setAtomicNumber(anum);
-        atom.setSymbol(Elements.ofNumber(anum).symbol());
+        atom.setSymbol(symbol);
         atom.setImplicitHydrogenCount(hcnt);
         atom.setFormalCharge(chg);
 
-        return pos == len && len > 0;
+        return true;
     }
 
     /**

--- a/base/silent/src/test/java/org/openscience/cdk/silent/AtomTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/AtomTest.java
@@ -251,4 +251,13 @@ public class AtomTest extends AbstractAtomTest {
     public void testNotifyChanged_RemoveProperty() {
         ChemObjectTestHelper.testNotifyChanged_RemoveProperty(newChemObject());
     }
+    
+    @Test
+    public void testNewAtomImplicitHydrogenCount() {
+        Assert.assertNotNull(new Atom("C").getImplicitHydrogenCount());
+        Assert.assertNotNull(new Atom("*").getImplicitHydrogenCount());
+        Assert.assertNotNull(new Atom("H").getImplicitHydrogenCount());
+        Assert.assertNotNull(new Atom("D").getImplicitHydrogenCount());
+        Assert.assertNotNull(new Atom("T").getImplicitHydrogenCount());
+    }   
 }

--- a/base/silent/src/test/java/org/openscience/cdk/silent/AtomTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/AtomTest.java
@@ -124,7 +124,7 @@ public class AtomTest extends AbstractAtomTest {
         IAtom a = new Atom("O-");
         Assert.assertEquals("O", a.getSymbol());
         Assert.assertEquals((Integer) 8, a.getAtomicNumber());
-        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals(null, a.getImplicitHydrogenCount());
         Assert.assertEquals(Integer.valueOf(-1), a.getFormalCharge());
         Assert.assertNull(a.getPoint2d());
         Assert.assertNull(a.getPoint3d());
@@ -136,7 +136,7 @@ public class AtomTest extends AbstractAtomTest {
         IAtom a = new Atom("Ca+2");
         Assert.assertEquals("Ca", a.getSymbol());
         Assert.assertEquals((Integer) 20, a.getAtomicNumber());
-        Assert.assertEquals((Integer) 0, a.getImplicitHydrogenCount());
+        Assert.assertEquals(null, a.getImplicitHydrogenCount());
         Assert.assertEquals(Integer.valueOf(+2), a.getFormalCharge());
         Assert.assertNull(a.getPoint2d());
         Assert.assertNull(a.getPoint3d());
@@ -254,10 +254,10 @@ public class AtomTest extends AbstractAtomTest {
     
     @Test
     public void testNewAtomImplicitHydrogenCount() {
-        Assert.assertNotNull(new Atom("C").getImplicitHydrogenCount());
-        Assert.assertNotNull(new Atom("*").getImplicitHydrogenCount());
-        Assert.assertNotNull(new Atom("H").getImplicitHydrogenCount());
-        Assert.assertNotNull(new Atom("D").getImplicitHydrogenCount());
-        Assert.assertNotNull(new Atom("T").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("C").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("*").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("H").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("D").getImplicitHydrogenCount());
+        Assert.assertNull(new Atom("T").getImplicitHydrogenCount());
     }   
 }

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptor.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.qsar.AbstractMolecularDescriptor;
@@ -115,6 +116,10 @@ public class AcidicGroupCountDescriptor extends AbstractMolecularDescriptor impl
         }
 
         atomContainer = clone(atomContainer); // don't mod original
+        for (IAtom atom : atomContainer.atoms()) {
+            if (atom.getImplicitHydrogenCount() == null)
+                atom.setImplicitHydrogenCount(0);
+        }
 
         // do aromaticity detection
         if (this.checkAromaticity) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/BasicGroupCountDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/BasicGroupCountDescriptor.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.qsar.AbstractMolecularDescriptor;
@@ -98,6 +99,10 @@ public class BasicGroupCountDescriptor extends AbstractMolecularDescriptor imple
         }
 
         atomContainer = clone(atomContainer);
+        for (IAtom atom : atomContainer.atoms()) {
+            if (atom.getImplicitHydrogenCount() == null)
+                atom.setImplicitHydrogenCount(0);
+        }
 
         try {
             int count = 0;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/KierHallSmartsDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/KierHallSmartsDescriptor.java
@@ -21,6 +21,7 @@ package org.openscience.cdk.qsar.descriptors.molecular;
 
 import org.openscience.cdk.config.fragments.EStateFragments;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.qsar.AbstractMolecularDescriptor;
 import org.openscience.cdk.qsar.DescriptorSpecification;
@@ -389,6 +390,10 @@ public class KierHallSmartsDescriptor extends AbstractMolecularDescriptor implem
         IAtomContainer atomContainer;
         try {
             atomContainer = (IAtomContainer) container.clone();
+            for (IAtom atom : atomContainer.atoms()) {
+                if (atom.getImplicitHydrogenCount() == null)
+                    atom.setImplicitHydrogenCount(0);
+            }
             atomContainer = AtomContainerManipulator.removeHydrogens(atomContainer);
         } catch (CloneNotSupportedException e) {
             return getDummyDescriptorValue(new CDKException("Error during clone"));

--- a/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
+++ b/tool/tautomer/src/main/java/org/openscience/cdk/tautomers/InChITautomerGenerator.java
@@ -155,6 +155,10 @@ public final class InChITautomerGenerator {
 
         // shallow copy since we will suppress hydrogens
         mol = mol.getBuilder().newInstance(IAtomContainer.class, mol);
+        for (IAtom atom : mol.atoms()) {
+            if (atom.getImplicitHydrogenCount() == null)
+                atom.setImplicitHydrogenCount(0);
+        }
 
         List<IAtomContainer> tautomers = new ArrayList<IAtomContainer>();
         if (!inchi.contains("(H")) { //No mobile H atoms according to InChI, so bail out.


### PR DESCRIPTION
It returns different value between new Atom("H").getImplicitHydrogenCount() and new Atom("D").getImplicitHydrogenCount(). 
Additionally, behaviors of new Atom(String) are different between org.openscience.cdk.Atom package and org.openscience.cdk.silent.
Several tests are failed because they expect to set null as implicitHydrogenCount.