### PR TITLE
Patch/alogp fixup

### DIFF
--- a/base/atomtype/src/main/java/org/openscience/cdk/atomtype/EStateAtomTypeMatcher.java
+++ b/base/atomtype/src/main/java/org/openscience/cdk/atomtype/EStateAtomTypeMatcher.java
@@ -63,8 +63,8 @@ public class EStateAtomTypeMatcher implements IAtomTypeMatcher {
         IAtomType atomType = null;
         try {
             String fragment = "";
-            int NumHAtoms = 0;
-            int NumSingleBonds2 = 0;
+            int NumHAtoms = atom.getImplicitHydrogenCount();
+            int NumSingleBonds2 = NumHAtoms;
             int NumDoubleBonds2 = 0;
             int NumTripleBonds2 = 0;
             int NumAromaticBonds2 = 0;

--- a/base/atomtype/src/main/java/org/openscience/cdk/atomtype/EStateAtomTypeMatcher.java
+++ b/base/atomtype/src/main/java/org/openscience/cdk/atomtype/EStateAtomTypeMatcher.java
@@ -63,7 +63,8 @@ public class EStateAtomTypeMatcher implements IAtomTypeMatcher {
         IAtomType atomType = null;
         try {
             String fragment = "";
-            int NumHAtoms = atom.getImplicitHydrogenCount();
+            int NumHAtoms = atom.getImplicitHydrogenCount() != null ?
+                            atom.getImplicitHydrogenCount() : 0;
             int NumSingleBonds2 = NumHAtoms;
             int NumDoubleBonds2 = 0;
             int NumTripleBonds2 = 0;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -100,7 +100,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
     AtomicProperties ap;                                                                           // needed to retrieve electronegativities
 
-    int[] frags = new int[121];                                               // counts of each type of fragment in the molecule
+    public int[] frags = new int[121];                                               // counts of each type of fragment in the molecule
     public int[] alogpfrag;                                                                    // alogp fragments for each atom (used to see which atoms have missing fragments)
     final static double[] FRAGVAL = new double[121];                                             // coefficients for alogp model
 

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -995,44 +995,36 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         }
     }
 
-    private int getHAtomType(IAtom ai, java.util.List connectedAtoms) {
+    private int getHAtomType(IAtom ai, List connectedAtoms) {
         //ai is the atom connected to a H atoms.
         //ai environment determines what is the H atom type
         //This procedure is applied only for carbons
         //i.e. H atom type 50 is never returned
 
-        java.util.List ca;
+        List<IAtom> ca;
         if (connectedAtoms == null)
             ca = atomContainer.getConnectedAtomsList(ai);
         else
             ca = connectedAtoms;
 
         // first check for alpha carbon:
+        // -C=X, -C#X and -C:X
         if (ai.getSymbol().equals("C") && !ai.getFlag(CDKConstants.ISAROMATIC)) {
             for (int j = 0; j <= ca.size() - 1; j++) {
                 if (atomContainer.getBond(ai, ((IAtom) ca.get(j))).getOrder() == IBond.Order.SINGLE
                         && ((IAtom) ca.get(j)).getSymbol().equals("C")) { // single bonded
-                    java.util.List ca2 = atomContainer.getConnectedAtomsList((IAtom) ca.get(j));
-
-                    for (int k = 0; k <= ca2.size() - 1; k++) {
-                        IAtom ca2k = (IAtom) ca2.get(k);
-                        if (!ca2k.getSymbol().equals("C")) {
-                            if (atomContainer.getBond(((IAtom) ca.get(j)), ca2k).getOrder() != IBond.Order.SINGLE)
+                    IAtom aCarbon = ca.get(j);
+                    for (IBond bond : aCarbon.bonds()) {
+                        IAtom nbor = bond.getOther(aCarbon);
+                        if (nbor.getAtomicNumber() != 6)
+                            if (bond.isAromatic() || bond.getOrder() != IBond.Order.SINGLE)
                                 return 51;
-
-                            if (((IAtom) ca.get(j)).getFlag(CDKConstants.ISAROMATIC)
-                                    && ca2k.getFlag(CDKConstants.ISAROMATIC)) {
-                                if (inSameAromaticRing(atomContainer, ((IAtom) ca.get(j)), ca2k, rs)) {
-                                    return 51;
-                                }
-                            }
-                        } // end !ca2[k].getSymbol().equals("C"))
-                    } // end k loop
+                    }
                 } // end if (atomContainer.getBond(ai, ((IAtom)ca.get(j))).getOrder() == IBond.Order.SINGLE) {
             }// end j loop
         } // end if(ai.getSymbol().equals("C") && !ai.getFlag(CDKConstants.ISAROMATIC))
 
-        java.util.List bonds = atomContainer.getConnectedBondsList(ai);
+        List bonds = atomContainer.getConnectedBondsList(ai);
         int doublebondcount = 0;
         int triplebondcount = 0;
         String hybrid = "";

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -444,6 +444,23 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
     }
 
+    private static boolean isHetero(IAtom atom) {
+        switch (atom.getAtomicNumber()) {
+            case 7: // N
+            case 8: // O
+            case 9: // F
+            case 15: // P
+            case 16: // S
+            case 17: // Cl
+            case 34: // Se
+            case 35: // Br
+            case 53: // I
+                return true;
+            default:
+                return false;
+        }
+    }
+
     private void calcGroup001_005(int i) {
         // C in CH3R
         if (fragment[i].equals("SsCH3")) {
@@ -1016,9 +1033,8 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                     IAtom aCarbon = ca.get(j);
                     for (IBond bond : aCarbon.bonds()) {
                         IAtom nbor = bond.getOther(aCarbon);
-                        if (nbor.getAtomicNumber() != 6)
-                            if (bond.isAromatic() || bond.getOrder() != IBond.Order.SINGLE)
-                                return 51;
+                        if (isHetero(nbor) && (bond.isAromatic() || bond.getOrder() != IBond.Order.SINGLE))
+                            xInSecondShell = true;
                     }
                 } // end if (atomContainer.getBond(ai, ((IAtom)ca.get(j))).getOrder() == IBond.Order.SINGLE) {
             }// end j loop

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1033,6 +1033,8 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         // first check for alpha carbon:
         // -C=X, -C#X and -C:X
         if (ai.getSymbol().equals("C") && !ai.getFlag(CDKConstants.ISAROMATIC)) {
+            boolean noXfirstShell = true;
+            boolean xInSecondShell = false;
             for (int j = 0; j <= ca.size() - 1; j++) {
                 if (atomContainer.getBond(ai, ((IAtom) ca.get(j))).getOrder() == IBond.Order.SINGLE
                         && ((IAtom) ca.get(j)).getSymbol().equals("C")) { // single bonded
@@ -1042,8 +1044,13 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                         if (isHetero(nbor) && (bond.isAromatic() || bond.getOrder() != IBond.Order.SINGLE))
                             xInSecondShell = true;
                     }
-                } // end if (atomContainer.getBond(ai, ((IAtom)ca.get(j))).getOrder() == IBond.Order.SINGLE) {
-            }// end j loop
+                } else {
+                    if (isHetero(ca.get(j)))
+                        noXfirstShell = false;
+                }
+            }
+            if (noXfirstShell && xInSecondShell)
+                return 51;
         } // end if(ai.getSymbol().equals("C") && !ai.getFlag(CDKConstants.ISAROMATIC))
 
         List bonds = atomContainer.getConnectedBondsList(ai);

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1160,8 +1160,6 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                 break;
         }
 
