### PR TITLE
Write stereogrps

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Writer.java
@@ -430,8 +430,7 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
         //write number of atom lists
         line.append(formatMDLInt(atomLists.size(), 3));
         line.append("  0");
-        // we mark all stereochemistry to absolute for now
-        line.append(atomstereo.isEmpty() ? "  0" : "  1");
+        line.append(getChiralFlag(atomstereo.values()) ? "  1" : "  0");
         line.append("  0  0  0  0  0999 V2000");
         writer.write(line.toString());
         writer.write('\n');
@@ -618,7 +617,7 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
                             case UNSET:
                                 if (bond.isAromatic()) {
                                     if (!writeAromaticBondTypes.isSet())
-                                        throw new CDKException("Bond at idx " + container.indexOf(bond) + " was an unspecific aromatic bond which should only be used for querie in Molfiles. These can be written if desired by enabling the option 'WriteAromaticBondTypes'.");
+                                        throw new CDKException("Bond at idx " + container.indexOf(bond) + " was an unspecific aromatic bond which should only be used for queries in Molfiles. These can be written if desired by enabling the option 'WriteAromaticBondTypes'.");
                                     bondType = 4;
                                 }
                                 break;
@@ -802,6 +801,40 @@ public class MDLV2000Writer extends DefaultChemObjectWriter {
         writer.write('\n');
         writer.flush();
     }
+
+    /**
+     * Determines the chiral flag, a molecule is chiral if all it's tetrahedral stereocenters are marked as absolute.
+     * This function also checks if there is enhanced stereochemistry that cannot be emitted (without information loss)
+     * in V2000.
+     *
+     * @param stereo tetrahedral stereo
+     * @return the chiral status
+     */
+    static boolean getChiralFlag(Iterable<? extends IStereoElement> stereo) {
+        boolean chiral = true;
+        int seenGrpInfo = 0;
+        int numTetrahedral = 0;
+        for (IStereoElement tc : stereo) {
+            if (tc.getConfigClass() != IStereoElement.TH)
+                continue;
+            numTetrahedral++;
+            if (tc.getGroupInfo() != IStereoElement.GRP_ABS) {
+                if (seenGrpInfo == 0) {
+                    seenGrpInfo = tc.getGroupInfo();
+                } else if (seenGrpInfo != tc.getGroupInfo()) {
+                    // we could check for racemic only but V2000 originally didn't differentiate between relative
+                    // or racemic so providing they're all the same it's okay. But we should warn if there is something
+                    // more complicated
+                    logger.warn("Molecule has enhanced stereochemistry that cannot be represented in V2000");
+                }
+                chiral = false;
+            }
+        }
+        if (numTetrahedral == 0)
+            chiral = false;
+        return chiral;
+    }
+
 
     private static void writeAtomLists(Map<Integer, IAtom> atomLists, BufferedWriter writer) throws IOException {
         //write out first as the legacy atom list way and then as the M  ALS way

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Writer.java
@@ -60,11 +60,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -674,6 +674,8 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
             if (sgroup.getType().isCtabStandard())
                 numSgroups++;
 
+        int chiralFlag = getChiralFlag(mol.stereoElements());
+
         writer.write("BEGIN CTAB\n");
         writer.write("COUNTS ")
               .write(mol.getAtomCount())
@@ -681,7 +683,9 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
               .write(mol.getBondCount())
               .write(' ')
               .write(numSgroups)
-              .write(" 0 0\n");
+              .write(" 0")
+              .write(chiralFlag == 1 ? " 1" : " 0")
+              .write("\n");
 
         // fast lookup atom indexes, MDL indexing starts at 1
         Map<IChemObject, Integer> idxs = new HashMap<>();
@@ -704,12 +708,55 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
         writeAtomBlock(mol, atoms, idxs, atomToStereo);
         writeBondBlock(mol, idxs);
         writeSgroupBlock(sgroups, idxs);
+        if (chiralFlag > 1)
+            writeEnhancedStereo(mol, idxs);
 
         writer.write("END CTAB\n");
         writer.writeDirect("M  END\n");
         writer.writer.flush();
     }
 
