### PR TITLE
Use SMARTS in XLogP instead of MCS UIT

### DIFF
--- a/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
+++ b/descriptor/qsarmolecular/src/main/java/org/openscience/cdk/qsar/descriptors/molecular/XLogPDescriptor.java
@@ -20,10 +20,6 @@
  */
 package org.openscience.cdk.qsar.descriptors.molecular;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;
@@ -32,18 +28,9 @@ import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.interfaces.IAtomType.Hybridization;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.interfaces.IBond.Order;
-import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IRing;
 import org.openscience.cdk.interfaces.IRingSet;
-import org.openscience.cdk.isomorphism.UniversalIsomorphismTester;
-import org.openscience.cdk.isomorphism.matchers.Expr;
-import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
-import org.openscience.cdk.isomorphism.matchers.QueryAtomContainerCreator;
-import org.openscience.cdk.isomorphism.matchers.QueryBond;
-import org.openscience.cdk.isomorphism.mcss.RMap;
 import org.openscience.cdk.qsar.AbstractMolecularDescriptor;
 import org.openscience.cdk.qsar.DescriptorSpecification;
 import org.openscience.cdk.qsar.DescriptorValue;
@@ -54,6 +41,10 @@ import org.openscience.cdk.smarts.SmartsPattern;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.RingSetManipulator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * <p>Prediction of logP based on the atom-type method called XLogP. <b>Requires
@@ -120,9 +111,14 @@ import org.openscience.cdk.tools.manipulator.RingSetManipulator;
  */
 public class XLogPDescriptor extends AbstractMolecularDescriptor implements IMolecularDescriptor {
 
-    private boolean               checkAromaticity = false;
+    private boolean checkAromaticity = false;
     private boolean               salicylFlag      = false;
     private static final String[] NAMES            = {"XLogP"};
+    public static final SmartsPattern C_TERMINAL_AMINO_ACID = SmartsPattern.create("N!@C-C(=O)-[O;X2H1+0,X1H0-]");
+    public static final SmartsPattern P_AMINO_SULPHONIC_ACID = SmartsPattern.create("CS(=O)(=O)c1ccc(N)cc1");
+    public static final SmartsPattern SALICYLIC_ACID_PTRN = SmartsPattern.create("O=C(O)c1ccccc1O");
+    public static final SmartsPattern ORTHOPAIR = SmartsPattern.create("OccO");
+
 
     /**
      *  Constructor for the XLogPDescriptor object.
@@ -871,80 +867,31 @@ public class XLogPDescriptor extends AbstractMolecularDescriptor implements IMol
             }
         }
 
-        UniversalIsomorphismTester universalIsomorphismTester = new UniversalIsomorphismTester();
-        if (checkAminoAcid > 1) {
-            //			alpha amino acid
-            QueryAtomContainer aminoAcid = QueryAtomContainerCreator.createBasicQueryContainer(createAminoAcid(ac
-                    .getBuilder()));
 
-            Iterator bonds = aminoAcid.bonds().iterator();
-            IAtom bondAtom0 = null;
-            IAtom bondAtom1 = null;
-            while (bonds.hasNext()) {
-                IBond bond = (IBond) bonds.next();
-                bondAtom0 = bond.getBegin();
-                bondAtom1 = bond.getEnd();
-                if ((bondAtom0.getAtomicNumber() == IElement.C && bondAtom1.getAtomicNumber() == IElement.N)
-                        || (bondAtom0.getAtomicNumber() == IElement.N && bondAtom1.getAtomicNumber() == IElement.C)
-                        && bond.getOrder() == IBond.Order.SINGLE) {
-                    aminoAcid.removeBond(bondAtom0, bondAtom1);
-                    QueryBond qbond = new QueryBond(bondAtom0, bondAtom1, Expr.Type.SINGLE_OR_AROMATIC);
-                    aminoAcid.addBond(qbond);
-                    break;
-                }
-            }
-
-            //AtomContainer aminoacid = sp.parseSmiles("NCC(=O)O");
-            try {
-                if (universalIsomorphismTester.isSubgraph(ac, aminoAcid)) {
-                    List list = universalIsomorphismTester.getSubgraphAtomsMap(ac, aminoAcid);
-                    RMap map = null;
-                    IAtom atom1 = null;
-                    for (int j = 0; j < list.size(); j++) {
-                        map = (RMap) list.get(j);
-                        atom1 = ac.getAtom(map.getId1());
-                        if (atom1.getAtomicNumber() == IElement.O && ac.getMaximumBondOrder(atom1) == IBond.Order.SINGLE) {
-                            if (ac.getConnectedBondsCount(atom1) == 2 && getHydrogenCount(ac, atom1) == 0) {
-                            } else {
-                                xlogP -= 2.166;
-                                //logger.debug("XLOGP: alpha amino acid	-2.166");
-                                break;
-                            }
-                        }
-                    }
-                }
-            } catch (CDKException e) {
-                return getDummyDescriptorValue(e);
-            }
+        /* Important: hydrogens are explicit so can't just do D1 like normal.
+         * - !@ needed for testno1782 but then this would not longer match proline
+         *   :/ */
+        if (C_TERMINAL_AMINO_ACID.matches(ac)) {
+            xlogP -= 2.166;
+//            logger.debug("XLOGP: alpha amino acid	-2.166");
         }
 
-        IAtomContainer paba = createPaba(ac.getBuilder());
         // p-amino sulphonic acid
-        try {
-            if (universalIsomorphismTester.isSubgraph(ac, paba)) {
-                xlogP -= 0.501;
-                //logger.debug("XLOGP: p-amino sulphonic acid	-0.501");
-            }
-        } catch (CDKException e) {
-            return getDummyDescriptorValue(e);
+        if (P_AMINO_SULPHONIC_ACID.matches(ac)) {
+          xlogP -= 0.501;
+//          logger.debug("XLOGP: p-amino sulphonic acid	-0.501");
         }
 
         // salicylic acid
         if (salicylFlag) {
-            IAtomContainer salicilic = createSalicylicAcid(ac.getBuilder());
-            try {
-                if (universalIsomorphismTester.isSubgraph(ac, salicilic)) {
-                    xlogP += 0.554;
-                    //logger.debug("XLOGP: salicylic acid	 0.554");
-                }
-            } catch (CDKException e) {
-                return getDummyDescriptorValue(e);
+            if (SALICYLIC_ACID_PTRN.matches(ac)) {
+                xlogP += 0.554;
+//              logger.debug("XLOGP: salicylic acid	 0.554");
             }
         }
 
         // ortho oxygen pair
-        SmartsPattern orthopair = SmartsPattern.create("OccO");
-        if (orthopair.matches(ac)) {
+        if (ORTHOPAIR.matches(ac)) {
             xlogP -= 0.268;
             //logger.debug("XLOGP: Ortho oxygen pair	-0.268");
         }
@@ -955,7 +902,7 @@ public class XLogPDescriptor extends AbstractMolecularDescriptor implements IMol
 
     /**
      * Returns the specific type of the DescriptorResult object.
-     * 
+     *
      * The return value from this method really indicates what type of result will
      * be obtained from the {@link org.openscience.cdk.qsar.DescriptorValue} object. Note that the same result
      * can be achieved by interrogating the {@link org.openscience.cdk.qsar.DescriptorValue} object; this method
@@ -1471,147 +1418,5 @@ public class XLogPDescriptor extends AbstractMolecularDescriptor implements IMol
     @Override
     public Object getParameterType(String name) {
         return true;
-    }
-
-    private IAtomContainer createPaba(IChemObjectBuilder builder) {
-        // SMILES CS(=O)(=O)c1ccc(N)cc1
-        IAtomContainer container = builder.newInstance(IAtomContainer.class);
-        IAtom atom1 = builder.newInstance(IAtom.class, "C");
-        container.addAtom(atom1);
-        IAtom atom2 = builder.newInstance(IAtom.class, "S");
-        container.addAtom(atom2);
-        IAtom atom3 = builder.newInstance(IAtom.class, "O");
-        container.addAtom(atom3);
-        IAtom atom4 = builder.newInstance(IAtom.class, "O");
-        container.addAtom(atom4);
-        IAtom atom5 = builder.newInstance(IAtom.class, "C");
-        atom5.setHybridization(Hybridization.SP2);
-        container.addAtom(atom5);
-        IAtom atom6 = builder.newInstance(IAtom.class, "C");
-        atom6.setHybridization(Hybridization.SP2);
-        container.addAtom(atom6);
-        IAtom atom7 = builder.newInstance(IAtom.class, "C");
-        atom7.setHybridization(Hybridization.SP2);
-        container.addAtom(atom7);
-        IAtom atom8 = builder.newInstance(IAtom.class, "C");
-        atom8.setHybridization(Hybridization.SP2);
-        container.addAtom(atom8);
-        IAtom atom9 = builder.newInstance(IAtom.class, "N");
-        container.addAtom(atom9);
-        IAtom atom10 = builder.newInstance(IAtom.class, "C");
-        atom10.setHybridization(Hybridization.SP2);
-        container.addAtom(atom10);
-        IAtom atom11 = builder.newInstance(IAtom.class, "C");
-        atom11.setHybridization(Hybridization.SP2);
-        container.addAtom(atom11);
-        IBond bond1 = builder.newInstance(IBond.class, atom1, atom2, Order.SINGLE);
-        container.addBond(bond1);
-        IBond bond2 = builder.newInstance(IBond.class, atom2, atom3, Order.DOUBLE);
-        container.addBond(bond2);
-        IBond bond3 = builder.newInstance(IBond.class, atom2, atom4, Order.DOUBLE);
-        container.addBond(bond3);
-        IBond bond4 = builder.newInstance(IBond.class, atom2, atom5, Order.SINGLE);
-        container.addBond(bond4);
-        IBond bond5 = builder.newInstance(IBond.class, atom5, atom6, Order.DOUBLE);
-        bond5.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond5);
-        IBond bond6 = builder.newInstance(IBond.class, atom6, atom7, Order.SINGLE);
-        bond6.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond6);
-        IBond bond7 = builder.newInstance(IBond.class, atom7, atom8, Order.DOUBLE);
-        bond7.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond7);
-        IBond bond8 = builder.newInstance(IBond.class, atom8, atom9, Order.SINGLE);
-        container.addBond(bond8);
-        IBond bond9 = builder.newInstance(IBond.class, atom8, atom10, Order.SINGLE);
-        bond9.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond9);
-        IBond bond10 = builder.newInstance(IBond.class, atom10, atom11, Order.DOUBLE);
-        bond10.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond10);
-        IBond bond11 = builder.newInstance(IBond.class, atom5, atom11, Order.SINGLE);
-        bond11.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond11);
-
-        return container;
-    }
-
-    private IAtomContainer createAminoAcid(IChemObjectBuilder builder) {
-        // SMILES NCC(=O)O
-        IAtomContainer container = builder.newInstance(IAtomContainer.class);
-        IAtom atom1 = builder.newInstance(IAtom.class, "N");
-        container.addAtom(atom1);
-        IAtom atom2 = builder.newInstance(IAtom.class, "C");
-        container.addAtom(atom2);
-        IAtom atom3 = builder.newInstance(IAtom.class, "C"); // carbonyl
-        container.addAtom(atom3);
-        IAtom atom4 = builder.newInstance(IAtom.class, "O"); // carbonyl
-        container.addAtom(atom4);
-        IAtom atom5 = builder.newInstance(IAtom.class, "O");
-        container.addAtom(atom5);
-        container.addBond(builder.newInstance(IBond.class, atom1, atom2, Order.SINGLE));
-        container.addBond(builder.newInstance(IBond.class, atom2, atom3, Order.SINGLE));
-        container.addBond(builder.newInstance(IBond.class, atom3, atom4, Order.DOUBLE));
-        container.addBond(builder.newInstance(IBond.class, atom3, atom5, Order.SINGLE));
-        return container;
-    }
-
-    private IAtomContainer createSalicylicAcid(IChemObjectBuilder builder) {
-        // SMILES O=C(O)c1ccccc1O
-        IAtomContainer container = builder.newInstance(IAtomContainer.class);
-        IAtom atom1 = builder.newInstance(IAtom.class, "C");
-        container.addAtom(atom1);
-        IAtom atom2 = builder.newInstance(IAtom.class, "O");
-        container.addAtom(atom2);
-        IAtom atom3 = builder.newInstance(IAtom.class, "O");
-        container.addAtom(atom3);
-        IAtom atom4 = builder.newInstance(IAtom.class, "C");
-        atom4.setHybridization(Hybridization.SP2);
-        container.addAtom(atom4);
-        IAtom atom5 = builder.newInstance(IAtom.class, "C");
-        atom5.setHybridization(Hybridization.SP2);
-        container.addAtom(atom5);
-        IAtom atom6 = builder.newInstance(IAtom.class, "C");
-        atom6.setHybridization(Hybridization.SP2);
-        container.addAtom(atom6);
-        IAtom atom7 = builder.newInstance(IAtom.class, "C");
-        atom7.setHybridization(Hybridization.SP2);
-        container.addAtom(atom7);
-        IAtom atom8 = builder.newInstance(IAtom.class, "C");
-        atom8.setHybridization(Hybridization.SP2);
-        container.addAtom(atom8);
-        IAtom atom9 = builder.newInstance(IAtom.class, "C");
-        atom9.setHybridization(Hybridization.SP2);
-        container.addAtom(atom9);
-        IAtom atom10 = builder.newInstance(IAtom.class, "O");
-        container.addAtom(atom10);
-        IBond bond1 = builder.newInstance(IBond.class, atom1, atom2, Order.DOUBLE);
-        container.addBond(bond1);
-        IBond bond2 = builder.newInstance(IBond.class, atom1, atom3, Order.SINGLE);
-        container.addBond(bond2);
-        IBond bond3 = builder.newInstance(IBond.class, atom1, atom4, Order.SINGLE);
-        container.addBond(bond3);
-        IBond bond4 = builder.newInstance(IBond.class, atom4, atom5, Order.DOUBLE);
-        bond4.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond4);
-        IBond bond5 = builder.newInstance(IBond.class, atom5, atom6, Order.SINGLE);
-        bond5.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond5);
-        IBond bond6 = builder.newInstance(IBond.class, atom6, atom7, Order.DOUBLE);
-        bond6.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond6);
-        IBond bond7 = builder.newInstance(IBond.class, atom7, atom8, Order.SINGLE);
-        bond7.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond7);
-        IBond bond8 = builder.newInstance(IBond.class, atom8, atom9, Order.DOUBLE);
-        bond8.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond8);
-        IBond bond9 = builder.newInstance(IBond.class, atom9, atom4, Order.SINGLE);
-        bond9.setFlag(CDKConstants.ISAROMATIC, true);
-        container.addBond(bond9);
-        IBond bond10 = builder.newInstance(IBond.class, atom9, atom10, Order.SINGLE);
-        container.addBond(bond10);
-
-        return container;
     }
 }


### PR DESCRIPTION
There are better LogP predictors (e.g. ALogP and JPLogP) - on the one hand I think hmm this could be useful to preserve for prosperity. However often the methods have very obvious coding bugs/misunderstandings. 

Like here... the alpha amino pattern expected by the tests doesn't match proline.
Also works on explicit hydrogens - sigh. Anyways tests are parsing but that doesn't mean much so want to read the XLogP paper to see how faithful this is to the actual description.