### PR TITLE
Add support for stereochemical groups

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
@@ -112,10 +112,18 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
         value = getConfigClass() | cfg;
     }
 
+    /**
+     * Access the stereo group in, this is present when this stereo element is racemic (AND) or relative (OR).
+     * @return the group info
+     */
     public int getGroupInfo() {
         return value & IStereoElement.GRP_MASK;
     }
 
+    /**
+     * Set the group info for this stereo center.
+     * @param grp the group info
+     */
     public void setGrpConfig(int grp) {
         value &= ~IStereoElement.GRP_MASK;
         value |= (grp & IStereoElement.GRP_MASK);

--- a/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
@@ -122,7 +122,7 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
     /**
      * {@inheritDoc}
      */
-    public void setGrpConfig(int grp) {
+    public void setGroupInfo(int grp) {
         value &= ~IStereoElement.GRP_MASK;
         value |= (grp & IStereoElement.GRP_MASK);
     }

--- a/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
@@ -101,7 +101,7 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
      */
     @Override
     public int getConfig() {
-        return value;
+        return value & 0xffff;
     }
 
     /**
@@ -110,6 +110,15 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
     @Override
     public void setConfigOrder(int cfg) {
         value = getConfigClass() | cfg;
+    }
+
+    public int getGroupInfo() {
+        return value & IStereoElement.GRP_MASK;
+    }
+
+    public void setGrpConfig(int grp) {
+        value &= ~IStereoElement.GRP_MASK;
+        value |= (grp & IStereoElement.GRP_MASK);
     }
 
     /**

--- a/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
@@ -113,16 +113,14 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
     }
 
     /**
-     * Access the stereo group in, this is present when this stereo element is racemic (AND) or relative (OR).
-     * @return the group info
+     * {@inheritDoc}
      */
     public int getGroupInfo() {
         return value & IStereoElement.GRP_MASK;
     }
 
     /**
-     * Set the group info for this stereo center.
-     * @param grp the group info
+     * {@inheritDoc}
      */
     public void setGrpConfig(int grp) {
         value &= ~IStereoElement.GRP_MASK;

--- a/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/AbstractStereo.java
@@ -123,8 +123,8 @@ abstract class AbstractStereo<F extends IChemObject, C extends IChemObject>
      * {@inheritDoc}
      */
     public void setGroupInfo(int grp) {
-        value &= ~IStereoElement.GRP_MASK;
-        value |= (grp & IStereoElement.GRP_MASK);
+        value &= ~IStereoElement.GRP_MASK; // clear existing hit bits
+        value |= (grp & IStereoElement.GRP_MASK); // set the new value ensure low bits aren't overwritten
     }
 
     /**

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
@@ -121,13 +121,13 @@ import java.util.Map;
 public interface IStereoElement<F extends IChemObject, C extends IChemObject>
     extends ICDKObject {
 
-    public static final int CLS_MASK = 0xff_00;
-    public static final int CFG_MASK = 0x00_ff;
+    int CLS_MASK = 0xff_00;
+    int CFG_MASK = 0x00_ff;
 
-    public static final int LEFT        = 0x00_01;
-    public static final int RIGHT       = 0x00_02;
-    public static final int OPPOSITE    = LEFT;
-    public static final int TOGETHER    = RIGHT;
+    int LEFT        = 0x00_01;
+    int RIGHT       = 0x00_02;
+    int OPPOSITE    = LEFT;
+    int TOGETHER    = RIGHT;
 
     /*
      * Important! The forth nibble of the stereo-class defines the number of
@@ -136,120 +136,120 @@ public interface IStereoElement<F extends IChemObject, C extends IChemObject>
      */
 
     /** Geometric CisTrans (e.g. but-2-ene) */
-    public static final int CT   = 0x21_00;
+    int CT   = 0x21_00;
 
     /** Tetrahedral (T-4) (e.g. butan-2-ol)*/
-    public static final int TH   = 0x42_00;
+    int TH   = 0x42_00;
 
     /** ExtendedTetrahedral a.k.a. allene (e.g. 2,3-pentadiene) */
-    public static final int AL   = 0x43_00;
+    int AL   = 0x43_00;
 
     /** ExtendedCisTrans a.k.a. cumulene (e.g. hexa-2,3,4-triene) */
-    public static final int CU   = 0x22_00;
+    int CU   = 0x22_00;
 
     /** Atropisomeric (e.g. BiNAP) */
-    public static final int AT   = 0x44_00;
+    int AT   = 0x44_00;
 
     /** Square Planar (SP-4) (e.g. cisplatin) */
-    public static final int SP   = 0x45_00;
+    int SP   = 0x45_00;
 
     /** Square Pyramidal (SPY-5) */
-    public static final int SPY  = 0x51_00;
+    int SPY  = 0x51_00;
 
     /** Trigonal Bipyramidal (TBPY-5) */
-    public static final int TBPY = 0x52_00;
+    int TBPY = 0x52_00;
 
     /** Octahedral (OC-6) */
-    public static final int OC   = 0x61_00;
+    int OC   = 0x61_00;
 
     /** Pentagonal Bipyramidal (PBPY-7) */
-    public static final int PBPY = 0x71_00;
+    int PBPY = 0x71_00;
 
     /** Hexagonal Bipyramidal (HBPY-8) */
-    public static final int HBPY8 = 0x81_00;
+    int HBPY8 = 0x81_00;
 
     /** Heptagonal Bipyramidal (HBPY-9) */
-    public static final int HBPY9 = 0x91_00;
+    int HBPY9 = 0x91_00;
 
     /** Geometric CisTrans (e.g. but-2-ene) */
-    public static final int CisTrans              = CT;
+    int CisTrans              = CT;
 
     /** Tetrahedral (T-4) (e.g. butan-2-ol)*/
-    public static final int Tetrahedral           = TH;
+    int Tetrahedral           = TH;
 
     /** ExtendedTetrahedral (e.g. 2,3-pentadiene) */
-    public static final int Allenal               = AL;
+    int Allenal               = AL;
 
     /** Cumulene */
-    public static final int Cumulene              = CU;
+    int Cumulene              = CU;
 
     /** Atropisomeric (e.g. BiNAP) */
-    public static final int Atropisomeric         = AT;
+    int Atropisomeric         = AT;
 
     /** Square Planar (SP-4) (e.g. cisplatin) */
-    public static final int SquarePlanar          = SP;
+    int SquarePlanar          = SP;
 
     /** Square Pyramidal (SPY-5) */
-    public static final int SquarePyramidal       = SPY;
+    int SquarePyramidal       = SPY;
 
     /** Trigonal Bipyramidal (TBPY-5) */
-    public static final int TrigonalBipyramidal   = TBPY;
+    int TrigonalBipyramidal   = TBPY;
 
     /** Octahedral (OC-6) */
-    public static final int Octahedral            = OC;
+    int Octahedral            = OC;
 
     /** Pentagonal Bipyramidal (PBPY-7) */
-    public static final int PentagonalBipyramidal = PBPY;
+    int PentagonalBipyramidal = PBPY;
 
     /** Hexagonal Bipyramidal (HBPY-8) */
-    public static final int HexagonalBipyramidal  = HBPY8;
+    int HexagonalBipyramidal  = HBPY8;
 
     /** Heptagonal Bipyramidal (HBPY-9) */
-    public static final int HeptagonalBipyramidal = HBPY9;
+    int HeptagonalBipyramidal = HBPY9;
 
     /** Square Planar Configutation in U Shape */
-    public static final int SPU = SP | 1;
+    int SPU = SP | 1;
     /** Square Planar Configutation in 4 Shape */
-    public static final int SP4 = SP | 2;
+    int SP4 = SP | 2;
     /** Square Planar Configutation in Z Shape */
-    public static final int SPZ = SP | 3;
+    int SPZ = SP | 3;
 
     /** Mask for the stereo group information */
-    public static final int GRP_MASK      = 0xff_0000;
+    int GRP_MASK      = 0xff_0000;
     /** Mask for the stereo group type information, GRP_ABS, GRP_AND, GRP_OR */
-    public static final int GRP_TYPE_MASK = 0x03_0000;
+    int GRP_TYPE_MASK = 0x03_0000;
     /** Mask for the stereo group number information, 0x0 .. 0xf (1..15) */
-    public static final int GRP_NUM_MASK   = 0xfc_0000;
-    public static final int GRP_NUM_SHIFT  = 18; // Integer.numberOfTrailingZeros(0xfc_0000);
+    int GRP_NUM_MASK   = 0xfc_0000;
+    int GRP_NUM_SHIFT  = 18; // Integer.numberOfTrailingZeros(0xfc_0000);
 
     /** Stereo group type ABS (absolute) */
-    public static final int GRP_ABS  = 0x00_0000;
+    int GRP_ABS  = 0x00_0000;
     /** Stereo group type AND (and enantiomer) */
-    public static final int GRP_AND  = 0x01_0000;
+    int GRP_AND  = 0x01_0000;
     /** Stereo group type OR (or enantiomer) */
-    public static final int GRP_OR   = 0x02_0000;
+    int GRP_OR   = 0x02_0000;
 
     /** Convenience field for testing if the stereo is group AND1 (&amp;1). */
-    public static final int GRP_AND1 = GRP_AND | (1 << GRP_NUM_SHIFT);
+    int GRP_AND1 = GRP_AND | (1 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group AND2 (&amp;2). */
-    public static final int GRP_AND2 = GRP_AND | (2 << GRP_NUM_SHIFT);
+    int GRP_AND2 = GRP_AND | (2 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group AND3 (&amp;3). */
-    public static final int GRP_AND3 = GRP_AND | (3 << GRP_NUM_SHIFT);
+    int GRP_AND3 = GRP_AND | (3 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group AND4 (&amp;4). */
-    public static final int GRP_AND4 = GRP_AND | (4 << GRP_NUM_SHIFT);
+    int GRP_AND4 = GRP_AND | (4 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group AND5 (&amp;5). */
-    public static final int GRP_AND5 = GRP_AND | (5 << GRP_NUM_SHIFT);
+    int GRP_AND5 = GRP_AND | (5 << GRP_NUM_SHIFT);
 
     /** Convenience field for testing if the stereo is group OR1 (&amp;1). */
-    public static final int GRP_OR1  = GRP_OR | (1 << GRP_NUM_SHIFT);
+    int GRP_OR1  = GRP_OR | (1 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group OR2 (&amp;2). */
-    public static final int GRP_OR2  = GRP_OR | (2 << GRP_NUM_SHIFT);
+    int GRP_OR2  = GRP_OR | (2 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group OR3 (&amp;3). */
-    public static final int GRP_OR3  = GRP_OR | (3 << GRP_NUM_SHIFT);
+    int GRP_OR3  = GRP_OR | (3 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group OR4 (&amp;4). */
-    public static final int GRP_OR4  = GRP_OR | (4 << GRP_NUM_SHIFT);
+    int GRP_OR4  = GRP_OR | (4 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group OR5 (&amp;5). */
-    public static final int GRP_OR5  = GRP_OR | (5 << GRP_NUM_SHIFT);
+    int GRP_OR5  = GRP_OR | (5 << GRP_NUM_SHIFT);
 
     /**
      * The focus atom or bond at the 'centre' of the stereo-configuration.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
@@ -71,6 +71,46 @@ import java.util.Map;
  *     <li>{@link #HBPY9}: Heptagonal Bipyramidal</li>
  * </ul>
  *
+ * <b><u>Stereo Groups (Enhanced stereo):</u></b>
+ * Stereochemistry group information, aka "enhanced stereochemistry" in V3000 MOLFile etc allows you to specify
+ * racemic and unknown enantiomers. In V2000 MOLfile the if chiral flag was 0 it indicates the structure was a mixture
+ * of enantiomers. V3000 extended this concept to not only encode mixtures (and enantiomer) but also unknown
+ * stereochemistry (or enantiomer) and to be per chiral centre. Reading an MDLV2000 molfile a chiral flag of 0 is
+ * equivalent to setting all stereocentres to {@link #GRP_AND1}. This information can also be encoded in CXSMILES. By
+ * default all stereocentres are {@link #GRP_ABS}.
+ *
+ * The stereo group information is stored in the high bytes of the stereo configuration. You can access the basic
+ * information as follows:
+ * <pre>{@code
+ * int grpconfig = stereo.getGroupInfo();
+ * if (grpconfig & IStereoElement.GRP_AND1) {
+ *     // group is AND1
+ * } else if (config & IStereoElement.GRP_OR1) {
+ *     // group is OR1
+ * }
+ * }</pre>
+ *
+ * You can also unpack the various parts of the information manually.
+ *
+ * <pre>{@code
+ * int grpconfig = stereo.getGroupInfo();
+ * switch (grpconfig & IStereoElement.GRP_TYPE_MASK) {
+ *   case IStereoElement.GRP_ABS:
+ *   break;
+ *   case IStereoElement.GRP_AND:
+ *   break;
+ *   case IStereoElement.GRP_OR:
+ *   break;
+ * }
+ *
+ * // the group number 1, 2, 3, 4 is a little more tricky, you can mask off the value as
+ * // follows but it's shifted up into position
+ * int num = grpconfig & IStereoElement.GRP_NUM_MASK;
+ *
+ * // to get the number 1, 2, 3, etc you can simply shift it down as follows
+ * int num_act = grpconfig >>> IStereoElement.GRP_NUM_SHIFT;
+ * }</pre>
+ *
  * @cdk.module interfaces
  * @cdk.githash
  *
@@ -174,6 +214,43 @@ public interface IStereoElement<F extends IChemObject, C extends IChemObject>
     /** Square Planar Configutation in Z Shape */
     public static final int SPZ = SP | 3;
 
+    /** Mask for the stereo group information */
+    public static final int GRP_MASK      = 0xff_0000;
+    /** Mask for the stereo group type information, GRP_ABS, GRP_AND, GRP_OR */
+    public static final int GRP_TYPE_MASK = 0x03_0000;
+    /** Mask for the stereo group number information, 0x0 .. 0xf (1..15) */
+    public static final int GRP_NUM_MASK   = 0xfc_0000;
+    public static final int GRP_NUM_SHIFT  = 18; // Integer.numberOfTrailingZeros(0xfc_0000);
+
+    /** Stereo group type ABS (absolute) */
+    public static final int GRP_ABS  = 0x00_0000;
+    /** Stereo group type AND (and enantiomer) */
+    public static final int GRP_AND  = 0x01_0000;
+    /** Stereo group type OR (or enantiomer) */
+    public static final int GRP_OR   = 0x02_0000;
+
+    /** Convenience field for testing if the stereo is group AND1 (&amp;1). */
+    public static final int GRP_AND1 = GRP_AND | (1 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group AND2 (&amp;2). */
+    public static final int GRP_AND2 = GRP_AND | (2 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group AND3 (&amp;3). */
+    public static final int GRP_AND3 = GRP_AND | (3 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group AND4 (&amp;4). */
+    public static final int GRP_AND4 = GRP_AND | (4 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group AND5 (&amp;5). */
+    public static final int GRP_AND5 = GRP_AND | (5 << GRP_NUM_SHIFT);
+
+    /** Convenience field for testing if the stereo is group OR1 (&amp;1). */
+    public static final int GRP_OR1  = GRP_OR | (1 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group OR2 (&amp;2). */
+    public static final int GRP_OR2  = GRP_OR | (2 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group OR3 (&amp;3). */
+    public static final int GRP_OR3  = GRP_OR | (3 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group OR4 (&amp;4). */
+    public static final int GRP_OR4  = GRP_OR | (4 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group OR5 (&amp;5). */
+    public static final int GRP_OR5  = GRP_OR | (5 << GRP_NUM_SHIFT);
+
     /**
      * The focus atom or bond at the 'centre' of the stereo-configuration.
      * @return the focus
@@ -209,6 +286,18 @@ public interface IStereoElement<F extends IChemObject, C extends IChemObject>
      * @return the configuration
      */
     int getConfig();
+
+    /**
+     * Access the stereo group information - see class doc.
+     * @return the group info
+     */
+    int getGroupInfo();
+
+    /**
+     * Set the stereo group information - see class doc.
+     * @param grp the group info
+     */
+    void setGrpConfig(int grp);
 
     /**
      * Does the stereo element contain the provided atom.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
@@ -297,7 +297,7 @@ public interface IStereoElement<F extends IChemObject, C extends IChemObject>
      * Set the stereo group information - see class doc.
      * @param grp the group info
      */
-    void setGrpConfig(int grp);
+    void setGroupInfo(int grp);
 
     /**
      * Does the stereo element contain the provided atom.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
@@ -76,16 +76,16 @@ import java.util.Map;
  * racemic and unknown enantiomers. In V2000 MOLfile if the chiral flag is 0 it indicates the structure is a mixture
  * of enantiomers. V3000 extended this concept to not only encode mixtures (and enantiomer) but also unknown
  * stereochemistry (or enantiomer) and to be per chiral centre allow representation of any epimers.
- * Reading an MDLV2000 molfile a chiral flag of 0 is equivalent to setting all stereocentres to {@link #GRP_AND1}.
+ * Reading an MDLV2000 molfile a chiral flag of 0 is equivalent to setting all stereocentres to {@link #GRP_RAC1}.
  * This information can also be encoded in CXSMILES. By default all stereocentres are {@link #GRP_ABS}.
  *
  * The stereo group information is stored in the high bytes of the stereo configuration. You can access the basic
  * information as follows:
  * <pre>{@code
  * int grpconfig = stereo.getGroupInfo();
- * if (grpconfig & IStereoElement.GRP_AND1) {
- *     // group is AND1
- * } else if (config & IStereoElement.GRP_OR1) {
+ * if (grpconfig & IStereoElement.GRP_RAC1) {
+ *     // group is RAC1
+ * } else if (config & IStereoElement.GRP_REL1) {
  *     // group is OR1
  * }
  * }</pre>
@@ -222,34 +222,37 @@ public interface IStereoElement<F extends IChemObject, C extends IChemObject>
     int GRP_NUM_MASK   = 0xfc_0000;
     int GRP_NUM_SHIFT  = 18; // Integer.numberOfTrailingZeros(0xfc_0000);
 
-    /** Stereo group type ABS (absolute) */
-    int GRP_ABS  = 0x00_0000;
-    /** Stereo group type AND (and enantiomer) */
-    int GRP_AND  = 0x01_0000;
-    /** Stereo group type OR (or enantiomer) */
-    int GRP_OR   = 0x02_0000;
+    /** Absolute stereo group, the exact stereo configuration of this atom is known. */
+    int GRP_ABS = 0x00_0000;
+    /** Racemic stereo group type, the stereo configuration of this atom is a mixture of R/S. An atom can be  */
+    int GRP_RAC = 0x01_0000;
+    /**
+     * Relative stereo group type, the stereo configuration of this atom is unknown but is relative to another
+     * atom in the same group.
+     */
+    int GRP_REL = 0x02_0000;
 
-    /** Convenience field for testing if the stereo is group AND1 (&amp;1). */
-    int GRP_AND1 = GRP_AND | (1 << GRP_NUM_SHIFT);
-    /** Convenience field for testing if the stereo is group AND2 (&amp;2). */
-    int GRP_AND2 = GRP_AND | (2 << GRP_NUM_SHIFT);
-    /** Convenience field for testing if the stereo is group AND3 (&amp;3). */
-    int GRP_AND3 = GRP_AND | (3 << GRP_NUM_SHIFT);
-    /** Convenience field for testing if the stereo is group AND4 (&amp;4). */
-    int GRP_AND4 = GRP_AND | (4 << GRP_NUM_SHIFT);
-    /** Convenience field for testing if the stereo is group AND5 (&amp;5). */
-    int GRP_AND5 = GRP_AND | (5 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group RAC1 (&amp;1). */
+    int GRP_RAC1 = GRP_RAC | (1 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group RAC2 (&amp;2). */
+    int GRP_RAC2 = GRP_RAC | (2 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group RAC3 (&amp;3). */
+    int GRP_RAC3 = GRP_RAC | (3 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group RAC4 (&amp;4). */
+    int GRP_RAC4 = GRP_RAC | (4 << GRP_NUM_SHIFT);
+    /** Convenience field for testing if the stereo is group RAC5 (&amp;5). */
+    int GRP_RAC5 = GRP_RAC | (5 << GRP_NUM_SHIFT);
 
     /** Convenience field for testing if the stereo is group OR1 (&amp;1). */
-    int GRP_OR1  = GRP_OR | (1 << GRP_NUM_SHIFT);
+    int GRP_REL1  = GRP_REL | (1 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group OR2 (&amp;2). */
-    int GRP_OR2  = GRP_OR | (2 << GRP_NUM_SHIFT);
+    int GRP_REL2  = GRP_REL | (2 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group OR3 (&amp;3). */
-    int GRP_OR3  = GRP_OR | (3 << GRP_NUM_SHIFT);
+    int GRP_REL3  = GRP_REL | (3 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group OR4 (&amp;4). */
-    int GRP_OR4  = GRP_OR | (4 << GRP_NUM_SHIFT);
+    int GRP_REL4  = GRP_REL | (4 << GRP_NUM_SHIFT);
     /** Convenience field for testing if the stereo is group OR5 (&amp;5). */
-    int GRP_OR5  = GRP_OR | (5 << GRP_NUM_SHIFT);
+    int GRP_REL5  = GRP_REL | (5 << GRP_NUM_SHIFT);
 
     /**
      * The focus atom or bond at the 'centre' of the stereo-configuration.

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IStereoElement.java
@@ -73,11 +73,11 @@ import java.util.Map;
  *
  * <b><u>Stereo Groups (Enhanced stereo):</u></b>
  * Stereochemistry group information, aka "enhanced stereochemistry" in V3000 MOLFile etc allows you to specify
- * racemic and unknown enantiomers. In V2000 MOLfile the if chiral flag was 0 it indicates the structure was a mixture
+ * racemic and unknown enantiomers. In V2000 MOLfile if the chiral flag is 0 it indicates the structure is a mixture
  * of enantiomers. V3000 extended this concept to not only encode mixtures (and enantiomer) but also unknown
- * stereochemistry (or enantiomer) and to be per chiral centre. Reading an MDLV2000 molfile a chiral flag of 0 is
- * equivalent to setting all stereocentres to {@link #GRP_AND1}. This information can also be encoded in CXSMILES. By
- * default all stereocentres are {@link #GRP_ABS}.
+ * stereochemistry (or enantiomer) and to be per chiral centre allow representation of any epimers.
+ * Reading an MDLV2000 molfile a chiral flag of 0 is equivalent to setting all stereocentres to {@link #GRP_AND1}.
+ * This information can also be encoded in CXSMILES. By default all stereocentres are {@link #GRP_ABS}.
  *
  * The stereo group information is stored in the high bytes of the stereo configuration. You can access the basic
  * information as follows:

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -389,10 +389,10 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
                     // generate the label &1, or1
                     String label = null;
                     switch ((groupInfo & IStereoElement.GRP_TYPE_MASK)) {
-                        case IStereoElement.GRP_AND:
+                        case IStereoElement.GRP_RAC:
                             label = "&";
                             break;
-                        case IStereoElement.GRP_OR:
+                        case IStereoElement.GRP_REL:
                             label = "or";
                             break;
                         case IStereoElement.GRP_ABS:
@@ -435,9 +435,9 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
             }
         }
         switch ((ref_grp & IStereoElement.GRP_TYPE_MASK)) {
-            case IStereoElement.GRP_AND:
+            case IStereoElement.GRP_RAC:
                 return "and enantiomer";
-            case IStereoElement.GRP_OR:
+            case IStereoElement.GRP_REL:
                 return "or enantiomer";
         }
         return null;

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -25,13 +25,13 @@
 package org.openscience.cdk.renderer.generators.standard;
 
 import org.openscience.cdk.CDKConstants;
-import org.openscience.cdk.geometry.GeometryUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
+import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.renderer.RendererModel;
 import org.openscience.cdk.renderer.SymbolVisibility;
 import org.openscience.cdk.renderer.color.IAtomColorer;
@@ -52,9 +52,7 @@ import org.openscience.cdk.sgroup.SgroupType;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Shape;
+import java.awt.*;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
@@ -72,16 +70,16 @@ import static org.openscience.cdk.renderer.generators.standard.HydrogenPosition.
  * diagram. These are generated together allowing the bonds to drawn cleanly without overlap. The
  * generate is heavily based on ideas documented in {@cdk.cite Brecher08} and {@cdk.cite Clark13}.
  *
- * 
+ *
  *
  * Atom symbols are provided as {@link GeneralPath} outlines. This allows the depiction to be
  * independent of the system used to view the diagram (primarily important for vector graphic
- * depictions). The font used to generate the diagram must be provided to the constructor. 
+ * depictions). The font used to generate the diagram must be provided to the constructor.
  *
  * Atoms and bonds can be highlighted by setting the {@link #HIGHLIGHT_COLOR}. The style of
  * highlight is set with the {@link Highlighting} parameter.
  *
- * 
+ *
  *
  * The <a href="https://github.com/cdk/cdk/wiki/Standard-Generator">Standard Generator - CDK Wiki
  * page</a> provides extended details of using and configuring this generator.
@@ -221,6 +219,12 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
                                                     stroke);
         IRenderingElement donuts = donutGenerator.generate();
 
+        String enantiomerText = determineEnantiomerText(container);
+        if (enantiomerText == null) {
+            // no global 'enantiomer text' add them per atom if exists
+            addStereoGroupAnnotations(container);
+        }
+
         AtomSymbol[] symbols = generateAtomSymbols(container, symbolRemap,
                                                    visibility, parameters,
                                                    annotations, foreground,
@@ -308,31 +312,31 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
                 middleLayer.add(MarkedElement.markupAtom(symbolElements, atom));
             }
         }
-        
+
         if (style == HighlightStyle.OuterGlowWhiteEdge) {
 	        for (int i = 0; i < container.getAtomCount(); i++) {
 	            IAtom atom = container.getAtom(i);
-	
+
 	            if (isHidden(atom))
 	                continue;
-	
+
 	            Color highlight = getHighlightColor(atom, parameters);
 	            Color color = highlight != null ? highlight : coloring.getAtomColor(atom);
 
 	            if (symbols[i] == null) {
 	                continue;
 	            }
-	
+
 	            ElementGroup symbolElements = new ElementGroup();
 	            for (Shape shape : symbols[i].getOutlines()) {
 	                GeneralPath path = GeneralPath.shapeOf(shape, color);
 	                symbolElements.add(path);
 	            }
-	
+
 	            if (highlight != null && !highlight.equals(Color.WHITE)) {
 	            	backLayer.add(MarkedElement.markup(outerGlow(symbolElements, Color.WHITE, 10*stroke, stroke), "outerglow"));
 	            }
-	        }  
+	        }
         }
 
         // Add the Sgroups display elements to the front layer
@@ -348,7 +352,95 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
         group.add(middleLayer);
         group.add(frontLayer);
 
+        // maybe move somewhere else (e.g. annotations)
+        Bounds bounds = new Bounds();
+        bounds.add(group);
+
+        if (enantiomerText != null) {
+            TextOutline chiralInfo = new TextOutline(enantiomerText, font).resize(1 / scale, -1 / scale);
+            if (chiralInfo.getBounds().getWidth() > bounds.width()) {
+                // position center right
+                double centerY = (bounds.minY + bounds.maxY) / 2;
+                chiralInfo = chiralInfo.translate(bounds.maxX - (chiralInfo.getBounds().getMinX() - (10*stroke)),
+                                                  centerY - (chiralInfo.getBounds().getCenterY()));
+            } else {
+                // position bottom right corner
+                chiralInfo = chiralInfo.translate(bounds.maxX - ((chiralInfo.getBounds().getMaxX() + chiralInfo.getCenter().getX()) / 2),
+                                                  bounds.minY - (chiralInfo.getBounds().getMaxY() + (5*stroke)));
+            }
+            group.add(GeneralPath.shapeOf(chiralInfo.getOutline(), foreground));
+        }
+
+
         return MarkedElement.markupMol(group, container);
+    }
+
+    /**
+     * Adds &1 and or1 to each atom in the those stereo groups.
+     * @param container the container
+     */
+    private void addStereoGroupAnnotations(IAtomContainer container) {
+        for (IStereoElement<?,?> se : container.stereoElements()) {
+            // tetrahedral only
+            if (se.getConfigClass() == IStereoElement.TH) {
+                int groupInfo = se.getGroupInfo();
+                if (groupInfo != 0) {
+
+                    // generate the label &1, or1
+                    String label = null;
+                    switch ((groupInfo & IStereoElement.GRP_TYPE_MASK)) {
+                        case IStereoElement.GRP_AND:
+                            label = "&";
+                            break;
+                        case IStereoElement.GRP_OR:
+                            label = "or";
+                            break;
+                        case IStereoElement.GRP_ABS:
+                            continue;
+                    }
+                    label += Integer.toString(groupInfo >> IStereoElement.GRP_NUM_SHIFT);
+
+                    // attach it to the central atom
+                    IAtom focus = (IAtom) se.getFocus();
+                    String annotation = focus.getProperty(StandardGenerator.ANNOTATION_LABEL);
+                    if (annotation == null)
+                        annotation = label;
+                    else
+                        annotation += ";" + label;
+                    focus.setProperty(StandardGenerator.ANNOTATION_LABEL,
+                                      annotation);
+                }
+            }
+        }
+    }
+
+    /**
+     * Determines the text to enantiomer text to display next to the structure, "and enantiomer" for racemic mixtures
+     * or "or enantiomer" for relative stereochemistry. These are generated if all grouped stereo is in the same group,
+     * i.e. all &1, all or1, all &2 etc.
+     *
+     * @param container the molecule
+     * @return the text
+     */
+    private String determineEnantiomerText(IAtomContainer container) {
+        int ref_grp = 0;
+        for (IStereoElement<?, ?> elem : container.stereoElements()) {
+            if (elem.getConfigClass() == IStereoElement.TH) {
+                if (elem.getGroupInfo() == 0)
+                    return null;
+                if (ref_grp == 0)
+                    ref_grp = elem.getGroupInfo();
+                else if (ref_grp != elem.getGroupInfo())
+                    return null;
+            }
+        }
+        switch ((ref_grp & IStereoElement.GRP_TYPE_MASK)) {
+            case IStereoElement.GRP_AND:
+                return "and enantiomer";
+            case IStereoElement.GRP_OR:
+                return "or enantiomer";
+        }
+        return null;
     }
 
     private Color getColorOfAtom(Map<IAtom, String> symbolRemap, IAtomColorer coloring, Color foreground,

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -549,7 +549,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
             if (chiral == 0) {
                 for (IStereoElement<?,?> se : outputContainer.stereoElements()) {
                     if (se.getConfigClass() == IStereoElement.TH) {
-                        se.setGroupInfo(IStereoElement.GRP_AND1);
+                        se.setGroupInfo(IStereoElement.GRP_RAC1);
                     }
                 }
             }

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -549,7 +549,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
             if (chiral == 0) {
                 for (IStereoElement<?,?> se : outputContainer.stereoElements()) {
                     if (se.getConfigClass() == IStereoElement.TH) {
-                        se.setGrpConfig(IStereoElement.GRP_AND1);
+                        se.setGroupInfo(IStereoElement.GRP_AND1);
                     }
                 }
             }

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -43,13 +43,13 @@ import org.openscience.cdk.interfaces.IChemSequence;
 import org.openscience.cdk.interfaces.IIsotope;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.ISingleElectron;
+import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality.Stereo;
 import org.openscience.cdk.io.formats.IResourceFormat;
 import org.openscience.cdk.io.formats.MDLV2000Format;
 import org.openscience.cdk.io.setting.BooleanIOSetting;
 import org.openscience.cdk.io.setting.IOSetting;
 import org.openscience.cdk.isomorphism.matchers.Expr;
-import org.openscience.cdk.isomorphism.matchers.IQueryAtom;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
 import org.openscience.cdk.isomorphism.matchers.IQueryBond;
 import org.openscience.cdk.isomorphism.matchers.QueryAtom;
@@ -383,6 +383,7 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
 
             int nAtoms = readMolfileInt(line, 0);
             int nBonds = readMolfileInt(line, 3);
+            int chiral = readMolfileInt(line, 13);
 
             final IAtom[] atoms = new IAtom[nAtoms];
             final IBond[] bonds = new IBond[nBonds];
@@ -539,6 +540,16 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                     } else if (!forceReadAs3DCoords.isSet()) { // has 2D coordinates (set as 2D coordinates)
                         outputContainer.setStereoElements(StereoElementFactory.using2DCoordinates(outputContainer)
                                 .createAll());
+                    }
+                }
+            }
+
+            // chiral flag not set which means this molecule is this stereoisomer "and" the enantiomer, mark all
+            // Tetrahedral stereo as AND1 (&1)
+            if (chiral == 0) {
+                for (IStereoElement<?,?> se : outputContainer.stereoElements()) {
+                    if (se.getConfigClass() == IStereoElement.TH) {
+                        se.setGrpConfig(IStereoElement.GRP_AND1);
                     }
                 }
             }

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -233,13 +233,13 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                 if (!chiral) {
                     int max = 0;
                     for (Integer val : stereoflags.values()) {
-                        if ((val&IStereoElement.GRP_TYPE_MASK) == IStereoElement.GRP_AND) {
+                        if ((val&IStereoElement.GRP_TYPE_MASK) == IStereoElement.GRP_RAC) {
                             int num = val >>> IStereoElement.GRP_NUM_SHIFT;
                             if (num > max)
                                 max = num;
                         }
                     }
-                    defaultRacGrp = IStereoElement.GRP_AND | (((max + 1) << IStereoElement.GRP_NUM_SHIFT));
+                    defaultRacGrp = IStereoElement.GRP_RAC | (((max + 1) << IStereoElement.GRP_NUM_SHIFT));
                 }
 
                 for (IStereoElement<?, ?> se : readData.stereoElements()) {
@@ -260,7 +260,7 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                 // Tetrahedral stereo as AND1 (&1)
                 for (IStereoElement<?, ?> se : readData.stereoElements()) {
                     if (se.getConfigClass() == IStereoElement.TH) {
-                        se.setGroupInfo(IStereoElement.GRP_AND1);
+                        se.setGroupInfo(IStereoElement.GRP_RAC1);
                     }
                 }
             }
@@ -330,9 +330,9 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
             if (command.startsWith("END COLLECTION"))
                 break;
             else if (command.startsWith("MDLV30/STERAC")) {
-                parseStereoGroup(flags, command, IStereoElement.GRP_AND);
+                parseStereoGroup(flags, command, IStereoElement.GRP_RAC);
             } else if (command.startsWith("MDLV30/STEREL")) {
-                parseStereoGroup(flags, command, IStereoElement.GRP_OR);
+                parseStereoGroup(flags, command, IStereoElement.GRP_REL);
             } else if (command.startsWith("MDLV30/STEABS")) {
                 parseStereoGroup(flags, command, IStereoElement.GRP_ABS);
             }

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -251,16 +251,16 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                         continue;
                     Integer grpinfo = stereoflags.get(idx);
                     if (grpinfo != null)
-                        se.setGrpConfig(grpinfo);
+                        se.setGroupInfo(grpinfo);
                     else if (!chiral)
-                        se.setGrpConfig(defaultRacGrp);
+                        se.setGroupInfo(defaultRacGrp);
                 }
             } else if (!chiral) {
                 // chiral flag not set which means this molecule is this stereoisomer "and" the enantiomer, mark all
                 // Tetrahedral stereo as AND1 (&1)
                 for (IStereoElement<?, ?> se : readData.stereoElements()) {
                     if (se.getConfigClass() == IStereoElement.TH) {
-                        se.setGrpConfig(IStereoElement.GRP_AND1);
+                        se.setGroupInfo(IStereoElement.GRP_AND1);
                     }
                 }
             }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -42,7 +42,6 @@ import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IChemFile;
-import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.IStereoElement;
@@ -77,11 +76,18 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -1956,6 +1962,71 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
                        CoreMatchers.is("33%"));
         } catch (IOException | CDKException e) {
             e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112282D          \n" +
+                "\n" +
+                "  7  7  0  0  0  0            999 V2000\n" +
+                "   -1.1468    6.5972    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.8613    6.1847    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.8613    5.3597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.1468    4.9472    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4323    5.3597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4323    6.1847    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.1468    7.4222    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "  1  2  1  0  0  0  0\n" +
+                "  2  3  1  0  0  0  0\n" +
+                "  3  4  1  0  0  0  0\n" +
+                "  4  5  1  0  0  0  0\n" +
+                "  5  6  1  0  0  0  0\n" +
+                "  1  6  1  0  0  0  0\n" +
+                "  1  7  1  1  0  0  0\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        try (MDLV2000Reader mdlr = new MDLV2000Reader(new StringReader(input))) {
+            IAtomContainer mol = mdlr.read(bldr.newAtomContainer());
+            Iterable<IStereoElement> iter = mol.stereoElements();
+            assertTrue(iter.iterator().hasNext());
+            for (IStereoElement<?,?> se : iter) {
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+            }
+        }
+    }
+
+    @Test
+    public void testChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112282D          \n" +
+                "\n" +
+                "  7  7  0  0  1  0            999 V2000\n" +
+                "   -1.1468    6.5972    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.8613    6.1847    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.8613    5.3597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.1468    4.9472    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4323    5.3597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4323    6.1847    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.1468    7.4222    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "  1  2  1  0  0  0  0\n" +
+                "  2  3  1  0  0  0  0\n" +
+                "  3  4  1  0  0  0  0\n" +
+                "  4  5  1  0  0  0  0\n" +
+                "  5  6  1  0  0  0  0\n" +
+                "  1  6  1  0  0  0  0\n" +
+                "  1  7  1  1  0  0  0\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        try (MDLV2000Reader mdlr = new MDLV2000Reader(new StringReader(input))) {
+            IAtomContainer mol = mdlr.read(bldr.newAtomContainer());
+            Iterable<IStereoElement> iter = mol.stereoElements();
+            assertTrue(iter.iterator().hasNext());
+            for (IStereoElement<?,?> se : iter) {
+                // Grp Abs is actually just 0
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_ABS));
+            }
         }
     }
 }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -1992,7 +1992,7 @@ public class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
             Iterable<IStereoElement> iter = mol.stereoElements();
             assertTrue(iter.iterator().hasNext());
             for (IStereoElement<?,?> se : iter) {
-                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_RAC1));
             }
         }
     }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000ReaderTest.java
@@ -32,10 +32,12 @@ import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.interfaces.IPseudoAtom;
+import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupType;
 import org.openscience.cdk.silent.AtomContainer;
-import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
@@ -45,8 +47,9 @@ import java.io.StringReader;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * TestCase for the reading MDL V3000 mol files using one test file.
@@ -168,6 +171,167 @@ public class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
                 assertNotNull(bond.getOrder());
             }
             assertThat(container.getBond(4).getOrder(), is(IBond.Order.UNSET));
+        }
+    }
+
+    @Test
+    public void testNoChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112362D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 END CTAB\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input))) {
+            IAtomContainer mol = mdlr.read(bldr.newAtomContainer());
+            Iterable<IStereoElement> iter = mol.stereoElements();
+            assertTrue(iter.iterator().hasNext());
+            for (IStereoElement<?,?> se : iter) {
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+            }
+        }
+    }
+
+    @Test
+    public void testChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112362D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 1\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 END CTAB\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input))) {
+            IAtomContainer mol = mdlr.read(bldr.newAtomContainer());
+            Iterable<IStereoElement> iter = mol.stereoElements();
+            assertTrue(iter.iterator().hasNext());
+            for (IStereoElement<?,?> se : iter) {
+                // Grp Abs is actually just 0
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_ABS));
+            }
+        }
+    }
+
+    @Test
+    public void testStereoRac1() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052113162D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(1 1)\n" +
+                "M  V30 END COLLECTION\n" +
+                "M  V30 END CTAB\n" +
+                "M  END";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input))) {
+            IAtomContainer mol = mdlr.read(bldr.newAtomContainer());
+            Iterable<IStereoElement> iter = mol.stereoElements();
+            assertTrue(iter.iterator().hasNext());
+            for (IStereoElement<?,?> se : iter) {
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+            }
+        }
+    }
+
+    @Test
+    public void testStereoRel1() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052113162D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEREL1 ATOMS=(1 1)\n" +
+                "M  V30 END COLLECTION\n" +
+                "M  V30 END CTAB\n" +
+                "M  END";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input))) {
+            IAtomContainer mol = mdlr.read(bldr.newAtomContainer());
+            for (IStereoElement<?,?> se : mol.stereoElements()) {
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_OR1));
+            }
         }
     }
 }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000ReaderTest.java
