### PR TITLE
Less code smell/More efficient connectivity splitting

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
@@ -40,9 +40,6 @@ import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtom;
 import org.openscience.cdk.isomorphism.matchers.IQueryBond;
 import org.openscience.cdk.sgroup.Sgroup;
-import org.openscience.cdk.stereo.DoubleBondStereochemistry;
-import org.openscience.cdk.stereo.ExtendedTetrahedral;
-import org.openscience.cdk.stereo.TetrahedralChirality;
 import org.openscience.cdk.tools.manipulator.SgroupManipulator;
 
 import java.util.ArrayList;
@@ -284,7 +281,7 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
     @Override
     public void setStereoElements(List<IStereoElement> elements) {
         this.stereo.clear();
-        for (IStereoElement se : elements) {
+        for (IStereoElement<?,?> se : elements) {
             addStereoElement(se);
         }
         notifyChanged();
@@ -886,9 +883,9 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
 
         // Determine which stereo elements are new (unvisited)
         List<IStereoElement<?,?>> newStereo = new ArrayList<>();
-        for (IStereoElement<?,?> stereo : that.stereoElements()) {
-            if (!stereo.getFocus().getFlag(CDKConstants.VISITED))
-                newStereo.add(stereo);
+        for (IStereoElement<?,?> se : that.stereoElements()) {
+            if (!se.getFocus().getFlag(CDKConstants.VISITED))
+                newStereo.add(se);
         }
 
         // append atoms/bonds not visited

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer2.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer2.java
@@ -22,6 +22,8 @@
  */
 package org.openscience.cdk.silent;
 
+import org.openscience.cdk.AtomRef;
+import org.openscience.cdk.BondRef;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.NoSuchAtomException;
 import org.openscience.cdk.exception.NoSuchBondException;
@@ -39,13 +41,8 @@ import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.interfaces.ISingleElectron;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtom;
-import org.openscience.cdk.AtomRef;
-import org.openscience.cdk.BondRef;
 import org.openscience.cdk.isomorphism.matchers.IQueryBond;
 import org.openscience.cdk.sgroup.Sgroup;
-import org.openscience.cdk.stereo.DoubleBondStereochemistry;
-import org.openscience.cdk.stereo.ExtendedTetrahedral;
-import org.openscience.cdk.stereo.TetrahedralChirality;
 import org.openscience.cdk.tools.manipulator.SgroupManipulator;
 
 import java.util.ArrayList;
@@ -286,7 +283,7 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
     @Override
     public void setStereoElements(List<IStereoElement> elements) {
         this.stereo.clear();
-        for (IStereoElement se : elements) {
+        for (IStereoElement<?,?> se : elements) {
             addStereoElement(se);
         }
     }
@@ -874,9 +871,9 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
 
         // Determine which stereo elements are new (unvisited)
         List<IStereoElement<?,?>> newStereo = new ArrayList<>();
-        for (IStereoElement<?,?> stereo : that.stereoElements()) {
-            if (!stereo.getFocus().getFlag(CDKConstants.VISITED))
-                newStereo.add(stereo);
+        for (IStereoElement<?,?> se : that.stereoElements()) {
+            if (!se.getFocus().getFlag(CDKConstants.VISITED))
+                newStereo.add(se);
         }
 
         // append atoms/bonds not visited

--- a/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
@@ -19,23 +19,23 @@
  */
 package org.openscience.cdk.graph;
 
-import java.util.*;
-
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObject;
-import org.openscience.cdk.interfaces.IChemObjectBuilder;
-import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.ILonePair;
 import org.openscience.cdk.interfaces.ISingleElectron;
 import org.openscience.cdk.interfaces.IStereoElement;
-import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
-import org.openscience.cdk.stereo.ExtendedTetrahedral;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Tool class for checking whether the (sub)structure in an
@@ -91,7 +91,7 @@ public class ConnectivityChecker {
     private static IAtomContainer getComponent(Map<IAtom, IAtomContainer> cmap,
                                                IChemObject cobj) {
         if (cobj instanceof IAtom)
-            return cmap.get((IAtom) cobj);
+            return cmap.get(cobj);
         else if (cobj instanceof IBond) {
             IAtomContainer begMol = cmap.get(((IBond) cobj).getBegin());
             IAtomContainer endMol = cmap.get(((IBond) cobj).getEnd());


### PR DESCRIPTION
- Minor things flagged by SonarCloud, will probably still complain about the duplication.
- Optimised the common case of a single component, we can avoid the copy. The SDG needed a minor update in that we can't delete the ionic bonds until we are finished.