### PR TITLE
Bumped CMLXOM to the latest version

### DIFF
--- a/descriptor/qsarcml/pom.xml
+++ b/descriptor/qsarcml/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.3</version>
+            <version>3.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>

--- a/storage/libiocml/pom.xml
+++ b/storage/libiocml/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.3</version>
+            <version>3.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>

--- a/storage/libiomd/pom.xml
+++ b/storage/libiomd/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.3</version>
+            <version>3.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>

--- a/storage/pdbcml/pom.xml
+++ b/storage/pdbcml/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>3.3</version>
+            <version>3.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Log4j 2.17.1 and also upgrade to Guava 31.0-jre which the current CDK pom's don't exclude, so now back in synch.