### PR TITLE
Update Apahe Jena to 4.5.0

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <artifactId>cdk</artifactId>
         <groupId>org.openscience.cdk</groupId>
@@ -11,9 +11,9 @@
     </parent>
 
     <artifactId>cdk-bundle</artifactId>
-    
+
     <name>cdk-bundle</name>
-    
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -242,11 +242,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>cdk-iordf</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-libiomd</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
@@ -315,17 +310,17 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.2</version>
                 <configuration>
-                <finalName>cdk-${project.parent.version}</finalName>
-                <filters>
-                    <filter>
-                        <artifact>*:*</artifact>
-                        <excludes>
-                            <exclude>META-INF/*.SF</exclude>
-                            <exclude>META-INF/*.DSA</exclude>
-                            <exclude>META-INF/*.RSA</exclude>
-                        </excludes>
-                    </filter>
-                </filters>
+                    <finalName>cdk-${project.parent.version}</finalName>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>
@@ -335,7 +330,22 @@
                         </goals>
                     </execution>
                 </executions>
-      </plugin>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>jdk11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>cdk-iordf</artifactId>
+                    <version>${project.parent.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/storage/iordf/pom.xml
+++ b/storage/iordf/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>2.7.4</version>
+            <version>4.5.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>

--- a/storage/iordf/src/main/java/org/openscience/cdk/io/rdf/CDKOWLReader.java
+++ b/storage/iordf/src/main/java/org/openscience/cdk/io/rdf/CDKOWLReader.java
@@ -27,6 +27,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemObject;
@@ -35,8 +37,6 @@ import org.openscience.cdk.io.formats.CDKOWLFormat;
 import org.openscience.cdk.io.formats.IResourceFormat;
 import org.openscience.cdk.libio.jena.Convertor;
 
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
 
 /**
  * Reads content from a CDK OWL serialization.

--- a/storage/iordf/src/main/java/org/openscience/cdk/io/rdf/CDKOWLWriter.java
+++ b/storage/iordf/src/main/java/org/openscience/cdk/io/rdf/CDKOWLWriter.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
+import org.apache.jena.rdf.model.Model;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemObject;
@@ -30,8 +31,6 @@ import org.openscience.cdk.io.DefaultChemObjectWriter;
 import org.openscience.cdk.io.formats.CDKOWLFormat;
 import org.openscience.cdk.io.formats.IResourceFormat;
 import org.openscience.cdk.libio.jena.Convertor;
-
-import com.hp.hpl.jena.rdf.model.Model;
 
 /**
  * Serializes the data model into CDK OWL.

--- a/storage/iordf/src/main/java/org/openscience/cdk/libio/jena/CDK.java
+++ b/storage/iordf/src/main/java/org/openscience/cdk/libio/jena/CDK.java
@@ -22,14 +22,13 @@
  */
 package org.openscience.cdk.libio.jena;
 
-import com.hp.hpl.jena.rdf.model.Property;
-import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
-import com.hp.hpl.jena.vocabulary.RDF;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
 
 /**
  * Helper class to provide a Java API to the CDK OWL ontology, following the design of similar namespace
- * classes in the Jena library, like {@link RDF}.
+ * classes in the Jena library, like {@link org.apache.jena.vocabulary.RDF}.
  *
  * @cdk.module iordf
  * @cdk.githash

--- a/storage/iordf/src/main/java/org/openscience/cdk/libio/jena/Convertor.java
+++ b/storage/iordf/src/main/java/org/openscience/cdk/libio/jena/Convertor.java
@@ -26,6 +26,13 @@ package org.openscience.cdk.libio.jena;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.ResIterator;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.RDF;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -39,14 +46,6 @@ import org.openscience.cdk.interfaces.IElectronContainer;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.interfaces.IIsotope;
 import org.openscience.cdk.interfaces.IPseudoAtom;
-
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.ResIterator;
-import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.rdf.model.Statement;
-import com.hp.hpl.jena.rdf.model.StmtIterator;
-import com.hp.hpl.jena.vocabulary.RDF;
 
 /**
  * Helper class that converts a CDK {@link IChemObject} into RDF using a

--- a/storage/iordf/src/test/java/org/openscience/cdk/libio/jena/ConvertorTest.java
+++ b/storage/iordf/src/test/java/org/openscience/cdk/libio/jena/ConvertorTest.java
@@ -22,6 +22,7 @@
  */
 package org.openscience.cdk.libio.jena;
 
+import org.apache.jena.rdf.model.Model;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.test.CDKTestCase;
@@ -37,8 +38,6 @@ import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.diff.AtomContainerDiff;
-
-import com.hp.hpl.jena.rdf.model.Model;
 
 /**
  * @cdk.module test-iordf

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -14,7 +14,6 @@
         <module>ctab</module>
         <module>io</module>
         <module>ioformats</module>
-        <module>iordf</module>
         <module>libiocml</module>
         <module>libiomd</module>
         <module>pdb</module>
@@ -25,5 +24,15 @@
     </modules>
     <packaging>pom</packaging>
     <artifactId>cdk-storage</artifactId>
-
+    <profiles>
+        <profile>
+            <id>jdk11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <modules>
+                <module>iordf</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Jena v4.5.0 is Java 11 so we do some maven profiles to exclude this from Java 8 builds. Not sure what to do on releases