### PR TITLE
CXSMILES optimisation - don't create and swap a new Pseudo atom if th…

### DIFF
--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -497,7 +497,18 @@ public final class SmilesParser {
                     continue;
 
                 IAtom old = atoms.get(e.getKey());
-                IPseudoAtom pseudo = bldr.newInstance(IPseudoAtom.class);
+                IPseudoAtom pseudo;
+                if (old instanceof IPseudoAtom) {
+                    pseudo = (IPseudoAtom) old;
+                } else {
+                    // possibly a warning, is "CCO |$R$|" valid?
+                    pseudo = bldr.newInstance(IPseudoAtom.class);
+                    IAtomContainer mol = atomToMol.get(old);
+                    AtomContainerManipulator.replaceAtomByAtom(mol, old, pseudo);
+                    atomToMol.put(pseudo, mol);
+                    atoms.set(e.getKey(), mol.getAtom(old.getIndex()));
+                }
+
                 String val = e.getValue();
 
                 // specialised label handling
@@ -509,10 +520,6 @@ public final class SmilesParser {
                 pseudo.setLabel(val);
                 pseudo.setAtomicNumber(0);
                 pseudo.setImplicitHydrogenCount(0);
-                IAtomContainer mol = atomToMol.get(old);
-                AtomContainerManipulator.replaceAtomByAtom(mol, old, pseudo);
-                atomToMol.put(pseudo, mol);
-                atoms.set(e.getKey(), mol.getAtom(old.getIndex()));
             }
         }
 


### PR DESCRIPTION
…e atom to set the label on is already a pseudo atom.

#813 fixes the but in #812 but actually there is an optimisation we can do which would have avoided the issue. The bug was still a bug so need that fix.