### PR TITLE
Fixes the ignoring of an IOSetting due to a missing customize() method

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -952,4 +952,11 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
                                                         "Program name to write at the top of the molfile header, should be exactly 8 characters long",
                                                         "CDK"));
     }
+
+    public void customizeJob() {
+        for (IOSetting setting : getSettings()) {
+            fireIOSettingQuestion(setting);
+        }
+    }
+
 }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -32,6 +32,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
+import org.openscience.cdk.io.listener.PropertiesListener;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.sgroup.SgroupType;
@@ -48,6 +49,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -444,6 +446,26 @@ public class MDLV3000WriterTest {
             mdlw.write(mol);
         }
         assertThat(sw.toString(), containsString("3D"));
+    }
+
+    @Test
+    public void writeCustomTitle() throws Exception {
+        IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
+        IAtomContainer mol = builder.newAtomContainer();
+        IAtom atom = builder.newAtom();
+        atom.setSymbol("C");
+        atom.setImplicitHydrogenCount(4);
+        atom.setPoint3d(new Point3d(0.5, 0.5, 0.1));
+        mol.addAtom(atom);
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
+            Properties sdfWriterProps = new Properties();
+            sdfWriterProps.put("PorgramName", "FakeNews");
+            mdlw.addChemObjectIOListener(new PropertiesListener(sdfWriterProps));
+            // mdlw.customizeJob();
+            mdlw.write(mol);
+        }
+        assertThat(sw.toString(), containsString("FakeNews"));
     }
 
     private String writeToStr(IAtomContainer mol) throws IOException, CDKException {

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -462,7 +462,7 @@ public class MDLV3000WriterTest {
             Properties sdfWriterProps = new Properties();
             sdfWriterProps.put("PorgramName", "FakeNews");
             mdlw.addChemObjectIOListener(new PropertiesListener(sdfWriterProps));
-            // mdlw.customizeJob();
+            mdlw.customizeJob();
             mdlw.write(mol);
         }
         assertThat(sw.toString(), containsString("FakeNews"));

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -460,7 +460,7 @@ public class MDLV3000WriterTest {
         StringWriter sw = new StringWriter();
         try (MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
             Properties sdfWriterProps = new Properties();
-            sdfWriterProps.put("PorgramName", "FakeNews");
+            sdfWriterProps.put(MDLV2000Writer.OptProgramName, "FakeNews");
             mdlw.addChemObjectIOListener(new PropertiesListener(sdfWriterProps));
             mdlw.customizeJob();
             mdlw.write(mol);


### PR DESCRIPTION
It adds a unit test, then the fix, and then a change to clean up my code. This patch is related to https://github.com/cdk/cdk/pull/564