### PR TITLE
The time out at the InChI level (5 secs) does not always work

### DIFF
--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
@@ -896,7 +896,7 @@ public class InChIGeneratorTest extends CDKTestCase {
         }
     }
 
-    @Test
+    @Test(timeout=8000)
     public void timeout() throws Exception {
         IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
         SmilesParser smipar = new SmilesParser(bldr);


### PR DESCRIPTION
Patch related to https://github.com/cdk/cdk/issues/507. It does not fix the problem, but at least causes it to not keep looping into infinity. 