### PR TITLE
Fix a v. subtle issue in up/down bond handling in SMILES. It's quite …

### DIFF
--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
@@ -434,8 +434,8 @@ final class BeamToCDK {
             if (b == Bond.UP || b == Bond.DOWN) {
                 if (first == null)
                     first = e;
-                else if (((first.either() == e.either()) == (first.bond() == b)))
-                    return null;
+                else if (first.bond(u) == e.bond(u))
+                    return null; // inconsistent e.g. C/C=C(/C)/C
             }
         }
         return first;

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -2690,6 +2690,17 @@ public class SmilesParserTest extends CDKTestCase {
         }
     }
 
+
+    @Test public void testCisTransBondsOnRings() throws InvalidSmilesException {
+        IAtomContainer mol = load("N\\2.C/C2=C\\C(=O)O");
+        int count = 0;
+        for (IStereoElement<?,?> se : mol.stereoElements()) {
+            if (se.getConfigClass() == IStereoElement.CisTrans)
+                count++;
+        }
+        Assert.assertEquals(1, count);
+    }
+
     /**
      * Counts aromatic atoms in a molecule.
      * @param mol molecule for which to count aromatic atoms.


### PR DESCRIPTION
…a corner case but it turns out some toolkits do write records like this (found one in ChEMBL). Only happens if the bond is written on the ring open (unusual but ok) and then multiple directional bonds are written. BEAM does more in recent releases to check/ignore innconsitent behaviour allready but we can add the correct check in the BEAM2CDK conversion.