### PR TITLE
Add FractionalCSP3Descriptor line to services info

### DIFF
--- a/descriptor/qsarmolecular/src/main/resources/META-INF/services/org.openscience.cdk.qsar.IMolecularDescriptor
+++ b/descriptor/qsarmolecular/src/main/resources/META-INF/services/org.openscience.cdk.qsar.IMolecularDescriptor
@@ -1,4 +1,5 @@
 # Molecular QSAR descriptors
+org.openscience.cdk.qsar.descriptors.molecular.FractionalCSP3Descriptor
 org.openscience.cdk.qsar.descriptors.molecular.SmallRingDescriptor
 org.openscience.cdk.qsar.descriptors.molecular.FractionalPSADescriptor
 org.openscience.cdk.qsar.descriptors.molecular.ZagrebIndexDescriptor


### PR DESCRIPTION
We forgot to need to add "org.openscience.cdk.qsar.descriptors.molecular.FractionalCSP3Descriptor" line to "resources\META-INF\services\org.openscience.cdk.qsar.IMolecularDescriptor".