### PR TITLE
Jna jni optional support

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -262,6 +262,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-jniinchi-support</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-group</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/storage/inchi/pom.xml
+++ b/storage/inchi/pom.xml
@@ -23,6 +23,12 @@
             <artifactId>vecmath</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.openscience.cdk</groupId>
+            <artifactId>cdk-jniinchi-support</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.github.dan2097</groupId>
             <artifactId>jna-inchi-api</artifactId>
             <version>${jna-inchi.version}</version>

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIGenerator.java
@@ -165,7 +165,7 @@ public class InChIGenerator {
     private static InchiOptions convertJniToJnaOpts(List<INCHI_OPTION> jniOpts) {
         InchiOptions.InchiOptionsBuilder builder = new InchiOptions.InchiOptionsBuilder();
         for (INCHI_OPTION jniOpt : jniOpts) {
-            InchiFlag flag = INCHI_OPTION.wrap(jniOpt);
+            InchiFlag flag = JniInchiSupport.toJnaOption(jniOpt);
             if (flag != null)
                 builder.withFlag(flag);
         }
@@ -507,7 +507,7 @@ public class InChIGenerator {
      * has failed.
      */
     public INCHI_RET getReturnStatus() {
-        return INCHI_RET.wrap(output.getStatus());
+        return JniInchiSupport.toJniStatus(output.getStatus());
     }
 
     /**

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
@@ -26,7 +26,6 @@ import io.github.dan2097.jnainchi.InchiInput;
 import io.github.dan2097.jnainchi.InchiStereo;
 import io.github.dan2097.jnainchi.InchiStereoParity;
 import io.github.dan2097.jnainchi.InchiStereoType;
-import net.sf.jniinchi.INCHI_OPTION;
 import net.sf.jniinchi.INCHI_RET;
 import io.github.dan2097.jnainchi.InchiInputFromInchiOutput;
 import io.github.dan2097.jnainchi.InchiOptions;
@@ -427,7 +426,7 @@ public class InChIToStructure {
      * has failed.
      */
     public INCHI_RET getReturnStatus() {
-        return INCHI_RET.wrap(output.getStatus());
+        return JniInchiSupport.toJniStatus(output.getStatus());
     }
 
     /**

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/JniInchiSupport.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/JniInchiSupport.java
@@ -1,5 +1,4 @@
-/*
- * Copyright (C) 2021  John Mayfield
+/* Copyright (C) 2006-2007  Sam Adams <sea36@users.sf.net>
  *
  * Contact: cdk-devel@lists.sourceforge.net
  *
@@ -18,58 +17,32 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package net.sf.jniinchi;
+package org.openscience.cdk.inchi;
 
 import io.github.dan2097.jnainchi.InchiFlag;
+import io.github.dan2097.jnainchi.InchiStatus;
+import net.sf.jniinchi.INCHI_OPTION;
+import net.sf.jniinchi.INCHI_RET;
 
 /**
- * This class provides backwards compatibility of JNA-INCHI with JNI-INCHI, this enum was exposed in the CDK API.
- * @author John Mayfield
+ * This class provides conversion from JNI InChI enum options to JNA (input) and
+ * from JNA return status to JNI status (output).
  */
-public enum INCHI_OPTION {
-    SUCF,
-    ChiralFlagON,
-    ChiralFlagOFF,
-    SNon,
-    SAbs,
-    SRel,
-    SRac,
-    SUU,
-    NEWPS,
-    RecMet,
-    FixedH,
-    AuxNone,
-    NoADP,
-    Compress,
-    DoNotAddH,
-    Wnumber,
-    OutputSDF,
-    WarnOnEmptyStructure,
-    FixSp3Bug,
-    FB,
-    SPXYZ,
-    SAsXYZ;
+final class JniInchiSupport {
 
-    public static INCHI_OPTION wrap(InchiFlag flag) {
-        switch (flag) {
-            case SUCF: return SUCF;
-            case ChiralFlagON: return ChiralFlagON;
-            case ChiralFlagOFF: return ChiralFlagOFF;
-            case SNon: return SNon;
-            case SRel: return SRel;
-            case SRac: return SRac;
-            case SUU: return SUU;
-            case RecMet: return RecMet;
-            case FixedH: return FixedH;
-            case AuxNone: return AuxNone;
-            case DoNotAddH: return DoNotAddH;
-            case WarnOnEmptyStructure: return WarnOnEmptyStructure;
+    private JniInchiSupport() {}
 
-            default: throw new IllegalArgumentException(flag + " not supported?");
+    static INCHI_RET toJniStatus(InchiStatus status) {
+        switch (status) {
+            case SUCCESS: return INCHI_RET.OKAY;
+            case WARNING: return INCHI_RET.WARNING;
+            case ERROR:   return INCHI_RET.ERROR;
+            default:
+                throw new IllegalArgumentException("Unexpected status!");
         }
     }
 
-    public static InchiFlag wrap(INCHI_OPTION flag) {
+    static InchiFlag toJnaOption(INCHI_OPTION flag) {
         switch (flag) {
             case SUCF: return InchiFlag.SUCF;
             case ChiralFlagON: return InchiFlag.ChiralFlagON;

--- a/storage/jniinchi-support/pom.xml
+++ b/storage/jniinchi-support/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>cdk-storage</artifactId>
+        <groupId>org.openscience.cdk</groupId>
+        <version>2.7-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cdk-jniinchi-support</artifactId>
+    <description>This module provides backwards compatibility support for the JNI based InChI APIs</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/storage/jniinchi-support/src/main/java/net/sf/jniinchi/INCHI_OPTION.java
+++ b/storage/jniinchi-support/src/main/java/net/sf/jniinchi/INCHI_OPTION.java
@@ -20,29 +20,32 @@
 
 package net.sf.jniinchi;
 
-import io.github.dan2097.jnainchi.InchiStatus;
-
 /**
- * This class provides backwards compatibility of JNA-INCHI with JNI-INCHI, this enum was exposed in the CDK API.
+ * This class provides backwards compatibility of JNA-INCHI with JNI-INCHI,
+ * this enum was exposed in the CDK API.
  * @author John Mayfield
  */
-public enum INCHI_RET {
-    SKIP,
-    EOF,
-    OKAY,
-    WARNING,
-    ERROR,
-    FATAL,
-    UNKNOWN,
-    BUSY;
-
-    public static INCHI_RET wrap(InchiStatus status) {
-        switch (status) {
-            case SUCCESS: return INCHI_RET.OKAY;
-            case WARNING: return INCHI_RET.WARNING;
-            case ERROR:   return INCHI_RET.ERROR;
-            default:
-                throw new IllegalArgumentException("Unexpected status!");
-        }
-    }
+public enum INCHI_OPTION {
+    SUCF,
+    ChiralFlagON,
+    ChiralFlagOFF,
+    SNon,
+    SAbs,
+    SRel,
+    SRac,
+    SUU,
+    NEWPS,
+    RecMet,
+    FixedH,
+    AuxNone,
+    NoADP,
+    Compress,
+    DoNotAddH,
+    Wnumber,
+    OutputSDF,
+    WarnOnEmptyStructure,
+    FixSp3Bug,
+    FB,
+    SPXYZ,
+    SAsXYZ;
 }

--- a/storage/jniinchi-support/src/main/java/net/sf/jniinchi/INCHI_RET.java
+++ b/storage/jniinchi-support/src/main/java/net/sf/jniinchi/INCHI_RET.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021  John Mayfield
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package net.sf.jniinchi;
+
+/**
+ * This class provides backwards compatibility of JNA-INCHI with JNI-INCHI,
+ * this enum was exposed in the CDK API.
+ * @author John Mayfield
+ */
+public enum INCHI_RET {
+    SKIP,
+    EOF,
+    OKAY,
+    WARNING,
+    ERROR,
+    FATAL,
+    UNKNOWN,
+    BUSY;
+}

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -20,6 +20,7 @@
         <module>pdb</module>
         <module>pdbcml</module>
         <module>inchi</module>
+        <module>jniinchi-support</module>
         <module>smiles</module>
     </modules>
     <packaging>pom</packaging>


### PR DESCRIPTION
Move the duplicated JNI enums to a separate (optional) module - see #779 