+    private void writeEnhancedStereo(IAtomContainer mol, Map<IChemObject, Integer> idxs) throws IOException {
+        // group together
+        Map<Integer,List<IAtom>> groups = new TreeMap<>();
+        for (IStereoElement<?,?> se : mol.stereoElements()) {
+            if (se.getConfigClass() == IStereoElement.TH) {
+               groups.computeIfAbsent(se.getGroupInfo(), e -> new ArrayList<>())
+                       .add((IAtom)se.getFocus());
+            }
+        }
+        writer.write("BEGIN COLLECTION\n");
+        int numRel = 0;
+        int numRac = 0;
+        for (Map.Entry<Integer,List<IAtom>> e : groups.entrySet()) {
+            int grpInfo = e.getKey();
+            List<IAtom> atoms = e.getValue();
+            writer.write("MDLV30/STE");
+            switch (grpInfo & IStereoElement.GRP_TYPE_MASK) {
+                case IStereoElement.GRP_ABS:
+                    writer.write("ABS");
+                    break;
+                case IStereoElement.GRP_RAC:
+                    writer.write("RAC");
+                    writer.write(++numRac);
+                    break;
+                case IStereoElement.GRP_REL:
+                    writer.write("REL");
+                    writer.write(++numRel);
+                    break;
+                default:
+                    throw new IllegalStateException("Unexpected ");
+            }
+            writer.write(" ATOMS=(");
+            writer.write(idxs.get(atoms.get(0)));
+            for (int i=1; i<atoms.size(); i++) {
+                writer.write(' ');
+                writer.write(idxs.get(atoms.get(i)));
+            }
+            writer.write(")\n");
+        }
+        writer.write("END COLLECTION\n");
+    }
 
     /**
      * Writes a molecule to the V3000 format. {@inheritDoc}
@@ -956,5 +1003,31 @@ public final class MDLV3000Writer extends DefaultChemObjectWriter {
         for (IOSetting setting : getSettings()) {
             fireIOSettingQuestion(setting);
         }
+    }
+
+    /**
+     * Determines the chiral flag, a molecule is chiral if all it's tetrahedral stereocenters are marked as absolute.
+     *
+     * @param stereo tetrahedral stereo
+     * @return the chiral status, 0=not chiral, 1=chiral (all abs), 2=enhanced
+     */
+    static int getChiralFlag(Iterable<? extends IStereoElement> stereo) {
+        boolean init     = false;
+        int     grp      = 0;
+        for (IStereoElement<?,?> se : stereo) {
+            if (se.getConfigClass() == IStereoElement.TH) {
+                if (!init) {
+                    init = true;
+                    grp = se.getGroupInfo();
+                } else if (grp != se.getGroupInfo()) {
+                    return 2; // mixed
+                }
+            }
+        }
+        if (!init)
+            return 0;
+        if (grp == IStereoElement.GRP_ABS)
+            return 1;
+        return 2;
     }
 }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
@@ -38,6 +38,7 @@ import org.openscience.cdk.interfaces.IChemModel;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.ISingleElectron;
+import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.io.listener.PropertiesListener;
 import org.openscience.cdk.sgroup.Sgroup;
