### PR TITLE
Fix for reading mol file with ALS lines into non-QueryAtomContainer

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -979,7 +979,11 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                             QueryAtom ref = (QueryAtom)AtomRef.deref(atom);
                             ref.setExpression(expr);
                         } else {
-                            container.setAtom(index, new QueryAtom(expr));
+                            QueryAtom queryAtom = new QueryAtom(expr);
+                            //keep coordinates from old atom
+                            queryAtom.setPoint2d(atom.getPoint2d());
+                            queryAtom.setPoint3d(atom.getPoint3d());
+                            container.setAtom(index, queryAtom);
                         }
                     }
                     break;

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -520,17 +520,26 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                 }
             }
 
-            // sanity check that we have a decent molecule, query bonds mean we
+            // sanity check that we have a decent molecule, query bonds or query atoms mean we
             // don't have a hydrogen count for atoms and stereo perception isn't
             // currently possible
             if (!(outputContainer instanceof IQueryAtomContainer) && !isQuery &&
                 addStereoElements.isSet() && hasX && hasY) {
-                if (hasZ) { // has 3D coordinates
-                    outputContainer.setStereoElements(StereoElementFactory.using3DCoordinates(outputContainer)
-                            .createAll());
-                } else if (!forceReadAs3DCoords.isSet()) { // has 2D coordinates (set as 2D coordinates)
-                    outputContainer.setStereoElements(StereoElementFactory.using2DCoordinates(outputContainer)
-                            .createAll());
+                //ALS property could have changed an atom into a QueryAtom
+                for(IAtom atom : outputContainer.atoms()){
+                    if (AtomRef.deref(atom) instanceof QueryAtom) {
+                        isQuery=true;
+                        break;
+                    }
+                }
+                if(!isQuery) {
+                    if (hasZ) { // has 3D coordinates
+                        outputContainer.setStereoElements(StereoElementFactory.using3DCoordinates(outputContainer)
+                                .createAll());
+                    } else if (!forceReadAs3DCoords.isSet()) { // has 2D coordinates (set as 2D coordinates)
+                        outputContainer.setStereoElements(StereoElementFactory.using2DCoordinates(outputContainer)
+                                .createAll());
+                    }
                 }
             }
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -1886,4 +1886,14 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
             assertThat(mol.getAtomCount(), is(108));
         }
     }
+    @Test
+    public void atomlistWithAtomContainer() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("query_notatomlist.mol");
+             MDLV2000Reader mdlr = new MDLV2000Reader(in)) {
+
+            IAtomContainer mol = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
+            IAtom               deref     = AtomRef.deref(mol.getAtom(0));
+            assertThat(deref, CoreMatchers.<IAtom>instanceOf(QueryAtom.class));
+        }
+    }
 }


### PR DESCRIPTION
if we read a  mol file containing `M  ALS` line(s) and write it to an `IAtomContainer` instead of a `IQueryAtomContainer` then the checks for avoiding atom typing won't see that that property parsing section converted some Atoms into QueryAtoms and trying to parse such mol files will error out with an error message "java.lang.IllegalArgumentException: an atom had an undefieind atomic number".

Added additional check just prior to atom typing to see if any atoms are QueryAtoms and added another test for this usecase.