### PR TITLE
Fix reading mass difference field of MDLReader

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLReader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLReader.java
@@ -449,7 +449,7 @@ public class MDLReader extends DefaultChemObjectReader {
                             int massDiff = Integer.parseInt(massDiffString);
                             if (massDiff != 0) {
                                 IIsotope major = Isotopes.getInstance().getMajorIsotope(element);
-                                atom.setAtomicNumber(major.getAtomicNumber() + massDiff);
+                                atom.setMassNumber(major.getMassNumber() + massDiff);
                             }
                         } catch (NumberFormatException | IOException exception) {
                             logger.error("Could not parse mass difference field");

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLReaderTest.java
@@ -108,6 +108,18 @@ public class MDLReaderTest extends SimpleChemObjectReaderTest {
         Assert.assertEquals(9, m.getAtomCount());
         Assert.assertEquals(9, m.getBondCount());
     }
+    
+    @Test
+    public void testMassDiff() throws Exception {
+        String mdl = "deuterium.mol\n" + "\n" + "\n" + "  1  0  0  0  0                 1\n"
+                + "    0.0000    0.0000    0.0000 H  +1  0  0  0  0\n";
+        try (MDLReader reader = new MDLReader(new StringReader(mdl), Mode.STRICT)) {
+            IAtomContainer mol = reader.read(new AtomContainer());
+            IAtom atom = mol.getAtom(0);
+            Assert.assertEquals(1, atom.getAtomicNumber().intValue());
+            Assert.assertEquals(2, atom.getMassNumber().intValue());
+        }
+    }
 
     /**
      * @cdk.bug 1542467

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -1727,8 +1727,20 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         }
     }
 
-
-
+	@Test
+    public void testMassDiff() throws Exception {
+        String mdl = "deuterium.mol\n" + "\n" + "\n" + "  1  0  0  0  0                 1 V2000\n"
+                + "    0.0000    0.0000    0.0000 H  +1  0  0  0  0\n"
+                + "M  END\n";
+        try (StringReader in = new StringReader(mdl)) {
+            MDLV2000Reader reader = new MDLV2000Reader(new StringReader(mdl), Mode.STRICT);
+            IAtomContainer mol = reader.read(new AtomContainer());
+            IAtom atom = mol.getAtom(0);
+            Assert.assertEquals(1, atom.getAtomicNumber().intValue());
+            Assert.assertEquals(2, atom.getMassNumber().intValue());
+        }
+    }
+	
     @Test
     public void testBadAtomCoordinateFormat() throws Exception {
 


### PR DESCRIPTION
Test case to test reading mass difference field is added.
MDLReader2000 is OK but deprecated MDLReader is not.
