### PR TITLE
Patch/rxn depict 16oct18

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -385,7 +385,8 @@ public class Abbreviations implements Iterable<String> {
                             best = sgroup2;
                     }
 
-                    return Collections.singletonList(best);
+                    if (best != null)
+                        return Collections.singletonList(best);
                 }
 
             } catch (CDKException ignored) {

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -272,6 +272,28 @@ public class AbbreviationsTest {
         assertThat(sgroups.get(0).getSubscript(), is("HOOH"));
     }
 
+    @Test public void multipleDisconnectedAbbreviations() throws Exception {
+        String smi = "ClCCl.Cl[Pd]Cl.[Fe+2].c1ccc(P([c-]2cccc2)c2ccccc2)cc1.c1ccc(P([c-]2cccc2)c2ccccc2)cc1";
+        Abbreviations factory = new Abbreviations();
+        factory.add("ClCCl DCM");
+        factory.add("Cl[Pd]Cl.[Fe+2].c1ccc(P([c-]2cccc2)c2ccccc2)cc1.c1ccc(P([c-]2cccc2)c2ccccc2)cc1 Pd(dppf)Cl2");
+        IAtomContainer mol = smi(smi);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("Pd(dppf)Cl2·DCM"));
+    }
+
+    @Test public void multipleDisconnectedAbbreviations2() throws Exception {
+        String smi = "ClCCl.Cl[Pd]Cl.[Fe+2].c1ccc(P([c-]2cccc2)c2ccccc2)cc1.c1ccc(P([c-]2cccc2)c2ccccc2)cc1";
+        Abbreviations factory = new Abbreviations();
+        factory.add("Cl[Pd]Cl.[Fe+2].c1ccc(P([c-]2cccc2)c2ccccc2)cc1.c1ccc(P([c-]2cccc2)c2ccccc2)cc1 Pd(dppf)Cl2");
+        factory.add("Cl[Pd]Cl PdCl2");
+        IAtomContainer mol = smi(smi);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("Pd(dppf)Cl2"));
+    }
+
     @Test
     public void loadFromFile() throws Exception {
         Abbreviations factory = new Abbreviations();

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -940,15 +940,14 @@ public class AtomPlacer {
      * -C=[N+]=N
      * -N=[N+]=N
      */
-    boolean isColinear(IAtom atom, List<IBond> bonds) {
-        if (bonds.size() != 2)
-            return false;
-
+    static boolean isColinear(IAtom atom, Iterable<IBond> bonds) {
         int numSgl = atom.getImplicitHydrogenCount() == null ? 0 : atom.getImplicitHydrogenCount();
         int numDbl = 0;
         int numTpl = 0;
+        int count  = 0;
 
         for (IBond bond : bonds) {
+            ++count;
             switch (bond.getOrder()) {
                 case SINGLE:
                     numSgl++;
@@ -965,6 +964,9 @@ public class AtomPlacer {
                     return false;
             }
         }
+
+        if (count != 2)
+            return false;
 
         switch (atom.getAtomicNumber()) {
             case 6:

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -236,6 +236,8 @@ public class StructureDiagramGenerator {
                 afix.clear();
                 bfix.clear();
 
+                boolean aggresive = false;
+
                 if (largest != null && largest.getAtomCount() > 1) {
 
                     int idx = largest.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
@@ -246,12 +248,21 @@ public class StructureDiagramGenerator {
                         idx = atom.getProperty(CDKConstants.ATOM_ATOM_MAPPING);
                         final IAtom src = reference.get(idx);
                         if (src == null) continue;
+                        if (!aggresive) {
+                            // no way to get the container of 'src' without
+                            // lots of refactoring, instead we just use the
+                            // new API points - first checking these will not
+                            // fail
+                            if (src.getContainer() != null
+                                && atom.getContainer() != null
+                                && AtomPlacer.isColinear(src, src.bonds())
+                                   != AtomPlacer.isColinear(atom, atom.bonds()))
+                                continue;
+                        }
                         atom.setPoint2d(new Point2d(src.getPoint2d()));
                         afix.put(atom, src);
                     }
                 }
-
-                boolean aggresive = false;
 
                 if (!afix.isEmpty()) {
                     if (aggresive) {


### PR DESCRIPTION
1) As per #270, improved alignment of reactions, this case was cumulated bond being bent to 30 degrees when it should not be.

2) Better abbreviation of multiple component molecules

![image](https://user-images.githubusercontent.com/983232/47152928-f11ee180-d2d5-11e8-8028-efc2841e2dcf.png)

is now

"Pd(pddf)Cl2 DCM"


