### PR TITLE
Add FractionalCSP3Descriptor known as Fsp3

### DIFF
--- a/base/dict/src/main/resources/org/openscience/cdk/dict/data/descriptor-algorithms.owl
+++ b/base/dict/src/main/resources/org/openscience/cdk/dict/data/descriptor-algorithms.owl
@@ -1101,6 +1101,23 @@
         <isClassifiedAs rdf:resource="#electronicDescriptor"/>
     </Descriptor>
 
+    <Descriptor rdf:ID="Fsp3">
+        <rdfs:label>Number of sp3 hybridized carbons/total carbon count</rdfs:label>
+        <annotation>
+            <documentation>
+                <dc:contributor rdf:resource="#ku"/>
+                <dc:date>2018-10-14</dc:date>
+            </documentation>
+        </annotation>
+        <definition rdf:parseType='Literal'>
+            Returns the number of sp3 hybridized carbons divided by total carbon count.
+        </definition>
+        <description rdf:parseType='Literal'>
+            This descriptor is described by Lovering et al <bibtex:cite ref="Lovering2009"/>.
+        </description>
+        <isClassifiedAs rdf:resource="#molecularDescriptor"/>
+    </Descriptor>
+    
     <Descriptor rdf:ID="gravitationalIndex">
         <rdfs:label>Gravitational Index</rdfs:label>
         <annotation>

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/FractionalCSP3Descriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/FractionalCSP3Descriptor.java
@@ -1,0 +1,137 @@
+/* Copyright (c) 2018 Kazuya Ujihara <ujihara.kazuya@gmail.com>
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ * All we ask is that proper credit is given for our work, which includes
+ * - but is not limited to - adding the above copyright notice to the beginning
+ * of your source code files, and to any copyright notice that you may distribute
+ * with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openscience.cdk.qsar.descriptors.molecular;
+
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IAtomType.Hybridization;
+import org.openscience.cdk.qsar.AbstractMolecularDescriptor;
+import org.openscience.cdk.qsar.DescriptorSpecification;
+import org.openscience.cdk.qsar.DescriptorValue;
+import org.openscience.cdk.qsar.IMolecularDescriptor;
+import org.openscience.cdk.qsar.result.DoubleResult;
+import org.openscience.cdk.qsar.result.DoubleResultType;
+import org.openscience.cdk.qsar.result.IDescriptorResult;
+import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+
+/**
+ * An implementation of the Fractional CSP3 descriptor characterizing non-flatness of a molecule.
+ * 
+ * This descriptor returns a single double value, labeled as "Fsp3"
+ * 
+ * @author Kazuya Ujihara
+ * @cdk.module qsarmolecular
+ * @cdk.dictref qsar-descriptors:Fsp3
+ * @cdk.githash
+ */
+public class FractionalCSP3Descriptor extends AbstractMolecularDescriptor implements IMolecularDescriptor {
+    public FractionalCSP3Descriptor() { }
+    
+
+    /** {@inheritDoc} */
+    @Override
+    public DescriptorSpecification getSpecification() {
+        return new DescriptorSpecification("http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Fsp3",
+                this.getClass().getName(), "The Chemistry Development Kit");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String[] getParameterNames() {
+        return new String[0];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Object getParameterType(String name) {
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setParameters(Object[] params) throws CDKException {
+        if (params.length != 0) {
+            throw new CDKException("The FractionalCSP3Descriptor expects zero parameters");
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Object[] getParameters() {
+        return new Object[0];
+    }
+
+    /**
+     * Calculates the Fsp<sup>3</sup> descriptor value for the given {@link IAtomContainer}.
+     *
+     * @param container An {@link org.openscience.cdk.interfaces.IAtomContainer} for which this descriptor
+     *                  should be calculated
+     * @return An object of {@link org.openscience.cdk.qsar.DescriptorValue} that contains the
+     *         calculated Fsp<sup>3</sup> descriptor value
+     */
+    @Override
+    public DescriptorValue calculate(IAtomContainer mol) {
+        try {
+            mol = mol.clone();
+        } catch (CloneNotSupportedException ex) {
+        }
+        
+        int nC = 0;
+        int nCSP3 = 0;
+        DoubleResult result;
+        try {
+            AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
+            for (IAtom atom: mol.atoms()) {
+                if (atom.getAtomicNumber() == 6) {
+                    nC++;
+                    if (atom.getHybridization() == Hybridization.SP3)
+                        nCSP3++;
+                }
+            }
+            result = new DoubleResult(nC == 0 ? 0 : (double)nCSP3 / nC);
+        }
+        catch (CDKException e) {
+            result = new DoubleResult(Double.NaN);
+        }
+        
+        return new DescriptorValue(getSpecification(), getParameterNames(), getParameters(), result,
+                getDescriptorNames());
+    }
+
+    /**
+     * Returns the specific type of the Fsp3 descriptor value.
+     *
+     * The Fsp3 descriptor is a single, double value.
+     *
+     * @return an instance of the {@link org.openscience.cdk.qsar.result.DoubleResultType}
+     */
+    @Override
+    public IDescriptorResult getDescriptorResultType() {
+        return new DoubleResultType();
+    }
+
+    @Override
+    public String[] getDescriptorNames() {
+        return new String[]{"Fsp3"};
+    }
+}

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FractionalCSP3DescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FractionalCSP3DescriptorTest.java
@@ -1,0 +1,71 @@
+/* Copyright (c) 2018 Kazuya Ujihara <ujihara.kazuya@gmail.com>
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ * All we ask is that proper credit is given for our work, which includes
+ * - but is not limited to - adding the above copyright notice to the beginning
+ * of your source code files, and to any copyright notice that you may distribute
+ * with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openscience.cdk.qsar.descriptors.molecular;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.qsar.result.DoubleResult;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
+
+public class FractionalCSP3DescriptorTest extends MolecularDescriptorTest {
+    public FractionalCSP3DescriptorTest() {}
+    
+    @Before
+    public void setUp() throws Exception {
+        setDescriptor(FractionalCSP3Descriptor.class);
+    }
+    
+    static class SmilesValue {
+        public SmilesValue(String smiles, double value) {
+            this.smiles = smiles;
+            this.value = value;
+        }
+        public String smiles;
+        public double value;
+    }
+    
+    private static final SmilesValue[] table = new SmilesValue[] {
+            new SmilesValue("HH", 0),
+            new SmilesValue("HOH", 0),
+            new SmilesValue("C1=CC=CC=C1", 0),
+            new SmilesValue("C1=CN=CC=C1", 0),
+            new SmilesValue("CC1=CC=CC(C)=N1", 0.29),
+            new SmilesValue("CC1CCCC(C)N1", 1),
+            new SmilesValue("CC1=NC(NC(NC2CN(C3=CC=CC(F)=C3)C(C2)=O)=O)=CC=C1", 0.24),
+    };
+    
+    @Test
+    public void testFractionalCSP3Descriptor() throws CDKException {
+        SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        for (SmilesValue e: table) {
+            IAtomContainer mol = sp.parseSmiles(e.smiles);
+            DoubleResult result = (DoubleResult)descriptor.calculate(mol).getValue();
+            Assert.assertEquals(e.value, result.doubleValue(), 0.01);
+        }
+    }
+}


### PR DESCRIPTION
Implement Fsp<sup>3</sup> descriptor as FractionalCSP3Descriptor. This descriptor has been widely used in recent years.

Lovering, F.; Bikker, J.; Humblet, C. Escape from Flatland: Increasing Saturation as an Approach to Improving Clinical Success. _J. Med. Chem._ **2009**, _52_, 6752–6756.