### PR TITLE
Ensure there is only one version of Log4J coming in.

### DIFF
--- a/descriptor/qsarcml/pom.xml
+++ b/descriptor/qsarcml/pom.xml
@@ -22,6 +22,20 @@
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/misc/test-extra/pom.xml
+++ b/misc/test-extra/pom.xml
@@ -39,6 +39,22 @@
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/misc/test-extra/pom.xml
+++ b/misc/test-extra/pom.xml
@@ -58,11 +58,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.vecmath</groupId>
             <artifactId>vecmath</artifactId>
             <scope>test</scope>

--- a/storage/inchi/pom.xml
+++ b/storage/inchi/pom.xml
@@ -21,6 +21,20 @@
         <dependency>
             <groupId>net.sf.jni-inchi</groupId>
             <artifactId>jni-inchi</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/storage/inchi/pom.xml
+++ b/storage/inchi/pom.xml
@@ -52,11 +52,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>

--- a/storage/io/pom.xml
+++ b/storage/io/pom.xml
@@ -60,11 +60,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>
             <scope>test</scope>

--- a/storage/io/pom.xml
+++ b/storage/io/pom.xml
@@ -41,6 +41,22 @@
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/ioformats/pom.xml
+++ b/storage/ioformats/pom.xml
@@ -51,11 +51,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.vecmath</groupId>
             <artifactId>vecmath</artifactId>
             <scope>test</scope>

--- a/storage/ioformats/pom.xml
+++ b/storage/ioformats/pom.xml
@@ -32,6 +32,22 @@
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/iordf/pom.xml
+++ b/storage/iordf/pom.xml
@@ -27,12 +27,22 @@
                     <artifactId>slf4j-log4j12</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.10</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/libiocml/pom.xml
+++ b/storage/libiocml/pom.xml
@@ -26,6 +26,20 @@
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/storage/libiocml/pom.xml
+++ b/storage/libiocml/pom.xml
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -49,11 +50,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/libiomd/pom.xml
+++ b/storage/libiomd/pom.xml
@@ -32,6 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -46,11 +47,6 @@
         <dependency>
             <groupId>javax.vecmath</groupId>
             <artifactId>vecmath</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/libiomd/pom.xml
+++ b/storage/libiomd/pom.xml
@@ -18,6 +18,20 @@
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/storage/pdbcml/pom.xml
+++ b/storage/pdbcml/pom.xml
@@ -22,6 +22,20 @@
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/storage/pdbcml/pom.xml
+++ b/storage/pdbcml/pom.xml
@@ -36,6 +36,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -50,11 +51,6 @@
         <dependency>
             <groupId>javax.vecmath</groupId>
             <artifactId>vecmath</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/smiles/pom.xml
+++ b/storage/smiles/pom.xml
@@ -58,6 +58,22 @@
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storage/smiles/pom.xml
+++ b/storage/smiles/pom.xml
@@ -45,11 +45,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>
             <scope>test</scope>

--- a/tool/tautomer/pom.xml
+++ b/tool/tautomer/pom.xml
@@ -30,11 +30,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sf.jni-inchi</groupId>
-            <artifactId>jni-inchi</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>uk.ac.ebi.beam</groupId>
             <artifactId>beam-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
WIP - I want to actually look at why CMLXOM is in so many places. I suspect we actually just need the CDK CML reader in those cases. Transitive dependencies are a pain in a project as big as CDK :-). 

Log4j v1 pulled in by JNI InChI is actually fine... but it's better to just use the most recent one since from experience the config parsing get messed up.

I would actually be more in favour of switching to slf4j, dropping the CDK custom logging, and using slf4j-simple in tests only. Generally a library should not push it's logging dependency to users.