### PR TITLE
Remove unused code

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
+++ b/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
@@ -1430,7 +1430,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
                 IAtomType type = getAtomType("Li.neutral");
                 if (isAcceptable(atom, atomContainer, type)) return type;
             }
-            if (atom.getFormalCharge() == CDKConstants.UNSET || atom.getFormalCharge() == +1) {
+            if (atom.getFormalCharge() == +1) {
                 IAtomType type = getAtomType("Li.plus");
                 if (isAcceptable(atom, atomContainer, type)) return type;
             }


### PR DESCRIPTION
The atom's FormalCharge never be null, but it is logically incorrect.