### PR TITLE
Travis OpenJDK 13-->14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 jdk:
 - openjdk8
 - openjdk11
-- openjdk13
+- openjdk14
 
 sudo: false
 


### PR DESCRIPTION
JDK 14 just went GA; update Travis

http://jdk.java.net/14/release-notes
