### PR TITLE
fix method 'readMolfileInt' if index+1 or +2 does not exist in 'line'

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -1519,6 +1519,9 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
             default:
                 return 0;
         }
+        if (line.length() <= index + 1) {
+			return result;
+		}
         switch ((c = line.charAt(index + 1))) {
             case ' ':
                 if (result > 0) return sign * result;
@@ -1542,6 +1545,9 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
             default:
                 return sign * result;
         }
+        if (line.length() <= index + 2) {
+			return result;
+		}
         switch ((c = line.charAt(index + 2))) {
             case ' ':
                 if (result > 0) return sign * result;


### PR DESCRIPTION
'readMolfileInt' relies on the existence of char index+1 and +2 in parameter line but the line might be shorter than that.