### PR TITLE
CMLXOM 4.3

### DIFF
--- a/descriptor/qsarcml/pom.xml
+++ b/descriptor/qsarcml/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>4.0</version>
+            <version>4.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>

--- a/storage/libiocml/pom.xml
+++ b/storage/libiocml/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>4.0</version>
+            <version>4.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>

--- a/storage/libiomd/pom.xml
+++ b/storage/libiomd/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>4.0</version>
+            <version>4.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>

--- a/storage/pdbcml/pom.xml
+++ b/storage/pdbcml/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.blueobelisk</groupId>
             <artifactId>cmlxom</artifactId>
-            <version>4.0</version>
+            <version>4.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Mostly dependency updates, but should also no longer force Xerces 2.8 (outdated, with security issues) onto CDK users.