### PR TITLE
Fix loop code for RDFProtonDescriptors

### DIFF
--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3R.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3R.java
@@ -422,13 +422,13 @@ public class RDFProtonDescriptor_G3R extends AbstractAtomicDescriptor implements
             IBond theInCycloexBond;
             limitInf = 0;
             limitSup = Math.PI;
-            step = (limitSup - limitInf) / 13;
             position = 0;
             smooth = -2.86;
             angle = 0;
             int yaCounter = 0;
             List<IAtom> connAtoms;
-            for (double g3r = 0; g3r < limitSup; g3r = g3r + step) {
+            for (int c = 0; c < G3R_DESC_LENGTH; c++) {
+            	double g3r = limitSup * ((double)c / G3R_DESC_LENGTH);
                 sum = 0;
                 for (Integer aBondsInCycloex : bondsInCycloex) {
                     yaCounter = 0;

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDR.java
@@ -404,14 +404,14 @@ public class RDFProtonDescriptor_GDR extends AbstractAtomicDescriptor implements
             IAtom goodAtom1;
             limitInf = 0;
             limitSup = Math.PI / 2;
-            step = (limitSup - limitInf) / 7;
             position = 0;
             partial = 0;
             IBond theDoubleBond;
             smooth = -1.15;
             int goodPosition = 0;
             IBond goodBond;
-            for (double ghd = limitInf; ghd < limitSup; ghd = ghd + step) {
+            for (int c = 0; c < gdr_desc_length; c++) {
+            	double ghd = limitInf + (limitSup - limitInf) * ((double)c / gdr_desc_length);
                 sum = 0;
                 for (int dou = 0; dou < doubles.size(); dou++) {
                     partial = 0;

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR.java
@@ -392,12 +392,12 @@ public class RDFProtonDescriptor_GHR extends AbstractAtomicDescriptor implements
         int position;
         double limitInf = 1.4;
         double limitSup = 4;
-        double step = (limitSup - limitInf) / 15;
         IAtom atom2;
 
         ///////////////////////THE FIRST CALCULATED DESCRIPTOR IS g(H)r	 WITH PARTIAL CHARGES:
         if (atoms.size() > 0) {
-            for (double ghr = limitInf; ghr < limitSup; ghr = ghr + step) {
+        	for (int c = 0; c < ghr_desc_length; c++) {
+            	double ghr = limitInf + (limitSup - limitInf) * ((double)c / ghr_desc_length);
                 sum = 0;
                 for (Object atom1 : atoms) {
                     distance = 0;

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topol.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topol.java
@@ -401,12 +401,12 @@ public class RDFProtonDescriptor_GHR_topol extends AbstractAtomicDescriptor impl
         Integer thisAtom;
         limitInf = 1.4;
         limitSup = 4;
-        step = (limitSup - limitInf) / 15;
 
         if (atoms.size() > 0) {
             //ArrayList gHr_topol_function = new ArrayList(15);
             ShortestPaths shortestPaths = new ShortestPaths(mol, startVertex);
-            for (double ghrt = limitInf; ghrt < limitSup; ghrt = ghrt + step) {
+            for (int c = 0; c < ghr_topol_desc_length; c++) {
+            	double ghrt = limitInf + (limitSup - limitInf) * ((double)c / ghr_topol_desc_length);
                 sum = 0;
                 for (int at = 0; at < atoms.size(); at++) {
                     distance = 0;

--- a/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSR.java
+++ b/descriptor/qsaratomic/src/main/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSR.java
@@ -404,9 +404,9 @@ public class RDFProtonDescriptor_GSR extends AbstractAtomicDescriptor implements
             IBond theSingleBond = null;
             limitInf = 0;
             limitSup = Math.PI / 2;
-            step = (limitSup - limitInf) / 7;
             smooth = -1.15;
-            for (double ghs = 0; ghs < limitSup; ghs = ghs + step) {
+            for (int c = 0; c < gsr_desc_length; c++) {
+            	double ghs = limitSup * ((double)c / gsr_desc_length);
                 sum = 0;
                 for (int sing = 0; sing < singles.size(); sing++) {
                     angle = 0;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3RTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3RTest.java
@@ -53,6 +53,7 @@ public class RDFProtonDescriptor_G3RTest extends AtomicDescriptorTest {
                 IDescriptorResult result = dv.getValue();
                 //				System.out.println("array: " + result.toString());
                 Assert.assertNotNull(result);
+                Assert.assertEquals(dv.getNames().length, result.length());
             }
 
         }

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDRTest.java
@@ -53,6 +53,7 @@ public class RDFProtonDescriptor_GDRTest extends AtomicDescriptorTest {
                 IDescriptorResult result = dv.getValue();
                 //				System.out.println("array: " + result.toString());
                 Assert.assertNotNull(result);
+                Assert.assertEquals(dv.getNames().length, result.length());
             }
 
         }

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHRTest.java
@@ -59,6 +59,7 @@ public class RDFProtonDescriptor_GHRTest extends AtomicDescriptorTest {
                 IDescriptorResult result = dv.getValue();
                 //				System.out.println("array: " + result.toString());
                 Assert.assertNotNull(result);
+                Assert.assertEquals(dv.getNames().length, result.length());
             }
         }
     }

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topolTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topolTest.java
@@ -53,6 +53,7 @@ public class RDFProtonDescriptor_GHR_topolTest extends AtomicDescriptorTest {
                 IDescriptorResult result = dv.getValue();
                 //				System.out.println("array: " + result.toString());
                 Assert.assertNotNull(result);
+                Assert.assertEquals(dv.getNames().length, result.length());
             }
 
         }

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSRTest.java
@@ -53,6 +53,7 @@ public class RDFProtonDescriptor_GSRTest extends AtomicDescriptorTest {
                 IDescriptorResult result = dv.getValue();
                 //				System.out.println("array: " + result.toString());
                 Assert.assertNotNull(result);
+                Assert.assertEquals(dv.getNames().length, result.length());
             }
 
         }


### PR DESCRIPTION
RDFProtonDescriptor_G3R creates an unnecessary element due to inappropriate use of floating point.