### PR TITLE
re-introduced CloneNotSupportedException to retain compatability for …

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulator.java
@@ -135,10 +135,12 @@ public class AtomContainerManipulator {
      * @param atomContainer the source container to extract from
      * @param atomIndices the indices of the substructure
      * @return a cloned atom container with a substructure of the source
+     * @throws CloneNotSupportedException not thrown any longer, kept to retain compatability
      * @deprecated use {@link #extractSubstructure(IAtomContainer, Collection)} instead
      */
     @Deprecated
-    public static IAtomContainer extractSubstructure(IAtomContainer atomContainer, int... atomIndices) {
+    public static IAtomContainer extractSubstructure(IAtomContainer atomContainer, int... atomIndices)
+            throws CloneNotSupportedException {
         return extractSubstructure(atomContainer,
                 Arrays.stream(atomIndices).mapToObj(atomContainer::getAtom).collect(Collectors.toSet()));
     }
@@ -690,7 +692,7 @@ public class AtomContainerManipulator {
         return hCount;
     }
 
-    private static final void replaceAtom(IAtom[] atoms, IAtom org, IAtom rep) {
+    private static void replaceAtom(IAtom[] atoms, IAtom org, IAtom rep) {
         for (int i = 0; i < atoms.length; i++) {
             if (atoms[i].equals(org))
                 atoms[i] = rep;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -72,7 +72,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     }
 
     @Test
-    void testExtractSubstructure() {
+    void testExtractSubstructure() throws CloneNotSupportedException {
         IAtomContainer source = TestMoleculeFactory.makeEthylCyclohexane();
         IAtomContainer ringSubstructure = AtomContainerManipulator.extractSubstructure(source, 0, 1, 2, 3, 4, 5);
         assertThat(ringSubstructure.getAtomCount(), is(6));


### PR DESCRIPTION
…any downstream code that calls AtomContainerManipulator::extractSubstructure(IAtomContainer,int[])
removed unnecessary final modifier from private static method