### PR TITLE
Patch/nsmarts finalize

### DIFF
--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
@@ -121,6 +121,13 @@ final class QueryStereoFilter implements Predicate<int[]> {
         return true;
     }
 
+    private static int indexOf(int[] xs, int x) {
+        for (int i = 0; i < xs.length; i++)
+            if (xs[x] == x)
+                return i;
+        return -1;
+    }
+
     /**
      * Verify the tetrahedral stereo-chemistry (clockwise/anticlockwise) of atom
      * {@code u} is preserved in the target when the {@code mapping} is used.
@@ -156,15 +163,13 @@ final class QueryStereoFilter implements Predicate<int[]> {
         // adjustment needed for implicit neighbor (H or lone pair)
         int focusIdx = targetMap.get(targetAtom);
         for (int i = 0; i < 4; i++) {
-            int j = 0, k = 0;
-            for (; j < 4; j++) {
-                if (vs[i] == us[j])
-                    break;
-                if (us[j] == focusIdx)
-                    k = j;
-            }
-            if (j == 4)
-                us[k] = vs[i];
+            // find mol neighbor in mapped query list
+            int j = indexOf(us, vs[i]);
+            // not found then it was implicit, replace the implicit neighbor
+            // (which we store as focusIdx) with this neighbor
+            if (j < 0)
+                us[indexOf(us, focusIdx)] = vs[i];
+
         }
 
         int parity = permutationParity(us)

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
@@ -123,7 +123,7 @@ final class QueryStereoFilter implements Predicate<int[]> {
 
     private static int indexOf(int[] xs, int x) {
         for (int i = 0; i < xs.length; i++)
-            if (xs[x] == x)
+            if (xs[i] == x)
                 return i;
         return -1;
     }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/Expr.java
@@ -492,8 +492,12 @@ public final class Expr {
         } else if (expr.type != Type.TRUE &&
                    expr.type != Type.FALSE &&
                    expr.type != Type.NONE) {
-            if (type.isLogical() && !expr.type.isLogical())
-                setLogical(Type.OR, expr, new Expr(this));
+            if (type.isLogical() && !expr.type.isLogical()) {
+                if (type == OR)
+                    right.or(expr);
+                else
+                    setLogical(Type.OR, expr, new Expr(this));
+            }
             else
                 setLogical(Type.OR, new Expr(this), expr);
         }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
@@ -1645,6 +1645,75 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
         this.stereoElements.addAll(elements);
     }
 
+    /**
+     * Create a query from a molecule and a provided set of expressions. The
+     * molecule is converted and any features specified in the {@code opts}
+     * will be matched. <br><br>
+     * A good starting point is the following options:
+     * <pre>{@code
+     * // [nH]1ccc(=O)cc1 => n1:c:c:c(=O):c:c:1
+     * QueryAtomContainer.create(mol, ALIPHATIC_ELEMENT,
+     *                                AROMATIC_ELEMENT,
+     *                                SINGLE_OR_AROMATIC,
+     *                                ALIPHATIC_ORDER,
+     *                                STEREOCHEMISTRY);
+     * }</pre>
+     * <br>
+     * Specifying {@link Expr.Type#DEGREE} (or {@link Expr.Type#TOTAL_DEGREE} +
+     * {@link Expr.Type#IMPL_H_COUNT}) means the molecule will not match as a
+     * substructure.
+     * <br>
+     * <pre>{@code
+     * // [nH]1ccc(=O)cc1 => [nD2]1:[cD2]:[cD2]:[cD2](=[OD1]):[cD2]:[cD2]:1
+     * QueryAtomContainer.create(mol, ALIPHATIC_ELEMENT,
+     *                                AROMATIC_ELEMENT,
+     *                                DEGREE,
+     *                                SINGLE_OR_AROMATIC,
+     *                                ALIPHATIC_ORDER);
+     * }</pre>
+     * <br>
+     * The {@link Expr.Type#RING_BOND_COUNT} property is useful for locking in
+     * ring systems. Specifying the ring bond count on benzene means it will
+     * not match larger ring systems (e.g. naphthalenee) but can still be
+     * substituted.
+     * <br>
+     * <pre>{@code
+     * // [nH]1ccc(=O)cc1 =>
+     * //   [nx2+0]1:[cx2+0]:[cx2+0]:[cx2+0](=[O&x0+0]):[cx2+0]:[cx2+0]:1
+     * // IMPORTANT! use Cycles.markRingAtomsAndBonds(mol) to set ring status
+     * QueryAtomContainer.create(mol, ALIPHATIC_ELEMENT,
+     *                                AROMATIC_ELEMENT,
+     *                                FORMAL_CHARGE,
+     *                                ISOTOPE,
+     *                                RING_BOND_COUNT,
+     *                                SINGLE_OR_AROMATIC,
+     *                                ALIPHATIC_ORDER);
+     * }</pre>
+     * <br>
+     * Note that {@link Expr.Type#FORMAL_CHARGE},
+     * {@link Expr.Type#IMPL_H_COUNT}, and {@link Expr.Type#ISOTOPE} are ignored
+     * if null. Explicitly setting these to zero (only required for Isotope from
+     * SMILES) forces their inclusion.
+     * <br>
+     * <pre>{@code
+     * // [nH]1ccc(=O)cc1 =>
+     * //   [0n+0]1:[0c+0]:[0c+0]:[0c+0](=[O+0]):[0c+0]:[0c+0]:1
+     * QueryAtomContainer.create(mol, ALIPHATIC_ELEMENT,
+     *                                AROMATIC_ELEMENT,
+     *                                FORMAL_CHARGE,
+     *                                ISOTOPE,
+     *                                RING_BOND_COUNT,
+     *                                SINGLE_OR_AROMATIC,
+     *                                ALIPHATIC_ORDER);
+     * }</pre>
+     *
+     * Please note not all {@link Expr.Type}s are currently supported, if you
+     * require a specific type that you think is useful please open an issue.
+     *
+     * @param mol the molecule
+     * @param opts set of the expr types to match
+     * @return the query molecule
+     */
     public static QueryAtomContainer create(IAtomContainer mol, Expr.Type... opts) {
         Set<Expr.Type> optset = EnumSet.noneOf(Expr.Type.class);
         optset.addAll(Arrays.asList(opts));
@@ -1659,6 +1728,10 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
 
         for (IAtom atom : mol.atoms()) {
             Expr expr = new Expr();
+
+            // isotope first
+            if (optset.contains(ISOTOPE) && atom.getMassNumber() != null)
+                expr.and(new Expr(ISOTOPE, atom.getMassNumber()));
 
             if (atom.getAtomicNumber() != null &&
                 atom.getAtomicNumber() != 0) {
@@ -1708,10 +1781,16 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
                 expr.and(new Expr(atom.isInRing() ? IS_IN_RING : IS_IN_CHAIN));
             if (optset.contains(IMPL_H_COUNT))
                 expr.and(new Expr(IMPL_H_COUNT));
+            if (optset.contains(RING_BOND_COUNT)) {
+                int rbonds = 0;
+                for (IBond bond : mol.getConnectedBondsList(atom))
+                    if (bond.isInRing())
+                        rbonds++;
+
+                expr.and(new Expr(RING_BOND_COUNT, rbonds));
+            }
             if (optset.contains(FORMAL_CHARGE) && atom.getFormalCharge() != null)
                 expr.and(new Expr(FORMAL_CHARGE, atom.getFormalCharge()));
-            if (optset.contains(ISOTOPE) && atom.getMassNumber() != null)
-                expr.and(new Expr(ISOTOPE, atom.getMassNumber()));
 
             IStereoElement se = stereos.get(atom);
             if (se != null &&

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainerCreator.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainerCreator.java
@@ -18,34 +18,33 @@
  */
 package org.openscience.cdk.isomorphism.matchers;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import com.google.common.collect.FluentIterable;
-import org.openscience.cdk.CDKConstants;
-import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.interfaces.IChemObject;
-import org.openscience.cdk.interfaces.IChemObjectBuilder;
-import org.openscience.cdk.interfaces.IPseudoAtom;
-import org.openscience.cdk.interfaces.IStereoElement;
+
+import java.util.Iterator;
 
 /**
- *@cdk.module   isomorphism
- * @cdk.githash
+ * Utilities for creating queries from 'real' molecules. Note that most of this
+ * functionality has now been replaced by the
+ * {@link QueryAtomContainer#create(IAtomContainer, Expr.Type...)} method and
+ * the documentation simply indicates what settings are used.
  */
 public class QueryAtomContainerCreator {
 
     /**
-     * Creates a QueryAtomContainer with SymbolQueryAtom's, AromaticQueryBond's and
-     * OrderQueryBond's. If a IBond of the input <code>container</code> is flagged
-     * aromatic, then it disregards bond order information and only match against
-     * an aromatic target atom instead.
+     * Creates a QueryAtomContainer with the following settings:
      *
-     *@param  container  The AtomContainer that stands as model
-     *@return            The new QueryAtomContainer created from container.
+     * <pre>
+     * QueryAtomContainer.create(container,
+     *                           Expr.Type.ALIPHATIC_ELEMENT,
+     *                           Expr.Type.AROMATIC_ELEMENT,
+     *                           Expr.Type.IS_AROMATIC,
+     *                           Expr.Type.ALIPHATIC_ORDER,
+     *                           Expr.Type.STEREOCHEMISTRY);
+     * </pre>
+     *
+     * @param container The AtomContainer that stands as model
+     * @return The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createBasicQueryContainer(IAtomContainer container) {
         return QueryAtomContainer.create(container,
@@ -57,11 +56,16 @@ public class QueryAtomContainerCreator {
     }
 
     /**
-     * Creates a QueryAtomContainer with SymbolQueryAtom's and OrderQueryBond's. Unlike
-     * <code>createBasicQueryContainer</code>, it disregards aromaticity flags.
+     * Creates a QueryAtomContainer with the following settings:
      *
-     * @param  container  The AtomContainer that stands as model
-     * @return            The new QueryAtomContainer created from container.
+     * <pre>
+     * QueryAtomContainer.create(container,
+     *                           Expr.Type.ELEMENT,
+     *                           Expr.Type.ORDER);
+     * </pre>
+     *
+     * @param container The AtomContainer that stands as model
+     * @return The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createSymbolAndBondOrderQueryContainer(IAtomContainer container) {
         return QueryAtomContainer.create(container,
@@ -70,11 +74,18 @@ public class QueryAtomContainerCreator {
     }
 
     /**
-     *  Creates a QueryAtomContainer with SymbolAncChargeQueryAtom's and
-     *  OrderQueryBond's.
+     * Creates a QueryAtomContainer with the following settings:
      *
-     *@param  container  The AtomContainer that stands as model
-     *@return            The new QueryAtomContainer created from container.
+     * <pre>
+     * QueryAtomContainer.create(container,
+     *                           Expr.Type.ELEMENT,
+     *                           Expr.Type.FORMAL_CHARGE,
+     *                           Expr.Type.IS_AROMATIC,
+     *                           Expr.Type.ORDER);
+     * </pre>
+     *
+     * @param container The AtomContainer that stands as model
+     * @return The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createSymbolAndChargeQueryContainer(IAtomContainer container) {
         return QueryAtomContainer.create(container,
@@ -112,12 +123,21 @@ public class QueryAtomContainerCreator {
     }
 
     /**
-     *  Creates a QueryAtomContainer with AnyAtoms / Aromatic Atoms and OrderQueryBonds / AromaticQueryBonds.
-     *  It uses the CDKConstants.ISAROMATIC flag to determine the aromaticity of container.
+     * Creates a QueryAtomContainer with the following settings:
      *
-     *@param  container    The AtomContainer that stands as model
-     *@param  aromaticity  True = use aromaticity flags to create AtomaticAtoms and AromaticQueryBonds
-     *@return              The new QueryAtomContainer created from container
+     * <pre>
+     * // aromaticity = true
+     * QueryAtomContainer.create(container,
+     *                           Expr.Type.IS_AROMATIC,
+     *                           Expr.Type.ALIPHATIC_ORDER);
+     * // aromaticity = false
+     * QueryAtomContainer.create(container,
+     *                           Expr.Type.ORDER);
+     * </pre>
+     *
+     * @param container The AtomContainer that stands as model
+     * @param aromaticity option flag
+     * @return The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createAnyAtomContainer(IAtomContainer container, boolean aromaticity) {
         if (aromaticity)
@@ -130,14 +150,19 @@ public class QueryAtomContainerCreator {
     }
 
     /**
-     * Creates a QueryAtomContainer with wildcard atoms and wildcard bonds.
+     * Creates a QueryAtomContainer with the following settings:
      *
-     * This method thus allows the user to search based only on connectivity.
+     * <pre>
+     * // aromaticity = true
+     * QueryAtomContainer.create(container,
+     *                           Expr.Type.IS_AROMATIC);
+     * // aromaticity = false
+     * QueryAtomContainer.create(container);
+     * </pre>
      *
-     * @param container   The AtomContainer that stands as the model
-     * @param aromaticity If True, aromaticity flags are checked to create AromaticAtoms
-     *                    and AromaticQueryBonds
-     * @return The new QueryAtomContainer
+     * @param container The AtomContainer that stands as model
+     * @param aromaticity option flag
+     * @return The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createAnyAtomAnyBondContainer(IAtomContainer container, boolean aromaticity) {
         if (aromaticity)
@@ -147,12 +172,17 @@ public class QueryAtomContainerCreator {
     }
 
     /**
-     *  Creates a QueryAtomContainer with SymbolQueryAtom's and
-     *  OrderQueryBond's. Each PseudoAtom will be replaced by a
-     *  AnyAtom
+     * Creates a QueryAtomContainer with the following settings:
      *
-     *@param  container  The AtomContainer that stands as model
-     *@return            The new QueryAtomContainer created from container.
+     * <pre>
+     * QueryAtomContainer.create(container,
+     *                           Expr.Type.ELEMENT,
+     *                           Expr.Type.IS_AROMATIC,
+     *                           Expr.Type.ALIPHATIC_ORDER);
+     * </pre>
+     *
+     * @param container The AtomContainer that stands as model
+     * @return The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createAnyAtomForPseudoAtomQueryContainer(IAtomContainer container) {
         return QueryAtomContainer.create(container,

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainerCreator.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainerCreator.java
@@ -18,14 +18,19 @@
  */
 package org.openscience.cdk.isomorphism.matchers;
 
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
+import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
+import org.openscience.cdk.interfaces.IStereoElement;
 
 /**
  *@cdk.module   isomorphism
@@ -43,33 +48,12 @@ public class QueryAtomContainerCreator {
      *@return            The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createBasicQueryContainer(IAtomContainer container) {
-        QueryAtomContainer queryContainer = new QueryAtomContainer(container.getBuilder());
-        for (int i = 0; i < container.getAtomCount(); i++) {
-            QueryAtom qatom = new QueryAtom(Expr.Type.ELEMENT,
-                                            container.getAtom(i).getAtomicNumber());
-            qatom.setSymbol(container.getAtom(i).getSymbol()); // backwards compatibility
-            queryContainer.addAtom(qatom);
-        }
-        Iterator<IBond> bonds = container.bonds().iterator();
-        while (bonds.hasNext()) {
-            IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBegin());
-            int index2 = container.indexOf(bond.getEnd());
-            if (bond.isAromatic()) {
-                QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                                 queryContainer.getAtom(index2),
-                                                 Expr.Type.IS_AROMATIC);
-                queryContainer.addBond(qbond);
-            } else {
-                QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                                queryContainer.getAtom(index2),
-                                                Expr.Type.ALIPHATIC_ORDER,
-                                                bond.getOrder().numeric());
-                qbond.setOrder(bond.getOrder()); // backwards compatibility
-                queryContainer.addBond(qbond);
-            }
-        }
-        return queryContainer;
+        return QueryAtomContainer.create(container,
+                                         Expr.Type.ALIPHATIC_ELEMENT,
+                                         Expr.Type.AROMATIC_ELEMENT,
+                                         Expr.Type.IS_AROMATIC,
+                                         Expr.Type.ALIPHATIC_ORDER,
+                                         Expr.Type.STEREOCHEMISTRY);
     }
 
     /**
@@ -80,26 +64,9 @@ public class QueryAtomContainerCreator {
      * @return            The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createSymbolAndBondOrderQueryContainer(IAtomContainer container) {
-        QueryAtomContainer queryContainer = new QueryAtomContainer(container.getBuilder());
-        for (int i = 0; i < container.getAtomCount(); i++) {
-            QueryAtom qatom = new QueryAtom(Expr.Type.ELEMENT,
-                                            container.getAtom(i).getAtomicNumber());
-            qatom.setSymbol(container.getAtom(i).getSymbol()); // backwards compatibility
-            queryContainer.addAtom(qatom);
-        }
-        Iterator<IBond> bonds = container.bonds().iterator();
-        while (bonds.hasNext()) {
-            IBond bond = (IBond) bonds.next();
-            int index1 = container.indexOf(bond.getBegin());
-            int index2 = container.indexOf(bond.getEnd());
-            QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                            queryContainer.getAtom(index2),
-                                            Expr.Type.ORDER,
-                                            bond.getOrder().numeric());
-            qbond.setOrder(bond.getOrder()); // backwards compatibility
-            queryContainer.addBond(qbond);
-        }
-        return queryContainer;
+        return QueryAtomContainer.create(container,
+                                         Expr.Type.ELEMENT,
+                                         Expr.Type.ORDER);
     }
 
     /**
@@ -110,38 +77,11 @@ public class QueryAtomContainerCreator {
      *@return            The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createSymbolAndChargeQueryContainer(IAtomContainer container) {
-        QueryAtomContainer queryContainer = new QueryAtomContainer(container.getBuilder());
-        for (int i = 0; i < container.getAtomCount(); i++) {
-            Expr expr = new Expr(Expr.Type.ELEMENT, container.getAtom(i).getAtomicNumber());
-            Integer q = container.getAtom(i).getFormalCharge();
-            if (q == null) q = 0;
-            expr.and(new Expr(Expr.Type.FORMAL_CHARGE, q));
-            QueryAtom qatom = new QueryAtom(expr);
-            // backwards compatibility
-            qatom.setSymbol(container.getAtom(i).getSymbol());
-            qatom.setFormalCharge(q);
-            queryContainer.addAtom(qatom);
-        }
-        Iterator<IBond> bonds = container.bonds().iterator();
-        while (bonds.hasNext()) {
-            IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBegin());
-            int index2 = container.indexOf(bond.getEnd());
-            if (bond.isAromatic()) {
-                QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                                queryContainer.getAtom(index2),
-                                                Expr.Type.IS_AROMATIC);
-                queryContainer.addBond(qbond);
-            } else {
-                QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                                queryContainer.getAtom(index2),
-                                                Expr.Type.ORDER,
-                                                bond.getOrder().numeric());
-                qbond.setOrder(bond.getOrder()); // backwards compatibility
-                queryContainer.addBond(qbond);
-            }
-        }
-        return queryContainer;
+        return QueryAtomContainer.create(container,
+                                         Expr.Type.ELEMENT,
+                                         Expr.Type.FORMAL_CHARGE,
+                                         Expr.Type.IS_AROMATIC,
+                                         Expr.Type.ORDER);
     }
 
     public static QueryAtomContainer createSymbolChargeIDQueryContainer(IAtomContainer container) {
@@ -180,41 +120,18 @@ public class QueryAtomContainerCreator {
      *@return              The new QueryAtomContainer created from container
      */
     public static QueryAtomContainer createAnyAtomContainer(IAtomContainer container, boolean aromaticity) {
-        QueryAtomContainer queryContainer = new QueryAtomContainer(container.getBuilder());
-
-        for (int i = 0; i < container.getAtomCount(); i++) {
-            if (aromaticity && container.getAtom(i).getFlag(CDKConstants.ISAROMATIC)) {
-                queryContainer.addAtom(new QueryAtom(Expr.Type.IS_AROMATIC));
-            } else {
-                queryContainer.addAtom(new QueryAtom(Expr.Type.TRUE));
-            }
-        }
-
-        Iterator<IBond> bonds = container.bonds().iterator();
-        while (bonds.hasNext()) {
-            IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBegin());
-            int index2 = container.indexOf(bond.getEnd());
-            if (aromaticity && bond.isAromatic()) {
-                QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                                queryContainer.getAtom(index2),
-                                                Expr.Type.IS_AROMATIC);
-                queryContainer.addBond(qbond);
-            } else {
-                QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                                queryContainer.getAtom(index2),
-                                                aromaticity ? Expr.Type.ALIPHATIC_ORDER : Expr.Type.ORDER,
-                                                bond.getOrder().numeric());
-                qbond.setOrder(bond.getOrder()); // backwards compatibility
-                queryContainer.addBond(qbond);
-            }
-        }
-        return queryContainer;
+        if (aromaticity)
+            return QueryAtomContainer.create(container,
+                                             Expr.Type.IS_AROMATIC,
+                                             Expr.Type.ALIPHATIC_ORDER);
+        else
+            return QueryAtomContainer.create(container,
+                                             Expr.Type.ORDER);
     }
 
     /**
      * Creates a QueryAtomContainer with wildcard atoms and wildcard bonds.
-     * 
+     *
      * This method thus allows the user to search based only on connectivity.
      *
      * @param container   The AtomContainer that stands as the model
@@ -223,24 +140,10 @@ public class QueryAtomContainerCreator {
      * @return The new QueryAtomContainer
      */
     public static QueryAtomContainer createAnyAtomAnyBondContainer(IAtomContainer container, boolean aromaticity) {
-        QueryAtomContainer queryContainer = new QueryAtomContainer(container.getBuilder());
-
-        for (int i = 0; i < container.getAtomCount(); i++) {
-            if (aromaticity && container.getAtom(i).getFlag(CDKConstants.ISAROMATIC)) {
-                queryContainer.addAtom(new QueryAtom(Expr.Type.IS_AROMATIC));
-            } else {
-                queryContainer.addAtom(new QueryAtom(Expr.Type.TRUE));
-            }
-        }
-
-        Iterator<IBond> bonds = container.bonds().iterator();
-        while (bonds.hasNext()) {
-            IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBegin());
-            int index2 = container.indexOf(bond.getEnd());
-            queryContainer.addBond(new QueryBond(queryContainer.getAtom(index1), queryContainer.getAtom(index2), Expr.Type.TRUE));
-        }
-        return queryContainer;
+        if (aromaticity)
+            return QueryAtomContainer.create(container, Expr.Type.IS_AROMATIC);
+        else
+            return QueryAtomContainer.create(container);
     }
 
     /**
@@ -252,35 +155,9 @@ public class QueryAtomContainerCreator {
      *@return            The new QueryAtomContainer created from container.
      */
     public static QueryAtomContainer createAnyAtomForPseudoAtomQueryContainer(IAtomContainer container) {
-        QueryAtomContainer queryContainer = new QueryAtomContainer(container.getBuilder());
-        for (int i = 0; i < container.getAtomCount(); i++) {
-            if (container.getAtom(i) instanceof IPseudoAtom) {
-                queryContainer.addAtom(new QueryAtom(Expr.Type.TRUE));
-            } else {
-                queryContainer.addAtom(new QueryAtom(Expr.Type.ELEMENT,
-                                                     container.getAtom(i).getAtomicNumber()));
-            }
-
-        }
-        Iterator<IBond> bonds = container.bonds().iterator();
-        while (bonds.hasNext()) {
-            IBond bond = bonds.next();
-            int index1 = container.indexOf(bond.getBegin());
-            int index2 = container.indexOf(bond.getEnd());
-            if (bond.isAromatic()) {
-                QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                                queryContainer.getAtom(index2),
-                                                Expr.Type.IS_AROMATIC);
-                queryContainer.addBond(qbond);
-            } else {
-                QueryBond qbond = new QueryBond(queryContainer.getAtom(index1),
-                                                queryContainer.getAtom(index2),
-                                                Expr.Type.ORDER,
-                                                bond.getOrder().numeric());
-                qbond.setOrder(bond.getOrder()); // backwards compatibility
-                queryContainer.addBond(qbond);
-            }
-        }
-        return queryContainer;
+        return QueryAtomContainer.create(container,
+                                         Expr.Type.ELEMENT,
+                                         Expr.Type.IS_AROMATIC,
+                                         Expr.Type.ALIPHATIC_ORDER);
     }
 }

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
@@ -1972,6 +1972,9 @@ public final class Smarts {
             case SINGLE_OR_DOUBLE:
                 sb.append("-,=");
                 break;
+            case ORDER:
+                LoggingToolFactory.createLoggingTool(Smarts.class)
+                                  .warn("Expr.Type.ORDER can not be round-tripped via SMARTS!");
             case ALIPHATIC_ORDER:
                 switch (expr.value()) {
                     case 1:

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
@@ -864,7 +864,7 @@ public final class Smarts {
                             default:  // Z=None
                                 unget();
                                 num = nextUnsignedInt();
-                                if (isFlavor(FLAVOR_LOOSE | FLAVOR_DAYLIGHT)) {
+                                if (isFlavor(FLAVOR_DAYLIGHT)) {
                                     if (num < 0)
                                         expr = new Expr(IS_IN_RING);
                                     else if (num == 0)

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
@@ -94,6 +94,10 @@ import static org.openscience.cdk.isomorphism.matchers.Expr.Type.*;
  *         explicit degree 3. '[^2]' means hybridisation (2=Sp2). '[G8]' periodic
  *         group 8</li>
  * </ul>
+ * <br>
+ * In addition to the flavors above CACTVS toolkit style ranges are supported.
+ * For example <code>[D{2-4}]</code> means degree 2, 3, or 4. On writing such
+ * ranges are converted to <code>[D2,D3,D4]</code>.
  */
 public final class Smarts {
 
@@ -1974,7 +1978,7 @@ public final class Smarts {
                 break;
             case ORDER:
                 LoggingToolFactory.createLoggingTool(Smarts.class)
-                                  .warn("Expr.Type.ORDER can not be round-tripped via SMARTS!");
+                                  .warn("Expr.Type.ORDER cannot be round-tripped via SMARTS!");
             case ALIPHATIC_ORDER:
                 switch (expr.value()) {
                     case 1:

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/MolToQueryTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/MolToQueryTest.java
@@ -25,6 +25,7 @@ package org.openscience.cdk.smarts;
 
 import org.junit.Test;
 import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -45,6 +46,7 @@ public class MolToQueryTest {
 
     private void test(String expected, String smi, Expr.Type... opts) throws InvalidSmilesException {
         IAtomContainer      mol   = smipar.parseSmiles(smi);
+        Cycles.markRingAtomsAndBonds(mol);
         IQueryAtomContainer query = QueryAtomContainer.create(mol, opts);
         String actual = Smarts.generate(query);
         assertThat(actual, is(expected));
@@ -86,20 +88,24 @@ public class MolToQueryTest {
              Expr.Type.ELEMENT, Expr.Type.DEGREE);
     }
 
-    @Test public void test() {
-        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
-        IAtomContainer query2 = builder.newInstance(IAtomContainer.class);
-        query2.addAtom(builder.newInstance(IAtom.class, "C"));
-        query2.addAtom(builder.newInstance(IAtom.class, "C"));
-        query2.addAtom(builder.newInstance(IAtom.class, "C"));
-        query2.addAtom(builder.newInstance(IAtom.class, "C"));
-        query2.addAtom(builder.newInstance(IAtom.class, "C"));
-        query2.addAtom(builder.newInstance(IAtom.class, "C"));
-        query2.addBond(0, 1, IBond.Order.DOUBLE);
-        query2.addBond(1, 2, IBond.Order.SINGLE);
-        query2.addBond(3, 0, IBond.Order.SINGLE);
-        query2.addBond(0, 4, IBond.Order.SINGLE);
-        query2.addBond(1, 5, IBond.Order.SINGLE);
-        System.out.println(Smarts.generate(QueryAtomContainerCreator.createSymbolAndBondOrderQueryContainer(query2)));
+    @Test
+    public void complexDocExample() throws InvalidSmilesException {
+        test("[nx2+0]1:[cx2+0]:[cx2+0]:[cx2+0](=[O&x0+0]):[cx2+0]:[cx2+0]:1",
+             "[nH]1ccc(=O)cc1",
+             Expr.Type.ALIPHATIC_ELEMENT,
+             Expr.Type.AROMATIC_ELEMENT,
+             Expr.Type.SINGLE_OR_AROMATIC,
+             Expr.Type.ALIPHATIC_ORDER,
+             Expr.Type.ISOTOPE,
+             Expr.Type.RING_BOND_COUNT,
+             Expr.Type.FORMAL_CHARGE);
+        test("[0n+0]1:[0c+0]:[0c+0]:[0c+0](=[O+0]):[0c+0]:[0c+0]:1",
+             "[0nH]1[0cH][0cH][0cH](=O)[0cH][0cH]1",
+             Expr.Type.ALIPHATIC_ELEMENT,
+             Expr.Type.AROMATIC_ELEMENT,
+             Expr.Type.SINGLE_OR_AROMATIC,
+             Expr.Type.ALIPHATIC_ORDER,
+             Expr.Type.ISOTOPE,
+             Expr.Type.FORMAL_CHARGE);
     }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/MolToQueryTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/MolToQueryTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2018  The Chemistry Development Kit (CDK) project
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.smarts;
+
+import org.junit.Test;
+import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.isomorphism.matchers.Expr;
+import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainerCreator;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class MolToQueryTest {
+
+    private final SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+
+    private void test(String expected, String smi, Expr.Type... opts) throws InvalidSmilesException {
+        IAtomContainer      mol   = smipar.parseSmiles(smi);
+        IQueryAtomContainer query = QueryAtomContainer.create(mol, opts);
+        String actual = Smarts.generate(query);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void noOptsSpecified() throws InvalidSmilesException {
+        test("*1~*~*~*~*~*~1~*", "c1cccnc1C");
+    }
+
+    @Test
+    public void aromaticWithBonds() throws InvalidSmilesException {
+        test("a1:a:a:a:a:a:1-A", "c1cccnc1C",
+             Expr.Type.IS_AROMATIC,
+             Expr.Type.IS_ALIPHATIC,
+             Expr.Type.SINGLE_OR_AROMATIC);
+    }
+
+    @Test
+    public void aromaticElementWithBonds() throws InvalidSmilesException {
+        test("c1:c:c:c:n:c:1-*", "c1cccnc1C",
+             Expr.Type.AROMATIC_ELEMENT,
+             Expr.Type.SINGLE_OR_AROMATIC);
+        test("c1:c:c:c:n:c:1-[#6]", "c1cccnc1C",
+             Expr.Type.IS_AROMATIC,
+             Expr.Type.ELEMENT,
+             Expr.Type.SINGLE_OR_AROMATIC);
+    }
+
+    @Test
+    public void pseudoAtoms() throws InvalidSmilesException {
+        test("[#6]~[#6]~*", "CC*",
+             Expr.Type.ELEMENT);
+    }
+
+    @Test
+    public void elementAndDegree() throws InvalidSmilesException {
+        test("[#6D2]1~[#6D2]~[#6D2]~[#6D2]~[#7D2]~[#6D3]~1~[#6D]", "c1cccnc1C",
+             Expr.Type.ELEMENT, Expr.Type.DEGREE);
+    }
+
+    @Test public void test() {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
+        IAtomContainer query2 = builder.newInstance(IAtomContainer.class);
+        query2.addAtom(builder.newInstance(IAtom.class, "C"));
+        query2.addAtom(builder.newInstance(IAtom.class, "C"));
+        query2.addAtom(builder.newInstance(IAtom.class, "C"));
+        query2.addAtom(builder.newInstance(IAtom.class, "C"));
+        query2.addAtom(builder.newInstance(IAtom.class, "C"));
+        query2.addAtom(builder.newInstance(IAtom.class, "C"));
+        query2.addBond(0, 1, IBond.Order.DOUBLE);
+        query2.addBond(1, 2, IBond.Order.SINGLE);
+        query2.addBond(3, 0, IBond.Order.SINGLE);
+        query2.addBond(0, 4, IBond.Order.SINGLE);
+        query2.addBond(1, 5, IBond.Order.SINGLE);
+        System.out.println(Smarts.generate(QueryAtomContainerCreator.createSymbolAndBondOrderQueryContainer(query2)));
+    }
+}

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
@@ -903,48 +903,48 @@ public class SmartsExprReadTest {
     @Test
     public void degreeRange() {
         Expr expr = getAtomExpr("[D{1-3}]");
-        assertThat(expr, is(or(expr(DEGREE, 3),
-                               or(expr(DEGREE, 1),
-                                  expr(DEGREE, 2)))));
+        assertThat(expr, is(or(expr(DEGREE, 1),
+                               or(expr(DEGREE, 2),
+                                  expr(DEGREE, 3)))));
     }
 
     @Test
     public void implHRange() {
         Expr expr = getAtomExpr("[h{1-3}]");
-        assertThat(expr, is(or(expr(IMPL_H_COUNT, 3),
-                               or(expr(IMPL_H_COUNT, 1),
-                                  expr(IMPL_H_COUNT, 2)))));
+        assertThat(expr, is(or(expr(IMPL_H_COUNT, 1),
+                               or(expr(IMPL_H_COUNT, 2),
+                                  expr(IMPL_H_COUNT, 3)))));
     }
 
     @Test
     public void totalHCountRange() {
         Expr expr = getAtomExpr("[H{1-3}]");
-        assertThat(expr, is(or(expr(TOTAL_H_COUNT, 3),
-                               or(expr(TOTAL_H_COUNT, 1),
-                                  expr(TOTAL_H_COUNT, 2)))));
+        assertThat(expr, is(or(expr(TOTAL_H_COUNT, 1),
+                               or(expr(TOTAL_H_COUNT, 2),
+                                  expr(TOTAL_H_COUNT, 3)))));
     }
 
     @Test
     public void valenceRange() {
         Expr expr = getAtomExpr("[v{1-3}]");
-        assertThat(expr, is(or(expr(VALENCE, 3),
-                               or(expr(VALENCE, 1),
-                                  expr(VALENCE, 2)))));
+        assertThat(expr, is(or(expr(VALENCE, 1),
+                               or(expr(VALENCE, 2),
+                                  expr(VALENCE, 3)))));
     }
 
     @Test
     public void ringBondCountRange() {
         Expr expr = getAtomExpr("[x{2-4}]");
-        assertThat(expr, is(or(expr(RING_BOND_COUNT, 4),
-                               or(expr(RING_BOND_COUNT, 2),
-                                  expr(RING_BOND_COUNT, 3)))));
+        assertThat(expr, is(or(expr(RING_BOND_COUNT, 2),
+                               or(expr(RING_BOND_COUNT, 3),
+                                  expr(RING_BOND_COUNT, 4)))));
     }
 
     @Test
     public void ringSmallestSizeCountRange() {
         Expr expr = getAtomExpr("[r{5-7}]");
-        assertThat(expr, is(or(expr(RING_SMALLEST, 7),
-                               or(expr(RING_SMALLEST, 5),
-                                  expr(RING_SMALLEST, 6)))));
+        assertThat(expr, is(or(expr(RING_SMALLEST, 5),
+                               or(expr(RING_SMALLEST, 6),
+                                  expr(RING_SMALLEST, 7)))));
     }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
@@ -899,4 +899,52 @@ public class SmartsExprReadTest {
         assertTrue(Smarts.parse(new QueryAtomContainer(null), "C-,=1CC-,=1"));
         assertTrue(Smarts.parse(new QueryAtomContainer(null), "C!~1CC!~1"));
     }
+
+    @Test
+    public void degreeRange() {
+        Expr expr = getAtomExpr("[D{1-3}]");
+        assertThat(expr, is(or(expr(DEGREE, 3),
+                               or(expr(DEGREE, 1),
+                                  expr(DEGREE, 2)))));
+    }
+
+    @Test
+    public void implHRange() {
+        Expr expr = getAtomExpr("[h{1-3}]");
+        assertThat(expr, is(or(expr(IMPL_H_COUNT, 3),
+                               or(expr(IMPL_H_COUNT, 1),
+                                  expr(IMPL_H_COUNT, 2)))));
+    }
+
+    @Test
+    public void totalHCountRange() {
+        Expr expr = getAtomExpr("[H{1-3}]");
+        assertThat(expr, is(or(expr(TOTAL_H_COUNT, 3),
+                               or(expr(TOTAL_H_COUNT, 1),
+                                  expr(TOTAL_H_COUNT, 2)))));
+    }
+
+    @Test
+    public void valenceRange() {
+        Expr expr = getAtomExpr("[v{1-3}]");
+        assertThat(expr, is(or(expr(VALENCE, 3),
+                               or(expr(VALENCE, 1),
+                                  expr(VALENCE, 2)))));
+    }
+
+    @Test
+    public void ringBondCountRange() {
+        Expr expr = getAtomExpr("[x{2-4}]");
+        assertThat(expr, is(or(expr(RING_BOND_COUNT, 4),
+                               or(expr(RING_BOND_COUNT, 2),
+                                  expr(RING_BOND_COUNT, 3)))));
+    }
+
+    @Test
+    public void ringSmallestSizeCountRange() {
+        Expr expr = getAtomExpr("[r{5-7}]");
+        assertThat(expr, is(or(expr(RING_SMALLEST, 7),
+                               or(expr(RING_SMALLEST, 5),
+                                  expr(RING_SMALLEST, 6)))));
+    }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
@@ -430,7 +430,7 @@ public class SmartsExprReadTest {
     @Test
     public void ringSize() {
         IAtomContainer mol = new AtomContainer();
-        assertTrue(Smarts.parse(mol, "[Z8]", Smarts.FLAVOR_LOOSE));
+        assertTrue(Smarts.parse(mol, "[Z8]", Smarts.FLAVOR_DAYLIGHT));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(RING_SIZE, 8);
         assertThat(actual, is(expected));
@@ -439,7 +439,7 @@ public class SmartsExprReadTest {
     @Test
     public void ringSize0() {
         IAtomContainer mol = new AtomContainer();
-        assertTrue(Smarts.parse(mol, "[Z0]", Smarts.FLAVOR_LOOSE));
+        assertTrue(Smarts.parse(mol, "[Z0]", Smarts.FLAVOR_DAYLIGHT));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(IS_IN_CHAIN);
         assertThat(actual, is(expected));
@@ -448,7 +448,7 @@ public class SmartsExprReadTest {
     @Test
     public void ringSizeDefault() {
         IAtomContainer mol = new AtomContainer();
-        assertTrue(Smarts.parse(mol, "[Z]", Smarts.FLAVOR_LOOSE));
+        assertTrue(Smarts.parse(mol, "[Z]", Smarts.FLAVOR_DAYLIGHT));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(IS_IN_RING);
         assertThat(actual, is(expected));
@@ -697,7 +697,9 @@ public class SmartsExprReadTest {
     @Test
     public void atomStereoSimpleLeft() {
         Expr actual   = getAtomExpr("[C@H]");
-        System.out.println(actual);
+        assertThat(actual, is(new Expr(ALIPHATIC_ELEMENT, 6)
+                                      .and(new Expr(STEREOCHEMISTRY, 1))
+                                      .and(new Expr(TOTAL_H_COUNT, 1))));
     }
 
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprWriteTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprWriteTest.java
@@ -23,6 +23,7 @@
 
 package org.openscience.cdk.smarts;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
@@ -479,5 +480,11 @@ public class SmartsExprWriteTest {
         assertTrue(Smarts.parse(mol, "C/C=C/C"));
         assertTrue(Smarts.parse(mol, "C/C=C\\C"));
         assertThat(Smarts.generate(mol), is("C/C=C/C.C/C=C\\C"));
+    }
+
+    @Test public void roundTripStereo() {
+        QueryAtomContainer mol = new QueryAtomContainer(null);
+        Smarts.parse(mol, "O1.[S@]=1(C)CC");
+        assertThat(Smarts.generate(mol), is("O=[S@@](C)CC"));
     }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprWriteTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprWriteTest.java
@@ -218,7 +218,7 @@ public class SmartsExprWriteTest {
             .or(new Expr(ELEMENT, 17))
             .or(new Expr(ELEMENT, 35))
             .negate();
-        assertThat(Smarts.generateAtom(expr), is("[!$([Br,F,Cl])]"));
+        assertThat(Smarts.generateAtom(expr), is("[!$([F,Cl,Br])]"));
     }
 
     // or -> and -> or needs to be recursive

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SubstructureTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SubstructureTest.java
@@ -352,6 +352,13 @@ public abstract class SubstructureTest {
         assertMismatch(sma("CC[C@@H](C)O"), smi("CC[C@](C)(N)O"));
     }
 
+    @Test
+    public void sulfoxide() throws Exception {
+        assertMatch(sma("[S@](=O)(C)CC"), smi("O=[S@@](C)CC"), 1);
+        assertMatch(smi("O1.[S@]=1(C)CC"), smi("O=[S@@](C)CC"), 1);
+        assertMatch(sma("O1.[S@]=1(C)CC"), smi("O=[S@@](C)CC"), 1);
+    }
+
     // doesn't matter if the match takes place but it should not cause and error
     // if the query is larger than the target
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SubstructureTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SubstructureTest.java
@@ -347,8 +347,9 @@ public abstract class SubstructureTest {
     }
 
     @Test
-    public void erm() throws Exception {
-        assertMismatch(smi("CC[C@@H](C)O"), smi("CC[C@](C)(N)O"));
+    public void shouldMatchAsSmilesButNotSmarts() throws Exception {
+        // H > 0
+        assertMismatch(sma("CC[C@@H](C)O"), smi("CC[C@](C)(N)O"));
     }
 
     // doesn't matter if the match takes place but it should not cause and error
@@ -396,10 +397,11 @@ public abstract class SubstructureTest {
     // Note: only use simple constructs! the target properties will not
     // currently be initialised. avoid aromaticity, rings etc.
     IAtomContainer sma(String sma) throws Exception {
-        IAtomContainer query = new QueryAtomContainer(null);
+        IAtomContainer query = new QueryAtomContainer(SilentChemObjectBuilder.getInstance());
         if (!Smarts.parse(query, sma)) {
             throw new IOException(Smarts.getLastErrorMesg());
         }
+        query.setTitle(sma);
         return query;
     }
 }


### PR DESCRIPTION
A few more commits, a lot of these are quite small. Mostly should be self explanatory some stereochemistry corner cases needed resolving - I think these were broken in the old Parser too I just didn't notice.

I still need to add update documentation, particularly for ``QueryAtomContainer.create()`` which is 911c4b7, the utility of it is shown in b154fea.