### PR TITLE
Fix a stuble corner case. When we split a molecule we now update the …

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
+++ b/base/standard/src/main/java/org/openscience/cdk/graph/ConnectivityChecker.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.interfaces.ILonePair;
 import org.openscience.cdk.interfaces.ISingleElectron;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.sgroup.Sgroup;
+import org.openscience.cdk.tools.manipulator.SgroupManipulator;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -222,7 +223,8 @@ public class ConnectivityChecker {
 
         // split Sgroups, only keep if all atoms/bond in the sgroup
         // are consistent and in the same container
-        List<Sgroup> sgroups = container.getProperty(CDKConstants.CTAB_SGROUPS);
+        List<Sgroup> sgroups = SgroupManipulator.copy(container.getProperty(CDKConstants.CTAB_SGROUPS),
+                                                       new HashMap<>());
         if (sgroups != null) {
             Map<Sgroup,IAtomContainer> sgroupMap = new HashMap<>();
             for (Sgroup sgroup : sgroups) {

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/ConnectivityCheckerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/ConnectivityCheckerTest.java
@@ -292,7 +292,20 @@ public class ConnectivityCheckerTest extends CDKTestCase {
             Assert.assertEquals(0, sgroups1.get(0).getParents().size());
             Assert.assertEquals(1, sgroups2.size());
             Assert.assertEquals(0, sgroups2.get(0).getParents().size());
+            List<Sgroup> orgSgroups = mol.getProperty(CDKConstants.CTAB_SGROUPS);
+            assertThat(orgSgroups.size(), is(3));
+            assertNonEmptySgrpParent(orgSgroups);
         }
+    }
+
+    // check at least one of the sgroups has a non-empty parent
+    private void assertNonEmptySgrpParent(List<Sgroup> orgSgroups) {
+        boolean found = false;
+        for (Sgroup orgSgroup : orgSgroups) {
+            if (!orgSgroup.getParents().isEmpty())
+                found = true;
+        }
+        assertTrue(found);
     }
 
 }

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardSgroupGenerator.java
@@ -286,7 +286,7 @@ final class StandardSgroupGenerator {
         Deque<Sgroup> deque = new ArrayDeque<>(map.getOrDefault(key, Collections.emptyList()));
         while (!deque.isEmpty()) {
             Sgroup sgroup = deque.poll();
-            deque.addAll(map.get(sgroup));
+            deque.addAll(map.getOrDefault(sgroup, Collections.emptyList()));
             ++count;
         }
         return count;
@@ -319,13 +319,7 @@ final class StandardSgroupGenerator {
 
         // generate child brackets first
         sgroups = new ArrayList<>(sgroups);
-        sgroups.sort(new Comparator<Sgroup>() {
-            @Override
-            public int compare(Sgroup o1, Sgroup o2) {
-                return Integer.compare(getTotalChildCount(children, o1),
-                        getTotalChildCount(children, o2));
-            }
-        });
+        sgroups.sort(Comparator.comparingInt(o -> getTotalChildCount(children, o)));
 
         for (Sgroup sgroup : sgroups) {
 


### PR DESCRIPTION
…Sgroups accordingly. If an sgroups spans multiple components (e.g. a mixture bracket) we now delete it since it is redundant or inconsistent (the other option would be to add it to all parts it occurs in). To make things work nicely we should leave the original Sgroups intact.