### PR TITLE
Patch/depict tweaks

### DIFF
--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -964,8 +964,9 @@ public class AtomPlacer {
      */
     static boolean isColinear(IAtom atom, Iterable<IBond> bonds) {
 
-        if (Elements.isMetal(atom))
-            return true;
+        if (Elements.isMetal(atom)) {
+            return FluentIterable.from(bonds).size() == 2;
+        }
 
         int numSgl = atom.getImplicitHydrogenCount() == null ? 0 : atom.getImplicitHydrogenCount();
         int numDbl = 0;


### PR DESCRIPTION
Main change tweaks how the highlighting is done for reactions.

From this:

![](https://www.simolecule.com/cdkdepict/depict/bow/svg?smi=%5BCH3%3A1%5D%2F%5BCH%3A2%5D%3D%5BCH%3A3%5D%2F%5BCH2%3A5%5D%5BCH2%3A6%5D%5BOH%3A4%5D%3E%3E%5BCH3%3A1%5D%2F%5BCH2%3A2%5D%5BCH2%3A3%5D%2F%5BCH2%3A5%5D%5BCH2%3A6%5D%5BOH%3A4%5D&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1.6&annotate=colmap)

To this:

![image](https://user-images.githubusercontent.com/983232/64955573-8462ed00-d880-11e9-9a35-1259d2d9b957.png)