-        System.out.println("Fall through");
-
         return 0;
     }
 
@@ -1261,22 +1259,19 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             } else {
 
                 for (int j = 0; j <= ca.size() - 1; j++) {
-                    // if (((IAtom)ca.get(j)).getSymbol().equals("C")) { // for malathion
-                    // O-P(=S)
-                    // was considered to count as group 60
-
-                    List ca2 = atomContainer.getConnectedAtomsList(((IAtom) ca.get(j)));
-                    for (int k = 0; k <= ca2.size() - 1; k++) {
-                        if (atomContainer.getBond(((IAtom) ca.get(j)), (IAtom) ca2.get(k)).getOrder() == IBond.Order.DOUBLE) {
-                            if (!((IAtom) ca2.get(k)).getSymbol().equals("C")) {
-                                frags[60]++;
-                                alogpfrag[i] = 60;
-                                return;
-                            }
-                        }
-                    }
-
-                } // end j ca loop
+                     if (((IAtom)ca.get(j)).getSymbol().equals("C")) {
+                         List ca2 = atomContainer.getConnectedAtomsList(((IAtom) ca.get(j)));
+                         for (int k = 0; k <= ca2.size() - 1; k++) {
+                             if (atomContainer.getBond(((IAtom) ca.get(j)), (IAtom) ca2.get(k)).getOrder() == IBond.Order.DOUBLE) {
+                                 if (!((IAtom) ca2.get(k)).getSymbol().equals("C")) {
+                                     frags[60]++;
+                                     alogpfrag[i] = 60;
+                                     return;
+                                 }
+                             }
+                         }
+                     }
+                }
 
                 if (ca0.getSymbol().equals("O") || ca1.getSymbol().equals("O")) {
                     frags[63]++;
@@ -1317,22 +1312,26 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                 nAl++;
         }
 
