### PR TITLE
Updated version: 2.20.1 has a forkBooster bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22</version>
                 <configuration>
                     <!-- prevent the annoying ForkedBooter process from stealing
                          window focus on Mac OS -->


### PR DESCRIPTION
On our Jenkins I'm getting a forkBooster exception, which is reported for 2.20.1 (and one other version). An alternative solution is to no allow forking. The phenotype is:

```
Please refer to /var/lib/jenkins/jobs/cdk/workspace/app/depict/target/surefire-reports for the individual test results.
Please refer to dump files (if any exist) [date]-jvmRun[N].dump, [date].dumpstream and [date]-jvmRun[N].dumpstream.
The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
Command was /bin/sh -c cd /var/lib/jenkins/jobs/cdk/workspace/app/depict && /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Djava.awt.headless=true -Dcdk.logging.level=ERROR -jar /var/lib/jenkins/jobs/cdk/workspace/app/depict/target/surefire/surefirebooter4348128345109234029.jar /var/lib/jenkins/jobs/cdk/workspace/app/depict/target/surefire 2018-11-10T13-46-13_110-jvmRun1 surefire5636495753901702235tmp surefire_493219910478475493137tmp
Error occurred in starting fork, check output in log
Process Exit Code: 1
org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
Command was /bin/sh -c cd /var/lib/jenkins/jobs/cdk/workspace/app/depict && /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Djava.awt.headless=true -Dcdk.logging.level=ERROR -jar /var/lib/jenkins/jobs/cdk/workspace/app/depict/target/surefire/surefirebooter4348128345109234029.jar /var/lib/jenkins/jobs/cdk/workspace/app/depict/target/surefire 2018-11-10T13-46-13_110-jvmRun1 surefire5636495753901702235tmp surefire_493219910478475493137tmp
Error occurred in starting fork, check output in log
Process Exit Code: 1
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:679)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:533)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:279)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:243)
```

Our Jenkins job: https://jenkins.bigcat.unimaas.nl/job/cdk/