### PR TITLE
Patch/ligandordering

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/sgroup/SgroupType.java
+++ b/base/core/src/main/java/org/openscience/cdk/sgroup/SgroupType.java
@@ -76,7 +76,9 @@ public enum SgroupType {
     CtabGeneric("GEN"),
 
     // extension for handling positional variation and distributed coordination bonds
-    ExtMulticenter("N/A");
+    ExtMulticenter("_MAP", false),
+    // extension for handling bond attachment, LO: in CXSMILES
+    ExtAttachOrdering("_APO", false);
 
 
     static final Map<String, SgroupType> map = new HashMap<>();
@@ -86,11 +88,28 @@ public enum SgroupType {
             map.put(t.ctabKey, t);
     }
 
-    private final String ctabKey;
+    private final String  ctabKey;
+    private final boolean ctabStandard;
 
     SgroupType(String ctabKey) {
-        this.ctabKey = ctabKey;
+        this(ctabKey, true);
     }
+
+    SgroupType(String ctabKey, boolean ctabStandard) {
+        this.ctabKey      = ctabKey;
+        this.ctabStandard = ctabStandard;
+    }
+
+
+    /**
+     * Indicates if this SGroup type is support by standard CTAB
+     * (Molfile/SDfile) sgroups.
+     * @return true/false
+     */
+    public boolean isCtabStandard() {
+        return ctabStandard;
+    }
+
 
     public String getKey() {
         return ctabKey;

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
@@ -912,11 +912,7 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
         sgroups = new ArrayList<>(sgroups);
 
         // remove non-ctab Sgroups
-        Iterator<Sgroup> iter = sgroups.iterator();
-        while (iter.hasNext()) {
-            if (iter.next().getType() == SgroupType.ExtMulticenter)
-                iter.remove();
-        }
+        sgroups.removeIf(sgroup -> !sgroup.getType().isCtabStandard());
 
         for (List<Sgroup> wrapSgroups : wrap(sgroups, 8)) {
             // Declare the SGroup type

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -541,11 +541,7 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
         sgroups = new ArrayList<>(sgroups);
 
         // remove non-ctab Sgroups
-        Iterator<Sgroup> iter = sgroups.iterator();
-        while (iter.hasNext()) {
-            if (iter.next().getType() == SgroupType.ExtMulticenter)
-                iter.remove();
-        }
+        sgroups.removeIf(sgroup -> !sgroup.getType().isCtabStandard());
 
         if (sgroups.isEmpty())
             return;
@@ -670,8 +666,8 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
         List<Sgroup> sgroups = getSgroups(mol);
 
         int numSgroups = 0;
-        for (int i = 0; i < sgroups.size(); i++)
-            if (sgroups.get(i).getType() != SgroupType.ExtMulticenter)
+        for (Sgroup sgroup : sgroups)
+            if (sgroup.getType().isCtabStandard())
                 numSgroups++;
 
         writer.write("BEGIN CTAB\n");

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesGenerator.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesGenerator.java
@@ -217,14 +217,7 @@ public class CxSmilesGenerator {
             List<Map.Entry<Integer, List<Integer>>> multicenters = new ArrayList<>(state.positionVar.entrySet());
 
             // consistent output order
-            Collections.sort(multicenters,
-                             new Comparator<Map.Entry<Integer, List<Integer>>>() {
-                                 @Override
-                                 public int compare(Map.Entry<Integer, List<Integer>> a,
-                                                    Map.Entry<Integer, List<Integer>> b) {
-                                     return comp.compare(a.getKey(), b.getKey());
-                                 }
-                             });
+            multicenters.sort((a, b) -> comp.compare(a.getKey(), b.getKey()));
 
             for (int i = 0; i < multicenters.size(); i++) {
                 if (i != 0) sb.append(',');
@@ -232,8 +225,29 @@ public class CxSmilesGenerator {
                 sb.append(ordering[e.getKey()]);
                 sb.append(':');
                 List<Integer> vals = new ArrayList<>(e.getValue());
-                Collections.sort(vals, comp);
+                vals.sort(comp);
                 appendIntegers(ordering, '.', sb, vals);
+            }
+
+        }
+
+        if (state.ligandOrdering != null && !state.ligandOrdering.isEmpty()) {
+
+            if (sb.length() > 2) sb.append(',');
+            sb.append("LO");
+            sb.append(':');
+
+            List<Map.Entry<Integer, List<Integer>>> ligandorderings = new ArrayList<>(state.ligandOrdering.entrySet());
+
+            // consistent output order
+            ligandorderings.sort((a, b) -> comp.compare(a.getKey(), b.getKey()));
+
+            for (int i = 0; i < ligandorderings.size(); i++) {
+                if (i != 0) sb.append(',');
+                Map.Entry<Integer, List<Integer>> e = ligandorderings.get(i);
+                sb.append(ordering[e.getKey()]);
+                sb.append(':');
+                appendIntegers(ordering, '.', sb, e.getValue());
             }
 
         }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesGenerator.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesGenerator.java
@@ -231,7 +231,8 @@ public class CxSmilesGenerator {
 
         }
 
-        if (state.ligandOrdering != null && !state.ligandOrdering.isEmpty()) {
+        if (SmiFlavor.isSet(opts, SmiFlavor.CxLigandOrder) &&
+            state.ligandOrdering != null && !state.ligandOrdering.isEmpty()) {
 
             if (sb.length() > 2) sb.append(',');
             sb.append("LO");

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesState.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesState.java
@@ -38,6 +38,7 @@ final class CxSmilesState {
     List<double[]>              atomCoords  = null;
     List<List<Integer>>         fragGroups  = null;
     Map<Integer, Radical>       atomRads    = null;
+    Map<Integer, List<Integer>> ligandOrdering = null;
     Map<Integer, List<Integer>> positionVar = null;
     List<PolymerSgroup>         sgroups     = null;
     List<DataSgroup>            dataSgroups = null;

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmiFlavor.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmiFlavor.java
@@ -165,14 +165,19 @@ public final class SmiFlavor {
     public static final int CxFragmentGroup     = 0x100000;
 
     /**
+     * Output ligand order information.
+     */
+    public static final int CxLigandOrder       = 0x200000;
+
+    /**
      * Renumber AtomAtomMaps during canonical generation
      */
-    public static final int AtomAtomMapRenumber = Canonical | AtomAtomMap | 0x200000;
+    public static final int AtomAtomMapRenumber = Canonical | AtomAtomMap | 0x2000000;
 
     /**
      * Output CXSMILES layers.
      */
-    public static final int CxSmiles            = CxAtomLabel | CxAtomValue | CxRadical | CxFragmentGroup | CxMulticenter | CxPolymer;
+    public static final int CxSmiles            = CxAtomLabel | CxAtomValue | CxRadical | CxFragmentGroup | CxMulticenter | CxPolymer | CxLigandOrder;
 
     /**
      * Output CXSMILES layers and coordinates.

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -26,7 +26,9 @@ package org.openscience.cdk.smiles;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import org.openscience.cdk.CDK;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.ConnectivityChecker;
 import org.openscience.cdk.interfaces.IAtom;
@@ -307,7 +309,7 @@ public final class SmilesParser {
      * @param title SMILES title field
      * @param mol   molecule
      */
-    private void parseMolCXSMILES(String title, IAtomContainer mol) {
+    private void parseMolCXSMILES(String title, IAtomContainer mol) throws InvalidSmilesException {
         CxSmilesState cxstate;
         int pos;
         if (title != null && title.startsWith("|")) {
@@ -335,7 +337,7 @@ public final class SmilesParser {
      * @param title SMILES title field
      * @param rxn   parsed reaction
      */
-    private void parseRxnCXSMILES(String title, IReaction rxn) {
+    private void parseRxnCXSMILES(String title, IReaction rxn) throws InvalidSmilesException {
         CxSmilesState cxstate;
         int pos;
         if (title != null && title.startsWith("|")) {
@@ -460,7 +462,7 @@ public final class SmilesParser {
                                     IChemObject chemObj,
                                     List<IAtom> atoms,
                                     Map<IAtom, IAtomContainer> atomToMol,
-                                    CxSmilesState cxstate) {
+                                    CxSmilesState cxstate) throws InvalidSmilesException {
 
         // atom-labels - must be done first as we replace atoms
         if (cxstate.atomLabels != null) {
@@ -486,7 +488,7 @@ public final class SmilesParser {
                 IAtomContainer mol = atomToMol.get(old);
                 AtomContainerManipulator.replaceAtomByAtom(mol, old, pseudo);
                 atomToMol.put(pseudo, mol);
-                atoms.set(e.getKey(), pseudo);
+                atoms.set(e.getKey(), mol.getAtom(old.getIndex()));
             }
         }
 
@@ -553,11 +555,34 @@ public final class SmilesParser {
                 IAtomContainer mol = atomToMol.get(beg);
                 List<IBond> bonds = mol.getConnectedBondsList(beg);
                 if (bonds.isEmpty())
-                    continue; // bad
+                    continue; // possibly okay
                 sgroup.addAtom(beg);
                 sgroup.addBond(bonds.get(0));
                 for (Integer endpt : e.getValue())
                     sgroup.addAtom(atoms.get(endpt));
+                sgroupMap.put(mol, sgroup);
+            }
+        }
+
+        // ligand ordering
+        if (cxstate.ligandOrdering != null) {
+            for (Map.Entry<Integer, List<Integer>> e : cxstate.ligandOrdering.entrySet()) {
+                Sgroup sgroup = new Sgroup();
+                sgroup.setType(SgroupType.ExtAttachOrdering);
+                IAtom beg = atoms.get(e.getKey());
+                IAtomContainer mol = atomToMol.get(beg);
+                List<IBond> bonds = mol.getConnectedBondsList(beg);
+                if (bonds.isEmpty())
+                    throw new InvalidSmilesException("CXSMILES LO: no bonds to order");
+                if (bonds.size() != e.getValue().size())
+                    throw new InvalidSmilesException("CXSMILES LO: bond count and ordering count was different");
+                sgroup.addAtom(beg);
+                for (Integer endpt : e.getValue()) {
+                    IBond bond = beg.getBond(atoms.get(endpt));
+                    if (bond == null)
+                        throw new InvalidSmilesException("CXSMILES LO: defined ordering to non-existant bond");
+                    sgroup.addBond(bond);
+                }
                 sgroupMap.put(mol, sgroup);
             }
         }

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
@@ -376,6 +377,22 @@ public class CxSmilesTest {
         IAtomContainer mol = smipar.parseSmiles("c1ccccc1O |$_AV:0;1;2;3;4;5;6$|");
         SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.Canonical | SmiFlavor.CxAtomValue);
         assertThat(smigen.create(mol), is("OC=1C=CC=CC1 |$_AV:6;5;0;1;2;3;4$|"));
+    }
+
+    @Test public void roundTripLigandOrdering() throws CDKException {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        SmilesParser smipar = new SmilesParser(bldr);
+        IAtomContainer mol = smipar.parseSmiles("Cl[*](Br)I |$;_R1;;$,LO:1:0.2.3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxSmiles);
+        assertThat(smigen.create(mol), is("Cl*(Br)I |$;R1$,LO:1:0.2.3|"));
+    }
+
+    @Test public void canonLigandOrdering() throws CDKException {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        SmilesParser smipar = new SmilesParser(bldr);
+        IAtomContainer mol = smipar.parseSmiles("Cl[*](I)Br |$;_R1;;$,LO:1:0.2.3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.Canonical|SmiFlavor.CxSmiles);
+        assertThat(smigen.create(mol), is("Cl*(Br)I |$;R1$,LO:1:0.3.2|"));
     }
 
 }


### PR DESCRIPTION
Support for ligand ordering in CXSMILES. When working with attachment points this information let's us know how things attach.

```
Cl[*](I)Br |$;_R1;;$,LO:1:0.2.3|
*CCCC(C*)CC* |$_AP3;;;;;;_AP2;;;_AP1$|
*CCCN(C*)CC* |$_AP3;;;;;;_AP2;;;_AP1$|
```
![image](https://user-images.githubusercontent.com/983232/87933678-9ce5fa00-ca85-11ea-9458-dd55d4d8f048.png)
*R<sup>1</sup>* = ![image](https://www.simolecule.com/cdkdepict/depict/bow/png?smi=*CCCC(C*)CC*%20%7C%24_AP3%3B%3B%3B%3B%3B%3B_AP2%3B%3B%3B_AP1%24%7C&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1&annotate=none), ![image](https://www.simolecule.com/cdkdepict/depict/bow/png?smi=*CCCN(C*)CC*%20%7C%24_AP3%3B%3B%3B%3B%3B%3B_AP2%3B%3B%3B_AP1%24%7C&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1&annotate=none)