@@ -208,7 +208,7 @@ public class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
             Iterable<IStereoElement> iter = mol.stereoElements();
             assertTrue(iter.iterator().hasNext());
             for (IStereoElement<?,?> se : iter) {
-                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_RAC1));
             }
         }
     }
@@ -290,7 +290,7 @@ public class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
             Iterable<IStereoElement> iter = mol.stereoElements();
             assertTrue(iter.iterator().hasNext());
             for (IStereoElement<?,?> se : iter) {
-                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_RAC1));
             }
         }
     }
@@ -330,7 +330,7 @@ public class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
         try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input))) {
             IAtomContainer mol = mdlr.read(bldr.newAtomContainer());
             for (IStereoElement<?,?> se : mol.stereoElements()) {
-                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_OR1));
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_REL1));
             }
         }
     }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesParser.java
@@ -470,11 +470,11 @@ final class CxSmilesParser {
                     }
                     break;
                 case '&': // &1, &2 etc
-                    if (!processStereoGrps(state, iter, IStereoElement.GRP_AND))
+                    if (!processStereoGrps(state, iter, IStereoElement.GRP_RAC))
                         return -1;
                     break;
                 case 'o': // o1, o2 etc
-                    if (!processStereoGrps(state, iter, IStereoElement.GRP_OR))
+                    if (!processStereoGrps(state, iter, IStereoElement.GRP_REL))
                         return -1;
                     break;
                 case 'a': // abs etc

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesState.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesState.java
@@ -45,6 +45,9 @@ final class CxSmilesState {
     Map<Integer, List<Integer>> positionVar = null;
     List<CxSgroup>              mysgroups   = null;
     boolean                     coordFlag   = false;
+    boolean                     racemic     = false;
+    List<Integer> racemicFrags = null;
+    Map<Integer,Integer> stereoGrps = null;
 
     enum Radical {
         Monovalent,

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -415,7 +415,7 @@ public final class SmilesParser {
                 for (IStereoElement<?, ?> e : mol.stereoElements()) {
                     // maybe also Al and AT?
                     if (e.getConfigClass() == IStereoElement.TH) {
-                        e.setGroupInfo(IStereoElement.GRP_AND1);
+                        e.setGroupInfo(IStereoElement.GRP_RAC1);
                     }
                 }
             }
@@ -770,7 +770,7 @@ public final class SmilesParser {
                 for (IStereoElement<?, ?> e : ((IAtomContainer) chemObj).stereoElements()) {
                     // maybe also Al and AT?
                     if (e.getConfigClass() == IStereoElement.TH) {
-                        e.setGroupInfo(IStereoElement.GRP_AND1);
+                        e.setGroupInfo(IStereoElement.GRP_RAC1);
                     }
                 }
             } else if (chemObj instanceof IReaction) {
@@ -778,7 +778,7 @@ public final class SmilesParser {
                     for (IStereoElement<?, ?> e : mol.stereoElements()) {
                         // maybe also Al and AT?
                         if (e.getConfigClass() == IStereoElement.TH) {
-                            e.setGroupInfo(IStereoElement.GRP_AND1);
+                            e.setGroupInfo(IStereoElement.GRP_RAC1);
                         }
                     }
                 }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -26,9 +26,7 @@ package org.openscience.cdk.smiles;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import org.openscience.cdk.CDK;
 import org.openscience.cdk.CDKConstants;
-import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.ConnectivityChecker;
 import org.openscience.cdk.interfaces.IAtom;
@@ -40,6 +38,7 @@ import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.interfaces.ISingleElectron;
+import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.sgroup.SgroupType;
@@ -48,6 +47,7 @@ import org.openscience.cdk.smiles.CxSmilesState.CxPolymerSgroup;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+import org.openscience.cdk.tools.manipulator.ReactionManipulator;
 import uk.ac.ebi.beam.Graph;
 
 import javax.vecmath.Point2d;
@@ -57,7 +57,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +77,7 @@ import java.util.Set;
  * </blockquote>
  *
  * <b>Reading Aromatic SMILES</b>
- *
+ * <p>
  * Aromatic SMILES are automatically kekulised producing a structure with
  * assigned bond orders. The aromatic specification on the atoms is maintained
  * from the SMILES even if the structures are not considered aromatic. For
@@ -95,7 +94,7 @@ import java.util.Set;
  * <a href="http://www.daylight.com/daycgi/depict">DEPICT</a> service.
  *
  * <b>Unsupported Features</b>
- *
+ * <p>
  * The following features are not supported by this parser. <ul> <li>variable
  * order of bracket atom attributes, '[C-H]', '[CH@]' are considered invalid.
  * The predefined order required by this parser follows the <a
@@ -107,7 +106,7 @@ import java.util.Set;
  * <li>octahedral stereochemistry</li> </ul>
  *
  * <b>Atom Class</b>
- *
+ * <p>
  * The atom class is stored as the {@link org.openscience.cdk.CDKConstants#ATOM_ATOM_MAPPING}
  * property.
  *
@@ -122,7 +121,6 @@ import java.util.Set;
  *
  * </pre>
  * </blockquote>
- *
  *
  * @author Christoph Steinbeck
  * @author Egon Willighagen
@@ -144,7 +142,7 @@ public final class SmilesParser {
     /**
      * Direct converter from Beam to CDK.
      */
-    private final BeamToCDK          beamToCDK;
+    private final BeamToCDK beamToCDK;
 
     /**
      * Kekulise the molecule on load. Generally this is a good idea as a
@@ -153,12 +151,12 @@ public final class SmilesParser {
      * bond orders (if possible) using an efficient algorithm from the
      * underlying Beam library (soon to be added to CDK).
      */
-    private boolean                  kekulise = true;
+    private boolean kekulise = true;
 
     /**
      * Whether the parser is in strict mode or not.
      */
-    private boolean                  strict = false;
+    private boolean strict = false;
 
     /**
      * Create a new SMILES parser which will create {@link IAtomContainer}s with
@@ -194,7 +192,7 @@ public final class SmilesParser {
         if (!smiles.contains(">"))
             throw new InvalidSmilesException("Not a reaction SMILES: " + smiles);
 
-        final int first  = smiles.indexOf('>');
+        final int first = smiles.indexOf('>');
         final int second = smiles.indexOf('>', first + 1);
 
         if (second < 0)
@@ -264,12 +262,12 @@ public final class SmilesParser {
             Set<String> warnings = new HashSet<>();
             Graph g = Graph.parse(smiles, strict, warnings);
             for (String warning : warnings)
-              logger.warn(warning);
+                logger.warn(warning);
 
             // convert the Beam object model to the CDK - note exception thrown
             // if a kekule structure could not be assigned.
             IAtomContainer mol = beamToCDK.toAtomContainer(kekulise ? g.kekule() : g,
-                                                           kekulise);
+                    kekulise);
 
             if (!isRxnPart) {
                 try {
@@ -379,39 +377,60 @@ public final class SmilesParser {
      * Handle fragment grouping of a reaction that specifies certain disconnected components
      * are actually considered a single molecule. Normally used for salts, [Na+].[OH-].
      *
-     * @param rxn reaction
+     * @param rxn     reaction
      * @param cxstate state
      */
     private void handleFragmentGrouping(IReaction rxn, CxSmilesState cxstate) {
+
+        if (cxstate.fragGroups == null && cxstate.racemicFrags == null)
+            return; // nothing to do here
+
+        final int reactant = 1;
+        final int agent = 2;
+        final int product = 3;
+
+        List<IAtomContainer> fragMap = new ArrayList<>();
+        Map<IAtomContainer, Integer> roleMap = new HashMap<>();
+
+        for (IAtomContainer mol : rxn.getReactants().atomContainers()) {
+            fragMap.add(mol);
+            roleMap.put(mol, reactant);
+        }
+        for (IAtomContainer mol : rxn.getAgents().atomContainers()) {
+            fragMap.add(mol);
+            roleMap.put(mol, agent);
+        }
+        for (IAtomContainer mol : rxn.getProducts().atomContainers()) {
+            fragMap.add(mol);
+            roleMap.put(mol, product);
+        }
+
+        if (cxstate.racemicFrags != null) {
+            for (Integer grp : cxstate.racemicFrags) {
+                if (grp >= fragMap.size())
+                    continue;
+                IAtomContainer mol = fragMap.get(grp);
+                if (mol == null)
+                    continue;
+                for (IStereoElement<?, ?> e : mol.stereoElements()) {
+                    // maybe also Al and AT?
+                    if (e.getConfigClass() == IStereoElement.TH) {
+                        e.setGrpConfig(IStereoElement.GRP_AND1);
+                    }
+                }
+            }
+        }
+
         // repartition/merge fragments
         if (cxstate.fragGroups != null) {
-
-            final int reactant = 1;
-            final int agent    = 2;
-            final int product  = 3;
-
-            // note we don't use a list for fragmap as the indexes need to stay consistent
-            Map<Integer,IAtomContainer> fragMap = new LinkedHashMap<>();
-            Map<IAtomContainer,Integer> roleMap = new HashMap<>();
-
-            for (IAtomContainer mol : rxn.getReactants().atomContainers()) {
-                fragMap.put(fragMap.size(), mol);
-                roleMap.put(mol, reactant);
-            }
-            for (IAtomContainer mol : rxn.getAgents().atomContainers()) {
-                fragMap.put(fragMap.size(), mol);
-                roleMap.put(mol, agent);
-            }
-            for (IAtomContainer mol : rxn.getProducts().atomContainers()) {
-                fragMap.put(fragMap.size(), mol);
-                roleMap.put(mol, product);
-            }
 
             // check validity of group
             boolean invalid = false;
             Set<Integer> visit = new HashSet<>();
 
             for (List<Integer> grouping : cxstate.fragGroups) {
+                if (grouping.get(0) >= fragMap.size())
+                    continue;
                 IAtomContainer dest = fragMap.get(grouping.get(0));
                 if (dest == null)
                     continue;
@@ -420,6 +439,8 @@ public final class SmilesParser {
                 for (int i = 1; i < grouping.size(); i++) {
                     if (!visit.add(grouping.get(i)))
                         invalid = true;
+                    if (grouping.get(i) >= fragMap.size())
+                        continue;
                     IAtomContainer src = fragMap.get(grouping.get(i));
                     if (src != null) {
                         dest.add(src);
@@ -432,7 +453,7 @@ public final class SmilesParser {
                 rxn.getReactants().removeAllAtomContainers();
                 rxn.getAgents().removeAllAtomContainers();
                 rxn.getProducts().removeAllAtomContainers();
-                for (IAtomContainer mol : fragMap.values()) {
+                for (IAtomContainer mol : fragMap) {
                     switch (roleMap.get(mol)) {
                         case reactant:
                             rxn.getReactants().addAtomContainer(mol);
@@ -544,7 +565,7 @@ public final class SmilesParser {
             }
         }
 
-        Multimap<IAtomContainer, Sgroup>    sgroupMap    = HashMultimap.create();
+        Multimap<IAtomContainer, Sgroup> sgroupMap = HashMultimap.create();
         Map<CxSmilesState.CxSgroup, Sgroup> sgroupRemap = new HashMap<>();
 
         // positional-variation
@@ -595,7 +616,7 @@ public final class SmilesParser {
             for (CxSmilesState.CxSgroup cxsgroup : cxstate.mysgroups) {
                 if (!(cxsgroup instanceof CxPolymerSgroup))
                     continue;
-                CxPolymerSgroup psgroup = (CxPolymerSgroup)cxsgroup;
+                CxPolymerSgroup psgroup = (CxPolymerSgroup) cxsgroup;
                 Sgroup sgroup = new Sgroup();
 
                 Set<IAtom> atomset = new HashSet<>();
@@ -724,7 +745,7 @@ public final class SmilesParser {
                     if (mol != null)
                         sgroupMap.put(mol, cdkSgroup);
                     else if (chemObj instanceof IAtomContainer)
-                        sgroupMap.put((IAtomContainer)chemObj, cdkSgroup);
+                        sgroupMap.put((IAtomContainer) chemObj, cdkSgroup);
                 }
             }
         }
@@ -739,6 +760,42 @@ public final class SmilesParser {
                     if (cdkChild == null)
                         continue;
                     cdkChild.addParent(cdkParent);
+                }
+            }
+        }
+
+        // IMPORTANT: state.racemicComps is handled in the fragment grouping step
+        if (cxstate.racemic) {
+            if (chemObj instanceof IAtomContainer) {
+                for (IStereoElement<?, ?> e : ((IAtomContainer) chemObj).stereoElements()) {
+                    // maybe also Al and AT?
+                    if (e.getConfigClass() == IStereoElement.TH) {
+                        e.setGrpConfig(IStereoElement.GRP_AND1);
+                    }
+                }
+            } else if (chemObj instanceof IReaction) {
+                for (IAtomContainer mol : ReactionManipulator.getAllAtomContainers((IReaction) chemObj)) {
+                    for (IStereoElement<?, ?> e : mol.stereoElements()) {
+                        // maybe also Al and AT?
+                        if (e.getConfigClass() == IStereoElement.TH) {
+                            e.setGrpConfig(IStereoElement.GRP_AND1);
+                        }
+                    }
+                }
+            }
+        }
+
+
+        if (cxstate.stereoGrps != null) {
+            for (Map.Entry<Integer, Integer> e : cxstate.stereoGrps.entrySet()) {
+                IAtom atm = atoms.get(e.getKey());
+                IAtomContainer mol = atomToMol.get(atm);
+                for (IStereoElement<?, ?> stereo : ((IAtomContainer) chemObj).stereoElements()) {
+                    // maybe also Al and AT?
+                    if (stereo.getConfigClass() == IStereoElement.TH &&
+                            stereo.getFocus().equals(atm)) {
+                        stereo.setGrpConfig(e.getValue());
+                    }
                 }
             }
         }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -415,7 +415,7 @@ public final class SmilesParser {
                 for (IStereoElement<?, ?> e : mol.stereoElements()) {
                     // maybe also Al and AT?
                     if (e.getConfigClass() == IStereoElement.TH) {
-                        e.setGrpConfig(IStereoElement.GRP_AND1);
+                        e.setGroupInfo(IStereoElement.GRP_AND1);
                     }
                 }
             }
@@ -770,7 +770,7 @@ public final class SmilesParser {
                 for (IStereoElement<?, ?> e : ((IAtomContainer) chemObj).stereoElements()) {
                     // maybe also Al and AT?
                     if (e.getConfigClass() == IStereoElement.TH) {
-                        e.setGrpConfig(IStereoElement.GRP_AND1);
+                        e.setGroupInfo(IStereoElement.GRP_AND1);
                     }
                 }
             } else if (chemObj instanceof IReaction) {
@@ -778,7 +778,7 @@ public final class SmilesParser {
                     for (IStereoElement<?, ?> e : mol.stereoElements()) {
                         // maybe also Al and AT?
                         if (e.getConfigClass() == IStereoElement.TH) {
-                            e.setGrpConfig(IStereoElement.GRP_AND1);
+                            e.setGroupInfo(IStereoElement.GRP_AND1);
                         }
                     }
                 }
@@ -794,7 +794,7 @@ public final class SmilesParser {
                     // maybe also Al and AT?
                     if (stereo.getConfigClass() == IStereoElement.TH &&
                             stereo.getFocus().equals(atm)) {
-                        stereo.setGrpConfig(e.getValue());
+                        stereo.setGroupInfo(e.getValue());
                     }
                 }
             }

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesParserTest.java
@@ -251,8 +251,8 @@ public class CxSmilesParserTest {
         CxSmilesState state = new CxSmilesState();
         assertThat(CxSmilesParser.processCx(cxsmilayers, state), is(not(-1)));
         Map<Integer,Integer> expected = new HashMap<>();
-        expected.put(0, IStereoElement.GRP_AND1);
-        expected.put(1, IStereoElement.GRP_AND1);
+        expected.put(0, IStereoElement.GRP_RAC1);
+        expected.put(1, IStereoElement.GRP_RAC1);
         assertThat(state.stereoGrps, is(expected));
     }
 
@@ -261,8 +261,8 @@ public class CxSmilesParserTest {
         CxSmilesState state = new CxSmilesState();
         assertThat(CxSmilesParser.processCx(cxsmilayers, state), is(not(-1)));
         Map<Integer,Integer> expected = new HashMap<>();
-        expected.put(0, IStereoElement.GRP_OR1);
-        expected.put(1, IStereoElement.GRP_OR1);
+        expected.put(0, IStereoElement.GRP_REL1);
+        expected.put(1, IStereoElement.GRP_REL1);
         assertThat(state.stereoGrps, is(expected));
     }
 
@@ -271,9 +271,9 @@ public class CxSmilesParserTest {
         CxSmilesState state = new CxSmilesState();
         assertThat(CxSmilesParser.processCx(cxsmilayers, state), is(not(-1)));
         Map<Integer,Integer> expected = new HashMap<>();
-        expected.put(0, IStereoElement.GRP_OR1);
-        expected.put(1, IStereoElement.GRP_OR1);
-        expected.put(6, IStereoElement.GRP_AND5);
+        expected.put(0, IStereoElement.GRP_REL1);
+        expected.put(1, IStereoElement.GRP_REL1);
+        expected.put(6, IStereoElement.GRP_RAC5);
         assertThat(state.stereoGrps, is(expected));
     }
 
@@ -299,7 +299,7 @@ public class CxSmilesParserTest {
         for (IStereoElement<?,?> se : iter) {
             IAtom focus = (IAtom)se.getFocus();
             if (focus.getIndex() == 2) {
-                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_RAC1));
             } else {
                 assertThat(se.getGroupInfo(), is(IStereoElement.GRP_ABS));
             }
@@ -312,7 +312,7 @@ public class CxSmilesParserTest {
         Iterable<IStereoElement> iter = mol.stereoElements();
         assertTrue(iter.iterator().hasNext());
         for (IStereoElement<?,?> se : iter) {
-            assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+            assertThat(se.getGroupInfo(), is(IStereoElement.GRP_RAC1));
         }
     }
 
@@ -330,7 +330,7 @@ public class CxSmilesParserTest {
             Iterable<IStereoElement> iter = mol.stereoElements();
             assertTrue(iter.iterator().hasNext());
             for (IStereoElement<?, ?> se : iter) {
-                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_RAC1));
             }
         }
     }
@@ -349,7 +349,7 @@ public class CxSmilesParserTest {
             Iterable<IStereoElement> iter = mol.stereoElements();
             assertTrue(iter.iterator().hasNext());
             for (IStereoElement<?, ?> se : iter) {
-                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_AND1));
+                assertThat(se.getGroupInfo(), is(IStereoElement.GRP_RAC1));
             }
         }
     }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SubstructureTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SubstructureTest.java
@@ -359,6 +359,26 @@ public abstract class SubstructureTest {
         assertMatch(sma("O1.[S@]=1(C)CC"), smi("O=[S@@](C)CC"), 1);
     }
 
+    @Test
+    public void stereoGroups() throws Exception {
+        assertMatch(sma("C[C@H](O)[C@H](O)CC"), smi("C[C@H](O)[C@H](O)CC |r|"), 1);
+        assertMatch(sma("C[C@@H](O)[C@@H](O)CC"), smi("C[C@H](O)[C@H](O)CC |r|"), 1);
+        assertMatch(sma("C[C@H](O)[C@H](O)CC"), smi("C[C@@H](O)[C@@H](O)CC |r|"), 1);
+        assertMatch(sma("C[C@@H](O)[C@@H](O)CC"), smi("C[C@@H](O)[C@@H](O)CC |r|"), 1);
+        assertMismatch(sma("C[C@H](O)[C@@H](O)CC"), smi("C[C@H](O)[C@H](O)CC |r|"));
+        assertMismatch(sma("C[C@@H](O)[C@H](O)CC"), smi("C[C@H](O)[C@H](O)CC |r|"));
+        assertMismatch(sma("C[C@H](O)[C@@H](O)CC"), smi("C[C@@H](O)[C@@H](O)CC |r|"));
+        assertMismatch(sma("C[C@@H](O)[C@H](O)CC"), smi("C[C@@H](O)[C@@H](O)CC |r|"));
+    }
+
+    @Test
+    public void stereoGroupsQuery() throws Exception {
+        assertMatch(sma("C[C;@,@@](O)[C@H](O)[C@H](O)CC"), smi("C[C@H](O)[C@H](O)[C@H](O)CC |r|"), 1);
+        assertMatch(sma("C[C;@,@@](O)[C@H](O)[C@H](O)CC"), smi("C[C@@H](O)[C@@H](O)[C@@H](O)CC |r|"), 1);
+        assertMismatch(sma("C[C;@,@@](O)[C@H](O)[C@H](O)CC"), smi("C[C@H](O)[C@@H](O)[C@H](O)CC |r|"));
+        assertMismatch(sma("C[C;@,@@](O)[C@H](O)[C@H](O)CC"), smi("C[C@H](O)[C@H](O)[C@@H](O)CC |r|"));
+    }
+
     // doesn't matter if the match takes place but it should not cause and error
     // if the query is larger than the target
     @Test


### PR DESCRIPTION
Often we don't know which enantiomer we have or we have a mix of them. V2000 MOLfile have a chiral flag to distinguish cases where the absolute configuration is known (chiral flag=1) vs the molecule should be treated as racemic. V3000 extended this with so called enhanced stereochemistry where by this could be specified on a per-atom basis. CXSMILES also supports this.

This PR adds an efficient (bit packed) representation as well as read support in V2000, V3000, and CXSMILES. Write support to follow in a separate PR.

Here are some examples, running live on CDK depict.

```
CC[C@H](O)[C@H](O)C1CCCCC1 |r| mol1
```
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=CC%5BC%40H%5D(O)%5BC%40H%5D(O)C1CCCCC1%20%7Cr%7C%20mol1&w=-1&h=-1&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&r=0)
Internally this is actually stored as all &1 which is equivalent according to BIOVIA doc. It's basically the old way of storing it where there is a single chiral flag and |r| in CXSMILES = chiral_flag=0. ChemAxon actually refer to it as the "relative" stereo flag but really it's racemic.
<hr/>

```
CC[C@H](O)[C@H](O)C1CCCCC1 |&1:2,4| mol2
```
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=CC%5BC%40H%5D(O)%5BC%40H%5D(O)C1CCCCC1%20%7C%261%3A2%2C4%7C%20mol2&w=-1&h=-1&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&r=0)
Because internally we store it as all &1 if you manually specified them you get the same depiction.

<hr/>

```
CC[C@H](O)[C@H](O)C1CCCCC1 |&1:2| mol2
```
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=CC%5BC%40H%5D(O)%5BC%40H%5D(O)C1CCCCC1%20%7C%261%3A2%7C%20mol2&w=-1&h=-1&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&r=0)
In this case only one add is racemic.

<hr/>

```
CC[C@H](O)[C@H](O)C1CCCCC1 |o1:2,4| mol3
```
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=CC%5BC%40H%5D(O)%5BC%40H%5D(O)C1CCCCC1%20%7Co1%3A2%2C4%7C%20mol3&w=-1&h=-1&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&r=0)

<hr/>

```
CC[C@H](O)[C@H](O)C1CCCCC1 |&1:2,&2:4| mol4
```
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=CC%5BC%40H%5D(O)%5BC%40H%5D(O)C1CCCCC1%20%7C%261%3A2%2C%262%3A4%7C%20mol4&w=-1&h=-1&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&r=0)

<hr/>

```
CC[C@H](O)[C@H](O)C1CCCCC1 |&1:2,o2:4| mol5
```
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=CC%5BC%40H%5D(O)%5BC%40H%5D(O)C1CCCCC1%20%7C%261%3A2%2Co2%3A4%7C%20mol5&w=-1&h=-1&abbr=on&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&r=0)





