### PR TITLE
Move jacoco into a profile now it executed by default

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,6 +22,6 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: mvn clean test -q
+      run: mvn clean test -q -Pjacoco
     - name: push JaCoCo stats to codecov.io
       run: bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -717,34 +717,7 @@
                     <linkXRef>false</linkXRef>
                     <logViolationsToConsole>true</logViolationsToConsole>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
-                <executions>
-                    <execution>
-                        <id>start-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>generate-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>aggregate-report</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>report-aggregate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            </plugin>            
         </plugins>
     </build>
     <reporting>
@@ -789,6 +762,40 @@
         </plugins>
     </reporting>
     <profiles>
+    	<profile>
+          <id>jacoco</id>
+          <build>
+            <plugins>
+							<plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <executions>
+                  <execution>
+                      <id>start-agent</id>
+                      <goals>
+                          <goal>prepare-agent</goal>
+                      </goals>
+                  </execution>
+                  <execution>
+                      <id>generate-report</id>
+                      <phase>test</phase>
+                      <goals>
+                          <goal>report</goal>
+                      </goals>
+                  </execution>
+                  <execution>
+                      <id>aggregate-report</id>
+                      <phase>verify</phase>
+                      <goals>
+                          <goal>report-aggregate</goal>
+                      </goals>
+                  </execution>
+                </executions>
+	            </plugin>
+            </plugins>
+          </build>
+        </profile>
         <profile>
             <id>slow-tests</id>
             <build>


### PR DESCRIPTION
I like faster builds...

```
[john@harbinger:cdk]% time mvn install -DskipTests -o -q
mvn install -DskipTests -o -q  29.03s user 2.17s system 269% cpu 11.560 total
[john@harbinger:cdk]% time mvn install -DskipTests -o -q -Pjacoco
mvn install -DskipTests -o -q -Pjacoco  83.89s user 25.68s system 144% cpu 1:15.88 total
```

Particularly in this if I skip tests Jacoco is going to do nothing so the default activation/report is just overhead. Hopefully you can configure coverage io thingy to use the profile flag? 