### PR TITLE
Patch/get mass

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/formula/MolecularFormula.java
+++ b/base/data/src/main/java/org/openscience/cdk/formula/MolecularFormula.java
@@ -113,6 +113,8 @@ public class MolecularFormula implements IMolecularFormula {
      */
     @Override
     public IMolecularFormula addIsotope(IIsotope isotope, int count) {
+        if (count == 0)
+            return this;
         boolean flag = false;
         for (IIsotope thisIsotope : isotopes()) {
             if (isTheSame(thisIsotope, isotope)) {

--- a/base/silent/src/main/java/org/openscience/cdk/silent/MolecularFormula.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/MolecularFormula.java
@@ -110,6 +110,8 @@ public class MolecularFormula implements IMolecularFormula {
      */
     @Override
     public IMolecularFormula addIsotope(IIsotope isotope, int count) {
+        if (count == 0)
+            return this;
         boolean flag = false;
         for (IIsotope thisIsotope : isotopes()) {
             if (isTheSame(thisIsotope, isotope)) {

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -24,27 +24,12 @@
  *  */
 package org.openscience.cdk.tools.manipulator;
 
-import static org.openscience.cdk.CDKConstants.SINGLE_OR_DOUBLE;
-import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
 import com.google.common.collect.Maps;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.atomtype.CDKAtomTypeMatcher;
-import org.openscience.cdk.config.Isotopes;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.config.IsotopeFactory;
+import org.openscience.cdk.config.Isotopes;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtom;
@@ -55,9 +40,9 @@ import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.IElectronContainer;
+import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.interfaces.IIsotope;
 import org.openscience.cdk.interfaces.ILonePair;
-import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.ISingleElectron;
 import org.openscience.cdk.interfaces.IStereoElement;
@@ -73,6 +58,21 @@ import org.openscience.cdk.stereo.TetrahedralChirality;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.openscience.cdk.CDKConstants.SINGLE_OR_DOUBLE;
+import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation;
 
 /**
  * Class with convenience methods that provide methods to manipulate

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -206,102 +206,207 @@ public class AtomContainerManipulator {
         return charge;
     }
 
-    /**
-     * Get the summed exact mass of all atoms in an AtomContainer. It
-     * requires isotope information for all atoms to be set. Either set
-     * this information using the {@link IsotopeFactory}, or use the
-     * {@link MolecularFormulaManipulator#getMajorIsotopeMass(org.openscience.cdk.interfaces.IMolecularFormula)}
-     * method, after converting the {@link IAtomContainer} to a
-     * {@link IMolecularFormula} with the {@link MolecularFormulaManipulator}.
-     *
-     * @param  atomContainer The IAtomContainer to manipulate
-     * @return The summed exact mass of all atoms in this AtomContainer.
-     * @see #getMolecularWeight(IAtomContainer)
-     */
-    public static double getTotalExactMass(IAtomContainer atomContainer) {
-        try {
+    private static boolean hasIsotopeSpecified(IIsotope atom) {
+        return atom.getMassNumber() != null && atom.getMassNumber() != 0;
+    }
 
-            Isotopes isotopes = Isotopes.getInstance();
-            double mass = 0.0;
-            double hExactMass = isotopes.getMajorIsotope(1).getExactMass();
-            for (IAtom atom : atomContainer.atoms()) {
-                if (atom.getImplicitHydrogenCount() == null)
-                    throw new IllegalArgumentException("an atom had with unknown (null) implicit hydrogens");
-                mass += atom.getExactMass();
-                mass += atom.getImplicitHydrogenCount() * hExactMass;
-            }
-            return mass;
-        } catch (IOException e) {
-            throw new RuntimeException("Isotopes definitions could not be loaded", e);
+    private static double getExactMass(IsotopeFactory isofact, IIsotope atom) {
+        if (atom.getExactMass() != null)
+            return atom.getExactMass();
+        else if (atom.getMassNumber() != null)
+            return isofact.getExactMass(getAtomicNum(atom),
+                                        atom.getMassNumber());
+        else
+            return isofact.getMajorIsotopeMass(getAtomicNum(atom));
+    }
+
+    private static double getMassOrAvg(IsotopeFactory isofact, IIsotope atom) {
+        if (!hasIsotopeSpecified(atom))
+            return isofact.getNaturalMass(atom);
+        return getExactMass(isofact, atom);
+    }
+
+    public static final int MolWeight     = 0x1;
+    public static final int AverageWeight = 0x2;
+    public static final int MonoIsotopic  = 0x3;
+    public static final int MostAbundant  = 0x4;
+
+    public static final Comparator<IIsotope> NAT_ABUN_COMP = new Comparator<IIsotope>() {
+        @Override
+        public int compare(IIsotope o1, IIsotope o2) {
+            return -Double.compare(o1.getNaturalAbundance(),
+                                   o2.getNaturalAbundance());
         }
+    };
+
+    private static double getDistMass(IsotopeFactory isofact,
+                                      IIsotope[] isos, int idx, int count) {
+        if (count == 0)
+            return 0;
+        double frac = 100d;
+        double res  = 0;
+        for (int i = 0; i < idx; i++)
+            frac -= isos[i].getNaturalAbundance();
+        double p    = isos[idx].getNaturalAbundance() / frac;
+        if (p >= 1.0)
+            return count * isos[idx].getExactMass();
+        double kMin = (count + 1) * (1 - p) - 1;
+        double kMax = (count + 1) * (1 - p);
+        if ((int) Math.ceil(kMin) == (int) Math.floor(kMax)) {
+            int k = (int) kMax;
+            res = (count - k) * getExactMass(isofact,
+                                             isos[idx]);
+            res += getDistMass(isofact, isos, idx + 1, k);
+        }
+        return res;
+    }
+
+    private static int getImplHCount(IAtom atom) {
+        Integer implh = atom.getImplicitHydrogenCount();
+        if (implh == null)
+            throw new IllegalArgumentException("An atom had 'null' implicit hydrogens!");
+        return implh;
+    }
+
+    private static int getAtomicNum(IElement atom) {
+        Integer atno = atom.getAtomicNumber();
+        if (atno == null)
+            throw new IllegalArgumentException("An atom had 'null' atomic number!");
+        return atno;
     }
 
     /**
-     * Returns the molecular mass of the IAtomContainer. For the calculation it
-     * uses the masses of the isotope mixture using natural abundances.
+     * Calculate the mass of a molecule, this function takes an optional
+     * 'mass flavour' that switches the computation type, the flavours are:
+     * <br>
+     * <ul>
+     *     <li>{@link #MolWeight} (default) - use and isotopes the natural mass
+     *     unless a specific isotope is specified</li>
+     *     <li>{@link #AverageWeight} - use and isotopes the natural mass even
+     *     if a specific isotope is specified</li>
+     *     <li>{@link #MonoIsotopic} - use and isotopes the major isotope mass
+     *     even if a specific isotope is specified</li>
+     *     <li>{@link #MostAbundant} - use the distribution of isotopes
+     *     based on their abundance and select the most abundant. For example
+     *     C<sub>6</sub>Br<sub>6</sub> would have three <sup>79</sup>Br and
+     *     <sup>81</sup>Br because their abundance is 51 and 49%.
+     * </ul>
      *
-     * @param atomContainer
-     * @cdk.keyword mass, molecular
-     * @see #getMolecularWeight(IAtomContainer)
+     * @param mol molecule to compute mass for
+     * @param flav the mass flavour
+     * @return the mass of the molecule
+     * @see #MolWeight
+     * @see #AverageWeight
+     * @see #MonoIsotopic
+     * @see #MostAbundant
      */
-    public static double getNaturalExactMass(IAtomContainer atomContainer) {
+    public static double getMass(IAtomContainer mol, int flav) {
+
+        final Isotopes isofact;
         try {
-            Isotopes isotopes = Isotopes.getInstance();
-            double hydgrogenMass = isotopes.getNaturalMass(Elements.HYDROGEN);
-
-            double mass = 0.0;
-            for (final IAtom atom : atomContainer.atoms()) {
-
-                if (atom.getAtomicNumber() == null)
-                    throw new IllegalArgumentException("an atom had with unknown (null) atomic number");
-                if (atom.getImplicitHydrogenCount() == null)
-                    throw new IllegalArgumentException("an atom had with unknown (null) implicit hydrogens");
-
-                mass += isotopes.getNaturalMass(Elements.ofNumber(atom.getAtomicNumber()).toIElement());
-                mass += hydgrogenMass * atom.getImplicitHydrogenCount();
-            }
-            return mass;
-
+            isofact = Isotopes.getInstance();
         } catch (IOException e) {
-            throw new RuntimeException("Isotopes definitions could not be loaded", e);
+            throw new IllegalStateException("Could not load Isotopes!");
         }
-    }
 
-    /**
-     * Calculate the molecular weight of a molecule.
-     *
-     * @param mol the molecule
-     * @return the molecular weight
-     */
-    public static double getMolecularWeight(IAtomContainer mol) {
-        try {
-            Isotopes isotopes = Isotopes.getInstance();
-            double hmass = isotopes.getNaturalMass(Elements.HYDROGEN);
-            double mw    = 0.0;
-            for (final IAtom atom : mol.atoms()) {
-                if (atom.getAtomicNumber() == null || atom.getAtomicNumber() == 0)
-                    throw new IllegalArgumentException("An atom had with unknown (null) atomic number");
-                if (atom.getImplicitHydrogenCount() == null)
-                    throw new IllegalArgumentException("An atom had with unknown (null) implicit hydrogens");
-                mw += hmass * atom.getImplicitHydrogenCount();
-                if (atom.getMassNumber() == null)
-                    mw += isotopes.getNaturalMass(atom);
-                else if (atom.getExactMass() != null)
-                    mw += atom.getExactMass();
-                else {
-                    IIsotope isotope = isotopes.getIsotope(atom.getSymbol(), atom.getMassNumber());
-                    if (isotope == null)
-                        mw += isotopes.getNaturalMass(atom);
+        double mass = 0;
+        int    hcnt = 0;
+
+        switch (flav & 0xf) {
+            case MolWeight:
+                for (IAtom atom : mol.atoms()) {
+                    mass += getMassOrAvg(isofact, atom);
+                    hcnt += getImplHCount(atom);
+                }
+                mass += hcnt * isofact.getNaturalMass(1);
+                break;
+            case AverageWeight:
+                for (IAtom atom : mol.atoms()) {
+                    mass += isofact.getNaturalMass(getAtomicNum(atom));
+                    hcnt += getImplHCount(atom);
+                }
+                mass += hcnt * isofact.getNaturalMass(1);
+                break;
+            case MonoIsotopic:
+                for (IAtom atom : mol.atoms()) {
+                    mass += getExactMass(isofact, atom);
+                    hcnt += getImplHCount(atom);
+                }
+                mass += hcnt * isofact.getMajorIsotopeMass(1);
+                break;
+            case MostAbundant:
+                int[] mf = new int[128];
+                for (IAtom atom : mol.atoms()) {
+                    if (hasIsotopeSpecified(atom))
+                        mass += getExactMass(isofact, atom);
                     else
-                        mw += isotope.getExactMass();
+                        mf[getAtomicNum(atom)]++;
+                    mf[1] += atom.getImplicitHydrogenCount();
                 }
 
-            }
-            return mw;
-
-        } catch (IOException e) {
-            throw new RuntimeException("Isotopes definitions could not be loaded", e);
+                for (int atno = 0; atno < mf.length; atno++) {
+                    if (mf[atno] == 0)
+                        continue;
+                    IIsotope[] isotopes = isofact.getIsotopes(atno);
+                    Arrays.sort(isotopes, NAT_ABUN_COMP);
+                    mass += getDistMass(isofact, isotopes, 0, mf[atno]);
+                }
+                break;
         }
+        return mass;
+    }
+
+    /**
+     * Calculate the mass of a molecule, this function takes an optional
+     * 'mass flavour' that switches the computation type, the flavours are:
+     * <br>
+     * <ul>
+     *     <li>{@link #MolWeight} (default) - use and isotopes the natural mass
+     *     unless a specific isotope is specified</li>
+     *     <li>{@link #AverageWeight} - use and isotopes the natural mass even
+     *     if a specific isotope is specified</li>
+     *     <li>{@link #MonoIsotopic} - use and isotopes the major isotope mass
+     *     even if a specific isotope is specified</li>
+     *     <li>{@link #MostAbundant} - use the distribution of isotopes
+     *     based on their abundance and select the most abundant. For example
+     *     C<sub>6</sub>Br<sub>6</sub> would have three <sup>79</sup>Br and
+     *     <sup>81</sup>Br because their abundance is 51 and 49%.
+     * </ul>
+     *
+     * @param mol molecule to compute mass for
+     * @return the mass of the molecule
+     * @see #getMass(IAtomContainer, int)
+     * @see #MolWeight
+     * @see #AverageWeight
+     * @see #MonoIsotopic
+     * @see #MostAbundant
+     */
+    public static double getMass(IAtomContainer mol) {
+        return getMass(mol, MolWeight);
+    }
+
+    /**
+     * @deprecated use {@link #getMass(IAtomContainer, int)} and
+     * {@link #MonoIsotopic}
+     */
+    public static double getTotalExactMass(IAtomContainer mol) {
+        return getMass(mol, MonoIsotopic);
+    }
+
+    /**
+     * @deprecated use {@link #getMass(IAtomContainer, int)} and
+     * {@link #AverageWeight}
+     */
+    public static double getNaturalExactMass(IAtomContainer mol) {
+        return getMass(mol, AverageWeight);
+    }
+
+    /**
+     * @deprecated use {@link #getMass(IAtomContainer, int)} and
+     * {@link #MolWeight}
+     */
+    public static double getMolecularWeight(IAtomContainer mol) {
+        return getMass(mol, MolWeight);
     }
 
     /**

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -313,13 +313,13 @@ public class AtomContainerManipulator {
      * <br>
      * <ul>
      *     <li>{@link #MolWeight} (default) - uses the exact mass of each
-     *     atom when specified, if not specified the average mass of the element
-     *     is used.</li>
+     *     atom when an isotope is specified, if not specified the average mass
+     *     of the element is used.</li>
      *     <li>{@link #MolWeightIgnoreSpecified} - uses the average mass of each
-     *     element ignoring any exact mass that has been specified.</li>
-     *     <li>{@link #MonoIsotopic} - uses the exact mass of each atom when
-     *      specified, if not specified the major isotope mass for that
-     *      element is used.</li>
+     *     element, ignoring any isotopic/exact mass specification</li>
+     *     <li>{@link #MonoIsotopic} - uses the exact mass of each
+     *     atom when an isotope is specified, if not specified the major isotope
+     *     mass for that element is used.</li>
      *     <li>{@link #MostAbundant} - uses the exact mass of each atom when
      *     specified, if not specified a distribution is calculated and the
      *     most abundant isotope pattern is used.</li>
@@ -401,13 +401,13 @@ public class AtomContainerManipulator {
      * <br>
      * <ul>
      *     <li>{@link #MolWeight} (default) - uses the exact mass of each
-     *     atom when specified, if not specified the average mass of the element
-     *     is used.</li>
+     *     atom when an isotope is specified, if not specified the average mass
+     *     of the element is used.</li>
      *     <li>{@link #MolWeightIgnoreSpecified} - uses the average mass of each
-     *     element ignoring any exact mass that has been specified.</li>
-     *     <li>{@link #MonoIsotopic} - uses the exact mass of each atom when
-     *      specified, if not specified the major isotope mass for that
-     *      element is used.</li>
+     *     element, ignoring any isotopic/exact mass specification</li>
+     *     <li>{@link #MonoIsotopic} - uses the exact mass of each
+     *     atom when an isotope is specified, if not specified the major isotope
+     *     mass for that element is used.</li>
      *     <li>{@link #MostAbundant} - uses the exact mass of each atom when
      *     specified, if not specified a distribution is calculated and the
      *     most abundant isotope pattern is used.</li>

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -18,23 +18,6 @@
  */
 package org.openscience.cdk.tools.manipulator;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,6 +52,18 @@ import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.stereo.TetrahedralChirality;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.junit.Assert.*;
+import static org.openscience.cdk.tools.manipulator.AtomContainerManipulator.*;
 
 /**
  * @cdk.module test-standard
@@ -1338,5 +1333,64 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
         String smiAct = new SmilesGenerator().create(AtomContainerManipulator.removeHydrogens(m));
 
         assertThat(smiAct, is(smiExp));
+    }
+
+    @Test public void getMassC6Br6() throws InvalidSmilesException {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        SmilesParser smipar = new SmilesParser(bldr);
+        IAtomContainer mol = smipar.parseSmiles("Brc1c(Br)c(Br)c(Br)c(Br)c1Br");
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
+                   closeTo(551.485, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
+                   closeTo(551.485, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
+                   closeTo(545.510, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, MostAbundant),
+                   closeTo(551.503, 0.001));
+    }
+
+    @Test public void getMassCranbin() {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IAtomContainer mol =
+                MolecularFormulaManipulator.getAtomContainer("C202H315N55O64S6",
+                                                              bldr);
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
+                   closeTo(4730.397, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
+                   closeTo(4730.397, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
+                   closeTo(4727.140, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, MostAbundant),
+                   closeTo(4729.147, 0.001));
+    }
+
+    @Test public void getMassCranbinSpecIsotopes() {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IAtomContainer mol =
+                MolecularFormulaManipulator.getAtomContainer("[12]C200[13]C2[1]H315[14]N55[16]O64[32]S6",
+                                                             bldr);
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
+                   closeTo(4729.147, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
+                   closeTo(4730.397, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
+                   closeTo(4729.147, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, MostAbundant),
+                   closeTo(4729.147, 0.001));
+    }
+
+    @Test public void getMassCranbinMixedSpecIsotopes() {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IAtomContainer mol =
+                MolecularFormulaManipulator.getAtomContainer("C200[13]C2H315N55O64S6",
+                                                             bldr);
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
+                   closeTo(4732.382, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
+                   closeTo(4730.397, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
+                   closeTo(4729.147, 0.001));
+        assertThat(AtomContainerManipulator.getMass(mol, MostAbundant),
+                   closeTo(4731.154, 0.001));
     }
 }

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -1341,7 +1341,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
         IAtomContainer mol = smipar.parseSmiles("Brc1c(Br)c(Br)c(Br)c(Br)c1Br");
         assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                    closeTo(551.485, 0.001));
-        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoringSpecified),
                    closeTo(551.485, 0.001));
         assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                    closeTo(545.510, 0.001));
@@ -1356,7 +1356,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
                                                               bldr);
         assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                    closeTo(4730.397, 0.001));
-        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoringSpecified),
                    closeTo(4730.397, 0.001));
         assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                    closeTo(4727.140, 0.001));
@@ -1371,7 +1371,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
                                                              bldr);
         assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                    closeTo(4729.147, 0.001));
-        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoringSpecified),
                    closeTo(4730.397, 0.001));
         assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                    closeTo(4729.147, 0.001));
@@ -1386,7 +1386,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
                                                              bldr);
         assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                    closeTo(4732.382, 0.001));
-        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoringSpecified),
                    closeTo(4730.397, 0.001));
         assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                    closeTo(4729.147, 0.001));

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -1341,7 +1341,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
         IAtomContainer mol = smipar.parseSmiles("Brc1c(Br)c(Br)c(Br)c(Br)c1Br");
         assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                    closeTo(551.485, 0.001));
-        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoringSpecified),
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoreSpecified),
                    closeTo(551.485, 0.001));
         assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                    closeTo(545.510, 0.001));
@@ -1356,7 +1356,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
                                                               bldr);
         assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                    closeTo(4730.397, 0.001));
-        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoringSpecified),
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoreSpecified),
                    closeTo(4730.397, 0.001));
         assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                    closeTo(4727.140, 0.001));
@@ -1371,7 +1371,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
                                                              bldr);
         assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                    closeTo(4729.147, 0.001));
-        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoringSpecified),
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoreSpecified),
                    closeTo(4730.397, 0.001));
         assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                    closeTo(4729.147, 0.001));
@@ -1386,7 +1386,7 @@ public class AtomContainerManipulatorTest extends CDKTestCase {
                                                              bldr);
         assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                    closeTo(4732.382, 0.001));
-        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoringSpecified),
+        assertThat(AtomContainerManipulator.getMass(mol, MolWeightIgnoreSpecified),
                    closeTo(4730.397, 0.001));
         assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                    closeTo(4729.147, 0.001));

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -813,6 +813,8 @@ public class MolecularFormulaManipulator {
      * @return          The mass with the correction
      */
     private static double correctMass(double mass, Integer charge) {
+        if (charge == null)
+            return mass;
         double massE = 0.00054857990927;
         if (charge > 0)
             mass -= massE * charge;

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -883,13 +883,13 @@ public class MolecularFormulaManipulator {
      * <br>
      * <ul>
      *     <li>{@link #MolWeight} (default) - uses the exact mass of each
-     *     atom when specified, if not specified the average mass of the element
-     *     is used.</li>
+     *     atom when an isotope is specified, if not specified the average mass
+     *     of the element is used.</li>
      *     <li>{@link #MolWeightIgnoreSpecified} - uses the average mass of each
-     *     element ignoring any exact mass that has been specified.</li>
-     *     <li>{@link #MonoIsotopic} - uses the exact mass of each atom when
-     *      specified, if not specified the major isotope mass for that
-     *      element is used.</li>
+     *     element, ignoring any isotopic/exact mass specification</li>
+     *     <li>{@link #MonoIsotopic} - uses the exact mass of each
+     *     atom when an isotope is specified, if not specified the major isotope
+     *     mass for that element is used.</li>
      *     <li>{@link #MostAbundant} - uses the exact mass of each atom when
      *     specified, if not specified a distribution is calculated and the
      *     most abundant isotope pattern is used.</li>
@@ -952,13 +952,13 @@ public class MolecularFormulaManipulator {
      * <br>
      * <ul>
      *     <li>{@link #MolWeight} (default) - uses the exact mass of each
-     *     atom when specified, if not specified the average mass of the element
-     *     is used.</li>
+     *     atom when an isotope is specified, if not specified the average mass
+     *     of the element is used.</li>
      *     <li>{@link #MolWeightIgnoreSpecified} - uses the average mass of each
-     *     element ignoring any exact mass that has been specified.</li>
-     *     <li>{@link #MonoIsotopic} - uses the exact mass of each atom when
-     *      specified, if not specified the major isotope mass for that
-     *      element is used.</li>
+     *     element, ignoring any isotopic/exact mass specification</li>
+     *     <li>{@link #MonoIsotopic} - uses the exact mass of each
+     *     atom when an isotope is specified, if not specified the major isotope
+     *     mass for that element is used.</li>
      *     <li>{@link #MostAbundant} - uses the exact mass of each atom when
      *     specified, if not specified a distribution is calculated and the
      *     most abundant isotope pattern is used.</li>

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -227,7 +227,7 @@ public class MolecularFormulaManipulator {
     }
 
     /**
-     * Returns the string representation of the molecule formula.
+     * Returns the string representation of the molecular formula.
      *
      * @param formula       The IMolecularFormula Object
      * @param orderElements The order of Elements
@@ -257,7 +257,7 @@ public class MolecularFormulaManipulator {
     }
 
     /**
-     * Returns the string representation of the molecule formula.
+     * Returns the string representation of the molecular formula.
      *
      * @param formula       The IMolecularFormula Object
      * @param orderElements The order of Elements
@@ -326,7 +326,7 @@ public class MolecularFormulaManipulator {
     }
 
     /**
-     * Returns the string representation of the molecule formula.
+     * Returns the string representation of the molecular formula.
      * Based on Hill System. The Hill system is a system of writing
      * chemical formulas such that the number of carbon atoms in a
      * molecule is indicated first, the number of hydrogen atoms next,
@@ -345,7 +345,7 @@ public class MolecularFormulaManipulator {
     }
 
     /**
-     * Returns the string representation of the molecule formula.
+     * Returns the string representation of the molecular formula.
      * Based on Hill System. The Hill system is a system of writing
      * chemical formulas such that the number of carbon atoms in a
      * molecule is indicated first, the number of hydrogen atoms next,
@@ -370,7 +370,7 @@ public class MolecularFormulaManipulator {
 
 
     /**
-     * Returns the string representation of the molecule formula.
+     * Returns the string representation of the molecular formula.
      * Based on Hill System. The Hill system is a system of writing
      * chemical formulas such that the number of carbon atoms in a
      * molecule is indicated first, the number of hydrogen atoms next,
@@ -464,7 +464,7 @@ public class MolecularFormulaManipulator {
     }
 
     /**
-     * Returns the string representation of the molecule formula based on Hill
+     * Returns the string representation of the molecular formula based on Hill
      * System with numbers wrapped in &lt;sub&gt;&lt;/sub&gt; tags. Useful for
      * displaying formulae in Swing components or on the web.
      *
@@ -479,7 +479,7 @@ public class MolecularFormulaManipulator {
     }
 
     /**
-     * Returns the string representation of the molecule formula based on Hill
+     * Returns the string representation of the molecular formula based on Hill
      * System with numbers wrapped in &lt;sub&gt;&lt;/sub&gt; tags and the
      * isotope of each Element in &lt;sup&gt;&lt;/sup&gt; tags and the total
      * charge of IMolecularFormula in &lt;sup&gt;&lt;/sup&gt; tags. Useful for
@@ -503,7 +503,7 @@ public class MolecularFormulaManipulator {
     }
 
     /**
-     * Returns the string representation of the molecule formula with numbers
+     * Returns the string representation of the molecular formula with numbers
      * wrapped in &lt;sub&gt;&lt;/sub&gt; tags and the isotope of each Element
      * in &lt;sup&gt;&lt;/sup&gt; tags and the total showCharge of IMolecularFormula
      * in &lt;sup&gt;&lt;/sup&gt; tags. Useful for displaying formulae in Swing
@@ -895,7 +895,7 @@ public class MolecularFormulaManipulator {
      *     most abundant isotope pattern is used.</li>
      * </ul>
      *
-     * @param mf molecule formula
+     * @param mf molecular formula
      * @param flav flavor
      * @return the mass of the molecule
      * @see #getMass(IMolecularFormula, int)
@@ -964,7 +964,7 @@ public class MolecularFormulaManipulator {
      *     most abundant isotope pattern is used.</li>
      * </ul>
      *
-     * @param mf molecule formula
+     * @param mf molecular formula
      * @return the mass of the molecule
      * @see #getMass(IMolecularFormula, int)
      * @see #MolWeight

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -40,6 +40,7 @@ import org.openscience.cdk.tools.LoggingToolFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -23,16 +23,11 @@
  *  */
 package org.openscience.cdk.tools.manipulator;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.AtomTypeFactory;
 import org.openscience.cdk.config.Elements;
-import org.openscience.cdk.config.Isotopes;
 import org.openscience.cdk.config.IsotopeFactory;
+import org.openscience.cdk.config.Isotopes;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -43,6 +38,14 @@ import org.openscience.cdk.interfaces.IIsotope;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
 /**
  * Class with convenience methods that provide methods to manipulate
  * {@link IMolecularFormula}'s. For example:

--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -821,10 +821,10 @@ public class MolecularFormulaManipulator {
         return mass;
     }
 
-    private static final int MolWeight     = 0x1;
-    private static final int AverageWeight = 0x2;
-    private static final int MonoIsotopic  = 0x3;
-    private static final int MostAbundant  = 0x4;
+    public static final int MolWeight     = 0x1;
+    public static final int AverageWeight = 0x2;
+    public static final int MonoIsotopic  = 0x3;
+    public static final int MostAbundant  = 0x4;
 
     private static double getExactMass(IsotopeFactory isofact, IIsotope atom) {
         if (atom.getExactMass() != null)

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -1397,4 +1397,49 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         assertThat(MolecularFormulaManipulator.getString(mamf, false, true),
                    is("[54]Fe6[56]Fe92[57]Fe2"));
     }
+
+    @Test public void getMassCranbin() {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IMolecularFormula mf =
+                MolecularFormulaManipulator.getMolecularFormula("C202H315N55O64S6",
+                                                                bldr);
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
+                          closeTo(4730.397, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, AverageWeight),
+                          closeTo(4730.397, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
+                          closeTo(4727.140, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MostAbundant),
+                          closeTo(4729.147, 0.001));
+    }
+
+    @Test public void getMassCranbinSpecIsotopes() {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IMolecularFormula mf =
+                MolecularFormulaManipulator.getMolecularFormula("[12]C200[13]C2[1]H315[14]N55[16]O64[32]S6",
+                                                               bldr);
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
+                          closeTo(4729.147, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, AverageWeight),
+                          closeTo(4730.397, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
+                          closeTo(4729.147, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MostAbundant),
+                          closeTo(4729.147, 0.001));
+    }
+
+    @Test public void getMassCranbinMixedSpecIsotopes() {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IMolecularFormula mf =
+                MolecularFormulaManipulator.getMolecularFormula("C200[13]C2H315N55O64S6",
+                                                                bldr);
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
+                          closeTo(4732.382, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, AverageWeight),
+                          closeTo(4730.397, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
+                          closeTo(4729.147, 0.001));
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MostAbundant),
+                          closeTo(4731.154, 0.001));
+    }
 }

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -1214,7 +1214,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         Assert.assertEquals("C6H6", MolecularFormulaManipulator.getString(f));
 
     }
-    
+
     @Test public void noNullPointerExceptionForExactMassOfRGroups() throws Exception {
         IMolecularFormula formula = new MolecularFormula();
         formula.addIsotope(new Isotope("C"));
@@ -1222,8 +1222,8 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         formula.addIsotope(new Isotope("R"));
         assertThat(MolecularFormulaManipulator.getTotalExactMass(formula),
                    closeTo(15.0234, 0.01));
-    } 
-    
+    }
+
     @Test public void noNullPointerExceptionForMassOfRGroups() throws Exception {
         IMolecularFormula formula = new MolecularFormula();
         formula.addIsotope(new Isotope("C"));
@@ -1231,7 +1231,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         formula.addIsotope(new Isotope("R"));
         assertThat(MolecularFormulaManipulator.getTotalMassNumber(formula),
                    closeTo(15.0, 0.01));
-    } 
+    }
 
     @Test public void noNullPointerExceptionForMajorMassOfRGroups() throws Exception {
         IMolecularFormula formula = new MolecularFormula();
@@ -1249,7 +1249,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         mf.addIsotope(carbon, 10);
         MolecularFormulaManipulator.getNaturalExactMass(mf);
     }
-    
+
     @Test public void acceptMinusAsInput() throws Exception {
         IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
         IMolecularFormula mf = MolecularFormulaManipulator.getMolecularFormula("[PO4]3–",
@@ -1385,6 +1385,25 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
         IMolecularFormula mamf = MolecularFormulaManipulator.getMostAbundant(mf);
         assertThat(MolecularFormulaManipulator.getString(mamf, false, true),
                    is("[12]C6[79]Br3[81]Br3"));
+    }
+
+
+    private static void assertMass(String str, double expMass, int flav) {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        IMolecularFormula mf =
+            MolecularFormulaManipulator.getMolecularFormula(str, bldr);
+        double act = MolecularFormulaManipulator.getMass(mf, flav);
+        assertThat(act, is(closeTo(expMass, 0.01)));
+    }
+
+    @Test
+    public void C6Br6() {
+        assertMass("C6Br6", 551.485, MolWeight);
+        assertMass("C6Br6", 545.510, MonoIsotopic);
+        assertMass("C6Br6", 551.503, MostAbundant);
+        assertMass("[12]C4[13]C2Br6", 553.427, MolWeight);
+        assertMass("[12]C4[13]C2Br6", 547.516, MonoIsotopic);
+        assertMass("[12]C4[13]C2Br6", 553.510, MostAbundant);
     }
 
     // Iron has 4 stable isotopes, 54 @ 5.85%, 56 @ 91.57%, 57 @ 2.12%, and

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -18,17 +18,6 @@
  */
 package org.openscience.cdk.tools.manipulator;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.Atom;
@@ -52,6 +41,18 @@ import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.openscience.cdk.tools.manipulator.AtomContainerManipulator.*;
 
 /**
  * Checks the functionality of the MolecularFormulaManipulator.
@@ -1374,5 +1375,26 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
                 MolecularFormulaManipulator.getMolecularFormula(f,
                                                                 SilentChemObjectBuilder.getInstance());
         assertThat(MolecularFormulaManipulator.getString(m), is("[C3H7]+"));
+    }
+
+    @Test
+    public void getMostAbundant() {
+        IMolecularFormula mf = new MolecularFormula();
+        mf.addIsotope(new Atom("C"), 6);
+        mf.addIsotope(new Atom("Br"), 6);
+        IMolecularFormula mamf = MolecularFormulaManipulator.getMostAbundant(mf);
+        assertThat(MolecularFormulaManipulator.getString(mamf, false, true),
+                   is("[12]C6[79]Br3[81]Br3"));
+    }
+
+    // Iron has 4 stable isotopes, 54 @ 5.85%, 56 @ 91.57%, 57 @ 2.12%, and
+    // 58 @ 0.28%. Given 100 iron's we expected ~6 @ 54, ~92 @ 56 and 2 @ 57
+    @Test
+    public void getMostAbundantFe100() {
+        IMolecularFormula mf = new MolecularFormula();
+        mf.addIsotope(new Atom("Fe"), 100);
+        IMolecularFormula mamf = MolecularFormulaManipulator.getMostAbundant(mf);
+        assertThat(MolecularFormulaManipulator.getString(mamf, false, true),
+                   is("[54]Fe6[56]Fe92[57]Fe2"));
     }
 }

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -1424,7 +1424,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
                                                                 bldr);
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
                           closeTo(4730.397, 0.001));
-        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, AverageWeight),
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoringSpecified),
                           closeTo(4730.397, 0.001));
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
                           closeTo(4727.140, 0.001));
@@ -1439,7 +1439,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
                                                                bldr);
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
                           closeTo(4729.147, 0.001));
-        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, AverageWeight),
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoringSpecified),
                           closeTo(4730.397, 0.001));
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
                           closeTo(4729.147, 0.001));
@@ -1454,7 +1454,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
                                                                 bldr);
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
                           closeTo(4732.382, 0.001));
-        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, AverageWeight),
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoringSpecified),
                           closeTo(4730.397, 0.001));
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
                           closeTo(4729.147, 0.001));

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -52,7 +52,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.openscience.cdk.tools.manipulator.AtomContainerManipulator.*;
+import static org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator.*;
 
 /**
  * Checks the functionality of the MolecularFormulaManipulator.
@@ -1424,7 +1424,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
                                                                 bldr);
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
                           closeTo(4730.397, 0.001));
-        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoringSpecified),
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoreSpecified),
                           closeTo(4730.397, 0.001));
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
                           closeTo(4727.140, 0.001));
@@ -1439,7 +1439,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
                                                                bldr);
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
                           closeTo(4729.147, 0.001));
-        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoringSpecified),
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoreSpecified),
                           closeTo(4730.397, 0.001));
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
                           closeTo(4729.147, 0.001));
@@ -1454,7 +1454,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
                                                                 bldr);
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeight),
                           closeTo(4732.382, 0.001));
-        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoringSpecified),
+        Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MolWeightIgnoreSpecified),
                           closeTo(4730.397, 0.001));
         Assert.assertThat(MolecularFormulaManipulator.getMass(mf, MonoIsotopic),
                           closeTo(4729.147, 0.001));


### PR DESCRIPTION
Adds `getMass()` functions to AtomContainerManipulator and MolecularFormulaManipulator unify the existing calculations. Existing methods are deprecated pointing to the new API.

Some open questions, I used integers for the options but a new 'MassType' enum might be useful. I really don't like adding new class but in this case might make sense. Naming of the options is flexible, would be good to get Emma's thoughts on this (can't find her GitHub handle ATM).

The tests summarise it nicely:

```java
    @Test public void getMassC6Br6() throws InvalidSmilesException {
        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
        SmilesParser smipar = new SmilesParser(bldr);
        IAtomContainer mol = smipar.parseSmiles("Brc1c(Br)c(Br)c(Br)c(Br)c1Br");
        assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                   closeTo(551.485, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
                   closeTo(551.485, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                   closeTo(545.510, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, MostAbundant),
                   closeTo(551.503, 0.001));
    }

    @Test public void getMassCranbin() {
        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
        IAtomContainer mol =
                MolecularFormulaManipulator.getAtomContainer("C202H315N55O64S6",
                                                              bldr);
        assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                   closeTo(4730.397, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
                   closeTo(4730.397, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                   closeTo(4727.140, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, MostAbundant),
                   closeTo(4729.147, 0.001));
    }

    @Test public void getMassCranbinSpecIsotopes() {
        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
        IAtomContainer mol =
                MolecularFormulaManipulator.getAtomContainer("[12]C200[13]C2[1]H315[14]N55[16]O64[32]S6",
                                                             bldr);
        assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                   closeTo(4729.147, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
                   closeTo(4730.397, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                   closeTo(4729.147, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, MostAbundant),
                   closeTo(4729.147, 0.001));
    }

    @Test public void getMassCranbinMixedSpecIsotopes() {
        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
        IAtomContainer mol =
                MolecularFormulaManipulator.getAtomContainer("C200[13]C2H315N55O64S6",
                                                             bldr);
        assertThat(AtomContainerManipulator.getMass(mol, MolWeight),
                   closeTo(4732.382, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, AverageWeight),
                   closeTo(4730.397, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, MonoIsotopic),
                   closeTo(4729.147, 0.001));
        assertThat(AtomContainerManipulator.getMass(mol, MostAbundant),
                   closeTo(4731.154, 0.001));
    }
```