### PR TITLE
Daniel Lowe notes passing null here through to the JNI-INCHI can cras…

### DIFF
--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
@@ -112,6 +112,8 @@ public class InChIToStructure {
      * @throws CDKException
      */
     protected InChIToStructure(String inchi, IChemObjectBuilder builder) throws CDKException {
+        if (inchi == null)
+            throw new NullPointerException();
         try {
             input = new JniInchiInputInchi(inchi, "");
         } catch (JniInchiException jie) {
@@ -127,6 +129,8 @@ public class InChIToStructure {
      * @throws CDKException
      */
     protected InChIToStructure(String inchi, IChemObjectBuilder builder, String options) throws CDKException {
+        if (inchi == null)
+            throw new NullPointerException();
         try {
             input = new JniInchiInputInchi(inchi, options);
         } catch (JniInchiException jie) {
@@ -142,6 +146,8 @@ public class InChIToStructure {
      * @throws CDKException
      */
     protected InChIToStructure(String inchi, IChemObjectBuilder builder, List<String> options) throws CDKException {
+        if (inchi == null)
+            throw new NullPointerException();
         try {
             input = new JniInchiInputInchi(inchi, options);
         } catch (JniInchiException jie) {


### PR DESCRIPTION
…h the JVM.

Extra note - we should switch to hit jna-inchi since it is InChi 1.06 and as of today also support Apple Silicon :-).