@@ -50,6 +51,7 @@ import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,6 +64,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.openscience.cdk.CDKConstants.ISAROMATIC;
 
 /**
@@ -451,9 +454,6 @@ public class MDLV2000WriterTest extends ChemObjectIOTest {
         MDLV2000Writer writer = new MDLV2000Writer(sw);
         writer.write(molecule);
         writer.close();
-
-
-        System.out.println(sw.toString());
 
         Assert.assertTrue(sw.toString().contains(
             "   -1.1749    0.1436    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0"));
@@ -955,7 +955,7 @@ public class MDLV2000WriterTest extends ChemObjectIOTest {
             mdlw.write(mdlr.read(new AtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("\n"
-                                              + "  5  4  0  0  1  0  0  0  0  0999 V2000\n"
+                                              + "  5  4  0  0  0  0  0  0  0  0999 V2000\n"
                                               + "    0.0000    0.0000    0.0000 C   0  0  1  0  0  0\n"
                                               + "    0.0000    0.0000    0.0000 C   0  0\n"
                                               + "    0.0000    0.0000    0.0000 C   0  0\n"
@@ -1071,5 +1071,65 @@ public class MDLV2000WriterTest extends ChemObjectIOTest {
       } catch (IOException | CDKException e) {
         Assert.fail(e.getMessage());
       }
+    }
+
+    @Test
+    public void testNoChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112282D          \n" +
+                "\n" +
+                "  7  7  0  0  0  0            999 V2000\n" +
+                "   -1.1468    6.5972    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.8613    6.1847    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.8613    5.3597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.1468    4.9472    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4323    5.3597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4323    6.1847    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.1468    7.4222    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "  1  2  1  0  0  0  0\n" +
+                "  2  3  1  0  0  0  0\n" +
+                "  3  4  1  0  0  0  0\n" +
+                "  4  5  1  0  0  0  0\n" +
+                "  5  6  1  0  0  0  0\n" +
+                "  1  6  1  0  0  0  0\n" +
+                "  1  7  1  1  0  0  0\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV2000Reader mdlr = new MDLV2000Reader(new StringReader(input));
+             MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("  7  7  0  0  0  0"));
+    }
+
+    @Test
+    public void testChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112282D          \n" +
+                "\n" +
+                "  7  7  0  0  1  0            999 V2000\n" +
+                "   -1.1468    6.5972    0.0000 C   0  0  2  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.8613    6.1847    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.8613    5.3597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.1468    4.9472    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4323    5.3597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -0.4323    6.1847    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "   -1.1468    7.4222    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" +
+                "  1  2  1  0  0  0  0\n" +
+                "  2  3  1  0  0  0  0\n" +
+                "  3  4  1  0  0  0  0\n" +
+                "  4  5  1  0  0  0  0\n" +
+                "  5  6  1  0  0  0  0\n" +
+                "  1  6  1  0  0  0  0\n" +
+                "  1  7  1  1  0  0  0\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV2000Reader mdlr = new MDLV2000Reader(new StringReader(input));
+             MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("  7  7  0  0  1  0"));
     }
 }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -31,6 +31,7 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.io.listener.PropertiesListener;
 import org.openscience.cdk.sgroup.Sgroup;
@@ -45,6 +46,7 @@ import org.openscience.cdk.stereo.TetrahedralChirality;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,7 +54,10 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class MDLV3000WriterTest {
 
@@ -476,4 +481,221 @@ public class MDLV3000WriterTest {
         return sw.toString();
     }
 
+    @Test
+    public void testNoChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112362D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 END CTAB\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("M  V30 COUNTS 7 7 0 0 0"));
+        assertThat(sw.toString(), not(containsString("BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(1)\n" +
+                "END COLLECTION")));
+    }
+
+    @Test
+    public void testChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112362D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 1\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 END CTAB\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("M  V30 COUNTS 7 7 0 0 1"));
+        assertThat(sw.toString(), not(containsString("BEGIN COLLECTION\n" +
+                "M  V30 M  V30 MDLV30/STEABS ATOMS=(1)\n" +
+                "END COLLECTION")));
+    }
+
+    @Test
+    public void testStereoRac1() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052113162D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(1 1)\n" +
+                "M  V30 END COLLECTION\n" +
+                "M  V30 END CTAB\n" +
+                "M  END";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("M  V30 COUNTS 7 7 0 0 0"));
+        assertThat(sw.toString(), not(containsString("BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(1)\n" +
+                "END COLLECTION")));
+    }
+
+    @Test
+    public void testStereoRel1() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052113162D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEREL5 ATOMS=(1 1)\n" +
+                "M  V30 END COLLECTION\n" +
+                "M  V30 END CTAB\n" +
+                "M  END";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEREL1 ATOMS=(1)\n" +
+                "M  V30 END COLLECTION"));
+    }
+
+    @Test
+    public void testStereoRac1And() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02062121432D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 11 11 0 0 1\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C 0 6.16 0 0\n" +
+                "M  V30 2 C 0 4.62 0 0 CFG=2\n" +
+                "M  V30 3 O -1.3337 3.85 0 0\n" +
+                "M  V30 4 C 1.3337 3.85 0 0 CFG=2\n" +
+                "M  V30 5 O 2.6674 4.62 0 0\n" +
+                "M  V30 6 C 1.3337 2.31 0 0\n" +
+                "M  V30 7 C 2.6674 1.54 0 0\n" +
+                "M  V30 8 C 2.6674 -0 0 0\n" +
+                "M  V30 9 C 1.3337 -0.77 0 0\n" +
+                "M  V30 10 C 0 0 0 0\n" +
+                "M  V30 11 C 0 1.54 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 2 1\n" +
+                "M  V30 2 1 2 3 CFG=1\n" +
+                "M  V30 3 1 2 4\n" +
+                "M  V30 4 1 4 5 CFG=3\n" +
+                "M  V30 5 1 4 6\n" +
+                "M  V30 6 1 6 7\n" +
+                "M  V30 7 1 7 8\n" +
+                "M  V30 8 1 8 9\n" +
+                "M  V30 9 1 9 10\n" +
+                "M  V30 10 1 10 11\n" +
+                "M  V30 11 1 6 11\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEABS ATOMS=(1 4)\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(1 2)\n" +
+                "M  V30 END COLLECTION\n" +
+                "M  V30 END CTAB\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("M  V30 COUNTS 11 11 0 0 0"));
+        assertThat(sw.toString(), containsString("M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEABS ATOMS=(4)\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(2)\n" +
+                "M  V30 END COLLECTION"));
+    }
 }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
@@ -23,6 +23,7 @@
 package org.openscience.cdk.io;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Properties;
@@ -45,9 +46,12 @@ import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.io.listener.PropertiesListener;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.InvPair;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.openscience.cdk.CDKConstants.ISAROMATIC;
 
@@ -398,5 +402,218 @@ public class SDFWriterTest extends ChemObjectWriterTest {
         String sdf = sw.toString();
         assertThat(sdf,
                    CoreMatchers.containsString("ThisIsAVeryLongFieldThatShouldBeWrappedThisIsAVeryLongFieldThatShouldBeWrappedThisIsAVeryLongFieldThatShouldBeWrappedThisIsAVeryLongFieldThatShouldBeWrappedThisIsAVeryLongFieldThatShouldBeWrappedThisI\n"));
+    }
+
+
+    @Test
+    public void testNoChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112362D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 END CTAB\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             SDFWriter mdlw = new SDFWriter(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("  7  7  0  0  0  0  0  0  0  0999 V2000"));
+        assertThat(sw.toString(), not(containsString("BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(1)\n" +
+                "END COLLECTION")));
+    }
+
+    @Test
+    public void testChiralFlag() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052112362D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 1\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 END CTAB\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             SDFWriter mdlw = new SDFWriter(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("7  7  0  0  1  0  0  0  0  0999 V2000"));
+    }
+
+    @Test
+    public void testStereoRac1() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052113162D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(1 1)\n" +
+                "M  V30 END COLLECTION\n" +
+                "M  V30 END CTAB\n" +
+                "M  END";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             SDFWriter mdlw = new SDFWriter(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("  7  7  0  0  0  0  0  0  0  0999 V2000"));
+    }
+
+    @Test
+    public void testStereoRel1() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02052113162D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 7 7 0 0 0\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C -2.1407 12.3148 0 0 CFG=2\n" +
+                "M  V30 2 C -3.4743 11.5447 0 0\n" +
+                "M  V30 3 C -3.4743 10.0047 0 0\n" +
+                "M  V30 4 C -2.1407 9.2347 0 0\n" +
+                "M  V30 5 C -0.807 10.0047 0 0\n" +
+                "M  V30 6 N -0.807 11.5447 0 0\n" +
+                "M  V30 7 O -2.1407 13.8548 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 1 2\n" +
+                "M  V30 2 1 2 3\n" +
+                "M  V30 3 1 3 4\n" +
+                "M  V30 4 1 4 5\n" +
+                "M  V30 5 1 5 6\n" +
+                "M  V30 6 1 1 6\n" +
+                "M  V30 7 1 1 7 CFG=1\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEREL5 ATOMS=(1 1)\n" +
+                "M  V30 END COLLECTION\n" +
+                "M  V30 END CTAB\n" +
+                "M  END";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             SDFWriter mdlw = new SDFWriter(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEREL1 ATOMS=(1)\n" +
+                "M  V30 END COLLECTION"));
+    }
+
+    @Test
+    public void testStereoRac1And() throws Exception {
+        final String input = "\n" +
+                "  Mrv1810 02062121432D          \n" +
+                "\n" +
+                "  0  0  0     0  0            999 V3000\n" +
+                "M  V30 BEGIN CTAB\n" +
+                "M  V30 COUNTS 11 11 0 0 1\n" +
+                "M  V30 BEGIN ATOM\n" +
+                "M  V30 1 C 0 6.16 0 0\n" +
+                "M  V30 2 C 0 4.62 0 0 CFG=2\n" +
+                "M  V30 3 O -1.3337 3.85 0 0\n" +
+                "M  V30 4 C 1.3337 3.85 0 0 CFG=2\n" +
+                "M  V30 5 O 2.6674 4.62 0 0\n" +
+                "M  V30 6 C 1.3337 2.31 0 0\n" +
+                "M  V30 7 C 2.6674 1.54 0 0\n" +
+                "M  V30 8 C 2.6674 -0 0 0\n" +
+                "M  V30 9 C 1.3337 -0.77 0 0\n" +
+                "M  V30 10 C 0 0 0 0\n" +
+                "M  V30 11 C 0 1.54 0 0\n" +
+                "M  V30 END ATOM\n" +
+                "M  V30 BEGIN BOND\n" +
+                "M  V30 1 1 2 1\n" +
+                "M  V30 2 1 2 3 CFG=1\n" +
+                "M  V30 3 1 2 4\n" +
+                "M  V30 4 1 4 5 CFG=3\n" +
+                "M  V30 5 1 4 6\n" +
+                "M  V30 6 1 6 7\n" +
+                "M  V30 7 1 7 8\n" +
+                "M  V30 8 1 8 9\n" +
+                "M  V30 9 1 9 10\n" +
+                "M  V30 10 1 10 11\n" +
+                "M  V30 11 1 6 11\n" +
+                "M  V30 END BOND\n" +
+                "M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEABS ATOMS=(1 4)\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(1 2)\n" +
+                "M  V30 END COLLECTION\n" +
+                "M  V30 END CTAB\n" +
+                "M  END\n";
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        StringWriter sw = new StringWriter();
+        try (MDLV3000Reader mdlr = new MDLV3000Reader(new StringReader(input));
+             SDFWriter mdlw = new SDFWriter(sw)) {
+            mdlw.write(mdlr.read(bldr.newAtomContainer()));
+        }
+        assertThat(sw.toString(), containsString("M  V30 COUNTS 11 11 0 0 0"));
+        assertThat(sw.toString(), containsString("M  V30 BEGIN COLLECTION\n" +
+                "M  V30 MDLV30/STEABS ATOMS=(4)\n" +
+                "M  V30 MDLV30/STERAC1 ATOMS=(2)\n" +
+                "M  V30 END COLLECTION"));
     }
 }

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
@@ -272,7 +272,7 @@ public class InChIGenerator {
                 } else {
                     iatom.setRadical(INCHI_RADICAL.TRIPLET);
                 }
-            } else {
+            } else if (count != 0) {
                 throw new CDKException("Unrecognised radical type");
             }
         }

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
@@ -258,12 +258,20 @@ public class InChIGenerator {
 
             // Check if radical
             int count = atomContainer.getConnectedSingleElectronsCount(atom);
-            if (count == 0) {
-                // TODO - how to check whether singlet or undefined multiplicity
-            } else if (count == 1) {
+            if (count == 1) {
                 iatom.setRadical(INCHI_RADICAL.DOUBLET);
             } else if (count == 2) {
-                iatom.setRadical(INCHI_RADICAL.TRIPLET);
+                Enum spin = atom.getProperty(CDKConstants.SPIN_MULTIPLICITY);
+                if (spin != null) {
+                    // cdk-ctab:SPIN_MULTIPLICITY not accessible by can access via Enum API although
+                    // a little brittle
+                    if (spin.name().equals("DivalentSinglet"))
+                        iatom.setRadical(INCHI_RADICAL.SINGLET);
+                    else
+                        iatom.setRadical(INCHI_RADICAL.TRIPLET);
+                } else {
+                    iatom.setRadical(INCHI_RADICAL.TRIPLET);
+                }
             } else {
                 throw new CDKException("Unrecognised radical type");
             }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmiFlavor.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmiFlavor.java
@@ -180,9 +180,14 @@ public final class SmiFlavor {
     public static final int CxDataSgroups       = 0x400000;
 
     /**
+     * Output enhanced stereo.
+     */
+    public static final int CxEnhancedStereo    = 0x800000 | StereoTetrahedral;
+
+    /**
      * Output CXSMILES layers.
      */
