### PR TITLE
Overflow logic was not quite correct. Restrict based on number of dig…

### DIFF
--- a/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator.java
@@ -644,7 +644,9 @@ public class MolecularFormulaManipulator {
             return pos == str.length() ? '\0' : str.charAt(pos++);
         }
 
+        // maximum of 6 digits
         int nextUInt() {
+            int mark = pos;
             char c = next();
             if (!isDigit(c)) {
                 if (c != '\0')
@@ -654,10 +656,9 @@ public class MolecularFormulaManipulator {
             int res = c - '0';
             while (isDigit(c = next())) {
                 res = (10 * res) + (c - '0');
-                if (res <= 0) {
-                    throw new NumberFormatException("Integer too large, overflowed");
-                }
             }
+            if (pos - mark > 7)
+                throw new NumberFormatException("Value too large, 7 digits max!");
             if (c != '\0')
                 pos--;
             return res;

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -1353,8 +1353,7 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
     @Test(expected = NumberFormatException.class)
     public void tooLargeNumberOfAtoms() {
         IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
-        assertThat(getAtomCount(getMolecularFormula("C10000000", builder)),
-                is(2147483647));
+        getAtomCount(getMolecularFormula("C10000000", builder)); // should throw
     }
 
     @Test

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -1346,14 +1346,14 @@ public class MolecularFormulaManipulatorTest extends CDKTestCase {
     @Test
     public void largeNumberOfAtoms() {
         IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
-        assertThat(getAtomCount(getMolecularFormula("C2147483647", builder)),
-                is(2147483647));
+        assertThat(getAtomCount(getMolecularFormula("C9999999", builder)),
+                is(9999999));
     }
 
     @Test(expected = NumberFormatException.class)
     public void tooLargeNumberOfAtoms() {
         IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
-        assertThat(getAtomCount(getMolecularFormula("C2147483648", builder)),
+        assertThat(getAtomCount(getMolecularFormula("C10000000", builder)),
                 is(2147483647));
     }
 


### PR DESCRIPTION
…its, in base 10, 7 digits is enough for 9.9 million atoms which is more than enough for any molecule.