### PR TITLE
Catch more specific Exception in LoggingTool

### DIFF
--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/LoggingTool.java
@@ -177,7 +177,7 @@ public class LoggingTool implements ILoggingTool {
                 if (System.getProperty("cdk.debug.stdout", "false").equals("true")) {
                     toSTDOUT = true;
                 }
-            } catch (Exception e) {
+            } catch (SecurityException e) {
                 System.err.println("Could not read the System property used to determine "
                         + "if logging should be turned on. So continuing without logging.");
             }


### PR DESCRIPTION
Catching the more specific `SecurityException` instead of the general `Exception` to avoid just swallowing all exceptions that might occur.

Discussed with @egonw in #873, more specifically at the end of this [comment](https://github.com/cdk/cdk/issues/873#issuecomment-1221667954).