-        // first check if have RC(=O)N or NX=X
-        for (int j = 0; j <= nbors.size() - 1; j++) {
-            if (nbors.get(j).getAtomicNumber() == 1)
-                continue;
-            List ca2 = atomContainer.getConnectedAtomsList((IAtom) nbors.get(j));
-            for (int k = 0; k <= ca2.size() - 1; k++) {
-                IAtom ca2k = (IAtom) ca2.get(k);
-                if (atomContainer.indexOf(ca2k) != i) {
-                    if (!ca2k.getSymbol().equals("C")) {
-                        if (!ca2k.getFlag(CDKConstants.ISAROMATIC)
+        if (fragment[i].equals("SsssN") ||
+            fragment[i].equals("SssNH") ||
+            fragment[i].equals("SsNH2")) {
+            // first check if have RC(=O)N or NX=X
+            for (int j = 0; j <= nbors.size() - 1; j++) {
+                if (nbors.get(j).getAtomicNumber() == 1)
+                    continue;
+                List ca2 = atomContainer.getConnectedAtomsList((IAtom) nbors.get(j));
+                for (int k = 0; k <= ca2.size() - 1; k++) {
+                    IAtom ca2k = (IAtom) ca2.get(k);
+                    if (atomContainer.indexOf(ca2k) != i) {
+                        if (!ca2k.getSymbol().equals("C")) {
+                            if (!ca2k.getFlag(CDKConstants.ISAROMATIC)
                                 && !((IAtom) nbors.get(j)).getFlag(CDKConstants.ISAROMATIC)
                                 && !ai.getFlag(CDKConstants.ISAROMATIC)) {
-                            if (atomContainer.getBond(((IAtom) nbors.get(j)), ca2k).getOrder() == IBond.Order.DOUBLE) {
-                                frags[72]++;
-                                alogpfrag[i] = 72;
-                                return;
+                                if (atomContainer.getBond(((IAtom) nbors.get(j)), ca2k).getOrder() == IBond.Order.DOUBLE) {
+                                    frags[72]++;
+                                    alogpfrag[i] = 72;
+                                    return;
+                                }
                             }
                         }
                     }
@@ -1437,7 +1436,6 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                     return;
                 }
             }
-
             boolean flag1 = false;
             boolean flag2 = false;
 

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -908,15 +908,15 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (!fragment[i].equals("SsaaC") && !fragment[i].equals("SaaaC")) return;
 
-        IAtom ai = atomContainer.getAtom(i);
-        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        IAtom       atm = atomContainer.getAtom(i);
+        List<IAtom> nbors = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
 
         IAtom[] sameringatoms = new IAtom[2];
         IAtom nonringatom = atomContainer.getBuilder().newInstance(IAtom.class);
 
         int sameringatomscount = 0;
-        for (int j = 0; j <= ca.size() - 1; j++) {
-            if (inSameAromaticRing(atomContainer, ai, ((IAtom) ca.get(j)), rs)) {
+        for (int j = 0; j <= nbors.size() - 1; j++) {
+            if (inSameAromaticRing(atomContainer, atm, ((IAtom) nbors.get(j)), rs)) {
                 sameringatomscount++;
             }
 

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -705,15 +705,21 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (haveCdX) {
             if (aromaticCount >= 1) { // Ar-C(=X)-R
-                // TODO: add code to check if have R or X for nonaromatic
-                // attachment to C?
-                // if we do this check we would have missing fragment for
-                // Ar-C(=X)-X
-                // TODO: which fragment to use if we have Ar-C(=X)-Ar? Currently
-                // this frag is used
+                for (IBond bond : ai.bonds()) {
+                    if (bond.getOrder() != IBond.Order.SINGLE)
+                        continue;
+                    IAtom nbor = bond.getOther(ai);
+                    if (!nbor.isAromatic()) {
+                        if (isHetero(nbor)) {
+                            frags[40]++;
+                            alogpfrag[i] = 40;
+                        } else {
+                            frags[39]++;
+                            alogpfrag[i] = 39;
+                        }
+                    }
+                }
 
-                frags[39]++;
-                alogpfrag[i] = 39;
             }
             else if (aromaticCount == 0) {
                 if (rCount == 1 && xCount == 1) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -421,6 +421,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                     calcGroup109(i);
                     calcGroup110(i);
                     calcGroup111(i);
+                    calcGroup112(i);
                     calcGroup116_117_120(i);
                     calcGroup118_119(i);
                 }
@@ -1890,6 +1891,14 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         if (fragment[i].equals("SssssSi")) {
             frags[111]++;
             alogpfrag[i] = 111;
+        }
+    }
+
+    private void calcGroup112(int i) {
+        if (fragment[i].equals("SsssB") ||
+            fragment[i].equals("SssBm")) {
+            frags[112]++;
+            alogpfrag[i] = 112;
         }
     }
 

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -675,7 +675,10 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         IAtom ai = atomContainer.getAtom(i);
 
-        if (!fragment[i].equals("SdssC")) return;
+        if (!fragment[i].equals("SdssC") &&
+            !fragment[i].equals("SdaaC")) {
+            return;
+        }
 
         List ca = atomContainer.getConnectedAtomsList(ai);
 

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1303,8 +1303,6 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         } else if (fragment[i].equals("SaaNH") || fragment[i].equals("SsaaN")) { // R...NH...R
             frags[73]++;
             alogpfrag[i] = 73;
-            if (fragment[i].equals("SaaNH"))
-                frags[htype]++;
         } else if (fragment[i].equals("SssNH")) {
             if (nAr == 2 && nAl == 0) { // Ar2NH
                 frags[73]++;
@@ -1317,7 +1315,6 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                 frags[67]++;
                 alogpfrag[i] = 67;
             }
-            frags[htype]++;
         } else if (fragment[i].equals("SsssN")) {
             if ((nAr == 3 && nAl == 0) || (nAr == 2 && nAl == 1)) { // Ar3N &
                 // Ar2NAl
@@ -1370,8 +1367,8 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         } else if (fragment[i].equals("SdNH") || fragment[i].equals("SdsN")) {
             // test for RO-NO
             if (fragment[i].equals("SdsN")) {
-                IAtom ca0 = (IAtom) nbors.get(0);
-                IAtom ca1 = (IAtom) nbors.get(1);
+                IAtom ca0 = nbors.get(0);
+                IAtom ca1 = nbors.get(1);
                 if (ca0.getSymbol().equals("O") && ca1.getSymbol().equals("O")) {
                     frags[76]++;
                     alogpfrag[i] = 76;
@@ -1402,13 +1399,12 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                 if (flag1 && flag2) { // X-N=X or Ar-N=X
                     frags[78]++;
                     alogpfrag[i] = 78;
+                    return;
                 } else {
                     //logger.debug("missing group: R-N=X");
                 }
             }
 
-            if (fragment[i].equals("SdNH"))
-                frags[50]++;
         } else if (fragment[i].indexOf('p') > -1) {
             frags[79]++;
             alogpfrag[i] = 79;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1944,6 +1944,17 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         EStateAtomTypeMatcher eStateMatcher = new EStateAtomTypeMatcher();
         eStateMatcher.setRingSet(rs);
 
+        for (IAtomContainer ring : rs.atomContainers()) {
+            boolean arom = true;
+            for (IBond bond : ring.bonds()) {
+                if (!bond.isAromatic()) {
+                    arom = false;
+                    break;
+                }
+            }
+            ring.setFlag(CDKConstants.ISAROMATIC, arom);
+        }
+
         for (int i = 0; i < container.getAtomCount(); i++) {
             IAtomType atomType = eStateMatcher.findMatchingAtomType(container, container.getAtom(i));
             if (atomType == null) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -919,20 +919,27 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (sameringatomscount == 2) {
             int count = 0;
-            for (int j = 0; j <= ca.size() - 1; j++) {
-                if (inSameAromaticRing(atomContainer, ai, ((IAtom) ca.get(j)), rs)) {
-                    sameringatoms[count] = (IAtom) ca.get(j);
+            for (int j = 0; j <= nbors.size() - 1; j++) {
+                if (inSameAromaticRing(atomContainer, atm, ((IAtom) nbors.get(j)), rs)) {
+                    sameringatoms[count] = (IAtom) nbors.get(j);
                     count++;
                 } else {
-                    nonringatom = (IAtom) ca.get(j);
+                    nonringatom = (IAtom) nbors.get(j);
                 }
 
             }
         } else { // sameringsatomscount==3
             // arbitrarily assign atoms: (no way to decide consistently)
-            sameringatoms[0] = (IAtom) ca.get(0);
-            sameringatoms[1] = (IAtom) ca.get(1);
-            nonringatom = (IAtom) ca.get(2);
+            // but to match VEGA we choose to but hetero atoms in the ring
+            Collections.sort(nbors, new Comparator<IAtom>() {
+                @Override
+                public int compare(IAtom a, IAtom b) {
+                    return -Boolean.compare(isHetero(a), isHetero(b));
+                }
+            });
+            sameringatoms[0] = (IAtom) nbors.get(0);
+            sameringatoms[1] = (IAtom) nbors.get(1);
+            nonringatom = (IAtom) nbors.get(2);
         }
 
         // check if both hetero atoms have at least one double bond

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1743,7 +1743,8 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         IAtom ai = atomContainer.getAtom(i);
         String s = ai.getSymbol();
 
-        if (ai.getFormalCharge() == -1) {
+        if (ai.getFormalCharge() == -1 ||
+            (ai.getFormalCharge() == 0 && isBondedToHydrogenOnly(ai))) {
             if (s.equals("F")) {
                 frags[101]++;
                 alogpfrag[i] = 101;
@@ -1760,6 +1761,11 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         }
 
+    }
+
+    private boolean isBondedToHydrogenOnly(IAtom ai) {
+        return ai.getBondCount() == 1 &&
+               ai.bonds().iterator().next().getOther(ai).getAtomicNumber() == 1;
     }
 
     private void calcGroup106(int i) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -43,6 +43,8 @@ import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.BondManipulator;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -422,6 +422,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                     calcGroup110(i);
                     calcGroup111(i);
                     calcGroup112(i);
+                    calcGroup115(i);
                     calcGroup116_117_120(i);
                     calcGroup118_119(i);
                 }
@@ -1899,6 +1900,13 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             fragment[i].equals("SssBm")) {
             frags[112]++;
             alogpfrag[i] = 112;
+        }
+    }
+
+    private void calcGroup115(int i) {
+        if (fragment[i].equals("SssssPp")) {
+            frags[115]++;
+            alogpfrag[i] = 115;
         }
     }
 

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1383,16 +1383,17 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         } else if (fragment[i].equals("SaaN")) {
             frags[75]++;
             alogpfrag[i] = 75;
-        } else if (fragment[i].equals("SssdNp")) {
-            boolean haveSsOm = false;
-            boolean haveSdO = false;
-            boolean ar = false;
+        } else if (fragment[i].equals("SdssNp") ||
+                   fragment[i].equals("SddsN")) {
+            int     haveSsOm = 0;
+            int     haveSdO  = 0;
+            boolean ar       = false;
 
             for (int j = 0; j <= nbors.size() - 1; j++) {
                 if (fragment[atomContainer.indexOf(((IAtom) nbors.get(j)))].equals("SsOm")) {
-                    haveSsOm = true;
+                    haveSsOm++;
                 } else if (fragment[atomContainer.indexOf(((IAtom) nbors.get(j)))].equals("SdO")) {
-                    haveSdO = true;
+                    haveSdO++;
                 } else {
                     if (((IAtom) nbors.get(j)).getFlag(CDKConstants.ISAROMATIC)) {
                         ar = true;
@@ -1400,10 +1401,12 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                 }
             }
 
-            if (haveSsOm && haveSdO && ar) {
+            boolean isNitro = haveSdO == 2 || (haveSsOm >= 1 && haveSdO >= 1);
+
+            if (isNitro && ar) {
                 frags[76]++;
                 alogpfrag[i] = 76;
-            } else if (haveSsOm && haveSdO && !ar) {
+            } else if (isNitro && !ar) {
                 frags[77]++;
                 alogpfrag[i] = 77;
             } else {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1222,11 +1222,13 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         IAtom ai = atomContainer.getAtom(i);
         if (!ai.getSymbol().equals("N")) return;
         List<IAtom> nbors = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
-        int htype = 50; //H atom attached to a hetero atom
 
+        int htype = 50; //H atom attached to a hetero atom
         for (IAtom nbor : nbors)
-            if (nbor.getAtomicNumber() == 1)
+            if (nbor.getAtomicNumber() == 1) {
                 alogpfrag[nbor.getIndex()] = htype;
+                frags[htype]++;
+            }
 
         for (int j = 0; j <= nbors.size() - 1; j++) {
             if (((IAtom) nbors.get(j)).getSymbol().equals("H")) continue;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1050,29 +1050,6 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         else
             ca = connectedAtoms;
 
-        // first check for alpha carbon:
-        // -C=X, -C#X and -C:X
-        if (ai.getSymbol().equals("C") && !ai.getFlag(CDKConstants.ISAROMATIC)) {
-            boolean noXfirstShell = true;
-            boolean xInSecondShell = false;
-            for (int j = 0; j <= ca.size() - 1; j++) {
-                if (atomContainer.getBond(ai, ((IAtom) ca.get(j))).getOrder() == IBond.Order.SINGLE
-                        && ((IAtom) ca.get(j)).getSymbol().equals("C")) { // single bonded
-                    IAtom aCarbon = ca.get(j);
-                    for (IBond bond : aCarbon.bonds()) {
-                        IAtom nbor = bond.getOther(aCarbon);
-                        if (isHetero(nbor) && (bond.isAromatic() || bond.getOrder() != IBond.Order.SINGLE))
-                            xInSecondShell = true;
-                    }
-                } else {
-                    if (isHetero(ca.get(j)))
-                        noXfirstShell = false;
-                }
-            }
-            if (noXfirstShell && xInSecondShell)
-                return 51;
-        } // end if(ai.getSymbol().equals("C") && !ai.getFlag(CDKConstants.ISAROMATIC))
-
         IAtomType.Hybridization hyb;
 
         int ndoub = 0;
@@ -1121,6 +1098,29 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             hyb = IAtomType.Hybridization.SP1;
         else
             return 0; // unknown
+
+        // first check for alpha carbon:
+        // -C=X, -C#X and -C:X
+        if (ai.getAtomicNumber() == 6 && !ai.isAromatic() && hyb == IAtomType.Hybridization.SP3) {
+            boolean noXfirstShell = true;
+            boolean xInSecondShell = false;
+            for (int j = 0; j <= ca.size() - 1; j++) {
+                if (atomContainer.getBond(ai, ((IAtom) ca.get(j))).getOrder() == IBond.Order.SINGLE
+                    && ((IAtom) ca.get(j)).getSymbol().equals("C")) { // single bonded
+                    IAtom aCarbon = ca.get(j);
+                    for (IBond bond : aCarbon.bonds()) {
+                        IAtom nbor = bond.getOther(aCarbon);
+                        if (isHetero(nbor) && (bond.isAromatic() || bond.getOrder() != IBond.Order.SINGLE))
+                            xInSecondShell = true;
+                    }
+                } else {
+                    if (isHetero(ca.get(j)))
+                        noXfirstShell = false;
+                }
+            }
+            if (noXfirstShell && xInSecondShell)
+                return 51;
+        }
 
         switch (hyb) {
             case SP1:

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1367,8 +1367,10 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                 frags[66]++;
                 alogpfrag[i] = 66;
             }
-            frags[50] += 2;
-        } else if (fragment[i].equals("SaaNH") || fragment[i].equals("SsaaN")) { // R...NH...R
+        } else if (fragment[i].equals("SaaNH") ||
+                   fragment[i].equals("SsaaN") ||
+                   fragment[i].equals("SaaaN") ||
+                   fragment[i].equals("SaaNm")) { // R...NH...R
             frags[73]++;
             alogpfrag[i] = 73;
         } else if (fragment[i].equals("SssNH")) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1248,10 +1248,8 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         // 58: O in =O
         // 61: --O in nitro, N-oxides
         // 62: O in O-
-        IAtom ca0 = (IAtom) ca.get(0);
-
         if (fragment[i].equals("SsOm")) {
-
+            IAtom ca0 = (IAtom) ca.get(0);
             if (ca0.getSymbol().equals("N") && ca0.getFormalCharge() == 1) {
                 frags[61]++;
                 alogpfrag[i] = 61;
@@ -1261,6 +1259,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             }
 
         } else if (fragment[i].equals("SdO")) {
+            IAtom ca0 = (IAtom) ca.get(0);
             if (ca0.getSymbol().equals("N") && ca0.getFormalCharge() == 1) {
                 frags[61]++;
                 alogpfrag[i] = 61;

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1455,16 +1455,8 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         for (int j = 0; j <= ca2.size() - 1; j++) {
             IAtom ca2j = (IAtom) ca2.get(j);
-
-            // // F,O,Cl,Br,N
-
-            // if (s.equals("F") || s.equals("O") || s.equals("Cl")
-            // || s.equals("Br") || s.equals("N") || s.equals("S"))
-
-            if (ap.getNormalizedElectronegativity(ca2j.getSymbol()) > 1) {
-                oxNum += BondManipulator.destroyBondOrder(atomContainer.getBond(ca0, ca2j).getOrder());
-            }
-
+            if (isHetero(ca2j))
+                oxNum += atomContainer.getBond(ca0, ca2j).getOrder().numeric();
         }
 
         if (hybrid.equals("sp3") && oxNum == 1) {

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -450,9 +450,11 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
     private static boolean isHetero(IAtom atom) {
         switch (atom.getAtomicNumber()) {
+            case 5: // B
             case 7: // N
             case 8: // O
             case 9: // F
+            case 14: // Si
             case 15: // P
             case 16: // S
             case 17: // Cl
@@ -1129,7 +1131,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                         if (isHetero(nbor2)) {
                             switch (bond2.getOrder()) {
                                 case SINGLE:
-                                    if (bond2.isAromatic() && !isPyrroleLikeHetero(nbor2))
+                                    if (bond2.isAromatic())
                                         numAromX++;
                                     break;
                                 case DOUBLE:

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -1520,20 +1520,25 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                 oxNum += atomContainer.getBond(ca0, ca2j).getOrder().numeric();
         }
 
-        if (hybrid.equals("sp3") && oxNum == 1) {
-            frags[81]++;
-            alogpfrag[i] = 81;
-        } else if (hybrid.equals("sp3") && oxNum == 2) {
-            frags[82]++;
-            alogpfrag[i] = 82;
-        } else if (hybrid.equals("sp3") && oxNum == 3) {
-            frags[83]++;
-            alogpfrag[i] = 83;
-        } else if (hybrid.equals("sp2") && oxNum == 1) {
-            frags[84]++;
-            alogpfrag[i] = 84;
-        } else if ((hybrid.equals("sp2") && oxNum > 1) || (hybrid.equals("sp") && oxNum >= 1)
-                || (hybrid.equals("sp3") && oxNum == 4) || !ca0.getSymbol().equals("C")) {
+        if (ca0.getAtomicNumber() == 6) {
+            if (hybrid.equals("sp3") && oxNum == 1) {
+                frags[81]++;
+                alogpfrag[i] = 81;
+            } else if (hybrid.equals("sp3") && oxNum == 2) {
+                frags[82]++;
+                alogpfrag[i] = 82;
+            } else if (hybrid.equals("sp3") && oxNum == 3) {
+                frags[83]++;
+                alogpfrag[i] = 83;
+            } else if (hybrid.equals("sp2") && oxNum == 1) {
+                frags[84]++;
+                alogpfrag[i] = 84;
+            } else if ((hybrid.equals("sp2") && oxNum > 1) || (hybrid.equals("sp") && oxNum >= 1)
+                       || (hybrid.equals("sp3") && oxNum == 4)) {
+                frags[85]++;
+                alogpfrag[i] = 85;
+            }
+        } else {
             frags[85]++;
             alogpfrag[i] = 85;
         }
@@ -1591,20 +1596,25 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             }
         }
 
-        if (hybrid.equals("sp3") && oxNum == 1) {
-            frags[86]++;
-            alogpfrag[i] = 86;
-        } else if (hybrid.equals("sp3") && oxNum == 2) {
-            frags[87]++;
-            alogpfrag[i] = 87;
-        } else if (hybrid.equals("sp3") && oxNum == 3) {
-            frags[88]++;
-            alogpfrag[i] = 88;
-        } else if (hybrid.equals("sp2") && oxNum == 1) {
-            frags[89]++;
-            alogpfrag[i] = 89;
-        } else if ((hybrid.equals("sp2") && oxNum > 1) || (hybrid.equals("sp") && oxNum >= 1)
-                || (hybrid.equals("sp3") && oxNum == 4) || !ca0.getSymbol().equals("C")) {
+        if (ca0.getAtomicNumber() == 6) {
+            if (hybrid.equals("sp3") && oxNum == 1) {
+                frags[86]++;
+                alogpfrag[i] = 86;
+            } else if (hybrid.equals("sp3") && oxNum == 2) {
+                frags[87]++;
+                alogpfrag[i] = 87;
+            } else if (hybrid.equals("sp3") && oxNum == 3) {
+                frags[88]++;
+                alogpfrag[i] = 88;
+            } else if (hybrid.equals("sp2") && oxNum == 1) {
+                frags[89]++;
+                alogpfrag[i] = 89;
+            } else if ((hybrid.equals("sp2") && oxNum > 1) || (hybrid.equals("sp") && oxNum >= 1)
+                       || (hybrid.equals("sp3") && oxNum == 4)) {
+                frags[90]++;
+                alogpfrag[i] = 90;
+            }
+        } else {
             frags[90]++;
             alogpfrag[i] = 90;
         }
@@ -1663,20 +1673,25 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         }
 
-        if (hybrid.equals("sp3") && oxNum == 1) {
-            frags[91]++;
-            alogpfrag[i] = 91;
-        } else if (hybrid.equals("sp3") && oxNum == 2) {
-            frags[92]++;
-            alogpfrag[i] = 92;
-        } else if (hybrid.equals("sp3") && oxNum == 3) {
-            frags[93]++;
-            alogpfrag[i] = 93;
-        } else if (hybrid.equals("sp2") && oxNum == 1) {
-            frags[94]++;
-            alogpfrag[i] = 94;
-        } else if ((hybrid.equals("sp2") && oxNum > 1) || (hybrid.equals("sp") && oxNum >= 1)
-                || (hybrid.equals("sp3") && oxNum == 4) || !ca0.getSymbol().equals("C")) {
+        if (ca0.getAtomicNumber() == 6) {
+            if (hybrid.equals("sp3") && oxNum == 1) {
+                frags[91]++;
+                alogpfrag[i] = 91;
+            } else if (hybrid.equals("sp3") && oxNum == 2) {
+                frags[92]++;
+                alogpfrag[i] = 92;
+            } else if (hybrid.equals("sp3") && oxNum == 3) {
+                frags[93]++;
+                alogpfrag[i] = 93;
+            } else if (hybrid.equals("sp2") && oxNum == 1) {
+                frags[94]++;
+                alogpfrag[i] = 94;
+            } else if ((hybrid.equals("sp2") && oxNum > 1) || (hybrid.equals("sp") && oxNum >= 1)
+                       || (hybrid.equals("sp3") && oxNum == 4)) {
+                frags[95]++;
+                alogpfrag[i] = 95;
+            }
+        } else {
             frags[95]++;
             alogpfrag[i] = 95;
         }
@@ -1735,20 +1750,25 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         }
 
-        if (hybrid.equals("sp3") && oxNum == 1) {
-            frags[96]++;
-            alogpfrag[i] = 96;
-        } else if (hybrid.equals("sp3") && oxNum == 2) {
-            frags[97]++;
-            alogpfrag[i] = 97;
-        } else if (hybrid.equals("sp3") && oxNum == 3) {
-            frags[98]++;
-            alogpfrag[i] = 98;
-        } else if (hybrid.equals("sp2") && oxNum == 1) {
-            frags[99]++;
-            alogpfrag[i] = 99;
-        } else if ((hybrid.equals("sp2") && oxNum > 1) || (hybrid.equals("sp") && oxNum >= 1)
-                || (hybrid.equals("sp3") && oxNum == 4) || !ca0.getSymbol().equals("C")) {
+        if (ca0.getAtomicNumber() == 6) {
+            if (hybrid.equals("sp3") && oxNum == 1) {
+                frags[96]++;
+                alogpfrag[i] = 96;
+            } else if (hybrid.equals("sp3") && oxNum == 2) {
+                frags[97]++;
+                alogpfrag[i] = 97;
+            } else if (hybrid.equals("sp3") && oxNum == 3) {
+                frags[98]++;
+                alogpfrag[i] = 98;
+            } else if (hybrid.equals("sp2") && oxNum == 1) {
+                frags[99]++;
+                alogpfrag[i] = 99;
+            } else if ((hybrid.equals("sp2") && oxNum > 1) || (hybrid.equals("sp") && oxNum >= 1)
+                       || (hybrid.equals("sp3") && oxNum == 4)) {
+                frags[100]++;
+                alogpfrag[i] = 100;
+            }
+        } else {
             frags[100]++;
             alogpfrag[i] = 100;
         }

--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptor.java
@@ -524,7 +524,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (fragment[i].equals("SsssCH")) {
 
-            java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+            List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
             int htype = getHAtomType(atomContainer.getAtom(i), ca);
             int carbonCount = 0;
             int heteroCount = 0;
@@ -562,7 +562,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
     private void calcGroup004_011_to_014(int i) {
         // C in CR4, CR3X, CX4
         if (fragment[i].equals("SssssC")) {
-            java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+            List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
             int carbonCount = 0;
             int heteroCount = 0;
             // logger.debug("here");
@@ -675,7 +675,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (!fragment[i].equals("SdssC")) return;
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(ai);
+        List ca = atomContainer.getConnectedAtomsList(ai);
 
         int rCount = 0;
         int xCount = 0;
@@ -848,7 +848,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         }
 
         // check if both hetero atoms have at least one double bond
-        java.util.List bonds = atomContainer.getConnectedBondsList(ca0);
+        List bonds = atomContainer.getConnectedBondsList(ca0);
         boolean haveDouble1 = false;
         for (int k = 0; k <= bonds.size() - 1; k++) {
             if (((IBond) bonds.get(k)).getOrder() == IBond.Order.DOUBLE) {
@@ -904,7 +904,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         if (!fragment[i].equals("SsaaC") && !fragment[i].equals("SaaaC")) return;
 
         IAtom ai = atomContainer.getAtom(i);
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
 
         IAtom[] sameringatoms = new IAtom[2];
         IAtom nonringatom = atomContainer.getBuilder().newInstance(IAtom.class);
@@ -936,7 +936,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         }
 
         // check if both hetero atoms have at least one double bond
-        java.util.List bonds = atomContainer.getConnectedBondsList(sameringatoms[0]);
+        List bonds = atomContainer.getConnectedBondsList(sameringatoms[0]);
 
         boolean haveDouble1 = false;
 
@@ -1151,7 +1151,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             return;
         }
 
-        java.util.List ca2 = atomContainer.getConnectedAtomsList(ca0);
+        List ca2 = atomContainer.getConnectedAtomsList(ca0);
         for (int j = 0; j <= ca2.size() - 1; j++) {
             if (atomContainer.getBond((IAtom) ca2.get(j), ca0).getOrder() == IBond.Order.DOUBLE) {
                 frags[57]++;
@@ -1164,7 +1164,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
     }
 
     private void calcGroup058_61(int i) {
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
 
         // 58: O in =O
         // 61: --O in nitro, N-oxides
@@ -1199,7 +1199,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         if (!fragment[i].equals("SssO") && !fragment[i].equals("SaaO")) return;
 
         // Al-O-Ar, Ar2O
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ca0 = (IAtom) ca.get(0);
         IAtom ca1 = (IAtom) ca.get(1);
 
@@ -1215,7 +1215,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
                     // O-P(=S)
                     // was considered to count as group 60
 
-                    java.util.List ca2 = atomContainer.getConnectedAtomsList(((IAtom) ca.get(j)));
+                    List ca2 = atomContainer.getConnectedAtomsList(((IAtom) ca.get(j)));
                     for (int k = 0; k <= ca2.size() - 1; k++) {
                         if (atomContainer.getBond(((IAtom) ca.get(j)), (IAtom) ca2.get(k)).getOrder() == IBond.Order.DOUBLE) {
                             if (!((IAtom) ca2.get(k)).getSymbol().equals("C")) {
@@ -1271,7 +1271,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         for (int j = 0; j <= nbors.size() - 1; j++) {
             if (nbors.get(j).getAtomicNumber() == 1)
                 continue;
-            java.util.List ca2 = atomContainer.getConnectedAtomsList((IAtom) nbors.get(j));
+            List ca2 = atomContainer.getConnectedAtomsList((IAtom) nbors.get(j));
             for (int k = 0; k <= ca2.size() - 1; k++) {
                 IAtom ca2k = (IAtom) ca2.get(k);
                 if (atomContainer.indexOf(ca2k) != i) {
@@ -1426,10 +1426,10 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (!fragment[i].equals("SsF")) return;
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ca0 = (IAtom) ca.get(0);
 
-        java.util.List bonds = atomContainer.getConnectedBondsList(ca0);
+        List bonds = atomContainer.getConnectedBondsList(ca0);
 
         int doublebondcount = 0;
         int triplebondcount = 0;
@@ -1456,10 +1456,9 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             hybrid = "sp";
         }
 
-        java.util.List ca2 = atomContainer.getConnectedAtomsList(ca0);
+        List ca2 = atomContainer.getConnectedAtomsList(ca0);
 
         int oxNum = 0;
-
         for (int j = 0; j <= ca2.size() - 1; j++) {
             IAtom ca2j = (IAtom) ca2.get(j);
             if (isHetero(ca2j))
@@ -1490,10 +1489,10 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (!fragment[i].equals("SsCl")) return;
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ca0 = (IAtom) ca.get(0);
 
-        java.util.List bonds = atomContainer.getConnectedBondsList(ca0);
+        List bonds = atomContainer.getConnectedBondsList(ca0);
 
         int doublebondcount = 0;
         int triplebondcount = 0;
@@ -1520,7 +1519,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             hybrid = "sp";
         }
 
-        java.util.List ca2 = atomContainer.getConnectedAtomsList(ca0);
+        List ca2 = atomContainer.getConnectedAtomsList(ca0);
 
         int oxNum = 0;
 
@@ -1561,10 +1560,10 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (!fragment[i].equals("SsBr")) return;
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ca0 = (IAtom) ca.get(0);
 
-        java.util.List bonds = atomContainer.getConnectedBondsList(ca0);
+        List bonds = atomContainer.getConnectedBondsList(ca0);
 
         int doublebondcount = 0;
         int triplebondcount = 0;
@@ -1591,7 +1590,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             hybrid = "sp";
         }
 
-        java.util.List ca2 = atomContainer.getConnectedAtomsList(ca0);
+        List ca2 = atomContainer.getConnectedAtomsList(ca0);
 
         int oxNum = 0;
 
@@ -1633,10 +1632,10 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         if (!fragment[i].equals("SsI")) return;
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ca0 = (IAtom) ca.get(0);
 
-        java.util.List bonds = atomContainer.getConnectedBondsList(ca0);
+        List bonds = atomContainer.getConnectedBondsList(ca0);
 
         int doublebondcount = 0;
         int triplebondcount = 0;
@@ -1663,7 +1662,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
             hybrid = "sp";
         }
 
-        java.util.List ca2 = atomContainer.getConnectedAtomsList(ca0);
+        List ca2 = atomContainer.getConnectedAtomsList(ca0);
 
         int oxNum = 0;
 
@@ -1780,7 +1779,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
         // (it doesn't check which atoms are singly bonded to S
         if (!fragment[i].equals("SdssS")) return;
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ai = atomContainer.getAtom(i);
         int sdOCount = 0;
         int ssCCount = 0;
@@ -1805,7 +1804,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
     private void calcGroup110(int i) {
         if (!fragment[i].equals("SddssS")) return;
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ai = atomContainer.getAtom(i);
         int sdOCount = 0;
         int ssCCount = 0;
@@ -1839,7 +1838,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
 
         // S in R=S
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ai = atomContainer.getAtom(i);
 
         int xCount = 0;
@@ -1880,7 +1879,7 @@ public class ALOGPDescriptor extends AbstractMolecularDescriptor implements IMol
     private void calcGroup118_119(int i) {
         if (!fragment[i].equals("SsssP")) return;
 
-        java.util.List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
+        List ca = atomContainer.getConnectedAtomsList(atomContainer.getAtom(i));
         IAtom ai = atomContainer.getAtom(i);
         int xCount = 0;
         int rCount = 0;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ALOGPDescriptorTest.java
@@ -69,8 +69,8 @@ public class ALOGPDescriptorTest extends MolecularDescriptorTest {
                         .addImplicitHydrogens(mol);
 
         DescriptorValue v = descriptor.calculate(mol);
-        Assert.assertEquals(0.5192, ((DoubleArrayResult) v.getValue()).get(0), 0.0001);
-        Assert.assertEquals(19.1381, ((DoubleArrayResult) v.getValue()).get(2), 0.0001);
+        Assert.assertEquals(1.719, ((DoubleArrayResult) v.getValue()).get(0), 0.01);
+        Assert.assertEquals(20.585, ((DoubleArrayResult) v.getValue()).get(2), 0.01);
     }
 
 }

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/MolecularDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/MolecularDescriptorTest.java
@@ -32,6 +32,7 @@ import org.openscience.cdk.dict.DictionaryDatabase;
 import org.openscience.cdk.dict.Entry;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomType;
@@ -87,6 +88,7 @@ public abstract class MolecularDescriptorTest extends DescriptorTest<IMolecularD
     public void descriptorDoesNotChangeFlags() throws CDKException {
         IAtomContainer mol = TestMoleculeFactory.makeBenzene();
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
+        Cycles.markRingAtomsAndBonds(mol);
         Number   mflags = mol.getFlagValue();
         Number[] aflags = getAtomFlags(mol);
         Number[] bflags = getBondFlags(mol);


### PR DESCRIPTION
Following analysis form #538, various tweaks to align closer with VEGA. Now in to diminising returns. Testing on 10K from ChEMBL we previously had an RSME of 7.14 and is now 0.10 with 86% of compounds have a LogP < 0.01 abs diff. 

Before:
```
Sample Size:    10000
N < 0.01 diff:  1048
Difference Sum: 15542.94
RMSE:           7.14
```

Now
```
Sample Size:    10000
N < 0.01 diff:  8665
Difference Sum: 838.09
RMSE:           0.10
```