### PR TITLE
Synchronization of getInstance might fail?

### DIFF
--- a/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/SilentChemObjectBuilder.java
@@ -220,8 +220,8 @@ public class SilentChemObjectBuilder implements IChemObjectBuilder {
     public static IChemObjectBuilder getInstance() {
         IChemObjectBuilder result = instance;
         if (result == null) {
-            result = instance;
             synchronized (LOCK) {
+                result = instance;
                 if (result == null) {
                     instance = result = new SilentChemObjectBuilder();
                 }


### PR DESCRIPTION
Hey everyone,

I found this getInstance method generating a static singleton. I think the second `result = instance` should be moved into the synchronized block. Otherwise, this might result in multiple instances.

One question, is it necessary to use a local variable here? (I mean it does not hurt either)
This could also be changed to:
```java
    public static IChemObjectBuilder getInstance() { 
        if (instance == null) {
            synchronized (LOCK) { 
                if (instance == null) {
                    instance = new SilentChemObjectBuilder();
                }
            }
        }
        return instance;
    }
```