-    public static final int CxSmiles            = CxAtomLabel | CxAtomValue | CxRadical | CxFragmentGroup | CxMulticenter | CxPolymer | CxLigandOrder;
+    public static final int CxSmiles            = CxAtomLabel | CxAtomValue | CxRadical | CxFragmentGroup | CxMulticenter | CxPolymer | CxLigandOrder | CxEnhancedStereo;
 
     /**
      * Output CXSMILES layers and coordinates.

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesGeneratorTest.java
@@ -140,4 +140,53 @@ public class CxSmilesGeneratorTest {
         SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.Canonical | SmiFlavor.CxRadical);
         assertThat(smigen.create(mola), is(smigen.create(molb)));
     }
+
+    @Test public void outputRFlagWhenAllRac1() throws Exception {
+        SmilesParser    smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer  mol    = smipar.parseSmiles("C[C@H](O)[C@H](O)C1CCCCC1 |&1:1,3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxEnhancedStereo);
+        assertThat(smigen.create(mol), is("C[C@H](O)[C@H](O)C1CCCCC1 |r|"));
+    }
+
+    @Test public void outputRFlagWhenAllRac3() throws Exception {
+        SmilesParser    smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer  mol    = smipar.parseSmiles("C[C@H](O)[C@H](O)C1CCCCC1 |&3:1,3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxEnhancedStereo);
+        assertThat(smigen.create(mol), is("C[C@H](O)[C@H](O)C1CCCCC1 |r|"));
+    }
+
+    @Test public void outputRFlagWhenAllAbs() throws Exception {
+        SmilesParser    smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer  mol    = smipar.parseSmiles("C[C@H](O)[C@H](O)C1CCCCC1 |a:1,3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxEnhancedStereo);
+        assertThat(smigen.create(mol), is("C[C@H](O)[C@H](O)C1CCCCC1"));
+    }
+
+    @Test public void outputRFlagWhenAllRel1() throws Exception {
+        SmilesParser    smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer  mol    = smipar.parseSmiles("C[C@H](O)[C@H](O)C1CCCCC1 |o1:1,3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxEnhancedStereo);
+        assertThat(smigen.create(mol), is("C[C@H](O)[C@H](O)C1CCCCC1 |o1:1,3|"));
+    }
+
+    @Test public void outputRFlagWhenAllRel1Rac1() throws Exception {
+        SmilesParser    smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer  mol    = smipar.parseSmiles("C[C@H](O)[C@H](O)C1CCCCC1 |o1:1,&1:3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxEnhancedStereo);
+        assertThat(smigen.create(mol), is("C[C@H](O)[C@H](O)C1CCCCC1 |o1:1,&1:3|"));
+    }
+
+    @Test public void outputRFlagWhenAllRel1Abs() throws Exception {
+        SmilesParser    smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer  mol    = smipar.parseSmiles("C[C@H](O)[C@H](O)C1CCCCC1 |o1:1,a:3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxEnhancedStereo);
+        assertThat(smigen.create(mol), is("C[C@H](O)[C@H](O)C1CCCCC1 |o1:1,a:3|"));
+    }
+
+    @Test public void outputRFlagWhenAllRel5Renumber() throws Exception {
+        SmilesParser    smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        IAtomContainer  mol    = smipar.parseSmiles("C[C@H](O)[C@H](O)C1CCCCC1 |&5:3|");
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxEnhancedStereo);
+        assertThat(smigen.create(mol), is("C[C@H](O)[C@H](O)C1CCCCC1 |a:1,&1:3|"));
+    }
 }

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
@@ -392,7 +392,7 @@ public class CxSmilesTest {
         IChemObjectBuilder bldr   = SilentChemObjectBuilder.getInstance();
         SmilesParser       smipar = new SmilesParser(bldr);
         IAtomContainer     mol    = smipar.parseSmiles("Cl[*](I)Br |$;_R1;;$,LO:1:0.2.3|");
-        SmilesGenerator    smigen = new SmilesGenerator(SmiFlavor.Canonical | SmiFlavor.CxSmiles);
+        SmilesGenerator    smigen = new SmilesGenerator(SmiFlavor.Canonical | SmiFlavor.CxLigandOrder | SmiFlavor.CxAtomLabel);
         assertThat(smigen.create(mol), is("Cl*(Br)I |$;R1$,LO:1:0.3.2|"));
     }
 


### PR DESCRIPTION
Writing of the new stereo groups, covered everything I can think of including choosing between V2000/V3000 in SDF and renumbering the groups automatically.

I also went in to check if we could set this in InChI, there is global SRac/SRel options but they generate a non-standard InChI so not sure it's sensible to automatically enable these.