### PR TITLE
methods to manipulate atom types in ReactionManipulator

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -1507,10 +1507,12 @@ public class AtomContainerManipulator {
      * matcher finds a matching atom type, the <code>IAtom</code> will be configured
      * to have the same properties as the <code>IAtomType</code>. If no matching atom
      * type is found, no configuration is performed.
+     * <br>
      * <b>This method overwrites existing values.</b>
      *
-     * @param container
+     * @param container the container whose atom types are to be perceived
      * @throws CDKException
+     * @see AtomTypeManipulator#configure(IAtom, IAtomType)
      */
     public static void percieveAtomTypesAndConfigureAtoms(IAtomContainer container) throws CDKException {
         CDKAtomTypeMatcher matcher = CDKAtomTypeMatcher.getInstance(container.getBuilder());
@@ -1526,10 +1528,12 @@ public class AtomContainerManipulator {
      * matcher finds a matching atom type, the <code>IAtom</code> will be configured
      * to have the same properties as the <code>IAtomType</code>. If no matching atom
      * type is found, no configuration is performed.
-     * <b>This method overwrites existing values.</b>
+     * <br>
+     * <b>This method only sets <code>null</code> values.</b>
      *
-     * @param container
+     * @param container the container whose atom types are to be perceived
      * @throws CDKException
+     * @see AtomTypeManipulator#configureUnsetProperties(IAtom, IAtomType)
      */
     public static void percieveAtomTypesAndConfigureUnsetProperties(IAtomContainer container) throws CDKException {
         CDKAtomTypeMatcher matcher = CDKAtomTypeMatcher.getInstance(container.getBuilder());
@@ -1541,15 +1545,15 @@ public class AtomContainerManipulator {
 
     /**
      * This method will reset all atom configuration to UNSET.
-     *
+     * <br>
      * This method is the reverse of {@link #percieveAtomTypesAndConfigureAtoms(org.openscience.cdk.interfaces.IAtomContainer)}
      * and after a call to this method all atoms will be "unconfigured".
-     *
+     * <br>
      * Note that it is not a complete reversal of {@link #percieveAtomTypesAndConfigureAtoms(org.openscience.cdk.interfaces.IAtomContainer)}
      * since the atomic symbol of the atoms remains unchanged. Also, all the flags that were set
      * by the configuration method (such as IS_HYDROGENBOND_ACCEPTOR or ISAROMATIC) will be set to False.
      *
-     * @param container The molecule, whose atoms are to be unconfigured
+     * @param container The molecule whose atoms are to be unconfigured
      * @see #percieveAtomTypesAndConfigureAtoms(org.openscience.cdk.interfaces.IAtomContainer)
      */
     public static void clearAtomConfigurations(IAtomContainer container) {

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
@@ -24,20 +24,9 @@ package org.openscience.cdk.tools.manipulator;
 
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.ReactionRole;
-import org.openscience.cdk.interfaces.IAtom;
-import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.interfaces.IAtomContainerSet;
-import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.interfaces.IChemObject;
-import org.openscience.cdk.interfaces.IChemObjectBuilder;
-import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
-import org.openscience.cdk.interfaces.IElectronContainer;
-import org.openscience.cdk.interfaces.ILonePair;
-import org.openscience.cdk.interfaces.IMapping;
-import org.openscience.cdk.interfaces.IReaction;
-import org.openscience.cdk.interfaces.ISingleElectron;
-import org.openscience.cdk.interfaces.IStereoElement;
-import org.openscience.cdk.interfaces.ITetrahedralChirality;
+import org.openscience.cdk.atomtype.CDKAtomTypeMatcher;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.*;
 import org.openscience.cdk.stereo.ExtendedTetrahedral;
 
 import java.util.ArrayList;
@@ -54,6 +43,7 @@ import java.util.Set;
  * @cdk.githash
  *
  * @see ChemModelManipulator
+ * @author uli-f
  */
 public class ReactionManipulator {
 
@@ -539,4 +529,64 @@ public class ReactionManipulator {
         }
         return mapped;
     }
+
+    /**
+     * Convenience method to perceive atom types for all {@link IAtom IAtoms} of all components of the provided {@link IReaction}.
+     * This method uses the {@link CDKAtomTypeMatcher}. If the
+     * matcher finds a matching atom type, the <code>IAtom</code> will be configured
+     * to have the same properties as the <code>IAtomType</code>. If no matching atom
+     * type is found, no configuration is performed.
+     * <br>
+     * <b>This method overwrites existing values.</b>
+     *
+     * @param reaction the reaction whose atom types are to be perceived
+     * @throws CDKException
+     * @see AtomTypeManipulator#configure(IAtom, IAtomType)
+     */
+    public static void perceiveAtomTypesAndConfigureAtoms(IReaction reaction) throws CDKException {
+        for (IAtomContainer atomContainer: getAllMolecules(reaction).atomContainers()) {
+            AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(atomContainer);
+        }
+    }
+
+    /**
+     * Convenience method to perceive atom types for all {@link IAtom IAtoms} of all components of the provided {@link IReaction}.
+     * This method uses the {@link CDKAtomTypeMatcher}. If the
+     * matcher finds a matching atom type, the <code>IAtom</code> will be configured
+     * to have the same properties as the <code>IAtomType</code>. If no matching atom
+     * type is found, no configuration is performed.
+     * <br>
+     * <b>This method only sets <code>null</code> values.</b>
+     *
+     * @param reaction the reaction whose atom types are to be perceived
+     * @throws CDKException
+     * @see AtomTypeManipulator#configureUnsetProperties(IAtom, IAtomType)
+     */
+    public static void perceiveAtomTypesAndConfigureUnsetProperties(IReaction reaction) throws CDKException {
+        for (IAtomContainer atomContainer: getAllMolecules(reaction).atomContainers()) {
+            AtomContainerManipulator.percieveAtomTypesAndConfigureUnsetProperties(atomContainer);
+        }
+    }
+
+    /**
+     * This method will reset all atom properties related to atom configuration to the value {@link CDKConstants#UNSET}.
+     * <br>
+     * This method reverses most of the effects of
+     * {@link #perceiveAtomTypesAndConfigureAtoms(org.openscience.cdk.interfaces.IReaction)}
+     * and after a call to this method all atoms will be "unconfigured".
+     * <br>
+     * Note that this method is not a complete reversal of {@link #perceiveAtomTypesAndConfigureAtoms(org.openscience.cdk.interfaces.IReaction)}
+     * since the atomic symbol of the atoms remain unchanged. Also, all flags that were set
+     * by the configuration method (such as {@link CDKConstants#IS_HYDROGENBOND_ACCEPTOR} or
+     * {@link CDKConstants#ISAROMATIC}) will be set to False.
+     *
+     * @param reaction the reaction whose atoms confiuration properties are to be cleared
+     * @see #perceiveAtomTypesAndConfigureAtoms(org.openscience.cdk.interfaces.IReaction)
+     */
+    public static void clearAtomConfigurations(IReaction reaction) {
+        for (IAtomContainer atomContainer: ReactionManipulator.getAllMolecules(reaction).atomContainers()) {
+            AtomContainerManipulator.clearAtomConfigurations(atomContainer);
+        }
+    }
+
 }

--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
@@ -544,6 +544,10 @@ public class ReactionManipulator {
      * @see AtomTypeManipulator#configure(IAtom, IAtomType)
      */
     public static void perceiveAtomTypesAndConfigureAtoms(IReaction reaction) throws CDKException {
+        if (reaction == null) {
+            return;
+        }
+
         for (IAtomContainer atomContainer: getAllMolecules(reaction).atomContainers()) {
             AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(atomContainer);
         }
@@ -563,6 +567,10 @@ public class ReactionManipulator {
      * @see AtomTypeManipulator#configureUnsetProperties(IAtom, IAtomType)
      */
     public static void perceiveAtomTypesAndConfigureUnsetProperties(IReaction reaction) throws CDKException {
+        if (reaction == null) {
+            return;
+        }
+
         for (IAtomContainer atomContainer: getAllMolecules(reaction).atomContainers()) {
             AtomContainerManipulator.percieveAtomTypesAndConfigureUnsetProperties(atomContainer);
         }
@@ -584,6 +592,10 @@ public class ReactionManipulator {
      * @see #perceiveAtomTypesAndConfigureAtoms(org.openscience.cdk.interfaces.IReaction)
      */
     public static void clearAtomConfigurations(IReaction reaction) {
+        if (reaction == null) {
+            return;
+        }
+
         for (IAtomContainer atomContainer: ReactionManipulator.getAllMolecules(reaction).atomContainers()) {
             AtomContainerManipulator.clearAtomConfigurations(atomContainer);
         }


### PR DESCRIPTION
- added methods to perceive and unset the atom type configurations in ReactionManipulator
- fixed a javadoc errors wrt content in AtomContainerManipulator#percieveAtomTypesAndConfigureUnsetProperties