### PR TITLE
First few compile fixes

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/tools/FormatStringBuffer.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/FormatStringBuffer.java
@@ -36,7 +36,9 @@ package org.openscience.cdk.tools;
 
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  * A class for formatting output similar to the C <tt>printf</tt> command.
@@ -333,9 +335,9 @@ public class FormatStringBuffer {
 
         NumberFormat nf;
         if ((fmt.flags & SCI) > 0) {
-            nf = new DecimalFormat("0.#E00");
+            nf = new DecimalFormat("0.#E00", DecimalFormatSymbols.getInstance(Locale.US));
         } else {
-            nf = NumberFormat.getInstance();
+            nf = NumberFormat.getInstance(Locale.US);
         }
         nf.setGroupingUsed((fmt.flags & GROUPING) != 0);
         if (fmt.precision != -1) {

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -51,6 +51,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -86,7 +87,7 @@ import static org.openscience.cdk.CDKConstants.ATOM_ATOM_MAPPING;
 public final class MDLV3000Writer extends DefaultChemObjectWriter {
 
     public static final  SimpleDateFormat HEADER_DATE_FORMAT = new SimpleDateFormat("MMddyyHHmm");
-    public static final  NumberFormat     DECIMAL_FORMAT     = new DecimalFormat("#.####");
+    public static final  NumberFormat     DECIMAL_FORMAT     = new DecimalFormat("#.####", DecimalFormatSymbols.getInstance(Locale.US));
     private static final Pattern          R_GRP_NUM          = Pattern.compile("R(\\d+)");
     private V30LineWriter writer;
 

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -627,8 +627,8 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
                             final Point2d p1 = bracket.getFirstPoint();
                             final Point2d p2 = bracket.getSecondPoint();
                             writer.write("9");
-                            writer.write(' ').write(p1.x).write(' ').write(DECIMAL_FORMAT.format(p1.y)).write(" 0");
-                            writer.write(' ').write(p2.x).write(' ').write(DECIMAL_FORMAT.format(p2.y)).write(" 0");
+                            writer.write(' ').write(DECIMAL_FORMAT.format(p1.x)).write(' ').write(DECIMAL_FORMAT.format(p1.y)).write(" 0");
+                            writer.write(' ').write(DECIMAL_FORMAT.format(p2.x)).write(' ').write(DECIMAL_FORMAT.format(p2.y)).write(" 0");
                             writer.write(" 0 0 0");
                             writer.write(")");
                         }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesGenerator.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesGenerator.java
@@ -26,6 +26,7 @@ package org.openscience.cdk.smiles;
 import org.openscience.cdk.smiles.CxSmilesState.PolymerSgroup;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -187,7 +188,7 @@ public class CxSmilesGenerator {
         // 2D/3D Coordinates
         if (SmiFlavor.isSet(opts, SmiFlavor.CxCoordinates) &&
             state.atomCoords != null && !state.atomCoords.isEmpty()) {
-            DecimalFormat fmt = new DecimalFormat("#.##");
+            DecimalFormat fmt = new DecimalFormat("#.##", DecimalFormatSymbols.getInstance(Locale.US));
             if (sb.length() > 2) sb.append(',');
             sb.append('(');
             for (int i = 0; i < ordering.length; i++) {

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/IdentityTemplateLibrary.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/IdentityTemplateLibrary.java
@@ -45,11 +45,13 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static java.util.AbstractMap.SimpleEntry;
@@ -83,7 +85,7 @@ import static java.util.Map.Entry;
  */
 final class IdentityTemplateLibrary {
 
-    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat(".##");
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat(".##", DecimalFormatSymbols.getInstance(Locale.US));
 
     private final Multimap<String, Point2d[]> templateMap = LinkedListMultimap.create();
 


### PR DESCRIPTION
The all have to do with the fact that on Java the default Locale does not have to be one using a period in decimal numbers (like Locale.US). The second patch, however, is a actual bug fix, I think.