### PR TITLE
Fix SMILESWriter.setFlavor

### DIFF
--- a/storage/smiles/src/main/java/org/openscience/cdk/io/SMILESWriter.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/io/SMILESWriter.java
@@ -86,7 +86,7 @@ public class SMILESWriter extends DefaultChemObjectWriter {
 
     public void setFlavor(int flav) {
         try {
-            flavorSetting.setSetting(Integer.toBinaryString(flav));
+            flavorSetting.setSetting(Integer.toString(flav)); 
         } catch (CDKException e) {
             // ignored
         }

--- a/storage/smiles/src/test/java/org/openscience/cdk/io/SMILESWriterTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/io/SMILESWriterTest.java
@@ -156,4 +156,17 @@ public class SMILESWriterTest extends ChemObjectIOTest {
         assertThat(wtr.toString(), not(containsString("mol 1")));
         assertThat(wtr.toString(), not(containsString("mol 2")));
     }
+    
+    @Test
+    public void testWriteSmiFlavor() throws Exception {
+        SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer mol1 = smipar.parseSmiles("c1ccccc1");
+        StringWriter wtr = new StringWriter();
+        try (SMILESWriter smigen = new SMILESWriter(wtr)) {
+        	smigen.setFlavor(SmiFlavor.InChILabelling);  
+        	smigen.write(mol1);
+        }
+        String[] lines = wtr.toString().split("\n");
+        assertThat(wtr.toString(), containsString("C=1C=CC=CC1"));
+    }
 }


### PR DESCRIPTION
This PR fixes a bug that `SMILESWriter.setFlavor` saves flavor as binary number but it reads it as decimal number.