### PR TITLE
Ensure consistent behaviour when non-matching atom-maps are provided.

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
@@ -56,8 +56,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -513,6 +515,18 @@ public final class DepictionGenerator {
     private Map<IChemObject, Color> makeHighlightAtomMap(List<IAtomContainer> reactants,
                                                          List<IAtomContainer> products) {
 
+        // only highlight atom-maps that appear in both the reactant+product
+        Set<Integer> reactantMapIdxs = new HashSet<>();
+        Set<Integer> productMapIdxs = new HashSet<>();
+        for (IAtomContainer mol : reactants) {
+            for (IAtom atom : mol.atoms())
+                reactantMapIdxs.add(accessAtomMap(atom));
+        }
+        for (IAtomContainer mol : products) {
+            for (IAtom atom : mol.atoms())
+                productMapIdxs.add(accessAtomMap(atom));
+        }
+
         Map<IChemObject, Color> colorMap = new HashMap<>();
         Map<Integer, Color> mapToColor = new HashMap<>();
         Map<Integer, IAtom> amap = new TreeMap<>();
@@ -521,7 +535,7 @@ public final class DepictionGenerator {
             int prevPalletIdx = colorIdx;
             for (IAtom atom : mol.atoms()) {
                 int mapidx = accessAtomMap(atom);
-                if (mapidx > 0) {
+                if (mapidx > 0 && productMapIdxs.contains(mapidx)) {
                     if (prevPalletIdx == colorIdx) {
                         colorIdx++; // select next color
                         if (colorIdx >= atomMapColors.length)
@@ -548,7 +562,7 @@ public final class DepictionGenerator {
         for (IAtomContainer mol : products) {
             for (IAtom atom : mol.atoms()) {
                 int mapidx = accessAtomMap(atom);
-                if (mapidx > 0) {
+                if (mapidx > 0 && reactantMapIdxs.contains(mapidx)) {
                     colorMap.put(atom, mapToColor.get(mapidx));
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/cdk/depict/issues/24.

There are different styles of atom-mapping, e.g. "complete" and "matching" see. https://docs.chemaxon.com/display/AutoMapper_User%27s_Guide.html.

Here we change the atom-map colouring to only highlight atoms that are present in both the reactant and product (i.e. matching). I missed this as I'd always work with that style :-).

![image](https://user-images.githubusercontent.com/983232/89282819-00eeed80-d644-11ea-8649-cd26380962cb.png)
