### PR TITLE
Feature/bond display

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
@@ -43,6 +43,8 @@ import org.openscience.cdk.renderer.generators.IGenerator;
 import org.openscience.cdk.renderer.generators.IGeneratorParameter;
 import org.openscience.cdk.renderer.generators.standard.SelectionVisibility;
 import org.openscience.cdk.renderer.generators.standard.StandardGenerator;
+import org.openscience.cdk.renderer.generators.standard.StandardGenerator.DelocalisedDonutsBondDisplay;
+import org.openscience.cdk.renderer.generators.standard.StandardGenerator.ForceDelocalisedBondDisplay;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
 import javax.vecmath.Point2d;
@@ -1069,6 +1071,25 @@ public final class DepictionGenerator {
      */
     public DepictionGenerator withFillToFit() {
         return withParam(BasicSceneGenerator.FitToScreen.class,
+                         true);
+    }
+
+    /**
+     * When aromaticity is set on bonds, display this in the diagram. IUPAC
+     * recommends depicting kekulé structures to avoid ambiguity but it's common
+     * practice to render delocalised rings "donuts" or "life buoys". With fused
+     * rings this can be somewhat confusing as you end up with three lines at
+     * the fusion point. <br>
+     * By default small rings are renders as donuts with dashed bonds used
+     * otherwise. You can use dashed bonds always by turning off the
+     * {@link DelocalisedDonutsBondDisplay}.
+     *
+     * @return new generator for method chaining
+     * @see ForceDelocalisedBondDisplay
+     * @see DelocalisedDonutsBondDisplay
+     */
+    public DepictionGenerator withAromaticDisplay() {
+        return withParam(ForceDelocalisedBondDisplay.class,
                          true);
     }
 

--- a/base/core/src/main/java/org/openscience/cdk/BondRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/BondRef.java
@@ -226,6 +226,23 @@ public class BondRef extends ChemObjectRef implements IBond {
         bond.setStereo(stereo);
     }
 
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Display getDisplay() {
+        return bond.getDisplay();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDisplay(Display display) {
+        bond.setDisplay(display);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/base/core/src/main/java/org/openscience/cdk/config/Elements.java
+++ b/base/core/src/main/java/org/openscience/cdk/config/Elements.java
@@ -24,6 +24,7 @@
  */
 package org.openscience.cdk.config;
 
+import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IElement;
 
 import java.util.HashMap;
@@ -506,4 +507,45 @@ public enum Elements {
     // Incorrect spelling
     @Deprecated
     public final static IElement PLUTOMNIUM    = PLUTONIUM;
+
+    /**
+     * Utility method to determine if an atomic number is a metal.
+     * @param atno atomic number
+     * @return the atomic number is a metal (or not)
+     */
+    public static boolean isMetal(int atno) {
+        switch (atno) {
+            case 0:  // *
+            case 1:  // H
+            case 2:  // He
+            case 6:  // C
+            case 7:  // N
+            case 8:  // O
+            case 9:  // F
+            case 10: // Ne
+            case 15: // P
+            case 16: // S
+            case 17: // Cl
+            case 18: // Ar
+            case 34: // Se
+            case 35: // Br
+            case 36: // Kr
+            case 53: // I
+            case 54: // Xe
+            case 86: // Rn
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * Utility method to determine if an atom is a metal.
+     *
+     * @param atom atom
+     * @return the atom is a metal (or not)
+     */
+    public static boolean isMetal(IAtom atom) {
+        return atom.getAtomicNumber() != null &&
+               isMetal(atom.getAtomicNumber());
+    }
 }

--- a/base/core/src/main/java/org/openscience/cdk/config/Elements.java
+++ b/base/core/src/main/java/org/openscience/cdk/config/Elements.java
@@ -534,6 +534,14 @@ public enum Elements {
             case 54: // Xe
             case 86: // Rn
                 return false;
+            case 5:   // B
+            case 14:  // Si
+            case 32:  // Ge
+            case 33:  // As
+            case 51:  // Sb
+            case 52:  // Te
+            case 85:  // At
+                return false;
         }
         return true;
     }

--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -81,6 +81,8 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      */
     protected IBond.Stereo    stereo;
 
+    protected IBond.Display display = Display.Solid;
+
     /**
      * Constructs an empty bond.
      */
@@ -408,6 +410,39 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     @Override
     public void setStereo(IBond.Stereo stereo) {
         this.stereo = stereo;
+        switch (stereo) {
+            case UP:
+                display = Display.WedgeBegin;
+                break;
+            case DOWN:
+                display = Display.WedgedHashBegin;
+                break;
+            case UP_INVERTED:
+                display = Display.WedgeEnd;
+                break;
+            case DOWN_INVERTED:
+                display = Display.WedgedHashEnd;
+                break;
+            case UP_OR_DOWN:
+            case UP_OR_DOWN_INVERTED:
+                display = Display.Wavy;
+                break;
+        }
+        notifyChanged();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IBond.Display getDisplay() {
+        return display;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setDisplay(IBond.Display display) {
+        this.display = display;
         notifyChanged();
     }
 

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -44,7 +44,7 @@ public interface IBond extends IElectronContainer {
 
         private final Integer bondedElectronPairs;
 
-        private Order(Integer bondedElectronPairs) {
+        Order(Integer bondedElectronPairs) {
             this.bondedElectronPairs = bondedElectronPairs;
         }
 
@@ -129,6 +129,54 @@ public interface IBond extends IElectronContainer {
          * by the 2D and/or 3D coordinates.
          */
         E_Z_BY_COORDINATES
+    }
+
+    /**
+     * Bond display style, controlling how bonds appear in a 2D depiction.
+     */
+    enum Display {
+        /** Display as a solid line (default). */
+        Solid,
+        /** Display as a dashed line. */
+        Dash,
+        /** Display as a hashed line. */
+        Hash,
+        /** Display as a bold line. */
+        Bold,
+        /** Display as a wavy line. */
+        Wavy,
+        /** Display as a dotted line. */
+        Dot,
+        /**
+         * Display as a hashed wedge, with the narrow end
+         * towards the begin atom of the bond ({@link IBond#getBegin()}).
+         */
+        WedgedHashBegin,
+        /**
+         * Display as a hashed wedge, with the narrow end
+         * towards the end atom of the bond ({@link IBond#getEnd()}).
+         */
+        WedgedHashEnd,
+        /**
+         * Display as a bold wedge, with the narrow end
+         * towards the begin atom of the bond ({@link IBond#getBegin()}).
+         */
+        WedgeBegin,
+        /**
+         * Display as a bold wedge, with the narrow end
+         * towards the end atom of the bond ({@link IBond#getEnd()}).
+         */
+        WedgeEnd,
+        /**
+         * Display as an arrow (e.g. coordination bond), the arrow points
+         * to the begin ({@link IBond#getBegin()}) atom.
+         */
+        ArrowBeg,
+        /**
+         * Display as an arrow (e.g. coordination bond), the arrow points
+         * to the end ({@link IBond#getEnd()}) atom.
+         */
+        ArrowEnd
     }
 
     /**
@@ -270,12 +318,26 @@ public interface IBond extends IElectronContainer {
     IBond.Stereo getStereo();
 
     /**
-     * Sets the stereo descriptor for this bond.
+     * Sets the stereo descriptor for this bond. Note this function will
+     * also modify the bond display style.
      *
      * @param stereo The stereo descriptor to be assigned to this bond.
      * @see #getStereo
+     * @see #setDisplay(Display)
      */
     void setStereo(IBond.Stereo stereo);
+
+    /**
+     * Access the bond display style.
+     * @return the bond display
+     */
+    IBond.Display getDisplay();
+
+    /**
+     * Set the bond display style.
+     * @param display the display
+     */
+    void setDisplay(IBond.Display display);
 
     /**
      * Returns the geometric 2D center of the bond.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -135,17 +135,17 @@ public interface IBond extends IElectronContainer {
      * Bond display style, controlling how bonds appear in a 2D depiction.
      */
     enum Display {
-        /** Display as a solid line (default). */
+        /** A solid line (default). */
         Solid,
-        /** Display as a dashed line. */
+        /** A dashed line. */
         Dash,
-        /** Display as a hashed line. */
+        /** A hashed line (bold dashed). */
         Hash,
-        /** Display as a bold line. */
+        /** A bold line. */
         Bold,
-        /** Display as a wavy line. */
+        /** A wavy line. */
         Wavy,
-        /** Display as a dotted line. */
+        /** A dotted line. */
         Dot,
         /**
          * Display as a hashed wedge, with the narrow end
@@ -168,12 +168,12 @@ public interface IBond extends IElectronContainer {
          */
         WedgeEnd,
         /**
-         * Display as an arrow (e.g. coordination bond), the arrow points
+         * Display as an arrow (e.g. co-ordination bond), the arrow points
          * to the begin ({@link IBond#getBegin()}) atom.
          */
         ArrowBeg,
         /**
-         * Display as an arrow (e.g. coordination bond), the arrow points
+         * Display as an arrow (e.g. co-ordination bond), the arrow points
          * to the end ({@link IBond#getEnd()}) atom.
          */
         ArrowEnd

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryBond.java
@@ -418,6 +418,22 @@ public class QueryBond extends QueryChemObject implements IQueryBond {
     }
 
     /**
+     * Not used for query bonds. {@inheritDoc}
+     */
+    @Override
+    public Display getDisplay() {
+        return null;
+    }
+
+    /**
+     * Not used for query bonds. {@inheritDoc}
+     */
+    @Override
+    public void setDisplay(Display display) {
+
+    }
+
+    /**
      * Returns the geometric 2D center of the query bond.
      *
      * @return The geometric 2D center of the query bond

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -84,6 +84,8 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
      */
     protected IBond.Stereo    stereo;
 
+    protected IBond.Display   display = Display.Solid;
+
     /**
      * Constructs an empty bond.
      */
@@ -402,6 +404,38 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
     @Override
     public void setStereo(IBond.Stereo stereo) {
         this.stereo = stereo;
+        switch (stereo) {
+            case UP:
+                display = Display.WedgeBegin;
+                break;
+            case DOWN:
+                display = Display.WedgedHashBegin;
+                break;
+            case UP_INVERTED:
+                display = Display.WedgeEnd;
+                break;
+            case DOWN_INVERTED:
+                display = Display.WedgedHashEnd;
+                break;
+            case UP_OR_DOWN:
+            case UP_OR_DOWN_INVERTED:
+                display = Display.Wavy;
+                break;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IBond.Display getDisplay() {
+        return display;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setDisplay(IBond.Display display) {
+        this.display = display;
     }
 
     /**

--- a/display/renderawt/src/main/java/org/openscience/cdk/renderer/visitor/AWTDrawVisitor.java
+++ b/display/renderawt/src/main/java/org/openscience/cdk/renderer/visitor/AWTDrawVisitor.java
@@ -215,6 +215,22 @@ public class AWTDrawVisitor extends AbstractAWTDrawVisitor {
             this.graphics.fillOval(transformX(oval.xCoord) - radius, transformY(oval.yCoord) - radius, diameter,
                     diameter);
         } else {
+            Stroke savedStroke = this.graphics.getStroke();
+
+            // scale the stroke by zoom + scale (both included in the AffineTransform)
+            float width = (float) (oval.stroke * transform.getScaleX());
+            if (width < minStroke) width = minStroke;
+
+            int key = (int) (width * 4); // store 2.25, 2.5, 2.75 etc to separate keys
+
+            if (strokeCache && strokeMap.containsKey(key)) {
+                this.graphics.setStroke(strokeMap.get(key));
+            } else {
+                BasicStroke stroke = new BasicStroke(width, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
+                this.graphics.setStroke(stroke);
+                strokeMap.put(key, stroke);
+            }
+
             this.graphics.drawOval(transformX(oval.xCoord) - radius, transformY(oval.yCoord) - radius, diameter,
                     diameter);
         }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/elements/OvalElement.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/elements/OvalElement.java
@@ -36,7 +36,10 @@ public class OvalElement implements IRenderingElement {
     public final double  yCoord;
 
     /** The radius of the oval. **/
-    public final double  radius; // TODO : width AND height
+    public final double  radius;
+
+    /** The stroke width. */
+    public final double stroke;
 
     /** If true, draw the oval as filled. **/
     public final boolean fill;
@@ -76,10 +79,22 @@ public class OvalElement implements IRenderingElement {
      * @param fill if true, fill the oval when drawing
      * @param color the color of the oval
      */
-    public OvalElement(double xCoord, double yCoord, double radius, boolean fill, Color color) {
+    public OvalElement(double xCoord, double yCoord, double radius, double stroke,
+                       boolean fill, Color color) {
         this.xCoord = xCoord;
         this.yCoord = yCoord;
         this.radius = radius;
+        this.stroke = stroke;
+        this.fill = fill;
+        this.color = color;
+    }
+
+    public OvalElement(double xCoord, double yCoord, double radius,
+                       boolean fill, Color color) {
+        this.xCoord = xCoord;
+        this.yCoord = yCoord;
+        this.radius = radius;
+        this.stroke = 1;
         this.fill = fill;
         this.color = color;
     }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -224,7 +224,7 @@ final class StandardBondGenerator {
                 if (bond.isAromatic()) {
                     if (donutGenerator.isDelocalised(bond))
                         elem = generateSingleBond(bond, atom1, atom2);
-                    else if (forceDelocalised)
+                    else if (forceDelocalised && bond.isInRing())
                         elem = generateDoubleBond(bond, forceDelocalised);
                     else
                         elem = generateSingleBond(bond, atom1, atom2);

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -146,7 +146,7 @@ final class StandardBondGenerator {
         // index atoms and rings
         for (int i = 0; i < container.getAtomCount(); i++)
             atomIndexMap.put(container.getAtom(i), i);
-        ringMap = ringPreferenceMap(container);
+        ringMap = ringPreferenceMap(container, donutGenerator.smallest);
 
         // set parameters
         this.scale = parameters.get(BasicSceneGenerator.Scale.class);
@@ -1588,12 +1588,16 @@ final class StandardBondGenerator {
      * Creates a mapping of bonds to preferred rings (stored as IAtomContainers).
      *
      * @param container structure representation
+     * @param smallest smallest ring set to use (e.g. through each bond)
      * @return bond to ring map
      */
-    static Map<IBond, IAtomContainer> ringPreferenceMap(IAtomContainer container) {
+    static Map<IBond, IAtomContainer> ringPreferenceMap(IAtomContainer container,
+                                                        IRingSet smallest) {
 
-        final IRingSet relevantRings = Cycles.edgeShort(container).toRingSet();
-        final List<IAtomContainer> rings = AtomContainerSetManipulator.getAllAtomContainers(relevantRings);
+        if (smallest == null)
+            smallest = Cycles.edgeShort(container).toRingSet();
+
+        final List<IAtomContainer> rings = AtomContainerSetManipulator.getAllAtomContainers(smallest);
 
         Collections.sort(rings, new RingBondOffsetComparator());
 
@@ -1609,6 +1613,16 @@ final class StandardBondGenerator {
         }
 
         return Collections.unmodifiableMap(ringMap);
+    }
+
+    /**
+     * Creates a mapping of bonds to preferred rings (stored as IAtomContainers).
+     *
+     * @param container structure representation
+     * @return bond to ring map
+     */
+    static Map<IBond, IAtomContainer> ringPreferenceMap(IAtomContainer container) {
+        return ringPreferenceMap(container, Cycles.edgeShort(container).toRingSet());
     }
 
     /**

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardDonutGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardDonutGenerator.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2019  The Chemistry Development Kit (CDK) project
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.openscience.cdk.renderer.generators.standard;
+
+import org.openscience.cdk.geometry.GeometryUtil;
+import org.openscience.cdk.graph.Cycles;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObject;
+import org.openscience.cdk.interfaces.IRingSet;
+import org.openscience.cdk.renderer.RendererModel;
+import org.openscience.cdk.renderer.elements.ElementGroup;
+import org.openscience.cdk.renderer.elements.IRenderingElement;
+import org.openscience.cdk.renderer.elements.OvalElement;
+import org.openscience.cdk.renderer.generators.standard.StandardGenerator.DelocalisedDonutsBondDisplay;
+import org.openscience.cdk.renderer.generators.standard.StandardGenerator.ForceDelocalisedBondDisplay;
+
+import javax.vecmath.Point2d;
+import java.awt.Color;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.openscience.cdk.interfaces.IBond.Order.UNSET;
+
+final class StandardDonutGenerator {
+
+    // bonds involved in donuts!
+    private final Set<IBond> bonds = new HashSet<>();
+    private final boolean    forceDelocalised;
+    private final boolean    delocalisedDonuts;
+    private final double     dbSpacing;
+    private final Color      fgColor;
+    private final IAtomContainer mol;
+
+    public StandardDonutGenerator(IAtomContainer mol, RendererModel model) {
+        this.forceDelocalised = model.get(ForceDelocalisedBondDisplay.class);
+        this.delocalisedDonuts = model.get(DelocalisedDonutsBondDisplay.class);
+        this.dbSpacing = model.get(StandardGenerator.BondSeparation.class);
+        this.fgColor = model.get(StandardGenerator.AtomColor.class).getAtomColor(
+                             mol.getBuilder().newInstance(IAtom.class, "C"));
+        this.mol = mol;
+    }
+
+    private boolean canDelocalise(final IAtomContainer ring) {
+        boolean okay = ring.getBondCount() <= 8;
+        if (!okay)
+            return false;
+        for (IBond bond : ring.bonds()) {
+            if (!bond.isAromatic())
+                okay = false;
+            if ((bond.getOrder() != null &&
+                 bond.getOrder() != UNSET) &&
+                !forceDelocalised)
+                okay = false;
+        }
+        return okay;
+    }
+
+    IRenderingElement generate() {
+        if (!delocalisedDonuts)
+            return null;
+        ElementGroup group = new ElementGroup();
+        IRingSet     rset  = Cycles.edgeShort(mol).toRingSet();
+        for (IAtomContainer ring : rset.atomContainers()) {
+            if (!canDelocalise(ring))
+                continue;
+            for (IBond bond : ring.bonds()) {
+                bonds.add(bond);
+            }
+            Point2d p2 = GeometryUtil.get2DCenter(ring);
+            double  s  = GeometryUtil.getBondLengthMedian(ring);
+            double  n  = ring.getBondCount();
+            double  r  = s / (2 * Math.tan(Math.PI / n));
+            group.add(new OvalElement(p2.x, p2.y, r - dbSpacing,
+                                      false, fgColor));
+        }
+        return group;
+    }
+
+    boolean isDelocalised(IBond bond) {
+        return bonds.contains(bond);
+    }
+}

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardDonutGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardDonutGenerator.java
@@ -28,7 +28,6 @@ import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.renderer.RendererModel;
 import org.openscience.cdk.renderer.elements.ElementGroup;
@@ -53,6 +52,9 @@ final class StandardDonutGenerator {
     private final Set<IBond> bonds = new HashSet<>();
     // atoms with delocalised charge
     private final Set<IAtom> atoms = new HashSet<>();
+    // smallest rings through each edge
+    IRingSet smallest;
+
     private final boolean    forceDelocalised;
     private final boolean    delocalisedDonuts;
     private final double     dbSpacing;
@@ -91,8 +93,8 @@ final class StandardDonutGenerator {
         if (!delocalisedDonuts)
             return null;
         ElementGroup group = new ElementGroup();
-        IRingSet     rset  = Cycles.edgeShort(mol).toRingSet();
-        for (IAtomContainer ring : rset.atomContainers()) {
+        smallest = Cycles.edgeShort(mol).toRingSet();
+        for (IAtomContainer ring : smallest.atomContainers()) {
             if (!canDelocalise(ring))
                 continue;
             for (IBond bond : ring.bonds()) {

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardDonutGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardDonutGenerator.java
@@ -67,6 +67,7 @@ final class StandardDonutGenerator {
     private final boolean    delocalisedDonuts;
     private final double     dbSpacing;
     private final double     scale;
+    private final double     stroke;
     private final Color      fgColor;
     private final Font       font;
     private final IAtomContainer mol;
@@ -77,13 +78,15 @@ final class StandardDonutGenerator {
      * @param font the font
      * @param model the rendering parameters
      */
-    StandardDonutGenerator(IAtomContainer mol, Font font, RendererModel model) {
+    StandardDonutGenerator(IAtomContainer mol, Font font, RendererModel model,
+                           double stroke) {
         this.mol = mol;
         this.font = font;
         this.forceDelocalised = model.get(ForceDelocalisedBondDisplay.class);
         this.delocalisedDonuts = model.get(DelocalisedDonutsBondDisplay.class);
         this.dbSpacing = model.get(StandardGenerator.BondSeparation.class);
         this.scale = model.get(BasicSceneGenerator.Scale.class);
+        this.stroke = stroke;
         this.fgColor = model.get(StandardGenerator.AtomColor.class).getAtomColor(
                              mol.getBuilder().newInstance(IAtom.class, "C"));
     }
@@ -150,7 +153,7 @@ final class StandardDonutGenerator {
             double  n  = ring.getBondCount();
             double  r  = s / (2 * Math.tan(Math.PI / n));
             group.add(new OvalElement(p2.x, p2.y, r - 1.5*dbSpacing,
-                                      false, fgColor));
+                                      stroke, false, fgColor));
         }
         return group;
     }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardDonutGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardDonutGenerator.java
@@ -46,6 +46,14 @@ import java.util.Set;
 
 import static org.openscience.cdk.interfaces.IBond.Order.UNSET;
 
+/**
+ * Generates aromatic donuts (or life buoys) as ovals in small (<8) aromatic
+ * rings. If the ring is charged (and the charged is not shared with another
+ * ring, e.g. rbonds > 2) it will be depicted in the middle of the ring.
+ *
+ * @see ForceDelocalisedBondDisplay
+ * @see DelocalisedDonutsBondDisplay
+ */
 final class StandardDonutGenerator {
 
     // bonds involved in donuts!
@@ -63,7 +71,13 @@ final class StandardDonutGenerator {
     private final Font       font;
     private final IAtomContainer mol;
 
-    public StandardDonutGenerator(IAtomContainer mol, Font font, RendererModel model) {
+    /**
+     * Create a new generator for a molecule.
+     * @param mol molecule
+     * @param font the font
+     * @param model the rendering parameters
+     */
+    StandardDonutGenerator(IAtomContainer mol, Font font, RendererModel model) {
         this.mol = mol;
         this.font = font;
         this.forceDelocalised = model.get(ForceDelocalisedBondDisplay.class);
@@ -75,7 +89,7 @@ final class StandardDonutGenerator {
     }
 
     private boolean canDelocalise(final IAtomContainer ring) {
-        boolean okay = ring.getBondCount() <= 8;
+        boolean okay = ring.getBondCount() < 8;
         if (!okay)
             return false;
         for (IBond bond : ring.bonds()) {

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -241,6 +241,11 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
             }
         }
 
+        // donuts for delocalised aromatic
+        if (bondElements.length > container.getBondCount()) {
+            frontLayer.add(bondElements[bondElements.length - 1]);
+        }
+
         // convert the atom symbols to IRenderingElements
         for (int i = 0; i < container.getAtomCount(); i++) {
             IAtom atom = container.getAtom(i);

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -168,12 +168,12 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
     private final IGeneratorParameter<?> atomColor = new AtomColor(), visibility = new Visibility(),
             strokeRatio = new StrokeRatio(), separationRatio = new BondSeparation(), wedgeRatio = new WedgeRatio(),
             marginRatio = new SymbolMarginRatio(), hatchSections = new HashSpacing(), dashSections = new DashSection(),
-            waveSections = new WaveSpacing(), fancyBoldWedges = new FancyBoldWedges(),
+            waveSections      = new WaveSpacing(), fancyBoldWedges = new FancyBoldWedges(),
             fancyHashedWedges = new FancyHashedWedges(), highlighting = new Highlighting(),
-            glowWidth = new OuterGlowWidth(), annCol = new AnnotationColor(), annDist = new AnnotationDistance(),
-            annFontSize = new AnnotationFontScale(), sgroupBracketDepth = new SgroupBracketDepth(),
-            sgroupFontScale = new SgroupFontScale(), omitMajorIsotopes = new OmitMajorIsotopes(),
-            forceDonuts = new ForceDelocalisedBondDisplay();
+            glowWidth         = new OuterGlowWidth(), annCol = new AnnotationColor(), annDist = new AnnotationDistance(),
+            annFontSize       = new AnnotationFontScale(), sgroupBracketDepth = new SgroupBracketDepth(),
+            sgroupFontScale   = new SgroupFontScale(), omitMajorIsotopes = new OmitMajorIsotopes(),
+            forceDelocalised  = new ForceDelocalisedBondDisplay(), delocaliseDonuts = new DelocalisedDonutsBondDisplay();
 
     /**
      * Create a new standard generator that utilises the specified font to display atom symbols.
@@ -606,8 +606,8 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
     @Override
     public List<IGeneratorParameter<?>> getParameters() {
         return Arrays.asList(atomColor, visibility, strokeRatio, separationRatio, wedgeRatio, marginRatio,
-                hatchSections, dashSections, waveSections, fancyBoldWedges, fancyHashedWedges, highlighting, glowWidth,
-                annCol, annDist, annFontSize, sgroupBracketDepth, sgroupFontScale, omitMajorIsotopes, forceDonuts);
+                             hatchSections, dashSections, waveSections, fancyBoldWedges, fancyHashedWedges, highlighting, glowWidth,
+                             annCol, annDist, annFontSize, sgroupBracketDepth, sgroupFontScale, omitMajorIsotopes, forceDelocalised, delocaliseDonuts);
     }
 
     static String getAnnotationLabel(IChemObject chemObject) {
@@ -1152,6 +1152,19 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
         @Override
         public Boolean getDefault() {
             return false;
+        }
+    }
+
+    /**
+     * Render small delocalised rings as donuts/life buoys? This can sometimes
+     * be misleading for fused rings but is commonly used.
+     */
+    public static final class DelocalisedDonutsBondDisplay extends AbstractGeneratorParameter<Boolean> {
+
+        /**{@inheritDoc} */
+        @Override
+        public Boolean getDefault() {
+            return true;
         }
     }
 }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -211,9 +211,15 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
 
         ElementGroup annotations = new ElementGroup();
 
+        StandardDonutGenerator donutGenerator = new StandardDonutGenerator(container, parameters);
+        IRenderingElement donuts = donutGenerator.generate();
+
         AtomSymbol[] symbols = generateAtomSymbols(container, symbolRemap, visibility, parameters, annotations, foreground, stroke);
-        IRenderingElement[] bondElements = StandardBondGenerator.generateBonds(container, symbols, parameters, stroke,
-                                                                               font, annotations);
+        IRenderingElement[] bondElements;
+        bondElements = StandardBondGenerator.generateBonds(container, symbols,
+                                                           parameters, stroke,
+                                                           font, annotations,
+                                                           donutGenerator);
 
         final HighlightStyle style = parameters.get(Highlighting.class);
         final double glowWidth = parameters.get(OuterGlowWidth.class);
@@ -241,10 +247,8 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
             }
         }
 
-        // donuts for delocalised aromatic
-        if (bondElements.length > container.getBondCount()) {
-            frontLayer.add(bondElements[bondElements.length - 1]);
-        }
+        // bonds for delocalised aromatic
+        frontLayer.add(donuts);
 
         // convert the atom symbols to IRenderingElements
         for (int i = 0; i < container.getAtomCount(); i++) {
@@ -1156,7 +1160,7 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
     }
 
     /**
-     * Render small delocalised rings as donuts/life buoys? This can sometimes
+     * Render small delocalised rings as bonds/life buoys? This can sometimes
      * be misleading for fused rings but is commonly used.
      */
     public static final class DelocalisedDonutsBondDisplay extends AbstractGeneratorParameter<Boolean> {

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -1156,13 +1156,16 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
      * there is a valid Kekule structure. Delocalised bonds will either be
      * rendered as a dashed bond to the side or as a circle/donut/life buoy
      * inside small rings. This depiction is used by default when a bond does
-     * not have an order assigned (e.g. null/unset). Turning this option on
-     * means all delocalised bonds will be rendered this way.
+     * not have an order assigned (e.g. null/unset), for example: c1cccc1.
+     * Turning this option on means all delocalised bonds will be rendered this
+     * way even when they have bond orders correctly assigned: e.g. c1ccccc1,
+     * [cH-]1cccc1.
      * <br>
      * <b>As recommended by IUPAC, their usage is discouraged and the Kekule
      * representation is more clear.</b>
      */
-    public static final class ForceDelocalisedBondDisplay extends AbstractGeneratorParameter<Boolean> {
+    public static final class ForceDelocalisedBondDisplay
+            extends AbstractGeneratorParameter<Boolean> {
 
         /**{@inheritDoc} */
         @Override
@@ -1175,7 +1178,8 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
      * Render small delocalised rings as bonds/life buoys? This can sometimes
      * be misleading for fused rings but is commonly used.
      */
-    public static final class DelocalisedDonutsBondDisplay extends AbstractGeneratorParameter<Boolean> {
+    public static final class DelocalisedDonutsBondDisplay
+            extends AbstractGeneratorParameter<Boolean> {
 
         /**{@inheritDoc} */
         @Override

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -211,10 +211,14 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
 
         ElementGroup annotations = new ElementGroup();
 
-        StandardDonutGenerator donutGenerator = new StandardDonutGenerator(container, parameters);
+        StandardDonutGenerator donutGenerator;
+        donutGenerator = new StandardDonutGenerator(container, font, parameters);
         IRenderingElement donuts = donutGenerator.generate();
 
-        AtomSymbol[] symbols = generateAtomSymbols(container, symbolRemap, visibility, parameters, annotations, foreground, stroke);
+        AtomSymbol[] symbols = generateAtomSymbols(container, symbolRemap,
+                                                   visibility, parameters,
+                                                   annotations, foreground,
+                                                   stroke, donutGenerator);
         IRenderingElement[] bondElements;
         bondElements = StandardBondGenerator.generateBonds(container, symbols,
                                                            parameters, stroke,
@@ -367,7 +371,8 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
                                              RendererModel parameters,
                                              ElementGroup annotations,
                                              Color foreground,
-                                             double stroke) {
+                                             double stroke,
+                                             StandardDonutGenerator donutGen) {
 
         final double scale = parameters.get(BasicSceneGenerator.Scale.class);
         final double annDist = parameters.get(AnnotationDistance.class)
@@ -424,9 +429,16 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
 
                 if (remapped) {
                     symbols[i] = atomGenerator.generateAbbreviatedSymbol(symbolRemap.get(atom), hPosition);
-                } else {
+                } else if (donutGen.isChargeDelocalised(atom)) {
+                    Integer charge = atom.getFormalCharge();
+                    atom.setFormalCharge(0);
+                    // can't think of a better way to handle this without API
+                    // change to symbol visibility
+                    if (atom.getAtomicNumber() != 6)
+                        symbols[i] = atomGenerator.generateSymbol(container, atom, hPosition, parameters);
+                    atom.setFormalCharge(charge);
+                } else
                     symbols[i] = atomGenerator.generateSymbol(container, atom, hPosition, parameters);
-                }
 
                 if (symbols[i] != null) {
 

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -929,7 +929,7 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
          */
         @Override
         public Double getDefault() {
-            return 0.18;
+            return 0.16;
         }
     }
 

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -212,7 +212,8 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
         ElementGroup annotations = new ElementGroup();
 
         StandardDonutGenerator donutGenerator;
-        donutGenerator = new StandardDonutGenerator(container, font, parameters);
+        donutGenerator = new StandardDonutGenerator(container, font, parameters,
+                                                    stroke);
         IRenderingElement donuts = donutGenerator.generate();
 
         AtomSymbol[] symbols = generateAtomSymbols(container, symbolRemap,

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/StandardBondGeneratorTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/StandardBondGeneratorTest.java
@@ -25,10 +25,14 @@
 package org.openscience.cdk.renderer.generators.standard;
 
 import org.junit.Test;
+import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 
+import javax.vecmath.Point2d;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -57,6 +61,31 @@ public class StandardBondGeneratorTest {
         // 4 bonds should point to the five member ring
         assertThat(nSize5, is(4));
         assertThat(nSize6, is(6));
+    }
+
+    @Test
+    public void metalRingPreference() throws Exception {
+
+        SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer mol = smipar.parseSmiles("C1[Fe]C=CC2=C1C=CN2");
+        for (IAtom atom : mol.atoms())
+            atom.setPoint2d(new Point2d(0,0));
+        Map<IBond, IAtomContainer> ringMap = StandardBondGenerator.ringPreferenceMap(mol);
+
+        int nSize5 = 0, nSize6 = 0;
+        for (IBond bond : mol.bonds()) {
+            IAtomContainer ring = ringMap.get(bond);
+            // exocyclic bond
+            if (ring == null) continue;
+            int size = ring.getAtomCount();
+            if (size == 5) nSize5++;
+            if (size == 6) nSize6++;
+        }
+
+        // 5 bonds should point to the six member ring
+        // 5 bonds should point to the five member ring
+        assertThat(nSize5, is(5));
+        assertThat(nSize6, is(5));
     }
 
     @Test

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -25,6 +25,7 @@ package org.openscience.cdk.layout;
 
 import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.BondTools;
 import org.openscience.cdk.geometry.GeometryUtil;
@@ -941,6 +942,10 @@ public class AtomPlacer {
      * -N=[N+]=N
      */
     static boolean isColinear(IAtom atom, Iterable<IBond> bonds) {
+
+        if (Elements.isMetal(atom))
+            return true;
+
         int numSgl = atom.getImplicitHydrogenCount() == null ? 0 : atom.getImplicitHydrogenCount();
         int numDbl = 0;
         int numTpl = 0;

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -382,7 +382,8 @@ public class AtomPlacer {
             nextAtom.setFlag(CDKConstants.ISPLACED, true);
             boolean trans = false;
 
-            if (prevBond != null && isColinear(atom, molecule.getConnectedBondsList(atom))) {
+            if (prevBond != null &&
+                isColinear(atom, molecule.getConnectedBondsList(atom))) {
 
                 int atomicNumber = atom.getAtomicNumber();
                 int charge = atom.getFormalCharge();
@@ -418,6 +419,20 @@ public class AtomPlacer {
         }
     }
 
+    private boolean isTerminalD4(IAtom atom) {
+        List<IBond> bonds = molecule.getConnectedBondsList(atom);
+        if (bonds.size() != 4)
+            return false;
+        int nonD1 = 0;
+        for (IBond bond : bonds) {
+            if (molecule.getConnectedBondsCount(bond.getOther(atom)) != 1) {
+                if (++nonD1 > 1)
+                    return false;
+            }
+        }
+        return true;
+    }
+
     /**
      *  Returns the next bond vector needed for drawing an extended linear chain of
      *  atoms. It assumes an angle of 120 deg for a nice chain layout and
@@ -449,7 +464,13 @@ public class AtomPlacer {
 
         double angle = GeometryUtil.getAngle(previousAtom.getPoint2d().x - atom.getPoint2d().x,
                 previousAtom.getPoint2d().y - atom.getPoint2d().y);
-        double addAngle = Math.toRadians(120);
+        double addAngle;
+
+        if (isTerminalD4(atom))
+            addAngle = Math.toRadians(45);
+        else
+            addAngle = Math.toRadians(120);
+
         if (!trans) addAngle = Math.toRadians(60);
         if (isColinear(atom, molecule.getConnectedBondsList(atom))) addAngle = Math.toRadians(180);
 


### PR DESCRIPTION
New BondDisplay property, controls wedge/dash/arrow display etc:

![image](https://user-images.githubusercontent.com/983232/62012354-29185680-b17d-11e9-815f-cbb9b8f4d94f.png)
Bold bonds allow you to do something like this:
![image](https://user-images.githubusercontent.com/983232/62012360-2f0e3780-b17d-11e9-8994-aaaa404c4c84.png)

Also added in aromatic donuts:

![image](https://user-images.githubusercontent.com/983232/62012366-3cc3bd00-b17d-11e9-81b1-99ce4ba2e79c.png)
![image](https://user-images.githubusercontent.com/983232/62012369-3e8d8080-b17d-11e9-9aef-db2c866b5d24.png)

And cleaned up some layouts:

![image](https://user-images.githubusercontent.com/983232/62012373-451bf800-b17d-11e9-806b-8e5b9465e987.png)
![image](https://user-images.githubusercontent.com/983232/62012374-46e5bb80-b17d-11e9-84db-1b54f4ae20e3.png)

Fine to go subject to review but still need to fix:
 - wedge double bonds
 - ovals for aromatic donuts need a stroke property, looks okay in SVG but too thin in the PNGs