### PR TITLE
Upgraded to CMLXOM 3.2

### DIFF
--- a/descriptor/qsarcml/pom.xml
+++ b/descriptor/qsarcml/pom.xml
@@ -19,9 +19,9 @@
             <artifactId>xom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.xml-cml</groupId>
+            <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/misc/test-extra/pom.xml
+++ b/misc/test-extra/pom.xml
@@ -36,9 +36,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.xml-cml</groupId>
+            <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/io/pom.xml
+++ b/storage/io/pom.xml
@@ -38,9 +38,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.xml-cml</groupId>
+            <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/ioformats/pom.xml
+++ b/storage/ioformats/pom.xml
@@ -29,9 +29,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.xml-cml</groupId>
+            <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/libiocml/pom.xml
+++ b/storage/libiocml/pom.xml
@@ -23,9 +23,9 @@
             <artifactId>xom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.xml-cml</groupId>
+            <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/storage/libiomd/pom.xml
+++ b/storage/libiomd/pom.xml
@@ -15,13 +15,9 @@
     <name>cdk-libiomd</name>
     <dependencies>
         <dependency>
-            <groupId>org.xml-cml</groupId>
+            <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
+            <version>3.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/storage/pdbcml/pom.xml
+++ b/storage/pdbcml/pom.xml
@@ -19,9 +19,9 @@
             <artifactId>xom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.xml-cml</groupId>
+            <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/storage/smiles/pom.xml
+++ b/storage/smiles/pom.xml
@@ -55,9 +55,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.xml-cml</groupId>
+            <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Now maintained by the Blue Obelisk community and now available from Maven Central. Also includes updated dependencies.