### PR TITLE
Guava removal

### DIFF
--- a/app/depict/pom.xml
+++ b/app/depict/pom.xml
@@ -31,10 +31,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.openscience.cdk</groupId>
             <artifactId>cdk-core</artifactId>
             <version>${project.version}</version>

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -23,8 +23,6 @@
 
 package org.openscience.cdk.depict;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
@@ -400,7 +398,7 @@ public class Abbreviations implements Iterable<String> {
         }
 
         List<IAtomContainer> fragments = generateFragments(mol);
-        Multimap<IAtom, Sgroup> sgroupAdjs = ArrayListMultimap.create();
+        Map<IAtom, List<Sgroup>> sgroupAdjs = new HashMap<>();
 
         for (IAtomContainer frag : fragments) {
             try {
@@ -445,7 +443,8 @@ public class Abbreviations implements Iterable<String> {
                 }
 
                 if (attachAtom != null)
-                    sgroupAdjs.put(attachAtom, sgroup);
+                    sgroupAdjs.computeIfAbsent(attachAtom, k -> new ArrayList<>())
+                              .add(sgroup);
                 newSgroups.add(sgroup);
 
              } catch (CDKException e) {
@@ -477,7 +476,7 @@ public class Abbreviations implements Iterable<String> {
 
             List<String> nbrSymbols = new ArrayList<>();
             Set<Sgroup> todelete = new HashSet<>();
-            for (Sgroup sgroup : sgroupAdjs.get(attach)) {
+            for (Sgroup sgroup : sgroupAdjs.getOrDefault(attach, Collections.emptyList())) {
                 if (containsChargeChar(sgroup.getSubscript()))
                     continue;
                 if (sgroup.getBonds().size() != 1)

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Depiction.java
@@ -18,7 +18,6 @@
  */
 package org.openscience.cdk.depict;
 
-import com.google.common.base.Charsets;
 import org.openscience.cdk.renderer.RendererModel;
 import org.openscience.cdk.renderer.elements.Bounds;
 import org.openscience.cdk.renderer.elements.IRenderingElement;
@@ -34,6 +33,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -245,11 +245,11 @@ public abstract class Depiction {
      */
     public final void writeTo(String fmt, OutputStream out) throws IOException {
         if (fmt.equalsIgnoreCase(SVG_FMT)) {
-            out.write(toSvgStr().getBytes(Charsets.UTF_8));
+            out.write(toSvgStr().getBytes(StandardCharsets.UTF_8));
         } else if (fmt.equalsIgnoreCase(PS_FMT)) {
-            out.write(toEpsStr().getBytes(Charsets.UTF_8));
+            out.write(toEpsStr().getBytes(StandardCharsets.UTF_8));
         } else if (fmt.equalsIgnoreCase(PDF_FMT)) {
-            out.write(toPdfStr().getBytes(Charsets.UTF_8));
+            out.write(toPdfStr().getBytes(StandardCharsets.UTF_8));
         } else {
             ImageIO.write(toImg(), fmt, out);
         }

--- a/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
@@ -18,7 +18,6 @@
  */
 package org.openscience.cdk.depict;
 
-import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.GeometryUtil;
@@ -61,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.StreamSupport;
 
 /**
  * A high-level API for depicting molecules and reactions.
@@ -321,8 +321,8 @@ public final class DepictionGenerator {
      * @see #depict(Iterable, int, int)
      */
     public Depiction depict(Iterable<IAtomContainer> mols) throws CDKException {
-        int nMols = FluentIterable.from(mols).size();
-        Dimension grid = Dimensions.determineGrid(nMols);
+        int count = (int) StreamSupport.stream(mols.spliterator(), false).count();
+        Dimension grid = Dimensions.determineGrid(count);
         return depict(mols, grid.height, grid.width);
     }
 
@@ -358,7 +358,8 @@ public final class DepictionGenerator {
             e.getKey().setProperty(StandardGenerator.HIGHLIGHT_COLOR, e.getValue());
 
         // setup the model scale
-        List<IAtomContainer> molList = FluentIterable.from(mols).toList();
+        List<IAtomContainer> molList = new ArrayList<>();
+        mols.forEach(molList::add);
         DepictionGenerator copy = this.withParam(BasicSceneGenerator.Scale.class,
                                                  caclModelScale(molList));
 
@@ -603,7 +604,9 @@ public final class DepictionGenerator {
     }
 
     private List<IAtomContainer> toList(IAtomContainerSet set) {
-        return FluentIterable.from(set.atomContainers()).toList();
+        List<IAtomContainer> mols = new ArrayList<>();
+        set.atomContainers().forEach(mols::add);
+        return mols;
     }
 
     private IRenderingElement generate(IAtomContainer molecule, RendererModel model, int atomNum) throws CDKException {

--- a/app/depict/src/main/java/org/openscience/cdk/depict/SvgDrawVisitor.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/SvgDrawVisitor.java
@@ -23,7 +23,6 @@
 
 package org.openscience.cdk.depict;
 
-import com.google.common.xml.XmlEscapers;
 import org.openscience.cdk.renderer.RendererModel;
 import org.openscience.cdk.renderer.elements.Bounds;
 import org.openscience.cdk.renderer.elements.ElementGroup;
@@ -432,6 +431,29 @@ final class SvgDrawVisitor implements IDrawVisitor {
         sb.append("/>\n");
     }
 
+    private void appendEscaped(StringBuilder sb, String text)
+    {
+        for (int i=0; i<text.length(); i++) {
+            char ch = text.charAt(i);
+            switch (ch) {
+                case '\n':
+                case '\r':
+                case '\t': sb.append(ch); break;
+                case '<':  sb.append("&lt;"); break;
+                case '>':  sb.append("&gt;"); break;
+                case '&':  sb.append("&amp;"); break;
+                default:
+                    if (ch < 0x1f)
+                        sb.append("\uFFFD"); // control chars
+                    else if (ch > 0xFFFD)
+                        sb.append("\uFFFD");
+                    else
+                        sb.append(ch);
+                    break;
+            }
+        }
+    }
+
     private void visit(TextElement elem) {
         appendIdent();
         double[] points = new double[]{elem.xCoord, elem.yCoord};
@@ -443,7 +465,7 @@ final class SvgDrawVisitor implements IDrawVisitor {
         sb.append(" text-anchor='middle'");
         // todo need font manager for scaling...
         sb.append(">");
-        sb.append(XmlEscapers.xmlContentEscaper().escape(elem.text));
+        appendEscaped(sb, elem.text);
         sb.append("</text>\n");
     }
 

--- a/app/depict/src/main/java/org/openscience/cdk/depict/SvgDrawVisitor.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/SvgDrawVisitor.java
@@ -23,7 +23,6 @@
 
 package org.openscience.cdk.depict;
 
-import com.google.common.base.Joiner;
 import com.google.common.xml.XmlEscapers;
 import org.openscience.cdk.renderer.RendererModel;
 import org.openscience.cdk.renderer.elements.Bounds;
@@ -356,7 +355,7 @@ final class SvgDrawVisitor implements IDrawVisitor {
     private void visit(MarkedElement elem) {
         String id = elem.getId();
         List<String> classes = elem.getClasses();
-        String cls = classes.isEmpty() ? null : Joiner.on(" ").join(classes);
+        String cls = classes.isEmpty() ? null : String.join(" ", classes);
 
         IRenderingElement marked = elem.element();
 

--- a/base/core/pom.xml
+++ b/base/core/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cdk-interfaces</artifactId>
             <version>${project.parent.version}</version>

--- a/base/core/src/main/java/org/openscience/cdk/config/Isotopes.java
+++ b/base/core/src/main/java/org/openscience/cdk/config/Isotopes.java
@@ -30,10 +30,8 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
-import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IIsotope;
@@ -132,19 +130,22 @@ public class Isotopes extends IsotopeFactory {
      * @param formula the formula
      */
     public static void clearMajorIsotopes(IMolecularFormula formula) {
-        for (IIsotope iso : FluentIterable.from(formula.isotopes()).toList())
-            if (isMajor(iso)) {
-                int count = formula.getIsotopeCount(iso);
-                formula.removeIsotope(iso);
-                iso.setMassNumber(null);
-                // may be immutable
-                if (iso.getMassNumber() != null) {
-                    iso = formula.getBuilder().newInstance(IIsotope.class, iso.getSymbol());
-                    iso.setAtomicNumber(iso.getAtomicNumber());
-                }
-                iso.setExactMass(null);
-                iso.setNaturalAbundance(null);
-                formula.addIsotope(iso, count);
+        List<IIsotope> majorIsotopes = new ArrayList<>();
+        formula.isotopes().forEach(i -> {
+            if (isMajor(i)) majorIsotopes.add(i);
+        });
+        for (IIsotope iso : majorIsotopes) {
+            int count = formula.getIsotopeCount(iso);
+            formula.removeIsotope(iso);
+            iso.setMassNumber(null);
+            // may be immutable
+            if (iso.getMassNumber() != null) {
+                iso = formula.getBuilder().newInstance(IIsotope.class, iso.getSymbol());
+                iso.setAtomicNumber(iso.getAtomicNumber());
             }
+            iso.setExactMass(null);
+            iso.setNaturalAbundance(null);
+            formula.addIsotope(iso, count);
+        }
     }
 }

--- a/base/core/src/main/java/org/openscience/cdk/graph/EssentialCycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/EssentialCycles.java
@@ -29,8 +29,8 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.openscience.cdk.graph.InitialCycles.Cycle;
 
 /**
@@ -94,8 +94,8 @@ public final class EssentialCycles {
      * @param initial a molecule graph
      */
     EssentialCycles(final RelevantCycles relevant, final InitialCycles initial) {
-        checkNotNull(relevant, "No RelevantCycles provided");
-        this.initial = checkNotNull(initial, "No InitialCycles provided");
+        Objects.requireNonNull(relevant, "No RelevantCycles provided");
+        this.initial = Objects.requireNonNull(initial, "No InitialCycles provided");
         this.basis = new GreedyBasis(initial.numberOfCycles(), initial.numberOfEdges());
         this.essential = new ArrayList<Cycle>();
 

--- a/base/core/src/main/java/org/openscience/cdk/graph/GraphUtil.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/GraphUtil.java
@@ -23,10 +23,10 @@
  */
 package org.openscience.cdk.graph;
 
-import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -312,7 +312,7 @@ public class GraphUtil {
          * @param n number of bonds expected
          */
         private EdgeToBondMap(int n) {
-            this.lookup = Maps.newHashMapWithExpectedSize(n);
+            this.lookup = new HashMap<>(2*n);
         }
 
         /**

--- a/base/core/src/main/java/org/openscience/cdk/graph/InitialCycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/InitialCycles.java
@@ -27,7 +27,6 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.google.common.primitives.Ints;
 
 import java.util.BitSet;
 import java.util.Collection;
@@ -542,7 +541,14 @@ final class InitialCycles {
 
         @Override
         public int compareTo(Cycle that) {
-            return Ints.lexicographicalComparator().compare(this.path, that.path);
+            int len = Math.min(this.path.length, that.path.length);
+            for (int i = 0; i < len; i++) {
+                int result = Integer.compare(this.path[i], that.path[i]);
+                if (result != 0) {
+                    return result;
+                }
+            }
+            return this.path.length - that.path.length;
         }
     }
 

--- a/base/core/src/main/java/org/openscience/cdk/graph/InitialCycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/InitialCycles.java
@@ -31,8 +31,8 @@ import com.google.common.primitives.Ints;
 
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.copyOf;
 
 /**
@@ -113,7 +113,7 @@ final class InitialCycles {
      * @throws NullPointerException the graph was null
      */
     private InitialCycles(final int[][] graph, final int limit, boolean biconnected) {
-        this.graph = checkNotNull(graph, "no graph provided");
+        this.graph = Objects.requireNonNull(graph, "no graph provided");
 
         // ordering ensures the number of initial cycles is polynomial
         this.biconnected = biconnected;

--- a/base/core/src/main/java/org/openscience/cdk/graph/JumboPathGraph.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/JumboPathGraph.java
@@ -29,9 +29,9 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A path graph (<b>P-Graph</b>) for graphs with more than 64 vertices - the
@@ -78,8 +78,8 @@ final class JumboPathGraph extends PathGraph {
     @SuppressWarnings("unchecked")
     JumboPathGraph(final int[][] mGraph, final int[] rank, final int limit) {
 
-        checkNotNull(mGraph, "no molecule graph");
-        checkNotNull(rank, "no rank provided");
+        Objects.requireNonNull(mGraph, "no molecule graph");
+        Objects.requireNonNull(rank, "no rank provided");
 
         this.graph = new List[mGraph.length];
         this.rank = rank;

--- a/base/core/src/main/java/org/openscience/cdk/graph/JumboPathGraph.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/JumboPathGraph.java
@@ -23,7 +23,6 @@
  */
 package org.openscience.cdk.graph;
 
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -89,7 +88,7 @@ final class JumboPathGraph extends PathGraph {
         if (limit < 3 || limit > ord) throw new IllegalArgumentException("limit should be from 3 to |V|");
 
         for (int v = 0; v < ord; v++)
-            graph[v] = Lists.newArrayList();
+            graph[v] = new ArrayList<>();
 
         // construct the path-graph
         for (int v = 0; v < ord; v++) {

--- a/base/core/src/main/java/org/openscience/cdk/graph/JumboPathGraph.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/JumboPathGraph.java
@@ -31,8 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 /**
  * A path graph (<b>P-Graph</b>) for graphs with more than 64 vertices - the
  * P-Graph provides efficient generation of all simple cycles in a graph
@@ -87,8 +85,8 @@ final class JumboPathGraph extends PathGraph {
         int ord = graph.length;
 
         // check configuration
-        checkArgument(ord > 2, "graph was acyclic");
-        checkArgument(limit >= 3 && limit <= ord, "limit should be from 3 to |V|");
+        if (ord <= 2) throw new IllegalArgumentException("graph was acyclic");
+        if (limit < 3 || limit > ord) throw new IllegalArgumentException("limit should be from 3 to |V|");
 
         for (int v = 0; v < ord; v++)
             graph[v] = Lists.newArrayList();

--- a/base/core/src/main/java/org/openscience/cdk/graph/MinimumCycleBasis.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/MinimumCycleBasis.java
@@ -23,7 +23,8 @@
  */
 package org.openscience.cdk.graph;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
+
 import static org.openscience.cdk.graph.InitialCycles.Cycle;
 
 /**
@@ -85,7 +86,7 @@ public final class MinimumCycleBasis {
      * @see GraphUtil#subgraph(int[][], int[])
      */
     public MinimumCycleBasis(final int[][] graph) {
-        this(new InitialCycles(checkNotNull(graph, "No graph provided")));
+        this(new InitialCycles(Objects.requireNonNull(graph, "No graph provided")));
     }
 
     /**
@@ -111,7 +112,7 @@ public final class MinimumCycleBasis {
      */
     MinimumCycleBasis(final InitialCycles initial, boolean connected) {
 
-        checkNotNull(initial, "No InitialCycles provided");
+        Objects.requireNonNull(initial, "No InitialCycles provided");
 
         this.graph = initial.graph();
         this.basis = new GreedyBasis(initial.numberOfCycles(), initial.numberOfEdges());

--- a/base/core/src/main/java/org/openscience/cdk/graph/RegularPathGraph.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/RegularPathGraph.java
@@ -28,9 +28,9 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A path graph (<b>P-Graph</b>) for graphs with less than 64 vertices - the
@@ -77,8 +77,8 @@ final class RegularPathGraph extends PathGraph {
     @SuppressWarnings("unchecked")
     RegularPathGraph(final int[][] mGraph, final int[] rank, final int limit) {
 
-        checkNotNull(mGraph, "no molecule graph");
-        checkNotNull(rank, "no rank provided");
+        Objects.requireNonNull(mGraph, "no molecule graph");
+        Objects.requireNonNull(rank, "no rank provided");
 
         this.graph = new List[mGraph.length];
         this.rank = rank;

--- a/base/core/src/main/java/org/openscience/cdk/graph/RegularPathGraph.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/RegularPathGraph.java
@@ -23,7 +23,6 @@
  */
 package org.openscience.cdk.graph;
 
-import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -90,7 +89,7 @@ final class RegularPathGraph extends PathGraph {
         if (ord >= 64) throw new IllegalArgumentException("graph has 64 or more atoms, use JumboPathGraph");
 
         for (int v = 0; v < ord; v++)
-            graph[v] = Lists.newArrayList();
+            graph[v] = new ArrayList<>();
 
         // construct the path-graph
         for (int v = 0; v < ord; v++) {

--- a/base/core/src/main/java/org/openscience/cdk/graph/RegularPathGraph.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/RegularPathGraph.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * A path graph (<b>P-Graph</b>) for graphs with less than 64 vertices - the
@@ -86,9 +85,9 @@ final class RegularPathGraph extends PathGraph {
         int ord = graph.length;
 
         // check configuration
-        checkArgument(ord > 2, "graph was acyclic");
-        checkArgument(limit >= 3 && limit <= ord, "limit should be from 3 to |V|");
-        checkArgument(ord < 64, "graph has 64 or more atoms, use JumboPathGraph");
+        if (ord <= 2) throw new IllegalArgumentException("graph was acyclic");
+        if (limit < 3 || limit > ord) throw new IllegalArgumentException("limit should be from 3 to |V|");
+        if (ord >= 64) throw new IllegalArgumentException("graph has 64 or more atoms, use JumboPathGraph");
 
         for (int v = 0; v < ord; v++)
             graph[v] = Lists.newArrayList();

--- a/base/core/src/main/java/org/openscience/cdk/graph/RelevantCycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/RelevantCycles.java
@@ -27,8 +27,8 @@ package org.openscience.cdk.graph;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.openscience.cdk.graph.InitialCycles.Cycle;
 
 /**
@@ -111,7 +111,7 @@ public final class RelevantCycles {
      */
     RelevantCycles(final InitialCycles initial) {
 
-        checkNotNull(initial, "No InitialCycles provided");
+        Objects.requireNonNull(initial, "No InitialCycles provided");
 
         this.basis = new GreedyBasis(initial.numberOfCycles(), initial.numberOfEdges());
 

--- a/base/data/pom.xml
+++ b/base/data/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
@@ -880,6 +880,7 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
                 addAtom(atom);
             }
         }
+        /* FIXME!!! */
         for (IBond bond : that.bonds()) {
             if (!bond.getFlag(CDKConstants.VISITED)) {
                 bond.setFlag(CDKConstants.VISITED, true);

--- a/base/data/src/main/java/org/openscience/cdk/AtomType.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomType.java
@@ -27,12 +27,12 @@
  */
 package org.openscience.cdk;
 
-import com.google.common.base.Objects;
 import org.openscience.cdk.interfaces.IAtomType;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IElement;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * The base class for atom types. Atom types are typically used to describe the
@@ -318,8 +318,8 @@ public class AtomType extends Isotope implements IAtomType, Serializable, Clonea
             return false;
         }
         AtomType type = (AtomType) object;
-        return Objects.equal(getAtomTypeName(), type.getAtomTypeName())
-                && Objects.equal(maxBondOrder, type.maxBondOrder) && Objects.equal(bondOrderSum, type.bondOrderSum);
+        return Objects.equals(getAtomTypeName(), type.getAtomTypeName())
+                && Objects.equals(maxBondOrder, type.maxBondOrder) && Objects.equals(bondOrderSum, type.bondOrderSum);
     }
 
     /**

--- a/base/data/src/main/java/org/openscience/cdk/ChemObject.java
+++ b/base/data/src/main/java/org/openscience/cdk/ChemObject.java
@@ -23,7 +23,6 @@
  */
 package org.openscience.cdk;
 
-import com.google.common.base.Objects;
 import org.openscience.cdk.event.ChemObjectChangeEvent;
 import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
@@ -37,6 +36,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  *  The base class for all chemical objects in this cdk. It provides methods for
@@ -333,7 +333,7 @@ public class ChemObject implements Serializable, IChemObject, Cloneable {
             return false;
         }
         ChemObject chemObj = (ChemObject) object;
-        return Objects.equal(identifier, chemObj.identifier);
+        return Objects.equals(identifier, chemObj.identifier);
     }
 
     /**

--- a/base/data/src/main/java/org/openscience/cdk/Element.java
+++ b/base/data/src/main/java/org/openscience/cdk/Element.java
@@ -27,7 +27,6 @@ package org.openscience.cdk;
 import com.google.common.base.Objects;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IElement;
-import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
 import java.io.Serializable;
 

--- a/base/data/src/main/java/org/openscience/cdk/Element.java
+++ b/base/data/src/main/java/org/openscience/cdk/Element.java
@@ -24,11 +24,11 @@
  */
 package org.openscience.cdk;
 
-import com.google.common.base.Objects;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IElement;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Implements the idea of an element in the periodic table.
@@ -212,6 +212,6 @@ public class Element extends ChemObject implements Serializable, IElement, Clone
             return false;
         }
         Element elem = (Element) object;
-        return Objects.equal(atomicNumber, elem.atomicNumber);
+        return Objects.equals(atomicNumber, elem.atomicNumber);
     }
 }

--- a/base/isomorphism/pom.xml
+++ b/base/isomorphism/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/AtomMapFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/AtomMapFilter.java
@@ -23,7 +23,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.primitives.Ints;
@@ -39,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A filter for substructure matches implementing the logic for Atom-Atom Mapping matching. The following
@@ -141,7 +141,7 @@ final class AtomMapFilter implements Predicate<int[]> {
      * @return whether the match should be accepted
      */
     @Override
-    public boolean apply(int[] perm) {
+    public boolean test(int[] perm) {
         for (MappedPairs mpair : mapped) {
 
             // possibly 'or' of query maps, need to use a set
@@ -176,6 +176,16 @@ final class AtomMapFilter implements Predicate<int[]> {
 
         }
         return true;
+    }
+
+    /**
+     * Backwards compatible method from when we used GUAVA predicates.
+     * @param ints atom index bijection
+     * @return true/false
+     * @see #test(int[])
+     */
+    public boolean apply(int[] ints) {
+        return test(ints);
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/AtomMapFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/AtomMapFilter.java
@@ -23,8 +23,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.ReactionRole;
 import org.openscience.cdk.interfaces.IAtom;
@@ -32,7 +30,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -72,8 +70,8 @@ final class AtomMapFilter implements Predicate<int[]> {
 
     AtomMapFilter(IAtomContainer query, IAtomContainer target) {
 
-        Multimap<Integer,Integer> reactInvMap = null;
-        Multimap<Integer,Integer> prodInvMap  = null;
+        Map<Integer,List<Integer>> reactInvMap = null;
+        Map<Integer,List<Integer>> prodInvMap  = null;
 
         this.target = target;
 
@@ -85,20 +83,20 @@ final class AtomMapFilter implements Predicate<int[]> {
             if (mapidx == 0) continue;
             switch (role(atom)) {
                 case Reactant:
-                    if (reactInvMap == null) reactInvMap = ArrayListMultimap.create();
-                    reactInvMap.put(mapidx, idx);
+                    if (reactInvMap == null) reactInvMap = new HashMap<>();
+                    reactInvMap.computeIfAbsent(mapidx, k -> new ArrayList<>()).add(idx);
                     break;
                 case Product:
-                    if (prodInvMap == null) prodInvMap = ArrayListMultimap.create();
-                    prodInvMap.put(mapidx, idx);
+                    if (prodInvMap == null) prodInvMap = new HashMap<>();
+                    prodInvMap.computeIfAbsent(mapidx, k -> new ArrayList<>()).add(idx);
                     break;
             }
         }
 
         if (reactInvMap != null && prodInvMap != null) {
-            for (Map.Entry<Integer, Collection<Integer>> e : reactInvMap.asMap().entrySet()) {
+            for (Map.Entry<Integer, List<Integer>> e : reactInvMap.entrySet()) {
                 int[] reacMaps = e.getValue().stream().mapToInt(i->i).toArray();
-                int[] prodMaps = prodInvMap.get(e.getKey()).stream().mapToInt(i->i).toArray();
+                int[] prodMaps = prodInvMap.getOrDefault(e.getKey(), new ArrayList<>()).stream().mapToInt(i->i).toArray();
                 if (prodMaps.length == 0)
                     continue; // unpaired
                 mapped.add(new MappedPairs(reacMaps, prodMaps));

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/AtomMapFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/AtomMapFilter.java
@@ -25,7 +25,6 @@ package org.openscience.cdk.isomorphism;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.primitives.Ints;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.ReactionRole;
 import org.openscience.cdk.interfaces.IAtom;
@@ -98,8 +97,8 @@ final class AtomMapFilter implements Predicate<int[]> {
 
         if (reactInvMap != null && prodInvMap != null) {
             for (Map.Entry<Integer, Collection<Integer>> e : reactInvMap.asMap().entrySet()) {
-                int[] reacMaps = Ints.toArray(e.getValue());
-                int[] prodMaps = Ints.toArray(prodInvMap.get(e.getKey()));
+                int[] reacMaps = e.getValue().stream().mapToInt(i->i).toArray();
+                int[] prodMaps = prodInvMap.get(e.getKey()).stream().mapToInt(i->i).toArray();
                 if (prodMaps.length == 0)
                     continue; // unpaired
                 mapped.add(new MappedPairs(reacMaps, prodMaps));

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/ComponentFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/ComponentFilter.java
@@ -25,13 +25,13 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.base.Predicate;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.graph.ConnectedComponents;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtomContainer;
 
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 /**
  * A predicate for verifying component level grouping in query/target structure
@@ -135,7 +135,7 @@ final class ComponentFilter implements Predicate<int[]> {
      * @return the mapping preserves the specified grouping
      */
     @Override
-    public boolean apply(final int[] mapping) {
+    public boolean test(final int[] mapping) {
 
         // no grouping required
         if (queryComponents == null) return true;
@@ -167,5 +167,15 @@ final class ComponentFilter implements Predicate<int[]> {
         }
 
         return true;
+    }
+
+    /**
+     * Backwards compatible method from when we used GUAVA predicates.
+     * @param ints atom index bijection
+     * @return true/false
+     * @see #test(int[])
+     */
+    public boolean apply(int[] ints) {
+        return test(ints);
     }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/DfState.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/DfState.java
@@ -109,8 +109,7 @@ final class DfState implements Iterable<int[]> {
                                                    "has a IChemObjectBuilder set!");
         }
 
-        IAtomContainer tmp = builder.newAtomContainer();
-        tmp.add(query);
+        IAtomContainer tmp = builder.newInstance(IAtomContainer.class, query);
         this.qbonds = new IQueryBond[tmp.getBondCount()];
         this.amap = new int[query.getAtomCount()];
 

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
@@ -534,12 +534,7 @@ public final class Mappings implements Iterable<int[]> {
      * @return number of matches
      */
     public int count() {
-        // Note: doesn't work when mocked due to forEachRemaining
-        // return (int)stream().count();
-        int count = 0;
-        for (int[] m : iterable)
-            count++;
-        return count;
+        return (int)stream().count();
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
@@ -534,7 +534,12 @@ public final class Mappings implements Iterable<int[]> {
      * @return number of matches
      */
     public int count() {
-        return Iterables.size(iterable);
+        // Note: doesn't work when mocked due to forEachRemaining
+        // return (int)stream().count();
+        int count = 0;
+        for (int[] m : iterable)
+            count++;
+        return count;
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
@@ -27,7 +27,6 @@ package org.openscience.cdk.isomorphism;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -40,6 +39,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
 
 /**
  * A fluent interface for handling (sub)-graph mappings from a query to a target
@@ -282,7 +282,8 @@ public final class Mappings implements Iterable<int[]> {
 
             @Override
             public Iterator<int[]> iterator() {
-                return Iterators.filter(iterable.iterator(), new UniqueAtomMatches()::test);
+                return StreamSupport.stream(iterable.spliterator(), false)
+                        .filter(new UniqueAtomMatches()).iterator();
             }
         });
     }
@@ -302,7 +303,8 @@ public final class Mappings implements Iterable<int[]> {
 
             @Override
             public Iterator<int[]> iterator() {
-                return Iterators.filter(iterable.iterator(), new UniqueBondMatches(g)::test);
+                return StreamSupport.stream(iterable.spliterator(), false)
+                                    .filter(new UniqueBondMatches(g)).iterator();
             }
         });
     }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
@@ -25,7 +25,6 @@
 package org.openscience.cdk.isomorphism;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -203,7 +202,7 @@ public final class Mappings implements Iterable<int[]> {
      * @return fluent-api reference
      */
     public Mappings filter(final Predicate<int[]> predicate) {
-        return new Mappings(query, target, Iterables.filter(iterable, predicate::test));
+        return new Mappings(query, target, () -> stream().filter(predicate).iterator());
     }
 
     /**
@@ -239,7 +238,7 @@ public final class Mappings implements Iterable<int[]> {
      * @return iterable of the transformed type
      */
     public <T> Iterable<T> map(final Function<int[], T> f) {
-        return Iterables.transform(iterable, f::apply);
+        return () -> stream().map(f).iterator();
     }
 
     /**
@@ -250,7 +249,7 @@ public final class Mappings implements Iterable<int[]> {
      * @return fluent-api instance
      */
     public Mappings limit(int limit) {
-        return new Mappings(query, target, Iterables.limit(iterable, limit));
+        return new Mappings(query, target, () -> stream().limit(limit).iterator());
     }
 
     /**
@@ -523,7 +522,7 @@ public final class Mappings implements Iterable<int[]> {
      * @return first match
      */
     public int[] first() {
-        return Iterables.getFirst(iterable, new int[0]);
+        return stream().findFirst().orElseGet(() -> new int[0]);
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Mappings.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.ImmutableMap;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -33,7 +32,10 @@ import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -578,10 +580,10 @@ public final class Mappings implements Iterable<int[]> {
         /**{@inheritDoc} */
         @Override
         public Map<IAtom, IAtom> apply(int[] mapping) {
-            ImmutableMap.Builder<IAtom, IAtom> map = ImmutableMap.builder();
+            Map<IAtom, IAtom> map = new HashMap<>();
             for (int i = 0; i < mapping.length; i++)
                 map.put(query.getAtom(i), target.getAtom(mapping[i]));
-            return map.build();
+            return Collections.unmodifiableMap(map);
         }
     }
 
@@ -610,7 +612,7 @@ public final class Mappings implements Iterable<int[]> {
         /**{@inheritDoc} */
         @Override
         public Map<IBond, IBond> apply(int[] mapping) {
-            ImmutableMap.Builder<IBond, IBond> map = ImmutableMap.builder();
+            Map<IBond, IBond> map = new LinkedHashMap<>();
             for (int u = 0; u < g1.length; u++) {
                 for (int v : g1[u]) {
                     if (v > u) {
@@ -618,7 +620,7 @@ public final class Mappings implements Iterable<int[]> {
                     }
                 }
             }
-            return map.build();
+            return Collections.unmodifiableMap(map);
         }
     }
 
@@ -647,7 +649,7 @@ public final class Mappings implements Iterable<int[]> {
         /**{@inheritDoc} */
         @Override
         public Map<IChemObject, IChemObject> apply(int[] mapping) {
-            ImmutableMap.Builder<IChemObject, IChemObject> map = ImmutableMap.builder();
+            Map<IChemObject, IChemObject> map = new LinkedHashMap<>();
             for (int u = 0; u < g1.length; u++) {
                 map.put(query.getAtom(u), target.getAtom(mapping[u]));
                 for (int v : g1[u]) {
@@ -656,7 +658,7 @@ public final class Mappings implements Iterable<int[]> {
                     }
                 }
             }
-            return map.build();
+            return Collections.unmodifiableMap(map);
         }
     }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
@@ -25,7 +25,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -38,6 +37,7 @@ import org.openscience.cdk.isomorphism.matchers.QueryAtom;
 import org.openscience.cdk.isomorphism.matchers.QueryBond;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -372,7 +372,7 @@ final class QueryStereoFilter implements Predicate<int[]> {
      * @return the index/lookup of atoms to the index they appear
      */
     private static Map<IAtom, Integer> indexAtoms(IAtomContainer container) {
-        Map<IAtom, Integer> map = Maps.newHashMapWithExpectedSize(container.getAtomCount());
+        Map<IAtom, Integer> map = new HashMap<>(2*container.getAtomCount());
         for (int i = 0; i < container.getAtomCount(); i++)
             map.put(container.getAtom(i), i);
         return map;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
@@ -25,7 +25,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -40,6 +39,7 @@ import org.openscience.cdk.isomorphism.matchers.QueryBond;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation;
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.TOGETHER;
@@ -115,7 +115,7 @@ final class QueryStereoFilter implements Predicate<int[]> {
      * @return the stereo chemistry is value
      */
     @Override
-    public boolean apply(final int[] mapping) {
+    public boolean test(final int[] mapping) {
 
         // reset augment group config if it was initialised
         if (groupConfigAdjust != null)
@@ -430,6 +430,16 @@ final class QueryStereoFilter implements Predicate<int[]> {
      */
     private int parity(Conformation conformation) {
         return conformation == TOGETHER ? 1 : -1;
+    }
+
+    /**
+     * Backwards compatible method from when we used GUAVA predicates.
+     * @param ints atom index bijection
+     * @return true/false
+     * @see #test(int[])
+     */
+    public boolean apply(int[] ints) {
+        return test(ints);
     }
 
     // could be moved into the IStereoElement to allow faster introspection

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -33,6 +32,7 @@ import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -342,7 +342,7 @@ final class StereoMatch implements Predicate<int[]> {
      * @return the index/lookup of atoms to the index they appear
      */
     private static Map<IAtom, Integer> indexAtoms(IAtomContainer container) {
-        Map<IAtom, Integer> map = Maps.newHashMapWithExpectedSize(container.getAtomCount());
+        Map<IAtom, Integer> map = new HashMap<>(2*container.getAtomCount());
         for (int i = 0; i < container.getAtomCount(); i++)
             map.put(container.getAtom(i), i);
         return map;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/StereoMatch.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -35,6 +34,7 @@ import org.openscience.cdk.interfaces.ITetrahedralChirality;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation;
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.TOGETHER;
@@ -109,7 +109,7 @@ final class StereoMatch implements Predicate<int[]> {
      * @return the stereo chemistry is value
      */
     @Override
-    public boolean apply(final int[] mapping) {
+    public boolean test(final int[] mapping) {
 
         // n.b. not true for unspecified queries e.g. [C@?H](*)(*)*
         if (queryStereoIndices.length > targetStereoIndices.length) return false;
@@ -129,6 +129,16 @@ final class StereoMatch implements Predicate<int[]> {
             }
         }
         return true;
+    }
+
+    /**
+     * Backwards compatible method from when we used GUAVA predicates.
+     * @param ints atom index bijection
+     * @return true/false
+     * @see #test(int[])
+     */
+    public boolean apply(int[] ints) {
+        return test(ints);
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/UniqueAtomMatches.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/UniqueAtomMatches.java
@@ -24,11 +24,11 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Sets;
 
 import java.util.BitSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A predicate for filtering atom-mapping results. This class is intended for
@@ -70,8 +70,18 @@ final class UniqueAtomMatches implements Predicate<int[]> {
      *{@inheritDoc}
      */
     @Override
-    public boolean apply(int[] input) {
+    public boolean test(int[] input) {
         return unique.add(toBitSet(input));
+    }
+
+    /**
+     * Backwards compatible method from when we used GUAVA predicates.
+     * @param ints atom index bijection
+     * @return true/false
+     * @see #test(int[])
+     */
+    public boolean apply(int[] ints) {
+        return test(ints);
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/UniqueAtomMatches.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/UniqueAtomMatches.java
@@ -24,9 +24,8 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.Sets;
-
 import java.util.BitSet;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -56,7 +55,7 @@ final class UniqueAtomMatches implements Predicate<int[]> {
      * @param expectedHits expected number of unique matches
      */
     private UniqueAtomMatches(int expectedHits) {
-        this.unique = Sets.newHashSetWithExpectedSize(expectedHits);
+        this.unique = new HashSet<>(2*expectedHits);
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/UniqueBondMatches.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/UniqueBondMatches.java
@@ -24,11 +24,11 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Sets;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A predicate for filtering atom-mapping results for those which cover unique
@@ -70,8 +70,18 @@ final class UniqueBondMatches implements Predicate<int[]> {
 
     /**{@inheritDoc} */
     @Override
-    public boolean apply(int[] input) {
+    public boolean test(int[] input) {
         return unique.add(toEdgeSet(input));
+    }
+
+    /**
+     * Backwards compatible method from when we used GUAVA predicates.
+     * @param ints atom index bijection
+     * @return true/false
+     * @see #test(int[])
+     */
+    public boolean apply(int[] ints) {
+        return test(ints);
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/UniqueBondMatches.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/UniqueBondMatches.java
@@ -24,8 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.Sets;
-
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -59,7 +57,7 @@ final class UniqueBondMatches implements Predicate<int[]> {
      * @param expectedHits expected number of unique matches
      */
     private UniqueBondMatches(int[][] g, int expectedHits) {
-        this.unique = Sets.newHashSetWithExpectedSize(expectedHits);
+        this.unique = new HashSet<>(2*expectedHits);
         this.g = g;
     }
 

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/UllmannTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/UllmannTest.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.FluentIterable;
 import org.junit.Test;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 
@@ -44,9 +43,8 @@ public class UllmannTest {
         int[] match = Ullmann.findSubstructure(TestMoleculeFactory.makeBenzene()).match(
                 TestMoleculeFactory.makeNaphthalene());
         assertThat(match, is(new int[]{2, 7, 6, 5, 4, 3}));
-        int count = FluentIterable.from(
-                Ullmann.findSubstructure(TestMoleculeFactory.makeBenzene()).matchAll(
-                        TestMoleculeFactory.makeNaphthalene())).size();
+        int count = Ullmann.findSubstructure(TestMoleculeFactory.makeBenzene())
+                           .matchAll(TestMoleculeFactory.makeNaphthalene()).count();
         assertThat(count, is(6)); // note: aromatic one would be 24
     }
 
@@ -55,9 +53,8 @@ public class UllmannTest {
         int[] match = Ullmann.findSubstructure(TestMoleculeFactory.makeNaphthalene()).match(
                 TestMoleculeFactory.makeBenzene());
         assertThat(match, is(new int[0]));
-        int count = FluentIterable.from(
-                Ullmann.findSubstructure(TestMoleculeFactory.makeNaphthalene()).matchAll(
-                        TestMoleculeFactory.makeBenzene())).size();
+        int count = Ullmann.findSubstructure(TestMoleculeFactory.makeNaphthalene())
+                           .matchAll(TestMoleculeFactory.makeBenzene()).count();
         assertThat(count, is(0));
     }
 }

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/VentoFoggiaTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/VentoFoggiaTest.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.FluentIterable;
 import org.junit.Test;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 
@@ -44,9 +43,9 @@ public class VentoFoggiaTest {
         int[] match = VentoFoggia.findIdentical(TestMoleculeFactory.makeBenzene()).match(
                 TestMoleculeFactory.makeBenzene());
         assertThat(match, is(new int[]{0, 1, 2, 3, 4, 5}));
-        int count = FluentIterable.from(
-                VentoFoggia.findIdentical(TestMoleculeFactory.makeBenzene())
-                        .matchAll(TestMoleculeFactory.makeBenzene())).size();
+        int count = VentoFoggia.findIdentical(TestMoleculeFactory.makeBenzene())
+                               .matchAll(TestMoleculeFactory.makeBenzene())
+                               .count();
         assertThat(count, is(6)); // note: aromatic one would be 12
     }
 
@@ -55,9 +54,9 @@ public class VentoFoggiaTest {
         int[] match = VentoFoggia.findIdentical(TestMoleculeFactory.makeBenzene()).match(
                 TestMoleculeFactory.makeNaphthalene());
         assertThat(match, is(new int[0]));
-        int count = FluentIterable.from(
-                VentoFoggia.findIdentical(TestMoleculeFactory.makeBenzene()).matchAll(
-                        TestMoleculeFactory.makeNaphthalene())).size();
+        int count = VentoFoggia.findIdentical(TestMoleculeFactory.makeBenzene())
+                               .matchAll(TestMoleculeFactory.makeNaphthalene())
+                               .count();
         assertThat(count, is(0));
     }
 
@@ -66,9 +65,9 @@ public class VentoFoggiaTest {
         int[] match = VentoFoggia.findSubstructure(TestMoleculeFactory.makeBenzene()).match(
                 TestMoleculeFactory.makeNaphthalene());
         assertThat(match, is(new int[]{2, 7, 6, 5, 4, 3}));
-        int count = FluentIterable.from(
-                VentoFoggia.findSubstructure(TestMoleculeFactory.makeBenzene()).matchAll(
-                        TestMoleculeFactory.makeNaphthalene())).size();
+        int count = VentoFoggia.findSubstructure(TestMoleculeFactory.makeBenzene())
+                               .matchAll(TestMoleculeFactory.makeNaphthalene())
+                               .count();
         assertThat(count, is(6)); // note: aromatic one would be 24
     }
 
@@ -77,9 +76,8 @@ public class VentoFoggiaTest {
         int[] match = VentoFoggia.findSubstructure(TestMoleculeFactory.makeNaphthalene()).match(
                 TestMoleculeFactory.makeBenzene());
         assertThat(match, is(new int[0]));
-        int count = FluentIterable.from(
-                VentoFoggia.findSubstructure(TestMoleculeFactory.makeNaphthalene()).matchAll(
-                        TestMoleculeFactory.makeBenzene())).size();
+        int count = VentoFoggia.findSubstructure(TestMoleculeFactory.makeNaphthalene())
+                               .matchAll(TestMoleculeFactory.makeBenzene()).count();
         assertThat(count, is(0));
     }
 }

--- a/base/silent/pom.xml
+++ b/base/silent/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomType.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomType.java
@@ -24,8 +24,8 @@
 package org.openscience.cdk.silent;
 
 import java.io.Serializable;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtomType;
 import org.openscience.cdk.interfaces.IBond;
@@ -309,8 +309,8 @@ public class AtomType extends Isotope implements IAtomType, Serializable, Clonea
             return false;
         }
         AtomType type = (AtomType) object;
-        return Objects.equal(getAtomTypeName(), type.getAtomTypeName())
-                && Objects.equal(maxBondOrder, type.maxBondOrder) && Objects.equal(bondOrderSum, type.bondOrderSum);
+        return Objects.equals(getAtomTypeName(), type.getAtomTypeName())
+                && Objects.equals(maxBondOrder, type.maxBondOrder) && Objects.equals(bondOrderSum, type.bondOrderSum);
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/ChemObject.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/ChemObject.java
@@ -28,8 +28,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
@@ -277,7 +277,7 @@ public class ChemObject implements Serializable, IChemObject, Cloneable {
             return false;
         }
         ChemObject chemObj = (ChemObject) object;
-        return Objects.equal(identifier, chemObj.identifier);
+        return Objects.equals(identifier, chemObj.identifier);
     }
 
     /**

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Element.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Element.java
@@ -20,8 +20,8 @@
 package org.openscience.cdk.silent;
 
 import java.io.Serializable;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IElement;
 
@@ -205,6 +205,6 @@ public class Element extends ChemObject implements Serializable, IElement, Clone
             return false;
         }
         Element elem = (Element) object;
-        return Objects.equal(atomicNumber, elem.atomicNumber);
+        return Objects.equals(atomicNumber, elem.atomicNumber);
     }
 }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Element.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Element.java
@@ -22,10 +22,8 @@ package org.openscience.cdk.silent;
 import java.io.Serializable;
 
 import com.google.common.base.Objects;
-import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IElement;
-import org.openscience.cdk.tools.periodictable.PeriodicTable;
 
 /**
  * Implements the idea of an element in the periodic table.

--- a/base/standard/pom.xml
+++ b/base/standard/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cdk-interfaces</artifactId>
             <version>${project.parent.version}</version>

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.aromaticity;
 
-import com.google.common.collect.Sets;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.graph.CycleFinder;
 import org.openscience.cdk.graph.Cycles;
@@ -35,6 +34,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.ringsearch.RingSearch;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -186,7 +186,7 @@ public final class Aromaticity {
         final RingSearch ringSearch = new RingSearch(molecule, graph);
         final int[] electrons = model.contribution(molecule, ringSearch);
 
-        final Set<IBond> bonds = Sets.newHashSetWithExpectedSize(molecule.getBondCount());
+        final Set<IBond> bonds = new HashSet<>(2*molecule.getBondCount());
 
         // obtain the subset of electron contributions which are >= 0 (i.e.
         // allowed to be aromatic) - we then find the cycles in this subgraph

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
@@ -35,9 +35,9 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.ringsearch.RingSearch;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.openscience.cdk.CDKConstants.ISAROMATIC;
 import static org.openscience.cdk.graph.GraphUtil.EdgeToBondMap;
 
@@ -151,8 +151,8 @@ public final class Aromaticity {
      * @see org.openscience.cdk.graph.Cycles
      */
     public Aromaticity(ElectronDonation model, CycleFinder cycles) {
-        this.model = checkNotNull(model);
-        this.cycles = checkNotNull(cycles);
+        this.model = Objects.requireNonNull(model);
+        this.cycles = Objects.requireNonNull(cycles);
     }
 
     /**

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
@@ -25,7 +25,6 @@
 package org.openscience.cdk.aromaticity;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.AtomTypeFactory;
 import org.openscience.cdk.exception.NoSuchAtomTypeException;
@@ -36,6 +35,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.ringsearch.RingSearch;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +86,7 @@ final class AtomTypeModel extends ElectronDonation {
 
         Arrays.fill(electrons, -1);
 
-        final Map<IAtom, Integer> indexMap = Maps.newHashMapWithExpectedSize(nAtoms);
+        final Map<IAtom, Integer> indexMap = new HashMap<>(2*nAtoms);
 
         for (int i = 0; i < nAtoms; i++) {
 

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.aromaticity;
 
-import com.google.common.collect.ImmutableMap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.AtomTypeFactory;
 import org.openscience.cdk.exception.NoSuchAtomTypeException;
@@ -35,6 +34,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.ringsearch.RingSearch;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -55,12 +55,23 @@ import static org.openscience.cdk.interfaces.IAtomType.Hybridization;
 // mores tests in - org.openscience.cdk.aromaticity.ExocyclicAtomTypeModelTest
 final class AtomTypeModel extends ElectronDonation {
 
+    // JDK 9+ has Map.of() which is more concise
+    private static Map<String, Integer> typeToElectronContribMap() {
+        Map<String,Integer> map = new HashMap<>();
+        map.put("N.planar3", 2);
+        map.put("N.minus.planar3", 2);
+        map.put("N.amide", 2);
+        map.put("S.2", 2);
+        map.put("S.planar3", 2);
+        map.put("C.minus.planar", 2);
+        map.put("O.planar3", 2);
+        map.put("N.sp2.3", 1);
+        map.put("C.sp2", 1);
+        return Collections.unmodifiableMap(map);
+    }
+
     /** Predefined electron contribution for several atom types. */
-    private final static Map<String, Integer> TYPES = ImmutableMap.<String, Integer> builder().put("N.planar3", 2)
-                                                            .put("N.minus.planar3", 2).put("N.amide", 2).put("S.2", 2)
-                                                            .put("S.planar3", 2).put("C.minus.planar", 2)
-                                                            .put("O.planar3", 2).put("N.sp2.3", 1).put("C.sp2", 1)
-                                                            .build();
+    private final static Map<String, Integer> TYPES = typeToElectronContribMap();
 
     /** Allow exocyclic pi bonds. */
     private final boolean                     exocyclic;

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
@@ -37,8 +37,8 @@ import org.openscience.cdk.ringsearch.RingSearch;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.openscience.cdk.interfaces.IAtomType.Hybridization;
 
 /**
@@ -98,7 +98,7 @@ final class AtomTypeModel extends ElectronDonation {
 
             Hybridization hyb = atom.getHybridization();
 
-            checkNotNull(atom.getAtomTypeName(), "atom has unset atom type");
+            Objects.requireNonNull(atom.getAtomTypeName(), "atom has unset atom type");
 
             // atom has been assigned an atom type but we don't know the hybrid state,
             // typically for atom type 'X' (unknown)

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
@@ -33,8 +33,7 @@ import org.openscience.cdk.ringsearch.RingSearch;
 
 import java.util.Arrays;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * Electron donation model closely mirroring the Daylight model for use in
@@ -98,8 +97,8 @@ final class DaylightModel extends ElectronDonation {
         for (int i = 0; i < n; i++) {
             IAtom a = container.getAtom(i);
             atomIndex.put(a, i);
-            int implH = checkNotNull(a.getImplicitHydrogenCount(),
-                                     "Aromaticity model requires implicit hydrogen count is set.");
+            int implH = Objects.requireNonNull(a.getImplicitHydrogenCount(),
+                                      "Aromaticity model requires implicit hydrogen count is set.");
             degree[i] = implH;
             valence[i] = implH;
         }
@@ -114,7 +113,7 @@ final class DaylightModel extends ElectronDonation {
             degree[u]++;
             degree[v]++;
 
-            IBond.Order order = checkNotNull(bond.getOrder(), "Aromaticity model requires that bond orders must be set");
+            IBond.Order order = Objects.requireNonNull(bond.getOrder(), "Aromaticity model requires that bond orders must be set");
 
             switch (order) {
                 case UNSET:

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.aromaticity;
 
-import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -32,6 +31,7 @@ import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.ringsearch.RingSearch;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -93,7 +93,7 @@ final class DaylightModel extends ElectronDonation {
         Arrays.fill(exocyclicPiBond, -1);
 
         // index atoms and set the degree to the number of implicit hydrogens
-        Map<IAtom, Integer> atomIndex = Maps.newHashMapWithExpectedSize(n);
+        Map<IAtom, Integer> atomIndex = new HashMap<>(2*n);
         for (int i = 0; i < n; i++) {
             IAtom a = container.getAtom(i);
             atomIndex.put(a, i);

--- a/base/standard/src/main/java/org/openscience/cdk/graph/invariant/MorganNumbersTools.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/invariant/MorganNumbersTools.java
@@ -19,9 +19,10 @@
  */
 package org.openscience.cdk.graph.invariant;
 
-import com.google.common.primitives.Ints;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
+
+import java.util.Arrays;
 
 /**
  * Compute the extended connectivity values (Morgan Numbers) {@cdk.cite MOR65}.
@@ -75,8 +76,8 @@ public class MorganNumbersTools {
         for (IBond bond : molecule.bonds()) {
             int u = molecule.indexOf(bond.getBegin());
             int v = molecule.indexOf(bond.getEnd());
-            graph[u] = Ints.ensureCapacity(graph[u], degree[u] + 1, INITIAL_DEGREE);
-            graph[v] = Ints.ensureCapacity(graph[v], degree[v] + 1, INITIAL_DEGREE);
+            graph[u] = ensureCapacity(graph[u], degree[u] + 1);
+            graph[v] = ensureCapacity(graph[v], degree[v] + 1);
             graph[u][degree[u]++] = v;
             graph[v][degree[v]++] = u;
             currentInvariants[u] += nonHydrogens[v];
@@ -99,6 +100,10 @@ public class MorganNumbersTools {
             }
         }
         return currentInvariants;
+    }
+
+    private static int[] ensureCapacity(int[] arr, int cap) {
+        return cap < arr.length ? arr : Arrays.copyOf(arr, cap);
     }
 
     /**

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -24,7 +24,6 @@
  *  */
 package org.openscience.cdk.tools.manipulator;
 
-import com.google.common.collect.Maps;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.atomtype.CDKAtomTypeMatcher;
 import org.openscience.cdk.config.Elements;
@@ -615,7 +614,7 @@ public class AtomContainerManipulator {
         List<IBond> newBonds = new ArrayList<IBond>();
 
         // store a single explicit hydrogen of each original neighbor
-        Map<IAtom, IAtom> hNeighbor = Maps.newHashMapWithExpectedSize(atomContainer.getAtomCount());
+        Map<IAtom, IAtom> hNeighbor = new HashMap<>(2*atomContainer.getAtomCount());
 
         for (IAtom atom : atomContainer.atoms()) {
             if (!"H".equals(atom.getSymbol())) {

--- a/base/test-core/pom.xml
+++ b/base/test-core/pom.xml
@@ -36,11 +36,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
             <version>1.3.03</version>

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/InitialCyclesTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/InitialCyclesTest.java
@@ -23,10 +23,10 @@
  */
 package org.openscience.cdk.graph;
 
-import com.google.common.collect.Lists;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -34,8 +34,8 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -137,7 +137,7 @@ public class InitialCyclesTest {
     @Test
     public void cycles_naphthalene() throws IOException {
         InitialCycles initial = new InitialCycles(naphthalene());
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.size(), is(2));
         assertThat(cycles.get(0).path(), is(new int[]{5, 0, 1, 2, 3, 4, 5}));
         assertThat(cycles.get(1).path(), is(new int[]{5, 4, 7, 8, 9, 6, 5}));
@@ -151,7 +151,7 @@ public class InitialCyclesTest {
     @Test
     public void cycles_anthracene() throws IOException {
         InitialCycles initial = new InitialCycles(anthracene());
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.size(), is(3));
         assertThat(cycles.get(0).path(), is(new int[]{5, 0, 1, 2, 3, 4, 5}));
         assertThat(cycles.get(1).path(), is(new int[]{9, 6, 5, 4, 7, 8, 9}));
@@ -166,7 +166,7 @@ public class InitialCyclesTest {
     @Test
     public void cycles_bicyclo() throws IOException {
         InitialCycles initial = new InitialCycles(bicyclo());
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.size(), is(3));
         assertThat(cycles.get(0).path(), is(new int[]{5, 0, 1, 2, 3, 4, 5}));
         assertThat(cycles.get(1).path(), is(new int[]{5, 0, 1, 2, 7, 6, 5}));
@@ -186,7 +186,7 @@ public class InitialCyclesTest {
     @Test
     public void cycles_cyclophane() throws IOException {
         InitialCycles initial = new InitialCycles(cyclophane_odd());
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.size(), is(2));
         assertThat(cycles.get(0).path(), is(new int[]{3, 2, 1, 0, 5, 4, 3}));
         assertThat(cycles.get(1).path(), is(new int[]{3, 2, 1, 0, 10, 9, 8, 7, 6, 3}));
@@ -195,14 +195,14 @@ public class InitialCyclesTest {
     @Test
     public void cycles_cyclophane_odd_limit_5() throws IOException {
         InitialCycles initial = new InitialCycles(cyclophane_odd(), 5);
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.size(), is(0));
     }
 
     @Test
     public void cycles_cyclophane_odd_limit_6() throws IOException {
         InitialCycles initial = new InitialCycles(cyclophane_odd(), 6);
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.size(), is(1));
         assertThat(cycles.get(0).path(), is(new int[]{3, 2, 1, 0, 5, 4, 3}));
     }
@@ -210,7 +210,7 @@ public class InitialCyclesTest {
     @Test
     public void cycles_cyclophane_odd_limit_7() throws IOException {
         InitialCycles initial = new InitialCycles(cyclophane_odd(), 7);
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.size(), is(1));
         assertThat(cycles.get(0).path(), is(new int[]{3, 2, 1, 0, 5, 4, 3}));
     }
@@ -218,7 +218,7 @@ public class InitialCyclesTest {
     @Test
     public void cycles_family_odd() {
         InitialCycles initial = new InitialCycles(cyclophane_odd());
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.get(1).path(), is(new int[]{3, 2, 1, 0, 10, 9, 8, 7, 6, 3}));
         int[][] family = cycles.get(1).family();
         assertThat(family.length, is(2));
@@ -229,7 +229,7 @@ public class InitialCyclesTest {
     @Test
     public void cycles_family_even() {
         InitialCycles initial = new InitialCycles(cyclophane_even());
-        List<InitialCycles.Cycle> cycles = Lists.newArrayList(initial.cycles());
+        List<InitialCycles.Cycle> cycles = new ArrayList<>(initial.cycles());
         assertThat(cycles.get(1).path(), is(new int[]{3, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3}));
         int[][] family = cycles.get(1).family();
         assertThat(family.length, is(2));

--- a/base/test-standard/pom.xml
+++ b/base/test-standard/pom.xml
@@ -36,11 +36,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/InvariantRankerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/InvariantRankerTest.java
@@ -24,12 +24,9 @@
 
 package org.openscience.cdk.graph.invariant;
 
-import com.google.common.primitives.Longs;
 import org.junit.Test;
 
-import java.util.HashSet;
 import java.util.Random;
-import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -115,11 +112,9 @@ public class InvariantRankerTest {
 
         // random (unique) values in random order
         Random rnd = new Random();
-        Set<Long> values = new HashSet<Long>();
-        while (values.size() < n)
-            values.add(rnd.nextLong());
-
-        long[] prev = Longs.toArray(values);
+        long[] prev = new long[n];
+        for (int i=0; i<n; i++)
+            prev[i] = rnd.nextLong();
 
         // ident array
         int[] vs = new int[n];
@@ -141,11 +136,9 @@ public class InvariantRankerTest {
 
         // random (unique) values in random order
         Random rnd = new Random();
-        Set<Long> values = new HashSet<Long>();
-        while (values.size() < n)
-            values.add(rnd.nextLong());
-
-        long[] prev = Longs.toArray(values);
+        long[] prev = new long[n];
+        for (int i=0; i<n; i++)
+            prev[i] = rnd.nextLong();
 
         // ident array
         int[] vs = new int[n];

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -24,9 +24,7 @@
 
 package org.openscience.cdk.stereo;
 
-import com.google.common.collect.Iterables;
 import org.junit.Test;
-import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -627,10 +625,11 @@ public class StereoElementFactoryTest {
             IAtomContainer ac = mdl.read(new AtomContainer());
 
             // MDL reader currently adds stereo automatically
-            IStereoElement[] ses = Iterables.toArray(ac.stereoElements(), IStereoElement.class);
+            List<IStereoElement> ses = new ArrayList<>();
+            ac.stereoElements().forEach(ses::add);
 
-            assertThat(ses.length, is(1));
-            assertNotNull(ses[0]);
+            assertThat(ses.size(), is(1));
+            assertNotNull(ses.get(0));
         } finally {
             if (mdl != null) mdl.close();
         }

--- a/display/renderbasic/pom.xml
+++ b/display/renderbasic/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardBondGenerator.java
@@ -25,9 +25,7 @@
 
 package org.openscience.cdk.renderer.generators.standard;
 
-import com.google.common.primitives.Ints;
 import org.openscience.cdk.config.Elements;
-import org.openscience.cdk.geometry.GeometryUtil;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -1724,12 +1722,12 @@ final class StandardBondGenerator {
             }
 
             // order by size 6,5,7,4,3,rest
-            int sizeCmp = Ints.compare(sizePreference(ringa.getAtomCount()),
+            int sizeCmp = Integer.compare(sizePreference(ringa.getAtomCount()),
                     sizePreference(ringb.getAtomCount()));
             if (sizeCmp != 0) return sizeCmp;
 
             // now order by number of double bonds
-            int piBondCmp = Ints.compare(nDoubleBonds(ringa), nDoubleBonds(ringb));
+            int piBondCmp = Integer.compare(nDoubleBonds(ringa), nDoubleBonds(ringb));
             if (piBondCmp != 0) return -piBondCmp;
 
             // order by element frequencies, all carbon rings are preferred
@@ -1738,7 +1736,7 @@ final class StandardBondGenerator {
 
             for (Elements element : Arrays.asList(Elements.Carbon, Elements.Nitrogen, Elements.Oxygen, Elements.Sulfur,
                     Elements.Phosphorus)) {
-                int elemCmp = Ints.compare(freqA[element.number()], freqB[element.number()]);
+                int elemCmp = Integer.compare(freqA[element.number()], freqB[element.number()]);
                 if (elemCmp != 0) return -elemCmp;
             }
 

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
@@ -23,8 +23,6 @@
 
 package org.openscience.cdk.renderer.generators.standard;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.geometry.GeometryUtil;
 import org.openscience.cdk.interfaces.IAtom;
@@ -78,8 +76,8 @@ final class StandardSgroupGenerator {
     private final double                labelScale;
     private final StandardAtomGenerator atomGenerator;
     private final RendererModel         parameters;
-    private final Multimap<Sgroup,Sgroup> children = HashMultimap.create();
-    private final Map<Sgroup,Bounds>      boundsMap = new HashMap<>();
+    private final Map<Sgroup,List<Sgroup>> children = new HashMap<>();
+    private final Map<Sgroup,Bounds>    boundsMap = new HashMap<>();
 
     private StandardSgroupGenerator(RendererModel parameters, StandardAtomGenerator atomGenerator, double stroke,
                                     Font font, Color foreground) {
@@ -283,9 +281,9 @@ final class StandardSgroupGenerator {
         }
     }
 
-    int getTotalChildCount(Multimap<Sgroup,Sgroup> map, Sgroup key) {
+    int getTotalChildCount(Map<Sgroup,List<Sgroup>> map, Sgroup key) {
         int count = 0;
-        Deque<Sgroup> deque = new ArrayDeque<>(map.get(key));
+        Deque<Sgroup> deque = new ArrayDeque<>(map.getOrDefault(key, Collections.emptyList()));
         while (!deque.isEmpty()) {
             Sgroup sgroup = deque.poll();
             deque.addAll(map.get(sgroup));
@@ -315,7 +313,7 @@ final class StandardSgroupGenerator {
         }
         for (Sgroup sgroup : sgroups) {
             for (Sgroup parent : sgroup.getParents()) {
-                children.put(parent, sgroup);
+                children.computeIfAbsent(parent, k -> new ArrayList<>()).add(sgroup);
             }
         }
 
@@ -815,7 +813,7 @@ final class StandardSgroupGenerator {
                     bounds.add(atom.getPoint2d().x, atom.getPoint2d().y);
                 }
             }
-            for (Sgroup child : children.get(sgroup)) {
+            for (Sgroup child : children.getOrDefault(sgroup, Collections.emptyList())) {
                 Bounds childBounds = boundsMap.get(child);
                 if (childBounds != null)
                     bounds.add(childBounds);

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/AbbreviationLabelTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/AbbreviationLabelTest.java
@@ -23,7 +23,6 @@
 
 package org.openscience.cdk.renderer.generators.standard;
 
-import com.google.common.base.Joiner;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -145,7 +144,7 @@ public class AbbreviationLabelTest {
         List<String> tokens = new ArrayList<>();
         assertTrue(AbbreviationLabel.parse("N(CH2CH2O)CH2", tokens));
         AbbreviationLabel.reverse(tokens);
-        assertThat(Joiner.on("").join(tokens), is("H2C(OH2CH2C)N"));
+        assertThat(String.join("", tokens), is("H2C(OH2CH2C)N"));
     }
 
     @Test
@@ -154,7 +153,7 @@ public class AbbreviationLabelTest {
         assertTrue(AbbreviationLabel.parse("PO(OH)OEt", tokens));
         AbbreviationLabel.reverse(tokens);
         AbbreviationLabel.format(tokens);
-        assertThat(Joiner.on("").join(tokens), is("EtO(HO)OP"));
+        assertThat(String.join("", tokens), is("EtO(HO)OP"));
     }
 
     @Test
@@ -162,7 +161,7 @@ public class AbbreviationLabelTest {
         List<String> tokens = new ArrayList<>();
         assertTrue(AbbreviationLabel.parse("B(OH)2", tokens));
         AbbreviationLabel.reverse(tokens);
-        assertThat(Joiner.on("").join(tokens), is("(HO)2B"));
+        assertThat(String.join("", tokens), is("(HO)2B"));
     }
 
     @Test

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -27,10 +27,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
             <version>1.3.03</version>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -130,12 +130,6 @@
         </dependency>
         <dependency>
             <groupId>org.openscience.cdk</groupId>
-            <artifactId>cdk-qsar</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openscience.cdk</groupId>
             <artifactId>cdk-charges</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/legacy/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
+++ b/legacy/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -39,6 +38,7 @@ import org.openscience.cdk.isomorphism.matchers.smarts.StereoBond;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation;
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.TOGETHER;
@@ -107,7 +107,7 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
      * @return the stereo chemistry is value
      */
     @Override
-    public boolean apply(final int[] mapping) {
+    public boolean test(final int[] mapping) {
         for (final int u : queryStereoIndices) {
             switch (queryTypes[u]) {
                 case Tetrahedral:
@@ -119,6 +119,16 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
             }
         }
         return true;
+    }
+
+    /**
+     * Backwards compatible method from when we used GUAVA predicates.
+     * @param ints atom index bijection
+     * @return true/false
+     * @see #test(int[])
+     */
+    public boolean apply(int[] ints) {
+        return test(ints);
     }
 
     /**

--- a/legacy/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
+++ b/legacy/src/main/java/org/openscience/cdk/isomorphism/SmartsStereoMatch.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -37,6 +36,7 @@ import org.openscience.cdk.isomorphism.matchers.smarts.SMARTSAtom;
 import org.openscience.cdk.isomorphism.matchers.smarts.StereoBond;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -320,7 +320,7 @@ public final class SmartsStereoMatch implements Predicate<int[]> {
      * @return the index/lookup of atoms to the index they appear
      */
     private static Map<IAtom, Integer> indexAtoms(IAtomContainer container) {
-        Map<IAtom, Integer> map = Maps.newHashMapWithExpectedSize(container.getAtomCount());
+        Map<IAtom, Integer> map = new HashMap<>(2*container.getAtomCount());
         for (int i = 0; i < container.getAtomCount(); i++)
             map.put(container.getAtom(i), i);
         return map;

--- a/legacy/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/AtomicNumberAtom.java
+++ b/legacy/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/AtomicNumberAtom.java
@@ -23,9 +23,10 @@
  */
 package org.openscience.cdk.isomorphism.matchers.smarts;
 
-import com.google.common.base.Preconditions;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
+
+import java.util.Objects;
 
 /**
  * This matches an atom using the atomic number.
@@ -55,7 +56,7 @@ public class AtomicNumberAtom extends SMARTSAtom {
      */
     @Override
     public boolean matches(IAtom atom) {
-        return Preconditions.checkNotNull(atom.getAtomicNumber(), "Atomic number is not set.").equals(
+        return Objects.requireNonNull(atom.getAtomicNumber(), "Atomic number is not set.").equals(
                 this.getAtomicNumber());
     }
 }

--- a/legacy/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/SMARTSAtomInvariants.java
+++ b/legacy/src/main/java/org/openscience/cdk/isomorphism/matchers/smarts/SMARTSAtomInvariants.java
@@ -34,9 +34,9 @@ import org.openscience.cdk.ringsearch.RingSearch;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.openscience.cdk.graph.GraphUtil.EdgeToBondMap;
 
 /**
@@ -290,7 +290,7 @@ final class SMARTSAtomInvariants {
 
             IAtom atom = container.getAtom(v);
 
-            int implHCount = checkNotNull(atom.getImplicitHydrogenCount(), "Implicit hydrogen count was not set.");
+            int implHCount = Objects.requireNonNull(atom.getImplicitHydrogenCount(), "Implicit hydrogen count was not set.");
 
             int totalHCount = implHCount;
             int valence = implHCount;

--- a/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
@@ -46,10 +46,10 @@ import java.util.BitSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * This class provides a easy to use wrapper around SMARTS matching functionality.  User code that wants to do
@@ -284,7 +284,7 @@ public class SMARTSQueryTool {
      * @see Cycles
      */
     public void setAromaticity(Aromaticity aromaticity) {
-        this.aromaticity = checkNotNull(aromaticity, "aromaticity was not provided");
+        this.aromaticity = Objects.requireNonNull(aromaticity, "aromaticity was not provided");
     }
 
     /**

--- a/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
@@ -19,7 +19,6 @@
 package org.openscience.cdk.smiles.smarts;
 
 import com.google.common.collect.FluentIterable;
-import com.google.common.primitives.Ints;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.aromaticity.ElectronDonation;
 import org.openscience.cdk.exception.CDKException;
@@ -49,6 +48,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 
 /**
@@ -383,6 +384,10 @@ public class SMARTSQueryTool {
         return mappings.size();
     }
 
+    private static List<Integer> toList(int[] values) {
+        return IntStream.of(values).boxed().collect(Collectors.toList());
+    }
+
     /**
      * Get the atoms in the target molecule that match the query pattern.  Since there may be multiple matches, the
      * return value is a List of List objects. Each List object contains the indices of the atoms in the target
@@ -393,7 +398,7 @@ public class SMARTSQueryTool {
     public List<List<Integer>> getMatchingAtoms() {
         List<List<Integer>> matched = new ArrayList<List<Integer>>(mappings.size());
         for (int[] mapping : mappings)
-            matched.add(Ints.asList(mapping));
+            matched.add(toList(mapping));
         return matched;
     }
 
@@ -411,7 +416,8 @@ public class SMARTSQueryTool {
             BitSet atomSet = new BitSet();
             for (int x : mapping)
                 atomSet.set(x);
-            if (atomSets.add(atomSet)) matched.add(Ints.asList(mapping));
+            if (atomSets.add(atomSet))
+                matched.add(toList(mapping));
         }
         return matched;
     }

--- a/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
@@ -18,7 +18,6 @@
  */
 package org.openscience.cdk.smiles.smarts;
 
-import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.aromaticity.ElectronDonation;
 import org.openscience.cdk.exception.CDKException;
@@ -50,6 +49,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
 
 
 /**
@@ -365,10 +365,10 @@ public class SMARTSQueryTool {
                 }
             }
         } else {
-            mappings = FluentIterable.from(VentoFoggia.findSubstructure(query)
-                                                      .matchAll(atomContainer)
-                                                      .filter(new SmartsStereoMatch(query, atomContainer)))
-                                     .toList();
+            mappings = StreamSupport.stream(VentoFoggia.findSubstructure(query)
+                                                       .matchAll(atomContainer)
+                                                       .filter(new SmartsStereoMatch(query, atomContainer)).spliterator(), false)
+                                    .collect(Collectors.toList());
         }
 
         return !mappings.isEmpty();

--- a/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SMARTSQueryTool.java
@@ -19,7 +19,6 @@
 package org.openscience.cdk.smiles.smarts;
 
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.aromaticity.ElectronDonation;
@@ -43,6 +42,7 @@ import org.openscience.cdk.tools.LoggingToolFactory;
 
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -406,7 +406,7 @@ public class SMARTSQueryTool {
      */
     public List<List<Integer>> getUniqueMatchingAtoms() {
         List<List<Integer>> matched = new ArrayList<List<Integer>>(mappings.size());
-        Set<BitSet> atomSets = Sets.newHashSetWithExpectedSize(mappings.size());
+        Set<BitSet> atomSets = new HashSet<>(2*mappings.size());
         for (int[] mapping : mappings) {
             BitSet atomSet = new BitSet();
             for (int x : mapping)

--- a/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SmartsAtomAtomMapFilter.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SmartsAtomAtomMapFilter.java
@@ -23,7 +23,6 @@
 
 package org.openscience.cdk.smiles.smarts;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.primitives.Ints;
@@ -39,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A filter for substructure matches implementing the logic for Atom-Atom Mapping matching. The following
@@ -142,7 +142,7 @@ final class SmartsAtomAtomMapFilter implements Predicate<int[]> {
      * @return whether the match should be accepted
      */
     @Override
-    public boolean apply(int[] perm) {
+    public boolean test(int[] perm) {
         for (MappedPairs mpair : mapped) {
 
             // possibly 'or' of query maps, need to use a set
@@ -177,6 +177,16 @@ final class SmartsAtomAtomMapFilter implements Predicate<int[]> {
 
         }
         return true;
+    }
+
+    /**
+     * Backwards compatible method from when we used GUAVA predicates.
+     * @param ints atom index bijection
+     * @return true/false
+     * @see #test(int[])
+     */
+    public boolean apply(int[] ints) {
+        return test(ints);
     }
 
     /**

--- a/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SmartsAtomAtomMapFilter.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SmartsAtomAtomMapFilter.java
@@ -23,8 +23,6 @@
 
 package org.openscience.cdk.smiles.smarts;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.ReactionRole;
 import org.openscience.cdk.interfaces.IAtom;
@@ -32,7 +30,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,8 +71,8 @@ final class SmartsAtomAtomMapFilter implements Predicate<int[]> {
 
     SmartsAtomAtomMapFilter(IAtomContainer query, IAtomContainer target) {
 
-        Multimap<Integer,Integer> reactInvMap = null;
-        Multimap<Integer,Integer> prodInvMap  = null;
+        Map<Integer,List<Integer>> reactInvMap = null;
+        Map<Integer,List<Integer>> prodInvMap  = null;
 
         this.target = target;
 
@@ -86,18 +84,18 @@ final class SmartsAtomAtomMapFilter implements Predicate<int[]> {
             if (mapidx == 0) continue;
             switch (role(atom)) {
                 case Reactant:
-                    if (reactInvMap == null) reactInvMap = ArrayListMultimap.create();
-                    reactInvMap.put(mapidx, idx);
+                    if (reactInvMap == null) reactInvMap = new HashMap<>();
+                    reactInvMap.computeIfAbsent(mapidx, k -> new ArrayList<>()).add(idx);
                     break;
                 case Product:
-                    if (prodInvMap == null) prodInvMap = ArrayListMultimap.create();
-                    prodInvMap.put(mapidx, idx);
+                    if (prodInvMap == null) prodInvMap = new HashMap<>();
+                    prodInvMap.computeIfAbsent(mapidx, k -> new ArrayList<>()).add(idx);
                     break;
             }
         }
 
         if (reactInvMap != null && prodInvMap != null) {
-            for (Map.Entry<Integer, Collection<Integer>> e : reactInvMap.asMap().entrySet()) {
+            for (Map.Entry<Integer, List<Integer>> e : reactInvMap.entrySet()) {
                 int[] reacMaps = e.getValue().stream().mapToInt(i->i).toArray();
                 int[] prodMaps = prodInvMap.get(e.getKey()).stream().mapToInt(i->i).toArray();
                 if (prodMaps.length == 0)

--- a/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SmartsAtomAtomMapFilter.java
+++ b/legacy/src/main/java/org/openscience/cdk/smiles/smarts/SmartsAtomAtomMapFilter.java
@@ -25,7 +25,6 @@ package org.openscience.cdk.smiles.smarts;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.primitives.Ints;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.ReactionRole;
 import org.openscience.cdk.interfaces.IAtom;
@@ -99,8 +98,8 @@ final class SmartsAtomAtomMapFilter implements Predicate<int[]> {
 
         if (reactInvMap != null && prodInvMap != null) {
             for (Map.Entry<Integer, Collection<Integer>> e : reactInvMap.asMap().entrySet()) {
-                int[] reacMaps = Ints.toArray(e.getValue());
-                int[] prodMaps = Ints.toArray(prodInvMap.get(e.getKey()));
+                int[] reacMaps = e.getValue().stream().mapToInt(i->i).toArray();
+                int[] prodMaps = prodInvMap.get(e.getKey()).stream().mapToInt(i->i).toArray();
                 if (prodMaps.length == 0)
                     continue; // unpaired
                 mapped.add(new MappedPairs(reacMaps, prodMaps));

--- a/legacy/src/test/java/org/openscience/cdk/smiles/smarts/parser/RecursiveTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smiles/smarts/parser/RecursiveTest.java
@@ -18,10 +18,11 @@
  */
 package org.openscience.cdk.smiles.smarts.parser;
 
+import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.stream.Collectors;
 
-import com.google.common.io.CharStreams;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -456,7 +457,8 @@ public class RecursiveTest extends CDKTestCase {
 
         int nmatch = 0;
         int nmol = 0;
-        for (String smi : CharStreams.readLines(new InputStreamReader(ins))) {
+        for (String smi : new BufferedReader(new InputStreamReader(ins)).lines()
+                                                                        .collect(Collectors.toList())) {
             IAtomContainer container = sp.parseSmiles(smi.split("\t")[0]);
             if (sqt.matches(container)) {
                 nmatch++;

--- a/pom.xml
+++ b/pom.xml
@@ -459,11 +459,6 @@
                 <version>1.3.4</version>
             </dependency>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>31.0-jre</version>
-            </dependency>
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,15 @@
         </dependencies>
     </dependencyManagement>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.7</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -771,7 +780,6 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.7</version>
                         <executions>
                             <execution>
                                 <id>start-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,6 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
     <!-- developer = commit access -->
     <developers>
         <developer>

--- a/storage/ctab/pom.xml
+++ b/storage/ctab/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -24,7 +24,6 @@
  */
 package org.openscience.cdk.io;
 
-import com.google.common.collect.ImmutableSet;
 import org.openscience.cdk.AtomRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
@@ -74,6 +73,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -137,17 +137,8 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
     /** Delimits Structure-Data (SD) Files. */
     private static final String      RECORD_DELIMITER = "$$$$";
 
-    /** 
-     *  @deprecated  Incorrect spelling
-    */
-    private static final Set<String> PSUEDO_LABELS    = ImmutableSet.<String> builder().add("*").add("A").add("Q")
-                                                              .add("L").add("LP").add("R") // XXX: not in spec
-                                                              .add("R#").build();
-
     /** Valid pseudo labels. */
-    private static final Set<String> PSEUDO_LABELS    = ImmutableSet.<String> builder().add("*").add("A").add("Q")
-                                                              .add("L").add("LP").add("R") // XXX: not in spec
-                                                              .add("R#").build();
+    private static final Set<String> PSEUDO_LABELS    = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("*","A","Q","L","LP","R","R#")));
     
     public MDLV2000Reader() {
         this(new StringReader(""));

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLValence.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLValence.java
@@ -32,11 +32,11 @@
 
 package org.openscience.cdk.io;
 
-import com.google.common.collect.Maps;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -63,7 +63,7 @@ final class MDLValence {
 
         int[] valences = new int[n];
 
-        Map<IAtom, Integer> atomToIndex = Maps.newHashMapWithExpectedSize(n);
+        Map<IAtom, Integer> atomToIndex = new HashMap<>(2*n);
         for (IAtom atom : container.atoms())
             atomToIndex.put(atom, atomToIndex.size());
 

--- a/storage/inchi/pom.xml
+++ b/storage/inchi/pom.xml
@@ -53,11 +53,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cdk-core</artifactId>
             <version>${project.parent.version}</version>

--- a/storage/inchi/src/test/java/org/openscience/cdk/smiles/AbsoluteSMILESTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/smiles/AbsoluteSMILESTest.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.smiles;
 
-import com.google.common.base.Joiner;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -139,7 +138,7 @@ public class AbsoluteSMILESTest {
         for (String input : inputs)
             output.add(sg.create(sp.parseSmiles(input)));
 
-        org.hamcrest.MatcherAssert.assertThat(Joiner.on(".").join(inputs) + " were not canonicalised, outputs were " + output,
+        org.hamcrest.MatcherAssert.assertThat(String.join(".", inputs) + " were not canonicalised, outputs were " + output,
                 output.size(), is(1));
 
     }

--- a/storage/io/pom.xml
+++ b/storage/io/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/storage/io/src/main/java/org/openscience/cdk/io/Mol2Reader.java
+++ b/storage/io/src/main/java/org/openscience/cdk/io/Mol2Reader.java
@@ -28,12 +28,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 
 import javax.vecmath.Point3d;
 
-import com.google.common.collect.ImmutableMap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.AtomTypeFactory;
 import org.openscience.cdk.config.Elements;
@@ -74,21 +75,29 @@ public class Mol2Reader extends DefaultChemObjectReader {
     private static ILoggingTool              logger              = LoggingToolFactory
                                                                          .createLoggingTool(Mol2Reader.class);
 
+    // helper function for immutable map of String -> String, JDK 9+ has Map.of()
+    private static Map<String,String> immutableMap(String ... strs) {
+        if ((strs.length & 0x1) != 0)
+            throw new IllegalArgumentException();
+        Map<String,String> map = new HashMap<>(2*strs.length);
+        for (int i=0; i<strs.length; i+=2)
+            map.put(strs[i],strs[i+1]);
+        return Collections.unmodifiableMap(map);
+    }
+
     /**
      * Dictionary of known atom type aliases. If the key is seen on input, it
      * is repleaced with the specified value. Bugs /openbabel/bug/214 and /cdk/bug/1346
      */
-    private static final Map<String, String> ATOM_TYPE_ALIASES   = ImmutableMap
-                                                                         .<String, String> builder()
-                                                                         // previously produced by Open Babel
-                                                                         .put("S.o2", "S.O2")
-                                                                         .put("S.o", "S.O")
-                                                                         // seen in MMFF94 validation suite
-                                                                         .put("CL", "Cl").put("CU", "Cu")
-                                                                         .put("FE", "Fe").put("BR", "Br")
-                                                                         .put("NA", "Na").put("SI", "Si")
-                                                                         .put("CA", "Ca").put("ZN", "Zn")
-                                                                         .put("LI", "Li").put("MG", "Mg").build();
+    private static final Map<String, String> ATOM_TYPE_ALIASES = immutableMap("S.o2", "S.O2", // previously produced by Open Babel
+                                                                              "S.o", "S.O",
+                                                                              // seen in MMFF94 validation suite
+                                                                              "CL", "Cl",
+                                                                              "CU", "Cu",
+                                                                              "FE", "Fe", "BR", "Br",
+                                                                              "NA", "Na", "SI", "Si",
+                                                                              "CA", "Ca", "ZN", "Zn",
+                                                                              "LI", "Li", "MG", "Mg");
 
     /**
      * Constructs a new MDLReader that can read Molecule from a given Reader.

--- a/storage/ioformats/pom.xml
+++ b/storage/ioformats/pom.xml
@@ -15,10 +15,6 @@
     <name>cdk-ioformats</name>
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/storage/ioformats/src/main/java/org/openscience/cdk/io/FormatFactory.java
+++ b/storage/ioformats/src/main/java/org/openscience/cdk/io/FormatFactory.java
@@ -19,20 +19,6 @@
  */
 package org.openscience.cdk.io;
 
-import java.io.BufferedReader;
-import java.io.CharArrayReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.TreeSet;
-
 import org.openscience.cdk.io.formats.IChemFormat;
 import org.openscience.cdk.io.formats.IChemFormatMatcher;
 import org.openscience.cdk.io.formats.IChemFormatMatcher.MatchResult;
@@ -40,7 +26,19 @@ import org.openscience.cdk.io.formats.XYZFormat;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
-import com.google.common.io.CharStreams;
+import java.io.BufferedReader;
+import java.io.CharArrayReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * A factory for recognizing chemical file formats. Formats
@@ -177,7 +175,7 @@ public class FormatFactory {
   
     private  IChemFormat getMatchResult( BufferedReader buffer) throws IOException{
     	 /* Search file for a line containing an identifying keyword */
-        List<String> lines = Collections.unmodifiableList(CharStreams.readLines(buffer));
+        List<String> lines = buffer.lines().collect(Collectors.toList());
         Set<MatchResult> results = new TreeSet<MatchResult>();
 
         for (IChemFormatMatcher format : formats) {

--- a/storage/ioformats/src/test/java/org/openscience/cdk/io/formats/ChemFormatMatcherTest.java
+++ b/storage/ioformats/src/test/java/org/openscience/cdk/io/formats/ChemFormatMatcherTest.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
-import com.google.common.io.CharStreams;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,7 +51,7 @@ abstract public class ChemFormatMatcherTest extends ChemFormatTest {
 
     protected boolean matches(String header) throws IOException {
         BufferedReader reader = new BufferedReader(new StringReader(header));
-        return matcher.matches(CharStreams.readLines(reader)).matched();
+        return matcher.matches(reader.lines().collect(Collectors.toList())).matched();
     }
 
     @Test

--- a/storage/smiles/pom.xml
+++ b/storage/smiles/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>uk.ac.ebi.beam</groupId>
             <artifactId>beam-core</artifactId>
         </dependency>

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.openscience.cdk.CDKConstants.ATOM_ATOM_MAPPING;
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.TOGETHER;
 import static org.openscience.cdk.interfaces.ITetrahedralChirality.Stereo.CLOCKWISE;
@@ -112,7 +111,7 @@ final class CDKToBeam {
 
     Edge toBeamEdge(IBond b, Map<IAtom, Integer> indices) throws CDKException {
 
-        checkArgument(b.getAtomCount() == 2, "Invalid number of atoms on bond");
+        if (b.getAtomCount() != 2) throw new IllegalArgumentException("Invalid number of atoms on bond");
 
         int u = indices.get(b.getBegin());
         int v = indices.get(b.getEnd());
@@ -253,7 +252,7 @@ final class CDKToBeam {
      */
     static Edge toBeamEdge(IBond b, int flavour, Map<IAtom, Integer> indices) throws CDKException {
 
-        checkArgument(b.getAtomCount() == 2, "Invalid number of atoms on bond");
+        if (b.getAtomCount() != 2) throw new IllegalArgumentException("Invalid number of atoms on bond");
 
         int u = indices.get(b.getBegin());
         int v = indices.get(b.getEnd());

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
@@ -50,11 +50,10 @@ import uk.ac.ebi.beam.Edge;
 import uk.ac.ebi.beam.GraphBuilder;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.openscience.cdk.CDKConstants.ATOM_ATOM_MAPPING;
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.TOGETHER;
 import static org.openscience.cdk.interfaces.ITetrahedralChirality.Stereo.CLOCKWISE;
@@ -209,7 +208,7 @@ final class CDKToBeam {
 
         final boolean aromatic = SmiFlavor.isSet(flavour, SmiFlavor.UseAromaticSymbols) && a.getFlag(CDKConstants.ISAROMATIC);
         final Integer charge = a.getFormalCharge();
-        final String symbol = checkNotNull(a.getSymbol(), "An atom had an undefined symbol");
+        final String symbol = Objects.requireNonNull(a.getSymbol(), "An atom had an undefined symbol");
 
         Element element = Element.ofSymbol(symbol);
         if (element == null) element = Element.Unknown;
@@ -221,7 +220,7 @@ final class CDKToBeam {
         if (element == Element.Unknown) {
             ab.hydrogens(hCount != null ? hCount : 0);
         } else {
-            ab.hydrogens(checkNotNull(hCount, "One or more atoms had an undefined number of implicit hydrogens"));
+            ab.hydrogens(Objects.requireNonNull(hCount, "One or more atoms had an undefined number of implicit hydrogens"));
         }
 
         if (charge != null) ab.charge(charge);

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CDKToBeam.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.smiles;
 
-import com.google.common.collect.Maps;
 
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Isotopes;
@@ -50,6 +49,7 @@ import uk.ac.ebi.beam.Edge;
 import uk.ac.ebi.beam.GraphBuilder;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -132,7 +132,7 @@ final class CDKToBeam {
         int order = ac.getAtomCount();
 
         GraphBuilder gb = GraphBuilder.create(order);
-        Map<IAtom, Integer> indices = Maps.newHashMapWithExpectedSize(order);
+        Map<IAtom, Integer> indices = new HashMap<>(2*order);
 
         for (IAtom a : ac.atoms()) {
             indices.put(a, indices.size());

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -24,7 +24,6 @@
 package org.openscience.cdk.smiles;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.InvalidSmilesException;
@@ -316,7 +315,7 @@ public final class SmilesParser {
                 // set the correct title
                 mol.setTitle(title.substring(pos));
 
-                final Map<IAtom, IAtomContainer> atomToMol = Maps.newHashMapWithExpectedSize(mol.getAtomCount());
+                final Map<IAtom, IAtomContainer> atomToMol = new HashMap<>(2*mol.getAtomCount());
                 final List<IAtom> atoms = new ArrayList<>(mol.getAtomCount());
 
                 for (IAtom atom : mol.atoms()) {

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -23,8 +23,6 @@
  */
 package org.openscience.cdk.smiles;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.ConnectivityChecker;
@@ -570,7 +568,7 @@ public final class SmilesParser {
             }
         }
 
-        Multimap<IAtomContainer, Sgroup> sgroupMap = HashMultimap.create();
+        Map<IAtomContainer, List<Sgroup>> sgroupMap = new HashMap<>();
         Map<CxSmilesState.CxSgroup, Sgroup> sgroupRemap = new HashMap<>();
 
         // positional-variation
@@ -587,7 +585,8 @@ public final class SmilesParser {
                 sgroup.addBond(bonds.get(0));
                 for (Integer endpt : e.getValue())
                     sgroup.addAtom(atoms.get(endpt));
-                sgroupMap.put(mol, sgroup);
+                sgroupMap.computeIfAbsent(mol, k -> new ArrayList<>())
+                         .add(sgroup);
             }
         }
 
@@ -610,7 +609,8 @@ public final class SmilesParser {
                         throw new InvalidSmilesException("CXSMILES LO: defined ordering to non-existant bond");
                     sgroup.addBond(bond);
                 }
-                sgroupMap.put(mol, sgroup);
+                sgroupMap.computeIfAbsent(mol, k -> new ArrayList<>())
+                         .add(sgroup);
             }
         }
 
@@ -705,7 +705,8 @@ public final class SmilesParser {
                         break;
                 }
 
-                sgroupMap.put(mol, sgroup);
+                sgroupMap.computeIfAbsent(mol, k -> new ArrayList<>())
+                         .add(sgroup);
                 // CxState Sgroup => CDK Sgroup lookup
                 sgroupRemap.put(psgroup, sgroup);
             }
@@ -748,9 +749,11 @@ public final class SmilesParser {
                     cdkSgroup.putValue(SgroupKey.Data, dsgroup.value);
                     sgroupRemap.put(dsgroup, cdkSgroup);
                     if (mol != null)
-                        sgroupMap.put(mol, cdkSgroup);
+                        sgroupMap.computeIfAbsent(mol, k -> new ArrayList<>())
+                                 .add(cdkSgroup);
                     else if (chemObj instanceof IAtomContainer)
-                        sgroupMap.put((IAtomContainer) chemObj, cdkSgroup);
+                        sgroupMap.computeIfAbsent((IAtomContainer) chemObj, k -> new ArrayList<>())
+                                 .add(cdkSgroup);
                 }
             }
         }
@@ -806,7 +809,7 @@ public final class SmilesParser {
         }
 
         // assign Sgroups
-        for (Map.Entry<IAtomContainer, Collection<Sgroup>> e : sgroupMap.asMap().entrySet())
+        for (Map.Entry<IAtomContainer, List<Sgroup>> e : sgroupMap.entrySet())
             e.getKey().setProperty(CDKConstants.CTAB_SGROUPS, new ArrayList<>(e.getValue()));
     }
 

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/BeamToCDKTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/BeamToCDKTest.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.smiles;
 
-import com.google.common.collect.FluentIterable;
 import org.junit.Test;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
@@ -45,6 +44,9 @@ import uk.ac.ebi.beam.Functions;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -271,7 +273,7 @@ public class BeamToCDKTest {
     public void _2R_butan_2_ol() throws Exception {
         IAtomContainer ac = convert("CC[C@@](C)(O)[H]");
 
-        IStereoElement se = FluentIterable.from(ac.stereoElements()).first().get();
+        IStereoElement se = getFirstStereoElement(ac);
 
         assertThat(se, is(instanceOf(ITetrahedralChirality.class)));
 
@@ -283,6 +285,12 @@ public class BeamToCDKTest {
         assertThat(tc.getStereo(), is(ITetrahedralChirality.Stereo.CLOCKWISE));
     }
 
+    private IStereoElement getFirstStereoElement(IAtomContainer ac) {
+        for (IStereoElement se : ac.stereoElements())
+            return se;
+        return null;
+    }
+
     /**
      * (2S)-butan-2-ol
      *
@@ -292,7 +300,7 @@ public class BeamToCDKTest {
     public void _2S_butan_2_ol() throws Exception {
         IAtomContainer ac = convert("CC[C@](C)(O)[H]");
 
-        IStereoElement se = FluentIterable.from(ac.stereoElements()).first().get();
+        IStereoElement se = getFirstStereoElement(ac);
 
         assertThat(se, is(instanceOf(ITetrahedralChirality.class)));
 
@@ -312,14 +320,14 @@ public class BeamToCDKTest {
     public void tetrahedralRingClosure() throws Exception {
         IAtomContainer ac = convert("O[C@]12CCCC[C@@]1(O)CCCC2");
 
-        IStereoElement[] ses = FluentIterable.from(ac.stereoElements()).toArray(IStereoElement.class);
+        List<IStereoElement> ses = StreamSupport.stream(ac.stereoElements().spliterator(), false).collect(Collectors.toList());
 
-        assertThat(ses.length, is(2));
-        assertThat(ses[0], is(instanceOf(ITetrahedralChirality.class)));
-        assertThat(ses[1], is(instanceOf(ITetrahedralChirality.class)));
+        assertThat(ses.size(), is(2));
+        assertThat(ses.get(0), is(instanceOf(ITetrahedralChirality.class)));
+        assertThat(ses.get(1), is(instanceOf(ITetrahedralChirality.class)));
 
-        ITetrahedralChirality tc1 = (ITetrahedralChirality) ses[0];
-        ITetrahedralChirality tc2 = (ITetrahedralChirality) ses[1];
+        ITetrahedralChirality tc1 = (ITetrahedralChirality) ses.get(0);
+        ITetrahedralChirality tc2 = (ITetrahedralChirality) ses.get(1);
 
         // we want the second atom stereo as tc1
         if (ac.indexOf(tc1.getChiralAtom()) > ac.indexOf(tc2.getChiralAtom())) {
@@ -353,7 +361,7 @@ public class BeamToCDKTest {
 
         IAtomContainer ac = convert("F/C=C/F");
 
-        IStereoElement se = FluentIterable.from(ac.stereoElements()).first().get();
+        IStereoElement se = getFirstStereoElement(ac);
 
         assertThat(se, is(instanceOf(IDoubleBondStereochemistry.class)));
 
@@ -374,7 +382,7 @@ public class BeamToCDKTest {
 
         IAtomContainer ac = convert("F/C=C\\F");
 
-        IStereoElement se = FluentIterable.from(ac.stereoElements()).first().get();
+        IStereoElement se = getFirstStereoElement(ac);
 
         assertThat(se, is(instanceOf(IDoubleBondStereochemistry.class)));
 
@@ -395,7 +403,7 @@ public class BeamToCDKTest {
 
         IAtomContainer ac = convert("F/C([H])=C(\\[H])F");
 
-        IStereoElement se = FluentIterable.from(ac.stereoElements()).first().get();
+        IStereoElement se = getFirstStereoElement(ac);
 
         assertThat(se, is(instanceOf(IDoubleBondStereochemistry.class)));
 
@@ -417,7 +425,7 @@ public class BeamToCDKTest {
 
         IAtomContainer ac = convert("FC(\\[H])=C([H])/F");
 
-        IStereoElement se = FluentIterable.from(ac.stereoElements()).first().get();
+        IStereoElement se = getFirstStereoElement(ac);
 
         assertThat(se, is(instanceOf(IDoubleBondStereochemistry.class)));
 

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.FluentIterable;
-import com.google.common.primitives.Ints;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Ignore;
@@ -2226,7 +2225,7 @@ public class SmilesParserTest extends CDKTestCase {
 
             @Override
             public int compare(IStereoElement o1, IStereoElement o2) {
-                return Ints.compare(mol.indexOf(((ITetrahedralChirality) o1).getChiralAtom()),
+                return Integer.compare(mol.indexOf(((ITetrahedralChirality) o1).getChiralAtom()),
                         mol.indexOf(((ITetrahedralChirality) o2).getChiralAtom()));
             }
         });

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.FluentIterable;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Ignore;
@@ -2218,8 +2217,8 @@ public class SmilesParserTest extends CDKTestCase {
     public void testNeighboringChirality() throws Exception {
         SmilesParser sp = new SmilesParser(DefaultChemObjectBuilder.getInstance());
         final IAtomContainer mol = sp.parseSmiles("C[C@H](O)[C@H](O)C");
-        List<IStereoElement> stereoElements = new ArrayList<IStereoElement>(FluentIterable.from(mol.stereoElements())
-                .toList());
+        List<IStereoElement<?,?>> stereoElements = new ArrayList<>();
+        mol.stereoElements().forEach(stereoElements::add);
 
         Collections.sort(stereoElements, new Comparator<IStereoElement>() {
 

--- a/tool/forcefield/pom.xml
+++ b/tool/forcefield/pom.xml
@@ -30,10 +30,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cdk-core</artifactId>
             <version>${project.parent.version}</version>

--- a/tool/forcefield/src/main/java/org/openscience/cdk/forcefield/mmff/MmffAromaticTypeMapping.java
+++ b/tool/forcefield/src/main/java/org/openscience/cdk/forcefield/mmff/MmffAromaticTypeMapping.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.forcefield.mmff;
 
-import com.google.common.collect.ImmutableMap;
 import org.openscience.cdk.exception.Intractable;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -32,6 +31,8 @@ import org.openscience.cdk.interfaces.IBond;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -427,36 +428,72 @@ final class MmffAromaticTypeMapping {
         }
     }
 
+    // helper function for immutable map of String -> String, JDK 9+ has Map.of()
+    private static Map<String,String> immutableMap(String ... strs) {
+        if ((strs.length & 0x1) != 0)
+            throw new IllegalArgumentException();
+        Map<String,String> map = new HashMap<>(2*strs.length);
+        for (int i=0; i<strs.length; i+=2)
+            map.put(strs[i],strs[i+1]);
+        return Collections.unmodifiableMap(map);
+    }
+
     /**
      * Mapping of preliminary atom MMFF symbolic types to aromatic types for atoms that contribute a
      * lone pair.
      */
-    private final Map<String, String> hetroTypes = ImmutableMap.<String, String>builder().put("S", STHI)
-                                                               .put("-O-", OFUR).put("OC=C", OFUR).put("OC=N", OFUR)
-                                                               .put(NCN_PLUS, NIM_PLUS).put(NGD_PLUS, NIM_PLUS)
-                                                               .put("NM", N5M).put("NC=C", NPYL).put("NC=N", NPYL).put("NN=N", NPYL)
-                                                               .put("NC=O", NPYL).put("NC=S", NPYL).put("NSO2", NPYL)
-                                                               .put("NR", NPYL).build();
+    private final Map<String, String> hetroTypes = immutableMap("S", STHI,
+                                                                "-O-", OFUR,
+                                                                "OC=C", OFUR,
+                                                                "OC=N", OFUR,
+                                                                NCN_PLUS, NIM_PLUS,
+                                                                NGD_PLUS, NIM_PLUS,
+                                                                "NM", N5M,
+                                                                "NC=C", NPYL,
+                                                                "NC=N", NPYL,
+                                                                "NN=N", NPYL,
+                                                                "NC=O", NPYL,
+                                                                "NC=S", NPYL,
+                                                                "NSO2", NPYL,
+                                                                "NR", NPYL);
     /**
      * Mapping of preliminary atom MMFF symbolic types to aromatic types for atoms that contribute
      * one electron and are alpha to an atom that contributes a lone pair.
      */
-    private final Map<String, String> alphaTypes = ImmutableMap.<String, String> builder().put("CNN+", CIM_PLUS)
-                                                         .put("CGD+", CIM_PLUS).put("C=C", C5A).put("C=N", C5A)
-                                                         .put("CGD", C5A).put("CB", C5A).put(C5B, C5).put("N2OX", N5AX)
-                                                         .put(NCN_PLUS, NIM_PLUS).put(NGD_PLUS, NIM_PLUS)
-                                                         .put("N+=C", N5A_PLUS).put("N+=N", N5A_PLUS)
-                                                         .put("NPD+", N5A_PLUS).put("N=C", N5A).put("N=N", N5A).build();
+    private final Map<String, String> alphaTypes = immutableMap("CNN+", CIM_PLUS,
+                                                                "CGD+", CIM_PLUS,
+                                                                "C=C", C5A,
+                                                                "C=N", C5A,
+                                                                "CGD", C5A,
+                                                                "CB", C5A,
+                                                                C5B, C5,
+                                                                "N2OX", N5AX,
+                                                                NCN_PLUS, NIM_PLUS,
+                                                                NGD_PLUS, NIM_PLUS,
+                                                                "N+=C", N5A_PLUS,
+                                                                "N+=N", N5A_PLUS,
+                                                                "NPD+", N5A_PLUS,
+                                                                "N=C", N5A,
+                                                                "N=N", N5A);
     /**
      * Mapping of preliminary atom MMFF symbolic types to aromatic types for atoms that contribute
      * one electron and are beta to an atom that contributes a lone pair.
      */
-    private final Map<String, String> betaTypes  = ImmutableMap.<String, String> builder().put("CNN+", CIM_PLUS)
-                                                         .put("CGD+", CIM_PLUS).put("C=C", C5B).put("C=N", C5B)
-                                                         .put("CGD", C5B).put("CB", C5B).put(C5A, C5).put("N2OX", N5BX)
-                                                         .put(NCN_PLUS, NIM_PLUS).put(NGD_PLUS, NIM_PLUS)
-                                                         .put("N+=C", N5B_PLUS).put("N+=N", N5B_PLUS)
-                                                         .put("NPD+", N5B_PLUS).put("N=C", N5B).put("N=N", N5B).build();
+    private final Map<String, String> betaTypes  = immutableMap("CNN+", CIM_PLUS,
+                                                                "CGD+", CIM_PLUS,
+                                                                "C=C", C5B,
+                                                                "C=N", C5B,
+                                                                "CGD", C5B,
+                                                                "CB", C5B,
+                                                                C5A, C5,
+                                                                "N2OX", N5BX,
+                                                                NCN_PLUS, NIM_PLUS,
+                                                                NGD_PLUS, NIM_PLUS,
+                                                                "N+=C", N5B_PLUS,
+                                                                "N+=N", N5B_PLUS,
+                                                                "NPD+", N5B_PLUS,
+                                                                "N=C", N5B,
+                                                                "N=N", N5B);
 
     @SuppressWarnings("PMD.ShortVariable")
     // C5 is intended

--- a/tool/forcefield/src/main/java/org/openscience/cdk/forcefield/mmff/MmffParamSet.java
+++ b/tool/forcefield/src/main/java/org/openscience/cdk/forcefield/mmff/MmffParamSet.java
@@ -23,13 +23,12 @@
 
 package org.openscience.cdk.forcefield.mmff;
 
-import com.google.common.base.Charsets;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -186,7 +185,7 @@ enum MmffParamSet {
     }
 
     private static void parseMMFFCHARGE(InputStream in, Map<BondKey, BigDecimal> map) throws IOException {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, Charsets.UTF_8))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
                 if (line.isEmpty() || line.charAt(0) == '*')
@@ -205,7 +204,7 @@ enum MmffParamSet {
     }
 
     private static void parseMMFFPBCI(InputStream in, MmffProp[] props) throws IOException {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, Charsets.UTF_8))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
                 if (line.isEmpty() || line.charAt(0) == '*')
@@ -221,7 +220,7 @@ enum MmffParamSet {
     }
 
     private static void parseMMFFPPROP(InputStream in, MmffProp[] props) throws IOException {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, Charsets.UTF_8))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
                 if (line.isEmpty() || line.charAt(0) == '*')
@@ -243,7 +242,7 @@ enum MmffParamSet {
     }
 
     private static void parseMMFFTypeMap(InputStream in, Map<String, Integer> types) throws IOException {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, Charsets.UTF_8))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
             String line = br.readLine(); // header
             while ((line = br.readLine()) != null) {
                 if (line.isEmpty() || line.charAt(0) == '*')
@@ -257,7 +256,7 @@ enum MmffParamSet {
     }
 
     private static void parseMMFFFORMCHG(InputStream in, Map<String, BigDecimal> fcharges) throws IOException {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, Charsets.UTF_8))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
             String line = br.readLine(); // header
             while ((line = br.readLine()) != null) {
                 if (line.isEmpty() || line.charAt(0) == '*')

--- a/tool/pcore/pom.xml
+++ b/tool/pcore/pom.xml
@@ -23,10 +23,6 @@
             <artifactId>xom</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
+++ b/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
@@ -18,25 +18,9 @@
  */
 package org.openscience.cdk.pharmacophore;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
-import javax.vecmath.Point3d;
-
-import com.google.common.collect.HashBiMap;
 import org.openscience.cdk.AtomRef;
-import org.openscience.cdk.CDKConstants;
-import org.openscience.cdk.aromaticity.Aromaticity;
-import org.openscience.cdk.aromaticity.ElectronDonation;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.GeometryUtil;
-import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -47,6 +31,16 @@ import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
 import org.openscience.cdk.smarts.SmartsPattern;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
+
+import javax.vecmath.Point3d;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Identifies atoms whose 3D arrangement matches a specified pharmacophore query.
@@ -280,7 +274,10 @@ public class PharmacophoreMatcher {
         // query -> target so need to inverse the mapping
         // XXX: re-subsearching the query
         for (Map<IBond,IBond> map : mappings.toBondMap()) {
-            bondMap.add(new HashMap<>(HashBiMap.create(map).inverse()));
+            HashMap<IBond, IBond> inv = new HashMap<>();
+            for (Map.Entry<IBond, IBond> e : map.entrySet())
+                inv.put(e.getValue(), e.getKey());
+            bondMap.add(inv);
         }
         
         return bondMap;

--- a/tool/sdg/pom.xml
+++ b/tool/sdg/pom.xml
@@ -24,10 +24,6 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/AtomPlacer.java
@@ -23,7 +23,6 @@
  */
 package org.openscience.cdk.layout;
 
-import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
@@ -47,6 +46,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  *  Methods for generating coordinates for atoms in various situations. They can
@@ -203,7 +204,8 @@ public class AtomPlacer {
                     startAngle = d1;
                 }
                 sweep /= (1 + unplacedNeighbours.getAtomCount());
-                populatePolygonCorners(FluentIterable.from(unplacedNeighbours.atoms()).toList(),
+                populatePolygonCorners(StreamSupport.stream(unplacedNeighbours.atoms().spliterator(), false)
+                                                    .collect(Collectors.toList()),
                                        atom.getPoint2d(), startAngle, sweep, bondLength);
 
                 markPlaced(unplacedNeighbours);
@@ -970,7 +972,7 @@ public class AtomPlacer {
     static boolean isColinear(IAtom atom, Iterable<IBond> bonds) {
 
         if (Elements.isMetal(atom)) {
-            return FluentIterable.from(bonds).size() == 2;
+            return StreamSupport.stream(bonds.spliterator(), false).count() == 2L;
         }
 
         int numSgl = atom.getImplicitHydrogenCount() == null ? 0 : atom.getImplicitHydrogenCount();

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
@@ -25,7 +25,6 @@
 package org.openscience.cdk.layout;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -37,6 +36,7 @@ import org.openscience.cdk.stereo.ExtendedCisTrans;
 
 import javax.vecmath.Point2d;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -103,7 +103,7 @@ final class CorrectGeometricConfiguration {
         this.container = container;
         this.graph = graph;
         this.visited = new boolean[graph.length];
-        this.atomToIndex = Maps.newHashMapWithExpectedSize(container.getAtomCount());
+        this.atomToIndex = new HashMap<>(2*container.getAtomCount());
         this.ringSearch = new RingSearch(container, graph);
 
         for (int i = 0; i < container.getAtomCount(); i++) {

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/CorrectGeometricConfiguration.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.layout;
 
-import com.google.common.collect.Iterables;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -78,7 +77,8 @@ final class CorrectGeometricConfiguration {
      * @throws IllegalArgumentException an atom had unset coordinates
      */
     public static IAtomContainer correct(IAtomContainer container) {
-        if (!Iterables.isEmpty(container.stereoElements())) new CorrectGeometricConfiguration(container);
+        if (container.stereoElements().iterator().hasNext())
+            new CorrectGeometricConfiguration(container);
         return container;
     }
 

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.layout;
 
-import com.google.common.primitives.Ints;
 import org.openscience.cdk.BondRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.geometry.GeometryUtil;
@@ -177,7 +176,7 @@ final class NonplanarBonds {
 
             @Override
             public int compare(Integer i, Integer j) {
-                return -Ints.compare(nAdjacentCentres(i), nAdjacentCentres(j));
+                return -Integer.compare(nAdjacentCentres(i), nAdjacentCentres(j));
             }
         });
 

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/NonplanarBonds.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.layout;
 
-import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
 import org.openscience.cdk.BondRef;
 import org.openscience.cdk.CDKConstants;
@@ -132,7 +131,7 @@ final class NonplanarBonds {
         this.tetrahedralElements = new ITetrahedralChirality[container.getAtomCount()];
         this.doubleBondElements = new IDoubleBondStereochemistry[container.getAtomCount()];
         this.graph = g;
-        this.atomToIndex = Maps.newHashMapWithExpectedSize(container.getAtomCount());
+        this.atomToIndex = new HashMap<>(2*container.getAtomCount());
         this.edgeToBond = edgeToBond;
         this.ringSearch = new RingSearch(container, graph);
 

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -23,7 +23,6 @@
  */
 package org.openscience.cdk.layout;
 
-import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
@@ -75,6 +74,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import static java.util.Comparator.comparingInt;
 
@@ -1564,7 +1564,9 @@ public class StructureDiagramGenerator {
      * @return list of fragments
      */
     private List<IAtomContainer> toList(IAtomContainerSet frags) {
-        return new ArrayList<>(FluentIterable.from(frags.atomContainers()).toList());
+        List<IAtomContainer> res = new ArrayList<>(frags.getAtomContainerCount());
+        frags.atomContainers().forEach(res::add);
+        return res;
     }
 
     /**

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/TemplateHandler.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/TemplateHandler.java
@@ -26,7 +26,6 @@
  */
 package org.openscience.cdk.layout;
 
-import com.google.common.collect.FluentIterable;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.GeometryUtil;
@@ -293,8 +292,8 @@ public final class TemplateHandler {
 
                 // only add if the atoms/bonds of this match don't overlap existing
                 if (!overlaps) {
-                    matchedChemObjs.addAll(FluentIterable.from(matched.atoms()).toList());
-                    matchedChemObjs.addAll(FluentIterable.from(matched.bonds()).toList());
+                    matched.atoms().forEach(matchedChemObjs::add);
+                    matched.bonds().forEach(matchedChemObjs::add);
                     matchedSubstructures.addAtomContainer(matched);
                 }
             }

--- a/tool/smarts/pom.xml
+++ b/tool/smarts/pom.xml
@@ -14,10 +14,6 @@
     <name>cdk-smarts</name>
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingPredicatesTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingPredicatesTest.java
@@ -61,10 +61,10 @@ public class MappingPredicatesTest {
         Iterable<int[]> mappings = VentoFoggia.findSubstructure(query).matchAll(target);
 
         // using unique atoms we may think we only found 1 mapping
-        assertThat(Iterables.size(Iterables.filter(mappings, new UniqueAtomMatches())), is(1));
+        assertThat(Iterables.size(Iterables.filter(mappings, new UniqueAtomMatches()::test)), is(1));
 
         // when in fact we found 4 different mappings
-        assertThat(Iterables.size(Iterables.filter(mappings, new UniqueBondMatches(GraphUtil.toAdjList(query)))), is(3));
+        assertThat(Iterables.size(Iterables.filter(mappings, new UniqueBondMatches(GraphUtil.toAdjList(query))::test)), is(3));
     }
 
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingPredicatesTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingPredicatesTest.java
@@ -24,7 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.collect.Iterables;
 import org.junit.Test;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -58,13 +57,13 @@ public class MappingPredicatesTest {
         IAtomContainer query = smi("C1CCC1");
         IAtomContainer target = smi("C12C3C1C23");
 
-        Iterable<int[]> mappings = VentoFoggia.findSubstructure(query).matchAll(target);
+        Mappings mappings = VentoFoggia.findSubstructure(query).matchAll(target);
 
         // using unique atoms we may think we only found 1 mapping
-        assertThat(Iterables.size(Iterables.filter(mappings, new UniqueAtomMatches()::test)), is(1));
+        assertThat(mappings.stream().filter(new UniqueAtomMatches()).count(), is(1L));
 
-        // when in fact we found 4 different mappings
-        assertThat(Iterables.size(Iterables.filter(mappings, new UniqueBondMatches(GraphUtil.toAdjList(query))::test)), is(3));
+        // when in fact we found 3 different mappings
+        assertThat(mappings.stream().filter(new UniqueBondMatches(GraphUtil.toAdjList(query))).count(), is(3L));
     }
 
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingsTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingsTest.java
@@ -24,8 +24,6 @@
 
 package org.openscience.cdk.isomorphism;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.openscience.cdk.interfaces.*;
@@ -34,6 +32,8 @@ import org.openscience.cdk.smiles.SmilesParser;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -70,10 +70,10 @@ public class MappingsTest {
         Mappings ms = new Mappings(mock(IAtomContainer.class), mock(IAtomContainer.class), iterable);
 
         Predicate<int[]> f = mock(Predicate.class);
-        when(f.apply(p1)).thenReturn(false);
-        when(f.apply(p2)).thenReturn(true);
-        when(f.apply(p3)).thenReturn(false);
-        when(f.apply(p4)).thenReturn(true);
+        when(f.test(p1)).thenReturn(false);
+        when(f.test(p2)).thenReturn(true);
+        when(f.test(p3)).thenReturn(false);
+        when(f.test(p4)).thenReturn(true);
 
         assertThat(ms.filter(f).toArray(), is(new int[][]{p2, p4}));
     }

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingsTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingsTest.java
@@ -32,6 +32,7 @@ import org.openscience.cdk.smiles.SmilesParser;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -42,6 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -293,7 +295,8 @@ public class MappingsTest {
         Iterator<int[]> iterator = mock(Iterator.class);
         when(iterable.iterator()).thenReturn(iterator);
         when(iterator.hasNext()).thenReturn(true, true, true, true, true, false);
-        when(iterator.next()).thenReturn(new int[0]);
+        doCallRealMethod().when(iterator)
+                          .forEachRemaining(ArgumentMatchers.any(Consumer.class));
 
         Mappings ms = new Mappings(mock(IAtomContainer.class), mock(IAtomContainer.class), iterable);
         assertThat(ms.count(), is(5));
@@ -306,6 +309,8 @@ public class MappingsTest {
         Iterator<int[]> iterator = mock(Iterator.class);
         when(iterable.iterator()).thenReturn(iterator);
         when(iterator.hasNext()).thenReturn(true, true, true, true, false);
+        doCallRealMethod().when(iterator)
+                .forEachRemaining(ArgumentMatchers.any(Consumer.class));
 
         int[] p1 = {0, 1, 2};
         int[] p2 = {0, 2, 1};


### PR DESCRIPTION
The majority of the Guava functionality used in CDK was integrated in some from into JDK 1.7/1.8. We can use the plain old JDK methods and remove any dependence on Guava.  The Stream API is not quite as succinct and ImmutableMap would need JDK 9+ for Map.of() but the more verbose form is OK since it's not used much.

Unfortunately Guava is still pulled in via CMLXOM but we'll worry about that later :-).