### PR TITLE
Fix signature for getMajorIsotope

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -223,7 +223,7 @@ public class AtomContainerManipulator {
 
             Isotopes isotopes = Isotopes.getInstance();
             double mass = 0.0;
-            double hExactMass = isotopes.getMajorIsotope(1).getExactMass();
+            double hExactMass = isotopes.getMajorIsotope("H").getExactMass();
             for (IAtom atom : atomContainer.atoms()) {
                 if (atom.getImplicitHydrogenCount() == null)
                     throw new IllegalArgumentException("an atom had with unknown (null) implicit hydrogens");
@@ -314,7 +314,7 @@ public class AtomContainerManipulator {
         try {
             Isotopes isotopes = Isotopes.getInstance();
             double abundance = 1.0;
-            double hAbundance = isotopes.getMajorIsotope(1).getNaturalAbundance();
+            double hAbundance = isotopes.getMajorIsotope("H").getNaturalAbundance();
 
             int nImplH = 0;
 


### PR DESCRIPTION
I was trying to debug an issue in rJava related to mass calculation. It seems these hydrogen-related functions use a `1` but he function signatures require a string. 

I've checked this works in rJava.