### PR TITLE
Inchi does not officially support fractions of seconds timeout

### DIFF
--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/JniInChIInputAdapter.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/JniInChIInputAdapter.java
@@ -27,7 +27,6 @@ import net.sf.jniinchi.INCHI_OPTION;
 import net.sf.jniinchi.JniInchiException;
 import net.sf.jniinchi.JniInchiInput;
 
-import java.text.DecimalFormat;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -55,22 +54,10 @@ public class JniInChIInputAdapter extends JniInchiInput {
 
     private static boolean isTimeoutOptions(String op) {
         if (op == null || op.length() < 2) return false;
-        int pos = 0;
-        int len = op.length();
-        if (op.charAt(pos) == 'W')
-            pos++;
-        while (pos < len && Character.isDigit(op.charAt(pos)))
-            pos++;
-        if (pos < len && (op.charAt(pos) == '.' || op.charAt(pos) == ','))
-            pos++;
-        while (pos < len && Character.isDigit(op.charAt(pos)))
-            pos++;
-        return pos == len;
+        return op.charAt(0) == 'W';
+
     }
 
-    private static boolean isSubSecondTimeout(String op) {
-        return op.indexOf('.') >= 0 || op.indexOf(',') >= 0;
-    }
 
     private static String checkOptions(final String ops) throws JniInchiException {
         if (ops == null) {
@@ -96,18 +83,14 @@ public class JniInChIInputAdapter extends JniInchiInput {
                     sbOptions.append(" ");
                 }
             } else if (isTimeoutOptions(op)) {
-                // only reformat if we actually have a decimal
-                if (isSubSecondTimeout(op)) {
-                    // because the JNI-InChI library is expecting an platform number, format it as such
-	                Double time = Double.parseDouble(op.substring(1));
-	                DecimalFormat format = new DecimalFormat("#.##");
-	                sbOptions.append(FLAG_CHAR).append('W').append(format.format(time));
-                } else {
-                    sbOptions.append(FLAG_CHAR).append(op);
-                }
-                hasUserSpecifiedTimeout = true;
-                if (tok.hasMoreTokens()) {
-                    sbOptions.append(" ");
+                final double time = Math.ceil(Double.parseDouble(op.substring(1)));
+                // fix #653: safer to use whole seconds, rounded to next bigger integer
+                if (time >= 0.0) {
+                    sbOptions.append(FLAG_CHAR).append(String.format("W%.0f", time));
+                    hasUserSpecifiedTimeout = true;
+                    if (tok.hasMoreTokens()) {
+                        sbOptions.append(" ");
+                    }
                 }
             }
             // 1,5 tautomer option

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
@@ -896,11 +896,7 @@ public class InChIGeneratorTest extends CDKTestCase {
         }
     }
 
-    // if this test hits the timeout it's likely the users Locale is mixed, the
-    // InChI library was loaded in one mode and java is in another, the issue
-    // is InChI takes timeout in seconds and fractional seconds will be either
-    // 0.1 or 0,1 depending on locale.
-    @Test(timeout = 500)
+    @Test(timeout = 1500)
     public void timeout() throws Exception {
         IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
         SmilesParser smipar = new SmilesParser(bldr);


### PR DESCRIPTION
in options.
For safety, input which is formatted accordingly will be reformatted to pass next higher integer value. If the supplied timeout is malformed, eg 0.01 and the locale of the system is wrong, the value will be altered to 0 (much larger or infinite? time to compute than specified).
This is a hotfix. Maybe there is better options, supporting fractions optionally? Fix it in the JNI-InChI library to use unit of timeout, another timeout option that takes ms as long value.
fix #653 