### PR TITLE
Fix RuleOfFiveDescriptor's molecular weight test

### DIFF
--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RuleOfFiveDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/RuleOfFiveDescriptor.java
@@ -162,7 +162,7 @@ public class RuleOfFiveDescriptor extends AbstractMolecularDescriptor implements
             int donors = ((IntegerResult) don.calculate(mol).getValue()).intValue();
 
             IMolecularDescriptor mw = new WeightDescriptor();
-            Object[] mwparams = {""};
+            Object[] mwparams = {"*"};
             mw.setParameters(mwparams);
             double mwvalue = ((DoubleResult) mw.calculate(mol).getValue()).doubleValue();
 

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/RuleOfFiveDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/RuleOfFiveDescriptorTest.java
@@ -51,7 +51,7 @@ public class RuleOfFiveDescriptorTest extends MolecularDescriptorTest {
         SmilesParser sp = new SmilesParser(DefaultChemObjectBuilder.getInstance());
         IAtomContainer mol = sp.parseSmiles("CCCC(OCC)OCC(c1cccc2ccccc12)C4CCC(CCCO)C(CC3CNCNC3)C4"); //
         addExplicitHydrogens(mol);
-        Assert.assertEquals(2, ((IntegerResult) descriptor.calculate(mol).getValue()).intValue());
+        Assert.assertEquals(3, ((IntegerResult) descriptor.calculate(mol).getValue()).intValue());
     }
 
     @Test


### PR DESCRIPTION
RuleOfFiveDescriptor always passes molecular weight test.
It has to pass parameter "*" to WeightDescriptor, not "".
