### PR TITLE
Patch/sachem

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/CDKConstants.java
+++ b/base/core/src/main/java/org/openscience/cdk/CDKConstants.java
@@ -424,6 +424,10 @@ public class CDKConstants {
      */
     public static final String      CTAB_SGROUPS                 = "cdk:CtabSgroups";
 
+    /**
+     * Enumeration of all valid radical values.
+     */
+    public static final String      SPIN_MULTIPLICITY            = "cdk:SpinMultiplicity";
 
     /**
      * Property for reaction objects where the conditions of reactions can be placed.

--- a/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
+++ b/base/core/src/main/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcher.java
@@ -494,7 +494,7 @@ public class CDKAtomTypeMatcher implements IAtomTypeMatcher {
     private Order getMaximumBondOrder(List<IBond> connectedBonds) {
     	IBond.Order max = IBond.Order.SINGLE;
     	for (IBond bond : connectedBonds) {
-            if (bond.getOrder().numeric() > max.numeric())
+            if (bond.getOrder() != null && bond.getOrder().numeric() > max.numeric())
             	max = bond.getOrder();
         }
         return max;

--- a/base/core/src/main/java/org/openscience/cdk/config/IsotopeFactory.java
+++ b/base/core/src/main/java/org/openscience/cdk/config/IsotopeFactory.java
@@ -214,8 +214,16 @@ public abstract class IsotopeFactory {
             }
             if (major != null)
                 this.majorIsotope[elem] = major;
-            else
+            else {
                 logger.error("Could not find major isotope for: ", elem);
+                // Note for SAChem:
+                // Major (most abundant) isotope means something specific and in general
+                // you shouldn't assign it to a structure unless you're working with mass
+                // spectra definitely setting the InChI values is not sensible "(98)Tc" is synthetic
+                // for example!!!
+                // see also:
+                // https://www.nextmovesoftware.com/talks/Mayfield_BuildingOnSand_InChI_201708.pdf
+            }
         }
         return clone(major);
     }

--- a/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
@@ -746,7 +746,7 @@ public final class Cycles {
             /** {@inheritDoc} */
             @Override
             int[][] apply(int[][] graph, int length) throws Intractable {
-                final int threshold = 684; // see. AllRingsFinder.Threshold.Pubchem_99
+                final int threshold = 3072; // see. AllRingsFinder.Threshold.Pubchem_994
                 AllCycles ac = new AllCycles(graph, Math.min(length, graph.length), threshold);
                 if (!ac.completed())
                     throw new Intractable("A large number of cycles were being generated and the"
@@ -807,7 +807,7 @@ public final class Cycles {
             /** {@inheritDoc} */
             @Override
             int[][] apply(int[][] graph, int length) throws Intractable {
-                final int threshold = 684; // see. AllRingsFinder.Threshold.Pubchem_99
+                final int threshold = 3072; // see. AllRingsFinder.Threshold.Pubchem_994
                 AllCycles ac = new AllCycles(graph, Math.min(length, graph.length), threshold);
 
                 return ac.completed() ? ac.paths() : VERTEX_SHORT.apply(graph, length);
@@ -978,8 +978,8 @@ public final class Cycles {
 
         private final int predefinedLength;
 
-        // see. AllRingsFinder.Threshold.Pubchem_99
-        private final int threshold = 684;
+        // see. AllRingsFinder.Threshold.Pubchem_994
+        private final int threshold = 3072;
 
         private AllUpToLength(int length) {
             this.predefinedLength = length;

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
@@ -85,7 +85,7 @@ final class DaylightModel extends ElectronDonation {
         // - this avoids costly operations such as looking up connected
         // bonds on each atom at the cost of memory
         int[] degree = new int[n];
-        int[] bondOrderSum = new int[n];
+        int[] valence = new int[n];
         int[] nCyclicPiBonds = new int[n];
         int[] exocyclicPiBond = new int[n];
         int[] electrons = new int[n];
@@ -97,8 +97,10 @@ final class DaylightModel extends ElectronDonation {
         for (int i = 0; i < n; i++) {
             IAtom a = container.getAtom(i);
             atomIndex.put(a, i);
-            degree[i] = checkNotNull(a.getImplicitHydrogenCount(),
-                    "Aromaticity model requires implicit hydrogen count is set.");
+            int implH = checkNotNull(a.getImplicitHydrogenCount(),
+                                     "Aromaticity model requires implicit hydrogen count is set.");
+            degree[i] = implH;
+            valence[i] = implH;
         }
 
         // for each bond we increase the degree count and check for cyclic and
@@ -128,8 +130,8 @@ final class DaylightModel extends ElectronDonation {
                 case SINGLE:
                 case TRIPLE:
                 case QUADRUPLE:
-                    bondOrderSum[u] += order.numeric();
-                    bondOrderSum[v] += order.numeric();
+                    valence[u] += order.numeric();
+                    valence[v] += order.numeric();
             }
         }
 
@@ -141,7 +143,7 @@ final class DaylightModel extends ElectronDonation {
 
             // abnormal valence, usually indicated a radical. these cause problems
             // with kekulisations
-            int bondedValence = bondOrderSum[i] + container.getAtom(i).getImplicitHydrogenCount();
+            int bondedValence = valence[i];
             if (!normal(element, charge, bondedValence)) {
                 electrons[i] = -1;
             }
@@ -170,7 +172,7 @@ final class DaylightModel extends ElectronDonation {
             // here is we count the number free valence electrons but also
             // check if the bonded valence is okay (i.e. not a radical)
             else if (charge <= 0 && charge > -3) {
-                if (valence(element, charge) - bondOrderSum[i] >= 2)
+                if (valence(element, charge) - valence[i] >= 2)
                     electrons[i] = 2;
                 else
                     electrons[i] = -1;

--- a/base/standard/src/main/java/org/openscience/cdk/graph/invariant/Canon.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/invariant/Canon.java
@@ -280,6 +280,9 @@ public final class Canon {
             System.arraycopy(nextVs, 0, currVs, 0, nnu);
         }
 
+        if (symmetry == null)
+            symmetry = new long[0];
+
         return symmetry;
     }
 

--- a/base/standard/src/main/java/org/openscience/cdk/graph/invariant/CanonOpts.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/invariant/CanonOpts.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 John Mayfield
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 U
+ */
+
+package org.openscience.cdk.graph.invariant;
+
+/**
+ * Basic flavor options to tweak canonical invariants, note these deliberately mirror some fields
+ * from the {@link SmiFlavor} settings.
+ */
+public class CanonOpts {
+    /**
+     * Default canon flavour options.
+     */
+    public static final int Default    = 0;
+    /**
+     * Distinguish atoms based on atomic mass.
+     */
+    public static final int AtomicMass = 0x008;
+}

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
@@ -795,6 +795,7 @@ public abstract class StereoElementFactory {
                 if (w == v) continue;
                 if (bond.getOrder() != IBond.Order.SINGLE) continue;
                 if (isUnspecified(bond)) return null;
+                if (n == 2) return null;
                 neighbors[n] = container.getAtom(w);
                 elevation[n] = elevationOf(terminals[0], bond);
                 n++;
@@ -806,6 +807,7 @@ public abstract class StereoElementFactory {
                 IBond bond = bondMap.get(t1, w);
                 if (bond.getOrder() != IBond.Order.SINGLE) continue;
                 if (isUnspecified(bond)) return null;
+                if (n == 4) return null;
                 neighbors[n] = container.getAtom(w);
                 elevation[n] = elevationOf(terminals[1], bond);
                 n++;
@@ -1208,6 +1210,9 @@ public abstract class StereoElementFactory {
             IAtom focus = container.getAtom(v);
 
             if (hasUnspecifiedParity(focus)) return null;
+            
+            if (container.getConnectedBondsCount(focus) != 2)
+        	    return null;
 
             IAtom[] terminals = ExtendedTetrahedral.findTerminalAtoms(container, focus);
             IAtom[] neighbors = new IAtom[4];

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/CanonTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/CanonTest.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.graph.invariant;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.graph.GraphUtil;
@@ -34,7 +33,6 @@ import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmiFlavor;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
-import org.xmlcml.euclid.Int;
 
 import java.util.Comparator;
 
@@ -132,6 +130,15 @@ public class CanonTest {
         IAtomContainer m = smi("B1[H]B[H]1");
         boolean[] mask = Canon.terminalHydrogens(m, GraphUtil.toAdjList(m));
         assertThat(mask, is(new boolean[]{false, false, false, false}));
+    }
+
+    @Test
+    public void isotopeFlavor() throws Exception {
+        IAtomContainer m = smi("CC[13CH3]");
+        long[] symmetry = Canon.symmetry(m, GraphUtil.toAdjList(m), CanonOpts.Default);
+        assertThat(symmetry, is(new long[]{1,3,1}));
+        long[] symmetry2 = Canon.symmetry(m, GraphUtil.toAdjList(m), CanonOpts.AtomicMass);
+        assertThat(symmetry2, is(new long[]{1,2,3}));
     }
 
     @Test

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/rules/MassNumberRule.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/rules/MassNumberRule.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import org.openscience.cdk.config.Isotopes;
 import org.openscience.cdk.config.IsotopeFactory;
 import org.openscience.cdk.geometry.cip.ILigand;
+import org.openscience.cdk.interfaces.IIsotope;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
@@ -63,7 +64,9 @@ class MassNumberRule implements ISequenceSubRule<ILigand> {
         Integer massNumber = ligand.getLigandAtom().getMassNumber();
         if (massNumber != null) return massNumber;
         if (factory == null) return 0;
-        return factory.getMajorIsotope(ligand.getLigandAtom().getSymbol()).getMassNumber();
+        IIsotope isotope = factory.getMajorIsotope(ligand.getLigandAtom().getSymbol());
+        if (isotope == null) return 0;
+        return isotope.getMassNumber();
     }
 
 }

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -704,6 +704,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                 hcount = readMolfileInt(line, 42);
             case 42: // sss: stereo parity
                 parity = toInt(line.charAt(41));
+            // case 40: SAChem: I don't think this can happen in a valid molfile, maybe with a trailing tab?
             case 39: // ccc: charge
                 charge = toCharge(line.charAt(38));
             case 36: // dd: mass difference

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -1073,6 +1073,8 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                         index = readMolfileInt(line, st) - 1;
                         int value = readMolfileInt(line, st + 4);
                         SPIN_MULTIPLICITY multiplicity = SPIN_MULTIPLICITY.ofValue(value);
+                        
+                        container.getAtom(offset + index).setProperty(CDKConstants.SPIN_MULTIPLICITY, multiplicity);
 
                         for (int e = 0; e < multiplicity.getSingleElectrons(); e++)
                             container.addSingleElectron(offset + index);

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
@@ -694,7 +694,8 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
         if (container.getSingleElectronCount() > 0) {
             Map<Integer, SPIN_MULTIPLICITY> atomIndexSpinMap = new LinkedHashMap<Integer, SPIN_MULTIPLICITY>();
             for (int i = 0; i < container.getAtomCount(); i++) {
-                int eCount = container.getConnectedSingleElectronsCount(container.getAtom(i));
+                IAtom atom = container.getAtom(i);
+                int eCount = container.getConnectedSingleElectronsCount(atom);
                 switch (eCount) {
                     case 0:
                         continue;
@@ -702,8 +703,13 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
                         atomIndexSpinMap.put(i, SPIN_MULTIPLICITY.Monovalent);
                         break;
                     case 2:
-                        // information loss, divalent but singlet or triplet?
-                        atomIndexSpinMap.put(i, SPIN_MULTIPLICITY.DivalentSinglet);
+                        SPIN_MULTIPLICITY multiplicity = atom.getProperty(CDKConstants.SPIN_MULTIPLICITY);
+                        if (multiplicity != null)
+                            atomIndexSpinMap.put(i, multiplicity);
+                        else {
+                            // information loss, divalent but singlet or triplet?
+                            atomIndexSpinMap.put(i, SPIN_MULTIPLICITY.DivalentSinglet);
+                        }
                         break;
                     default:
                         logger.debug("Invalid number of radicals found: " + eCount);

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -343,8 +343,9 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                                     }
                                     break;
                                 case "RAD":
-                                    int numElectons = MDLV2000Writer.SPIN_MULTIPLICITY.ofValue(Integer.parseInt(value))
-                                                                                      .getSingleElectrons();
+                                    MDLV2000Writer.SPIN_MULTIPLICITY spinMultiplicity = MDLV2000Writer.SPIN_MULTIPLICITY.ofValue(Integer.parseInt(value));
+                                    int numElectons = spinMultiplicity.getSingleElectrons();
+                                    atom.setProperty(CDKConstants.SPIN_MULTIPLICITY, spinMultiplicity);
                                     while (numElectons-- > 0) {
                                         readData.addSingleElectron(readData.getBuilder().newInstance(ISingleElectron.class, atom));
                                     }

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -261,8 +261,12 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
                 case 1: // 2
                     rad = MDLV2000Writer.SPIN_MULTIPLICITY.Monovalent.getValue();
                     break;
-                case 2: // 1 or 3? Information loss as to which
-                    rad = MDLV2000Writer.SPIN_MULTIPLICITY.DivalentSinglet.getValue();
+                case 2:
+                    MDLV2000Writer.SPIN_MULTIPLICITY spinMultiplicity = atom.getProperty(CDKConstants.SPIN_MULTIPLICITY);
+                    if (spinMultiplicity != null)
+                        rad = spinMultiplicity.getValue();
+                    else // 1 or 3? Information loss as to which
+                        rad = MDLV2000Writer.SPIN_MULTIPLICITY.DivalentSinglet.getValue();
                     break;
             }
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
@@ -622,8 +622,6 @@ public class MDLV2000WriterTest extends ChemObjectIOTest {
 
     }
 
-    // XXX: information loss, CDK does not distinquish between divalence
-    //      singlet and triplet and only stores the unpaired electrons
     @Test
     public void testSingleTripletRadical() throws Exception {
 
@@ -641,7 +639,7 @@ public class MDLV2000WriterTest extends ChemObjectIOTest {
         String[] lines = sw.toString().split("\n");
 
         assertThat("incorrect file length", lines.length, is(9));
-        assertThat("incorrect radical output", lines[7], is("M  RAD  1   2   1"));
+        assertThat("incorrect radical output", lines[7], is("M  RAD  1   2   3"));
     }
 
     @Test

--- a/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/MmffAromaticTypeMappingTest.java
+++ b/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/MmffAromaticTypeMappingTest.java
@@ -286,20 +286,20 @@ public class MmffAromaticTypeMappingTest {
     public void intractableNumberOfCycles() throws Exception {
 
         // to ensure intractable cycles are handled we create a complete graph
-        // where every vertex is attached to every other vertex. K8 is sufficient
-        // to trigger an abort when finding cycles
+        // where every vertex is attached to every other vertex. K9 is sufficient
+        // to trigger an abort when finding cycles for setting PubChem_994
         IAtomContainer container = Mockito.mock(IAtomContainer.class);
-        int[][] graphK8 = new int[8][7];
+        int[][] graphK9 = new int[9][8];
 
-        for (int i = 0; i < graphK8.length; i++) {
+        for (int i = 0; i < graphK9.length; i++) {
             int n = 0;
-            for (int j = 0; j < graphK8.length; j++) {
+            for (int j = 0; j < graphK9.length; j++) {
                 if (i == j) continue;
-                graphK8[i][n++] = j;
+                graphK9[i][n++] = j;
             }
         }
 
-        assertThat(MmffAromaticTypeMapping.cyclesOfSizeFiveOrSix(container, graphK8).length, is(0));
+        assertThat(MmffAromaticTypeMapping.cyclesOfSizeFiveOrSix(container, graphK9).length, is(0));
     }
 
     @Test


### PR DESCRIPTION
Split up and curate the changes from #688.

The last one actually is quite useful, TBH I have always found the way CDK does radicals a little quirky, it's inefficient and in the case of MOLfile lossy (until now). Maybe we've discussed before but why isn't it just a field on the atom? I presume it's something to do with the reaction transform stuff and mapping where the electrons go but I've not thought it's useful the way it is.