### PR TITLE
Allow wildcards when perceiving aromaticity.

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
@@ -67,6 +67,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 final class DaylightModel extends ElectronDonation {
 
+    private static final int WILDCARD   = 0;
     private static final int CARBON     = 6;
     private static final int NITROGEN   = 7;
     private static final int OXYGEN     = 8;
@@ -172,7 +173,9 @@ final class DaylightModel extends ElectronDonation {
             // here is we count the number free valence electrons but also
             // check if the bonded valence is okay (i.e. not a radical)
             else if (charge <= 0 && charge > -3) {
-                if (valence(element, charge) - valence[i] >= 2)
+                if (element == WILDCARD)
+                    electrons[i] = 2;
+                else if (valence(element, charge) - valence[i] >= 2)
                     electrons[i] = 2;
                 else
                     electrons[i] = -1;
@@ -216,6 +219,7 @@ final class DaylightModel extends ElectronDonation {
      */
     private static int exocyclicContribution(int element, int otherElement, int charge, int nCyclic) {
         switch (element) {
+            case WILDCARD:
             case CARBON:
                 return otherElement != CARBON ? 0 : 1;
             case NITROGEN:
@@ -241,6 +245,7 @@ final class DaylightModel extends ElectronDonation {
      */
     private static boolean aromaticElement(int element) {
         switch (element) {
+            case WILDCARD:
             case CARBON:
             case NITROGEN:
             case OXYGEN:
@@ -263,6 +268,8 @@ final class DaylightModel extends ElectronDonation {
      */
     private static boolean normal(int element, int charge, int valence) {
         switch (element) {
+            case WILDCARD:
+                return true;
             case CARBON:
                 if (charge == -1 || charge == +1) return valence == 3;
                 return charge == 0 && valence == 4;

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/DaylightModelTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/DaylightModelTest.java
@@ -197,6 +197,16 @@ public class DaylightModelTest {
         test(smiles("[P]1[P][P][P][P]1"), -1, -1, -1, -1, -1);
     }
 
+    @Test
+    public void wildcardIndoleLike() throws Exception {
+        test(smiles("*1C=CC=C1"), 2, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void wildcardBenzeneLike() throws Exception {
+        test(smiles("*1=CC=CC=C1"), 1, 1, 1, 1, 1, 1);
+    }
+
     /**
      * A 3 valent nitrogen cation should be aromatic, otherwise when we make it
      * lower case we can not convert it back.


### PR DESCRIPTION
Bit of a grey area...  but Daylight allowed wildcards in aromatic systems. Since depending on what the atom is the ring may or may not be aromatic:

```
*1C=CC=C1  
N1C=CC=C1 # aromatic
C1C=CC=C1 # not aromatic
```

However reasonable assumption is if it has a pi-bond then it contributes 1 (benzene/pyridine like), else 2 (indole like).