### PR TITLE
MapIdx and QueryContainers

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/AtomRef.java
+++ b/base/core/src/main/java/org/openscience/cdk/AtomRef.java
@@ -442,6 +442,17 @@ public class AtomRef extends ChemObjectRef implements IAtom {
         atom.setIsInRing(ring);
     }
 
+
+    @Override
+    public int getMapIdx() {
+      return atom.getMapIdx();
+    }
+
+    @Override
+    public void setMapIdx(int mapidx) {
+      atom.setMapIdx(mapidx);
+    }
+
     @Override
     public int hashCode() {
         return atom.hashCode();

--- a/base/data/src/main/java/org/openscience/cdk/Atom.java
+++ b/base/data/src/main/java/org/openscience/cdk/Atom.java
@@ -490,6 +490,21 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         setFlag(CDKConstants.ISINRING, ring);
     }
 
+    @Override
+    public int getMapIdx() {
+      Integer mapidx = getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+      if (mapidx == null)
+        return 0;
+      return mapidx;
+    }
+
+    @Override
+    public void setMapIdx(int mapidx) {
+      if (mapidx < 0)
+        throw new IllegalArgumentException("setMapIdx(val) value must be >= 0");
+      setProperty(CDKConstants.ATOM_ATOM_MAPPING, mapidx);
+    }
+
     /**
      * Returns a one line string representation of this Atom.
      * Methods is conform RFC #9.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IAtom.java
@@ -257,6 +257,20 @@ public interface IAtom extends IAtomType {
     void setIsInRing(boolean ring);
 
     /**
+     * Access the map index for this atom.
+     *
+     * @return the map index (0 if not set)
+     */
+    int getMapIdx();
+
+    /**
+     * Set the map index for this atom.
+     *
+     * @param mapidx the new map index
+     */
+    void setMapIdx(int mapidx);
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/DfState.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/DfState.java
@@ -99,7 +99,7 @@ final class DfState implements Iterable<int[]> {
     private int          sptr;
     private StackFrame[] stack;
 
-    DfState(IQueryAtomContainer query) {
+    DfState(IAtomContainer query) {
 
         IChemObjectBuilder builder = query.getBuilder();
         if (builder == null) {

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtom.java
@@ -35,7 +35,7 @@ import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
 /**
- * @cdk.module  isomorphism
+ * @cdk.module isomorphism
  * @cdk.githash
  */
 public class QueryAtom extends QueryChemObject implements IQueryAtom {
@@ -43,101 +43,113 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     private static ILoggingTool logger = LoggingToolFactory.createLoggingTool(QueryAtom.class);
 
     /**
-     *  The partial charge of the atom.
-     *
+     * The partial charge of the atom.
+     * <p>
      * The default value is {@link CDKConstants#UNSET} and serves to provide a check whether the charge has been
      * set or not
      */
-    protected Double                  charge               = (Double) CDKConstants.UNSET;
+    protected Double charge = (Double) CDKConstants.UNSET;
 
     /**
-     *  A 2D point specifying the location of this atom in a 2D coordinate
-     *  space.
+     * A 2D point specifying the location of this atom in a 2D coordinate
+     * space.
      */
-    protected Point2d                 point2d              = (Point2d) CDKConstants.UNSET;
+    protected Point2d point2d = (Point2d) CDKConstants.UNSET;
 
     /**
-     *  A 3 point specifying the location of this atom in a 3D coordinate
-     *  space.
+     * A 3 point specifying the location of this atom in a 3D coordinate
+     * space.
      */
-    protected Point3d                 point3d              = (Point3d) CDKConstants.UNSET;
+    protected Point3d point3d = (Point3d) CDKConstants.UNSET;
 
     /**
-     *  A 3 point specifying the location of this atom in a crystal unit cell.
+     * A 3 point specifying the location of this atom in a crystal unit cell.
      */
-    protected Point3d                 fractionalPoint3d    = (Point3d) CDKConstants.UNSET;
+    protected Point3d fractionalPoint3d = (Point3d) CDKConstants.UNSET;
 
     /**
-     *  The number of implicitly bound hydrogen atoms for this atom.
+     * The number of implicitly bound hydrogen atoms for this atom.
      */
-    protected Integer                 hydrogenCount        = (Integer) CDKConstants.UNSET;
+    protected Integer hydrogenCount = (Integer) CDKConstants.UNSET;
 
     /**
-     *  A stereo parity descriptor for the stereochemistry of this atom.
+     * A stereo parity descriptor for the stereochemistry of this atom.
      */
-    protected Integer                 stereoParity         = (Integer) CDKConstants.UNSET;
+    protected Integer stereoParity = (Integer) CDKConstants.UNSET;
 
     /**
-     *  The maximum bond order allowed for this atom type.
+     * The maximum bond order allowed for this atom type.
      */
-    IBond.Order                       maxBondOrder         = null;
+    IBond.Order maxBondOrder = null;
     /**
-     *  The maximum sum of all bond orders allowed for this atom type.
+     * The maximum sum of all bond orders allowed for this atom type.
      */
-    Double                            bondOrderSum         = (Double) CDKConstants.UNSET;
+    Double bondOrderSum = (Double) CDKConstants.UNSET;
 
     /**
      * The covalent radius of this atom type.
      */
-    Double                            covalentRadius       = (Double) CDKConstants.UNSET;
+    Double covalentRadius = (Double) CDKConstants.UNSET;
 
     /**
-     *  The formal charge of the atom with CDKConstants.UNSET as default. Implements RFC #6.
-     *
-     *  Note that some constructors e.g. ({@link org.openscience.cdk.silent.AtomType#AtomType(String)} and
+     * The formal charge of the atom with CDKConstants.UNSET as default. Implements RFC #6.
+     * <p>
+     * Note that some constructors e.g. ({@link org.openscience.cdk.silent.AtomType#AtomType(String)} and
      * {@link org.openscience.cdk.silent.AtomType#AtomType(String, String)} ) will explicitly set this field to 0
      */
-    protected Integer                 formalCharge         = (Integer) CDKConstants.UNSET;
+    protected Integer formalCharge = (Integer) CDKConstants.UNSET;
 
     /**
      * The hybridization state of this atom with CDKConstants.HYBRIDIZATION_UNSET
      * as default.
      */
-    protected IAtomType.Hybridization hybridization        = (Hybridization) CDKConstants.UNSET;
+    protected IAtomType.Hybridization hybridization = (Hybridization) CDKConstants.UNSET;
 
     /**
-     *  The electron Valency of this atom with CDKConstants.UNSET as default.
+     * The electron Valency of this atom with CDKConstants.UNSET as default.
      */
-    protected Integer                 electronValency      = (Integer) CDKConstants.UNSET;
+    protected Integer electronValency = (Integer) CDKConstants.UNSET;
 
     /**
      * The formal number of neighbours this atom type can have with CDKConstants_UNSET
      * as default. This includes explicitely and implicitely connected atoms, including
      * implicit hydrogens.
      */
-    protected Integer                 formalNeighbourCount = (Integer) CDKConstants.UNSET;
+    protected Integer formalNeighbourCount = (Integer) CDKConstants.UNSET;
 
     /**
      * String representing the identifier for this atom type with null as default.
      */
-    private String                    identifier           = (String) CDKConstants.UNSET;
+    private String identifier = (String) CDKConstants.UNSET;
 
-    /** Exact mass of this isotope. */
-    public Double                     exactMass;
+    /**
+     * Exact mass of this isotope.
+     */
+    public Double exactMass;
 
-    /** Natural abundance of this isotope. */
-    public Double                     naturalAbundance;
+    /**
+     * Natural abundance of this isotope.
+     */
+    public Double naturalAbundance;
 
-    /** The mass number for this isotope. */
-    private Integer                   massNumber;
+    /**
+     * The mass number for this isotope.
+     */
+    private Integer massNumber;
 
-    /** The element symbol for this element as listed in the periodic table. */
-    protected String                  symbol;
+    /**
+     * The element symbol for this element as listed in the periodic table.
+     */
+    protected String symbol;
 
-    /** The atomic number for this element giving their position in the periodic table. */
-    protected Integer                 atomicNumber         = (Integer) CDKConstants.UNSET;
+    /**
+     * The atomic number for this element giving their position in the periodic table.
+     */
+    protected Integer atomicNumber = (Integer) CDKConstants.UNSET;
 
-    /** Atom Expression */
+    /**
+     * Atom Expression
+     */
     private Expr expr = new Expr(Expr.Type.TRUE);
 
     public QueryAtom(String symbol, IChemObjectBuilder builder) {
@@ -190,11 +202,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the partial charge of this atom.
+     * Sets the partial charge of this atom.
      *
-     * @param  charge  The partial charge
-     *
-     * @see    #getCharge
+     * @param charge The partial charge
+     * @see #getCharge
      */
     @Override
     public void setCharge(Double charge) {
@@ -203,13 +214,12 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Returns the partial charge of this atom.
-     *
+     * Returns the partial charge of this atom.
+     * <p>
      * If the charge has not been set the return value is Double.NaN
      *
      * @return the charge of this atom
-     *
-     * @see    #setCharge
+     * @see #setCharge
      */
     @Override
     public Double getCharge() {
@@ -217,11 +227,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the number of implicit hydrogen count of this atom.
+     * Sets the number of implicit hydrogen count of this atom.
      *
-     * @param  hydrogenCount  The number of hydrogen atoms bonded to this atom.
-     *
-     * @see    #getImplicitHydrogenCount
+     * @param hydrogenCount The number of hydrogen atoms bonded to this atom.
+     * @see #getImplicitHydrogenCount
      */
     @Override
     public void setImplicitHydrogenCount(Integer hydrogenCount) {
@@ -230,11 +239,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Returns the hydrogen count of this atom.
+     * Returns the hydrogen count of this atom.
      *
-     * @return    The hydrogen count of this atom.
-     *
-     * @see       #setImplicitHydrogenCount
+     * @return The hydrogen count of this atom.
+     * @see #setImplicitHydrogenCount
      */
     @Override
     public Integer getImplicitHydrogenCount() {
@@ -242,14 +250,12 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-    *
-    * Sets a point specifying the location of this
-    * atom in a 2D space.
-    *
-    * @param  point2d  A point in a 2D plane
-    *
-    * @see    #getPoint2d
-    */
+     * Sets a point specifying the location of this
+     * atom in a 2D space.
+     *
+     * @param point2d A point in a 2D plane
+     * @see #getPoint2d
+     */
     @Override
     public void setPoint2d(Point2d point2d) {
         this.point2d = point2d;
@@ -257,13 +263,11 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *
      * Sets a point specifying the location of this
      * atom in 3D space.
      *
-     * @param  point3d  A point in a 3-dimensional space
-     *
-     * @see    #getPoint3d
+     * @param point3d A point in a 3-dimensional space
+     * @see #getPoint3d
      */
     @Override
     public void setPoint3d(Point3d point3d) {
@@ -275,10 +279,9 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Sets a point specifying the location of this
      * atom in a Crystal unit cell.
      *
-     * @param  point3d  A point in a 3d fractional unit cell space
-     *
-     * @see    #getFractionalPoint3d
-     * @see    org.openscience.cdk.Crystal
+     * @param point3d A point in a 3d fractional unit cell space
+     * @see #getFractionalPoint3d
+     * @see org.openscience.cdk.Crystal
      */
     @Override
     public void setFractionalPoint3d(Point3d point3d) {
@@ -289,10 +292,9 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     /**
      * Sets the stereo parity for this atom.
      *
-     * @param  stereoParity  The stereo parity for this atom
-     *
-     * @see    org.openscience.cdk.CDKConstants for predefined values.
-     * @see    #getStereoParity
+     * @param stereoParity The stereo parity for this atom
+     * @see org.openscience.cdk.CDKConstants for predefined values.
+     * @see #getStereoParity
      */
     @Override
     public void setStereoParity(Integer stereoParity) {
@@ -304,9 +306,8 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Returns a point specifying the location of this
      * atom in a 2D space.
      *
-     * @return    A point in a 2D plane. Null if unset.
-     *
-     * @see       #setPoint2d
+     * @return A point in a 2D plane. Null if unset.
+     * @see #setPoint2d
      */
     @Override
     public Point2d getPoint2d() {
@@ -317,9 +318,8 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Returns a point specifying the location of this
      * atom in a 3D space.
      *
-     * @return    A point in 3-dimensional space. Null if unset.
-     *
-     * @see       #setPoint3d
+     * @return A point in 3-dimensional space. Null if unset.
+     * @see #setPoint3d
      */
     @Override
     public Point3d getPoint3d() {
@@ -330,10 +330,9 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Returns a point specifying the location of this
      * atom in a Crystal unit cell.
      *
-     * @return    A point in 3d fractional unit cell space. Null if unset.
-     *
-     * @see       #setFractionalPoint3d
-     * @see       org.openscience.cdk.CDKConstants for predefined values.
+     * @return A point in 3d fractional unit cell space. Null if unset.
+     * @see #setFractionalPoint3d
+     * @see org.openscience.cdk.CDKConstants for predefined values.
      */
     @Override
     public Point3d getFractionalPoint3d() {
@@ -341,13 +340,12 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Returns the stereo parity of this atom. It uses the predefined values
-     *  found in CDKConstants.
+     * Returns the stereo parity of this atom. It uses the predefined values
+     * found in CDKConstants.
      *
-     * @return    The stereo parity for this atom
-     *
-     * @see       org.openscience.cdk.CDKConstants
-     * @see       #setStereoParity
+     * @return The stereo parity for this atom
+     * @see org.openscience.cdk.CDKConstants
+     * @see #setStereoParity
      */
     @Override
     public Integer getStereoParity() {
@@ -355,11 +353,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the if attribute of the AtomType object.
+     * Sets the if attribute of the AtomType object.
      *
-     * @param  identifier  The new AtomTypeID value. Null if unset.
-     *
-     * @see    #getAtomTypeName
+     * @param identifier The new AtomTypeID value. Null if unset.
+     * @see #getAtomTypeName
      */
     @Override
     public void setAtomTypeName(String identifier) {
@@ -368,11 +365,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the MaxBondOrder attribute of the AtomType object.
+     * Sets the MaxBondOrder attribute of the AtomType object.
      *
-     * @param  maxBondOrder  The new MaxBondOrder value
-     *
-     * @see       #getMaxBondOrder
+     * @param maxBondOrder The new MaxBondOrder value
+     * @see #getMaxBondOrder
      */
     @Override
     public void setMaxBondOrder(IBond.Order maxBondOrder) {
@@ -381,11 +377,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the the exact bond order sum attribute of the AtomType object.
+     * Sets the the exact bond order sum attribute of the AtomType object.
      *
-     * @param  bondOrderSum  The new bondOrderSum value
-     *
-     * @see       #getBondOrderSum
+     * @param bondOrderSum The new bondOrderSum value
+     * @see #getBondOrderSum
      */
     @Override
     public void setBondOrderSum(Double bondOrderSum) {
@@ -394,11 +389,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Gets the id attribute of the AtomType object.
+     * Gets the id attribute of the AtomType object.
      *
-     * @return    The id value
-     *
-     * @see       #setAtomTypeName
+     * @return The id value
+     * @see #setAtomTypeName
      */
     @Override
     public String getAtomTypeName() {
@@ -406,11 +400,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Gets the MaxBondOrder attribute of the AtomType object.
+     * Gets the MaxBondOrder attribute of the AtomType object.
      *
-     * @return    The MaxBondOrder value
-     *
-     * @see       #setMaxBondOrder
+     * @return The MaxBondOrder value
+     * @see #setMaxBondOrder
      */
     @Override
     public IBond.Order getMaxBondOrder() {
@@ -418,11 +411,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Gets the bondOrderSum attribute of the AtomType object.
+     * Gets the bondOrderSum attribute of the AtomType object.
      *
-     * @return    The bondOrderSum value
-     *
-     * @see       #setBondOrderSum
+     * @return The bondOrderSum value
+     * @see #setBondOrderSum
      */
     @Override
     public Double getBondOrderSum() {
@@ -430,11 +422,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the formal charge of this atom.
+     * Sets the formal charge of this atom.
      *
-     * @param  charge  The formal charge
-     *
-     * @see    #getFormalCharge
+     * @param charge The formal charge
+     * @see #getFormalCharge
      */
     @Override
     public void setFormalCharge(Integer charge) {
@@ -443,11 +434,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Returns the formal charge of this atom.
+     * Returns the formal charge of this atom.
      *
      * @return the formal charge of this atom
-     *
-     * @see    #setFormalCharge
+     * @see #setFormalCharge
      */
     @Override
     public Integer getFormalCharge() {
@@ -457,9 +447,8 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     /**
      * Sets the formal neighbour count of this atom.
      *
-     * @param  count  The neighbour count
-     *
-     * @see    #getFormalNeighbourCount
+     * @param count The neighbour count
+     * @see #getFormalNeighbourCount
      */
     @Override
     public void setFormalNeighbourCount(Integer count) {
@@ -471,8 +460,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Returns the formal neighbour count of this atom.
      *
      * @return the formal neighbour count of this atom
-     *
-     * @see    #setFormalNeighbourCount
+     * @see #setFormalNeighbourCount
      */
     @Override
     public Integer getFormalNeighbourCount() {
@@ -480,11 +468,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the hybridization of this atom.
+     * Sets the hybridization of this atom.
      *
-     * @param  hybridization  The hybridization
-     *
-     * @see    #getHybridization
+     * @param hybridization The hybridization
+     * @see #getHybridization
      */
     @Override
     public void setHybridization(IAtomType.Hybridization hybridization) {
@@ -493,11 +480,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Returns the hybridization of this atom.
+     * Returns the hybridization of this atom.
      *
      * @return the hybridization of this atom
-     *
-     * @see    #setHybridization
+     * @see #setHybridization
      */
     @Override
     public IAtomType.Hybridization getHybridization() {
@@ -505,11 +491,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the NaturalAbundance attribute of the Isotope object.
+     * Sets the NaturalAbundance attribute of the Isotope object.
      *
-     * @param  naturalAbundance  The new NaturalAbundance value
-     *
-     * @see       #getNaturalAbundance
+     * @param naturalAbundance The new NaturalAbundance value
+     * @see #getNaturalAbundance
      */
     @Override
     public void setNaturalAbundance(Double naturalAbundance) {
@@ -518,11 +503,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the ExactMass attribute of the Isotope object.
+     * Sets the ExactMass attribute of the Isotope object.
      *
-     * @param  exactMass  The new ExactMass value
-     *
-     * @see       #getExactMass
+     * @param exactMass The new ExactMass value
+     * @see #getExactMass
      */
     @Override
     public void setExactMass(Double exactMass) {
@@ -531,9 +515,9 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Gets the NaturalAbundance attribute of the Isotope object.
+     * Gets the NaturalAbundance attribute of the Isotope object.
      *
-     *  <p>Once instantiated all field not filled by passing parameters
+     * <p>Once instantiated all field not filled by passing parameters
      * to the constructor are null. Isotopes can be configured by using
      * the IsotopeFactory.configure() method:
      * </p>
@@ -543,9 +527,8 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      *   if.configure(isotope);
      * </pre>
      *
-     * @return    The NaturalAbundance value
-     *
-     * @see       #setNaturalAbundance
+     * @return The NaturalAbundance value
+     * @see #setNaturalAbundance
      */
     @Override
     public Double getNaturalAbundance() {
@@ -553,8 +536,8 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Gets the ExactMass attribute of the Isotope object.
-     *  <p>Once instantiated all field not filled by passing parameters
+     * Gets the ExactMass attribute of the Isotope object.
+     * <p>Once instantiated all field not filled by passing parameters
      * to the constructor are null. Isotopes can be configured by using
      * the IsotopeFactory.configure() method:
      * </p>
@@ -564,9 +547,8 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      *   if.configure(isotope);
      * </pre>
      *
-     * @return    The ExactMass value
-     *
-     * @see       #setExactMass
+     * @return The ExactMass value
+     * @see #setExactMass
      */
     @Override
     public Double getExactMass() {
@@ -587,8 +569,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * </pre>
      *
      * @return The atomic mass of this element
-     *
-     * @see    #setMassNumber(Integer)
+     * @see #setMassNumber(Integer)
      */
     @Override
     public Integer getMassNumber() {
@@ -598,9 +579,8 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     /**
      * Sets the atomic mass of this element.
      *
-     * @param   massNumber The atomic mass to be assigned to this element
-     *
-     * @see    #getMassNumber
+     * @param massNumber The atomic mass to be assigned to this element
+     * @see #getMassNumber
      */
     @Override
     public void setMassNumber(Integer massNumber) {
@@ -621,8 +601,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * </pre>
      *
      * @return The atomic number of this element
-     *
-     * @see    #setAtomicNumber
+     * @see #setAtomicNumber
      */
     @Override
     public Integer getAtomicNumber() {
@@ -632,9 +611,8 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     /**
      * Sets the atomic number of this element.
      *
-     * @param   atomicNumber The atomic mass to be assigned to this element
-     *
-     * @see    #getAtomicNumber
+     * @param atomicNumber The atomic mass to be assigned to this element
+     * @see #getAtomicNumber
      */
     @Override
     public void setAtomicNumber(Integer atomicNumber) {
@@ -646,8 +624,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Returns the element symbol of this element.
      *
      * @return The element symbol of this element. Null if unset.
-     *
-     * @see    #setSymbol
+     * @see #setSymbol
      */
     @Override
     public String getSymbol() {
@@ -658,8 +635,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Sets the element symbol of this element.
      *
      * @param symbol The element symbol to be assigned to this atom
-     *
-     * @see    #getSymbol
+     * @see #getSymbol
      */
     @Override
     public void setSymbol(String symbol) {
@@ -671,7 +647,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Sets the covalent radius for this AtomType.
      *
      * @param radius The covalent radius for this AtomType
-     * @see    #getCovalentRadius
+     * @see #getCovalentRadius
      */
     @Override
     public void setCovalentRadius(Double radius) {
@@ -683,7 +659,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * Returns the covalent radius for this AtomType.
      *
      * @return The covalent radius for this AtomType
-     * @see    #setCovalentRadius
+     * @see #setCovalentRadius
      */
     @Override
     public Double getCovalentRadius() {
@@ -691,11 +667,10 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Sets the the exact electron valency of the AtomType object.
+     * Sets the the exact electron valency of the AtomType object.
      *
-     * @param  valency  The new valency value
+     * @param valency The new valency value
      * @see #getValency
-     *
      */
     @Override
     public void setValency(Integer valency) {
@@ -704,43 +679,72 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
     }
 
     /**
-     *  Gets the the exact electron valency of the AtomType object.
+     * Gets the the exact electron valency of the AtomType object.
      *
      * @return The valency value
      * @see #setValency
-     *
      */
     @Override
     public Integer getValency() {
         return this.electronValency;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isAromatic() {
         return getFlag(CDKConstants.ISAROMATIC);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setIsAromatic(boolean arom) {
         setFlag(CDKConstants.ISAROMATIC, arom);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isInRing() {
         return getFlag(CDKConstants.ISINRING);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setIsInRing(boolean ring) {
         setFlag(CDKConstants.ISINRING, ring);
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getMapIdx() {
+        Integer mapidx = getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+        if (mapidx == null)
+            return 0;
+        return mapidx;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setMapIdx(int mapidx) {
+        if (mapidx < 0)
+            throw new IllegalArgumentException("setMapIdx(val) value must be >= 0");
+        setProperty(CDKConstants.ATOM_ATOM_MAPPING, mapidx);
+    }
+
+    /**
      * Set the atom-expression predicate for this query atom.
+     *
      * @param expr the expression
      */
     public void setExpression(Expr expr) {
@@ -749,6 +753,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
 
     /**
      * Get the atom-expression predicate for this query atom.
+     *
      * @return the expression
      */
     public Expr getExpression() {
@@ -813,7 +818,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      *
      * @param type the expr type
      */
-    public QueryAtom (Expr.Type type) {
+    public QueryAtom(Expr.Type type) {
         this(new Expr(type));
     }
 
@@ -826,7 +831,7 @@ public class QueryAtom extends QueryChemObject implements IQueryAtom {
      * }</pre>
      *
      * @param type the expr type
-     * @param val the expr value
+     * @param val  the expr value
      */
     public QueryAtom(Expr.Type type, int val) {
         this(new Expr(type, val));

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
@@ -1776,9 +1776,10 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
             if (optset.contains(TOTAL_DEGREE))
                 expr.and(new Expr(DEGREE,
                                   atom.getBondCount() + atom.getImplicitHydrogenCount()));
-            if (optset.contains(IS_IN_RING) ||
-                optset.contains(IS_IN_CHAIN))
-                expr.and(new Expr(atom.isInRing() ? IS_IN_RING : IS_IN_CHAIN));
+            if (optset.contains(IS_IN_RING) && atom.isInRing())
+                expr.and(new Expr(IS_IN_RING));
+            if (optset.contains(IS_IN_CHAIN) && !atom.isInRing())
+              expr.and(new Expr(IS_IN_CHAIN));
             if (optset.contains(IMPL_H_COUNT))
                 expr.and(new Expr(IMPL_H_COUNT));
             if (optset.contains(RING_BOND_COUNT)) {

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.openscience.cdk.AtomRef;
+import org.openscience.cdk.BondRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -1646,6 +1648,250 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     }
 
     /**
+     * Populate a query from a molecule and a provided set of expressions. The
+     * molecule is converted and any features specified in the {@code opts}
+     * will be matched. <br><br>
+     * A good starting point is the following options:
+     * <pre>{@code
+     * // [nH]1ccc(=O)cc1 => n1:c:c:c(=O):c:c:1
+     * QueryAtomContainer.create(qry, mol,
+     *                                ALIPHATIC_ELEMENT,
+     *                                AROMATIC_ELEMENT,
+     *                                SINGLE_OR_AROMATIC,
+     *                                ALIPHATIC_ORDER,
+     *                                STEREOCHEMISTRY);
+     * }</pre>
+     * <br>
+     * Specifying {@link Expr.Type#DEGREE} (or {@link Expr.Type#TOTAL_DEGREE} +
+     * {@link Expr.Type#IMPL_H_COUNT}) means the molecule will not match as a
+     * substructure.
+     * <br>
+     * <pre>{@code
+     * // [nH]1ccc(=O)cc1 => [nD2]1:[cD2]:[cD2]:[cD2](=[OD1]):[cD2]:[cD2]:1
+     * QueryAtomContainer.create(qry, mol,
+     *                                ALIPHATIC_ELEMENT,
+     *                                AROMATIC_ELEMENT,
+     *                                DEGREE,
+     *                                SINGLE_OR_AROMATIC,
+     *                                ALIPHATIC_ORDER);
+     * }</pre>
+     * <br>
+     * The {@link Expr.Type#RING_BOND_COUNT} property is useful for locking in
+     * ring systems. Specifying the ring bond count on benzene means it will
+     * not match larger ring systems (e.g. naphthalenee) but can still be
+     * substituted.
+     * <br>
+     * <pre>{@code
+     * // [nH]1ccc(=O)cc1 =>
+     * //   [nx2+0]1:[cx2+0]:[cx2+0]:[cx2+0](=[O&x0+0]):[cx2+0]:[cx2+0]:1
+     * // IMPORTANT! use Cycles.markRingAtomsAndBonds(mol) to set ring status
+     * QueryAtomContainer.create(qry, mol,
+     *                                ALIPHATIC_ELEMENT,
+     *                                AROMATIC_ELEMENT,
+     *                                FORMAL_CHARGE,
+     *                                ISOTOPE,
+     *                                RING_BOND_COUNT,
+     *                                SINGLE_OR_AROMATIC,
+     *                                ALIPHATIC_ORDER);
+     * }</pre>
+     * <br>
+     * Note that {@link Expr.Type#FORMAL_CHARGE},
+     * {@link Expr.Type#IMPL_H_COUNT}, and {@link Expr.Type#ISOTOPE} are ignored
+     * if null. Explicitly setting these to zero (only required for Isotope from
+     * SMILES) forces their inclusion.
+     * <br>
+     * <pre>{@code
+     * // [nH]1ccc(=O)cc1 =>
+     * //   [0n+0]1:[0c+0]:[0c+0]:[0c+0](=[O+0]):[0c+0]:[0c+0]:1
+     * QueryAtomContainer.create(qry, mol,
+     *                                ALIPHATIC_ELEMENT,
+     *                                AROMATIC_ELEMENT,
+     *                                FORMAL_CHARGE,
+     *                                ISOTOPE,
+     *                                RING_BOND_COUNT,
+     *                                SINGLE_OR_AROMATIC,
+     *                                ALIPHATIC_ORDER);
+     * }</pre>
+     *
+     * Please note not all {@link Expr.Type}s are currently supported, if you
+     * require a specific type that you think is useful please open an issue.
+     *
+     * @param dst the output destination
+     * @param src the input molecule
+     * @param opts set of the expr types to match
+     */
+    public static void create(IAtomContainer dst,
+                              IAtomContainer src,
+                              Expr.Type... opts) {
+        Set<Expr.Type> optset = EnumSet.noneOf(Expr.Type.class);
+        optset.addAll(Arrays.asList(opts));
+
+        Map<IChemObject, IChemObject>    mapping = new HashMap<>();
+        Map<IChemObject, IStereoElement> stereos = new HashMap<>();
+
+        for (IStereoElement se : src.stereoElements())
+            stereos.put(se.getFocus(), se);
+        List<IStereoElement> qstereo = new ArrayList<>();
+
+        for (IAtom atom : src.atoms()) {
+            Expr expr;
+            if (atom instanceof IQueryAtom) {
+                expr = ((QueryAtom)AtomRef.deref(atom)).getExpression();
+                IStereoElement se = stereos.get(atom);
+                if (se != null) qstereo.add(se);
+            } else {
+                expr = new Expr();
+
+                // isotope first
+                if (optset.contains(ISOTOPE) && atom.getMassNumber() != null)
+                    expr.and(new Expr(ISOTOPE, atom.getMassNumber()));
+
+                if (atom.getAtomicNumber() != null &&
+                        atom.getAtomicNumber() != 0) {
+                    if (atom.isAromatic()) {
+                        if (optset.contains(AROMATIC_ELEMENT)) {
+                            expr.and(new Expr(AROMATIC_ELEMENT,
+                                    atom.getAtomicNumber()));
+                        } else {
+                            if (optset.contains(IS_AROMATIC)) {
+                                if (optset.contains(ELEMENT))
+                                    expr.and(new Expr(AROMATIC_ELEMENT,
+                                            atom.getAtomicNumber()));
+                                else
+                                    expr.and(new Expr(Expr.Type.IS_AROMATIC));
+                            } else if (optset.contains(ELEMENT)) {
+                                expr.and(new Expr(ELEMENT,
+                                        atom.getAtomicNumber()));
+                            }
+                        }
+                    } else {
+                        if (optset.contains(ALIPHATIC_ELEMENT)) {
+                            expr.and(new Expr(ALIPHATIC_ELEMENT,
+                                    atom.getAtomicNumber()));
+                        } else {
+                            if (optset.contains(IS_ALIPHATIC)) {
+                                if (optset.contains(ELEMENT))
+                                    expr.and(new Expr(ALIPHATIC_ELEMENT,
+                                            atom.getAtomicNumber()));
+                                else
+                                    expr.and(new Expr(Expr.Type.IS_ALIPHATIC));
+                            } else if (optset.contains(ELEMENT)) {
+                                expr.and(new Expr(ELEMENT,
+                                        atom.getAtomicNumber()));
+                            }
+                        }
+                    }
+                }
+
+                if (optset.contains(DEGREE))
+                    expr.and(new Expr(DEGREE,
+                            atom.getBondCount()));
+                if (optset.contains(TOTAL_DEGREE))
+                    expr.and(new Expr(DEGREE,
+                            atom.getBondCount() + atom.getImplicitHydrogenCount()));
+                if (optset.contains(IS_IN_RING) && atom.isInRing())
+                    expr.and(new Expr(IS_IN_RING));
+                if (optset.contains(IS_IN_CHAIN) && !atom.isInRing())
+                    expr.and(new Expr(IS_IN_CHAIN));
+                if (optset.contains(IMPL_H_COUNT))
+                    expr.and(new Expr(IMPL_H_COUNT));
+                if (optset.contains(RING_BOND_COUNT)) {
+                    int rbonds = 0;
+                    for (IBond bond : src.getConnectedBondsList(atom))
+                        if (bond.isInRing())
+                            rbonds++;
+
+                    expr.and(new Expr(RING_BOND_COUNT, rbonds));
+                }
+                if (optset.contains(FORMAL_CHARGE) && atom.getFormalCharge() != null)
+                    expr.and(new Expr(FORMAL_CHARGE, atom.getFormalCharge()));
+
+                IStereoElement se = stereos.get(atom);
+                if (se != null &&
+                        se.getConfigClass() == IStereoElement.TH &&
+                        optset.contains(STEREOCHEMISTRY)) {
+                    expr.and(new Expr(STEREOCHEMISTRY, se.getConfigOrder()));
+                    qstereo.add(se);
+                }
+            }
+
+            QueryAtom qatom = new QueryAtom(expr);
+
+            // backward compatibility for naughty methods that are expecting
+            // these to be set for a query!
+            if (optset.contains(Expr.Type.ELEMENT) ||
+                optset.contains(Expr.Type.AROMATIC_ELEMENT) ||
+                optset.contains(Expr.Type.ALIPHATIC_ELEMENT)) {
+                qatom.setSymbol(atom.getSymbol());
+                qatom.setAtomicNumber(atom.getAtomicNumber());
+            }
+            if (optset.contains(Expr.Type.AROMATIC_ELEMENT) ||
+                optset.contains(Expr.Type.IS_AROMATIC))
+                qatom.setIsAromatic(atom.isAromatic());
+
+            mapping.put(atom, qatom);
+            dst.addAtom(qatom);
+        }
+
+        for (IBond bond : src.bonds()) {
+            Expr expr;
+            if (bond instanceof IQueryBond) {
+                expr = ((QueryBond)BondRef.deref(bond)).getExpression();
+                IStereoElement se = stereos.get(bond);
+                if (se != null) qstereo.add(se);
+            } else {
+                expr = new Expr();
+
+                if (bond.isAromatic() &&
+                        (optset.contains(SINGLE_OR_AROMATIC) ||
+                                optset.contains(DOUBLE_OR_AROMATIC) ||
+                                optset.contains(IS_AROMATIC)))
+                    expr.and(new Expr(Expr.Type.IS_AROMATIC));
+                else if ((optset.contains(SINGLE_OR_AROMATIC) ||
+                        optset.contains(DOUBLE_OR_AROMATIC) ||
+                        optset.contains(ALIPHATIC_ORDER)) && !bond.isAromatic())
+                    expr.and(new Expr(ALIPHATIC_ORDER, bond.getOrder().numeric()));
+                else if (bond.isAromatic() && optset.contains(IS_ALIPHATIC))
+                    expr.and(new Expr(IS_ALIPHATIC));
+                else if (optset.contains(ORDER))
+                    expr.and(new Expr(ORDER, bond.getOrder().numeric()));
+
+
+                if (optset.contains(IS_IN_RING) && bond.isInRing())
+                    expr.and(new Expr(IS_IN_RING));
+                else if (optset.contains(IS_IN_CHAIN) && !bond.isInRing())
+                    expr.and(new Expr(IS_IN_CHAIN));
+
+                IStereoElement se = stereos.get(bond);
+                if (se != null &&
+                        optset.contains(STEREOCHEMISTRY)) {
+                    expr.and(new Expr(STEREOCHEMISTRY, se.getConfigOrder()));
+                    qstereo.add(se);
+                }
+            }
+
+            QueryBond qbond = new QueryBond((IAtom) mapping.get(bond.getBegin()),
+                                            (IAtom) mapping.get(bond.getEnd()),
+                                            expr);
+            // backward compatibility for naughty methods that are expecting
+            // these to be set for a query!
+            if (optset.contains(Expr.Type.ALIPHATIC_ORDER) ||
+                optset.contains(Expr.Type.ORDER))
+                qbond.setOrder(bond.getOrder());
+            if (optset.contains(Expr.Type.SINGLE_OR_AROMATIC) ||
+                optset.contains(Expr.Type.DOUBLE_OR_AROMATIC) ||
+                optset.contains(Expr.Type.IS_AROMATIC))
+                qbond.setIsAromatic(bond.isAromatic());
+
+            mapping.put(bond, qbond);
+            dst.addBond(qbond);
+        }
+
+        for (IStereoElement se : qstereo)
+            dst.addStereoElement(se.map(mapping));
+    }
+
+    /**
      * Create a query from a molecule and a provided set of expressions. The
      * molecule is converted and any features specified in the {@code opts}
      * will be matched. <br><br>
@@ -1710,165 +1956,14 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
      * Please note not all {@link Expr.Type}s are currently supported, if you
      * require a specific type that you think is useful please open an issue.
      *
-     * @param mol the molecule
+     * @param src the input molecule
      * @param opts set of the expr types to match
-     * @return the query molecule
+     * @return the query container
      */
-    public static QueryAtomContainer create(IAtomContainer mol, Expr.Type... opts) {
-        Set<Expr.Type> optset = EnumSet.noneOf(Expr.Type.class);
-        optset.addAll(Arrays.asList(opts));
-
-        QueryAtomContainer               query   = new QueryAtomContainer(mol.getBuilder());
-        Map<IChemObject, IChemObject>    mapping = new HashMap<>();
-        Map<IChemObject, IStereoElement> stereos = new HashMap<>();
-
-        for (IStereoElement se : mol.stereoElements())
-            stereos.put(se.getFocus(), se);
-        List<IStereoElement> qstereo = new ArrayList<>();
-
-        for (IAtom atom : mol.atoms()) {
-            Expr expr = new Expr();
-
-            // isotope first
-            if (optset.contains(ISOTOPE) && atom.getMassNumber() != null)
-                expr.and(new Expr(ISOTOPE, atom.getMassNumber()));
-
-            if (atom.getAtomicNumber() != null &&
-                atom.getAtomicNumber() != 0) {
-                if (atom.isAromatic()) {
-                    if (optset.contains(AROMATIC_ELEMENT)) {
-                        expr.and(new Expr(AROMATIC_ELEMENT,
-                                          atom.getAtomicNumber()));
-                    } else {
-                        if (optset.contains(IS_AROMATIC)) {
-                            if (optset.contains(ELEMENT))
-                                expr.and(new Expr(AROMATIC_ELEMENT,
-                                                  atom.getAtomicNumber()));
-                            else
-                                expr.and(new Expr(Expr.Type.IS_AROMATIC));
-                        } else if (optset.contains(ELEMENT)) {
-                            expr.and(new Expr(ELEMENT,
-                                              atom.getAtomicNumber()));
-                        }
-                    }
-                } else {
-                    if (optset.contains(ALIPHATIC_ELEMENT)) {
-                        expr.and(new Expr(ALIPHATIC_ELEMENT,
-                                          atom.getAtomicNumber()));
-                    }  else {
-                        if (optset.contains(IS_ALIPHATIC)) {
-                            if (optset.contains(ELEMENT))
-                                expr.and(new Expr(ALIPHATIC_ELEMENT,
-                                                  atom.getAtomicNumber()));
-                            else
-                                expr.and(new Expr(Expr.Type.IS_ALIPHATIC));
-                        } else if (optset.contains(ELEMENT)) {
-                            expr.and(new Expr(ELEMENT,
-                                              atom.getAtomicNumber()));
-                        }
-                    }
-                }
-            }
-
-            if (optset.contains(DEGREE))
-                expr.and(new Expr(DEGREE,
-                                  atom.getBondCount()));
-            if (optset.contains(TOTAL_DEGREE))
-                expr.and(new Expr(DEGREE,
-                                  atom.getBondCount() + atom.getImplicitHydrogenCount()));
-            if (optset.contains(IS_IN_RING) && atom.isInRing())
-                expr.and(new Expr(IS_IN_RING));
-            if (optset.contains(IS_IN_CHAIN) && !atom.isInRing())
-              expr.and(new Expr(IS_IN_CHAIN));
-            if (optset.contains(IMPL_H_COUNT))
-                expr.and(new Expr(IMPL_H_COUNT));
-            if (optset.contains(RING_BOND_COUNT)) {
-                int rbonds = 0;
-                for (IBond bond : mol.getConnectedBondsList(atom))
-                    if (bond.isInRing())
-                        rbonds++;
-
-                expr.and(new Expr(RING_BOND_COUNT, rbonds));
-            }
-            if (optset.contains(FORMAL_CHARGE) && atom.getFormalCharge() != null)
-                expr.and(new Expr(FORMAL_CHARGE, atom.getFormalCharge()));
-
-            IStereoElement se = stereos.get(atom);
-            if (se != null &&
-                se.getConfigClass() == IStereoElement.TH &&
-                optset.contains(STEREOCHEMISTRY)) {
-                expr.and(new Expr(STEREOCHEMISTRY, se.getConfigOrder()));
-                qstereo.add(se);
-            }
-
-            QueryAtom qatom = new QueryAtom(expr);
-
-            // backward compatibility for naughty methods that are expecting
-            // these to be set for a query!
-            if (optset.contains(Expr.Type.ELEMENT) ||
-                optset.contains(Expr.Type.AROMATIC_ELEMENT) ||
-                optset.contains(Expr.Type.ALIPHATIC_ELEMENT)) {
-                qatom.setSymbol(atom.getSymbol());
-                qatom.setAtomicNumber(atom.getAtomicNumber());
-            }
-            if (optset.contains(Expr.Type.AROMATIC_ELEMENT) ||
-                optset.contains(Expr.Type.IS_AROMATIC))
-                qatom.setIsAromatic(atom.isAromatic());
-
-            mapping.put(atom, qatom);
-            query.addAtom(qatom);
-        }
-
-        for (IBond bond : mol.bonds()) {
-            Expr expr = new Expr();
-
-            if (bond.isAromatic() &&
-                (optset.contains(SINGLE_OR_AROMATIC) ||
-                 optset.contains(DOUBLE_OR_AROMATIC) ||
-                 optset.contains(IS_AROMATIC)))
-                expr.and(new Expr(Expr.Type.IS_AROMATIC));
-            else if ((optset.contains(SINGLE_OR_AROMATIC) ||
-                      optset.contains(DOUBLE_OR_AROMATIC) ||
-                      optset.contains(ALIPHATIC_ORDER)) && !bond.isAromatic())
-                expr.and(new Expr(ALIPHATIC_ORDER, bond.getOrder().numeric()));
-            else if (bond.isAromatic() && optset.contains(IS_ALIPHATIC))
-                expr.and(new Expr(IS_ALIPHATIC));
-            else if (optset.contains(ORDER))
-                expr.and(new Expr(ORDER, bond.getOrder().numeric()));
-
-
-            if (optset.contains(IS_IN_RING) && bond.isInRing())
-                expr.and(new Expr(IS_IN_RING));
-            else if (optset.contains(IS_IN_CHAIN) && !bond.isInRing())
-                expr.and(new Expr(IS_IN_CHAIN));
-
-            IStereoElement se = stereos.get(bond);
-            if (se != null &&
-                optset.contains(STEREOCHEMISTRY)) {
-                expr.and(new Expr(STEREOCHEMISTRY, se.getConfigOrder()));
-                qstereo.add(se);
-            }
-
-            QueryBond qbond = new QueryBond((IAtom) mapping.get(bond.getBegin()),
-                                            (IAtom) mapping.get(bond.getEnd()),
-                                            expr);
-            // backward compatibility for naughty methods that are expecting
-            // these to be set for a query!
-            if (optset.contains(Expr.Type.ALIPHATIC_ORDER) ||
-                optset.contains(Expr.Type.ORDER))
-                qbond.setOrder(bond.getOrder());
-            if (optset.contains(Expr.Type.SINGLE_OR_AROMATIC) ||
-                optset.contains(Expr.Type.DOUBLE_OR_AROMATIC) ||
-                optset.contains(Expr.Type.IS_AROMATIC))
-                qbond.setIsAromatic(bond.isAromatic());
-
-            mapping.put(bond, qbond);
-            query.addBond(qbond);
-        }
-
-        for (IStereoElement se : qstereo)
-            query.addStereoElement(se.map(mapping));
-
-        return query;
+    public static QueryAtomContainer create(IAtomContainer src,
+                                            Expr.Type... opts) {
+        QueryAtomContainer dst = new QueryAtomContainer(src.getBuilder());
+        create(dst, src, opts);
+        return dst;
     }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
@@ -1816,6 +1816,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
             }
 
             QueryAtom qatom = new QueryAtom(expr);
+            qatom.setIsInRing(atom.isInRing());
 
             // backward compatibility for naughty methods that are expecting
             // these to be set for a query!
@@ -1873,6 +1874,7 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
             QueryBond qbond = new QueryBond((IAtom) mapping.get(bond.getBegin()),
                                             (IAtom) mapping.get(bond.getEnd()),
                                             expr);
+            qbond.setIsInRing(bond.isInRing());
             // backward compatibility for naughty methods that are expecting
             // these to be set for a query!
             if (optset.contains(Expr.Type.ALIPHATIC_ORDER) ||

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Atom.java
@@ -522,6 +522,19 @@ public class Atom extends AtomType implements IAtom, Serializable, Cloneable {
         return stringContent.toString();
     }
 
+    public int getMapIdx() {
+      Integer mapidx = getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+      if (mapidx == null)
+        return 0;
+      return mapidx;
+    }
+
+    public void setMapIdx(int mapidx) {
+      if (mapidx < 0)
+        throw new IllegalArgumentException("setMapIdx(val) value must be >= 0");
+      setProperty(CDKConstants.ATOM_ATOM_MAPPING, mapidx);
+    }
+
     /**
      * Clones this atom object and its content.
      *

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/ImmutableHydrogen.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/ImmutableHydrogen.java
@@ -628,4 +628,14 @@ class ImmutableHydrogen implements IAtom {
     public IBond getBond(IAtom atom) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public int getMapIdx() {
+      return 0;
+    }
+
+    @Override
+    public void setMapIdx(int mapidx) {
+
+    }
 }


### PR DESCRIPTION
- adds a utility method for setting and getting the mapidx of an atom. I end up using this so much and the logic to handle the nulls is annoying. This works similar to getTitle() on the AtomContainer
- updates how query molecules are created from "real" molecules. More precisely if a molecule has some query features we would previously blast these away, now we are a bit smarter and only add new query features when we have "real" atom/bonds. This is most useful for input like MOLfiles that may have an Atom List but the rest of the molecule is normal atoms. We can now convert this nicely for matching.