### PR TITLE
Fix NullPointerException in AtomPairs2DFingerprinter.getBitFingerprint.

### DIFF
--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/AtomPairs2DFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/AtomPairs2DFingerprinter.java
@@ -160,8 +160,11 @@ public class AtomPairs2DFingerprinter extends AbstractFingerprinter implements I
         BitSet fp = new BitSet(pathToBit.size());
         List<String> paths = new ArrayList<>();
         calculate(paths, container);
-        for (String path : paths)
+        for (String path : paths) {
+        	if (!pathToBit.containsKey(path))
+        		continue;
             fp.set(pathToBit.get(path));
+        }
         return new BitSetFingerprint(fp);
     }
 

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/AtomPairs2DFingerprintTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/AtomPairs2DFingerprintTest.java
@@ -83,4 +83,14 @@ public class AtomPairs2DFingerprintTest extends AbstractFingerprinterTest {
     public void testGetRawFingerprint() throws Exception {
         IFingerprinter printer = new AtomPairs2DFingerprinter();
     }
+    
+    @Test
+    public void testNullPointerExceptionInGetBitFingerprint() throws Exception {
+        IFingerprinter printer = new AtomPairs2DFingerprinter();
+        IAtomContainer chlorobenzene;
+        chlorobenzene = parser.parseSmiles("Clc1ccccc1");
+        BitSetFingerprint bsfp1 = (BitSetFingerprint) printer.getBitFingerprint(chlorobenzene);
+        chlorobenzene = parser.parseSmiles("c1ccccc1Cl");
+        BitSetFingerprint bsfp2 = (BitSetFingerprint) printer.getBitFingerprint(chlorobenzene);
+    }
 }


### PR DESCRIPTION
It makes both direction for each bond but pathToBit table stores only one direction. If it selects opposite side, it throw NullPointerException. This patch fixes it. 
This is from https://github.com/kazuyaujihara/NCDK/issues/13.