### PR TITLE
fix bug when checking for 3D coordinates

### DIFF
--- a/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
+++ b/descriptor/fingerprint/src/main/java/org/openscience/cdk/fingerprint/CircularFingerprinter.java
@@ -919,7 +919,7 @@ public class CircularFingerprinter extends AbstractFingerprinter implements IFin
                 break;
             }
             if (stereo == IBond.Stereo.UP_OR_DOWN) return null; // squiggly line: definitely not
-            Point3d o3d = atom.getPoint3d();
+            Point3d o3d = mol.getBond(bondAdj[aidx][n]).getOther(atom).getPoint3d();
             if (a3d != null && o3d != null && a3d.z != o3d.z) {
                 wedgeOr3D = true;
                 break;


### PR DESCRIPTION
I don't understand much of this code, but I'm pretty sure that this is incorrect.

The circular fingerprinter allows for calculating stereochemistry properties from 3D coordinates. However, the function that checks for the presence of 3D coordinates is always returning false, because the 3D coordinates of an atom are compared with itself instead of the neighbour atom.