### PR TITLE
Improved CML XSD loading using an entity resolver. Also use try-with-…

### DIFF
--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -75,7 +75,7 @@ public class DepictionTest {
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer ac = sp.parseSmiles("[nH]1cccc1");
         String svg = dg.depict(ac).toSvgStr();
-        String nl = System.getProperty("line.separator");
+        String nl = "\n";
         String[] lines = svg.split(nl,3);
         assertEquals("<?xml version='1.0' encoding='UTF-8'?>", lines[0]);
         assertEquals("<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">", lines[1]);

--- a/misc/test-extra/src/test/java/org/openscience/cdk/config/XMLIsotopeFactoryTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/config/XMLIsotopeFactoryTest.java
@@ -19,30 +19,24 @@
  */
 package org.openscience.cdk.config;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
-import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.Element;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.interfaces.IIsotope;
-import org.openscience.cdk.tools.LoggingToolFactory;
+import org.openscience.cdk.test.CDKTestCase;
 import org.w3c.dom.Document;
 import org.xml.sax.ErrorHandler;
-import org.xml.sax.SAXException;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXParseException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
 
 /**
  * Checks the functionality of the IsotopeFactory
@@ -52,25 +46,9 @@ import org.xml.sax.SAXParseException;
 public class XMLIsotopeFactoryTest extends CDKTestCase {
 
     final boolean standAlone = false;
-
     final static AtomTypeFactory atf = AtomTypeFactory.getInstance(new ChemObject().getBuilder());
-
-    private static final String JAXP_SCHEMA_LANGUAGE = "http://java.sun.com/xml/jaxp/properties/schemaLanguage";
-
-    private static final String W3C_XML_SCHEMA = "http://www.w3.org/2001/XMLSchema";
-
-    static File tmpCMLSchema;
-
-    static {
-        try {
-            InputStream in = XMLIsotopeFactory.class.getClassLoader().getResourceAsStream(
-                    "org/openscience/cdk/io/cml/data/cml25b1.xsd");
-            tmpCMLSchema = copyFileToTmp("cml2.5.b1", ".xsd", in, null, null);
-        } catch (IOException e) {
-            LoggingToolFactory.createLoggingTool(XMLIsotopeFactoryTest.class)
-                              .warn("Unexpected Error:", e);
-        }
-    }
+    private static final String CML_XSD_FILENAME = "cml25b1.xsd";
+    private static final String CML_XSD_ABSOLUTE_PATH = "/org/openscience/cdk/io/cml/data" + "/" + CML_XSD_FILENAME;
 
     @Test
     public void testGetInstance_IChemObjectBuilder() throws Exception {
@@ -209,79 +187,47 @@ public class XMLIsotopeFactoryTest extends CDKTestCase {
 
     @Test
     public void testXMLValidityHybrid() throws Exception {
-        assertValidCML("org/openscience/cdk/config/data/isotopes.xml", "Isotopes");
+        assertValidCML("/org/openscience/cdk/config/data/isotopes.xml", "Isotopes");
     }
 
     private void assertValidCML(String atomTypeList, String shortcut) throws Exception {
-        InputStream ins = this.getClass().getClassLoader().getResourceAsStream(atomTypeList);
-        File tmpInput = copyFileToTmp(shortcut, ".cmlinput", ins, "../../io/cml/data/cml25b1.xsd", "file://"
-                                                                                                   + tmpCMLSchema.getAbsolutePath());
-        Assert.assertNotNull("Could not find the atom type list CML source", ins);
+        try (InputStream inputStreamAtomTypeList = this.getClass().getResourceAsStream(atomTypeList);
+             InputStream inputStreamCmlSchema = this.getClass().getResourceAsStream(CML_XSD_ABSOLUTE_PATH)) {
 
-        InputStream cmlSchema = new FileInputStream(tmpCMLSchema);
-        Assert.assertNotNull("Could not find the CML schema", cmlSchema);
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setNamespaceAware(true);
-        factory.setValidating(true);
-        factory.setAttribute(JAXP_SCHEMA_LANGUAGE, W3C_XML_SCHEMA);
-        factory.setAttribute(JAXP_SCHEMA_LANGUAGE, cmlSchema);
-        factory.setFeature("http://apache.org/xml/features/validation/schema", true);
+            Assert.assertNotNull("Could not find the atom type list CML source", inputStreamAtomTypeList);
+            Assert.assertNotNull("Could not find the CML schema", inputStreamCmlSchema);
 
-        DocumentBuilder parser = factory.newDocumentBuilder();
-        parser.setErrorHandler(new SAXValidityErrorHandler(shortcut));
-        parser.parse(new FileInputStream(tmpInput));
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setValidating(true);
+            factory.setFeature("http://apache.org/xml/features/validation/schema", true);
+
+            DocumentBuilder parser = factory.newDocumentBuilder();
+            parser.setErrorHandler(new SAXValidityErrorHandler(shortcut));
+            parser.setEntityResolver((publicId, systemId) -> {
+                if (systemId.endsWith(CML_XSD_FILENAME))
+                    return new InputSource(inputStreamCmlSchema);
+                return null;
+            });
+            parser.parse(inputStreamAtomTypeList);
+        }
     }
 
     @Test
     public void testCanReadCMLSchema() throws Exception {
-        InputStream cmlSchema = new FileInputStream(tmpCMLSchema);
-        Assert.assertNotNull("Could not find the CML schema", cmlSchema);
+        try (InputStream cmlSchema = getClass().getResourceAsStream(CML_XSD_ABSOLUTE_PATH)) {
+            Assert.assertNotNull("Could not find the CML schema", cmlSchema);
 
-        DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 
-        // make sure the schema is read
-        Document schemaDoc = parser.parse(cmlSchema);
-        Assert.assertNotNull(schemaDoc.getFirstChild());
-        Assert.assertEquals("xsd:schema", schemaDoc.getFirstChild().getNodeName());
-    }
-
-    /**
-     * Copies a file to TMP (whatever that is on your platform), and optionally
-     * replaces a String on the fly. The temporary file will be named prefix+suffix
-     *
-     * @param prefix      Prefix of the temporary file name
-     * @param suffix      Suffix of the temporary file name
-     * @param in          InputStream to copy from
-     * @param toReplace   String to replace. Null, if nothing needs to be replaced.
-     * @param replaceWith String that replaces the toReplace. Null, if nothing needs to be replaced.
-     * @return The temporary file/
-     * @throws IOException
-     */
-    private static File copyFileToTmp(String prefix, String suffix, InputStream in, String toReplace,
-                                      String replaceWith)
-            throws IOException {
-        File tmpFile = File.createTempFile(prefix, suffix);
-        FileOutputStream out = new FileOutputStream(tmpFile);
-        byte[] buf = new byte[4096];
-        int i;
-        while ((i = in.read(buf)) != -1) {
-            if (toReplace != null && replaceWith != null && i >= toReplace.length()
-                && new String(buf).contains(toReplace)) {
-                // a replacement has been defined
-                String newString = new String(buf).replaceAll(toReplace, replaceWith);
-                out.write(newString.getBytes());
-            } else {
-                // no replacement needs to be done
-                out.write(buf, 0, i);
-            }
+            // make sure the schema is read
+            Document schemaDoc = parser.parse(cmlSchema);
+            Assert.assertNotNull(schemaDoc.getFirstChild());
+            Assert.assertEquals("xsd:schema", schemaDoc.getFirstChild().getNodeName());
         }
-        in.close();
-        out.close();
-        tmpFile.deleteOnExit();
-        return tmpFile;
     }
 
-    class SAXValidityErrorHandler implements ErrorHandler {
+    static class SAXValidityErrorHandler implements ErrorHandler {
 
         private final String atomTypeList;
 
@@ -290,17 +236,17 @@ public class XMLIsotopeFactoryTest extends CDKTestCase {
         }
 
         @Override
-        public void error(SAXParseException arg0) throws SAXException {
+        public void error(SAXParseException arg0) {
             Assert.fail(atomTypeList + " is not valid on line " + arg0.getLineNumber() + ": " + arg0.getMessage());
         }
 
         @Override
-        public void fatalError(SAXParseException arg0) throws SAXException {
+        public void fatalError(SAXParseException arg0) {
             Assert.fail(atomTypeList + " is not valid on line " + arg0.getLineNumber() + ": " + arg0.getMessage());
         }
 
         @Override
-        public void warning(SAXParseException arg0) throws SAXException {
+        public void warning(SAXParseException arg0) {
             // warnings are fine
         }
 


### PR DESCRIPTION
…resources to ensure all streams are closed correctly.