### PR TITLE
A subtle bug introduced by a SonarCloud suggestion in ModelBuilder. 1…

### DIFF
--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3D.java
@@ -361,7 +361,7 @@ public class ModelBuilder3D {
         Point3d pointRingCenter = GeometryUtil.get3DCenter(ac);
         double distance = 0;
         double rotAngleMax = 0;
-        angle = 1.0 / 180 * Math.PI;
+        angle = Math.toRadians(180);
         ringCenter = new Vector3d(pointRingCenter.x, pointRingCenter.y, pointRingCenter.z);
         ringCenter.x = ringCenter.x - newCoord.x;
         ringCenter.y = ringCenter.y - newCoord.y;

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
@@ -374,7 +374,6 @@ class ModelBuilder3DTest extends CDKTestCase {
 
     @Test
     @Tag("SlowTest")
-    @Disabled("JWM - to fix, spotted in JUnit 5 migration")
     void testModelBuilder3D_reserpine() throws Exception {
         ModelBuilder3D mb3d = ModelBuilder3D.getInstance(DefaultChemObjectBuilder.getInstance());
         String filename = "reserpine.mol";


### PR DESCRIPTION
…/180 is a const expression and int div was probably not intended. Updating to 1.0/180*π was not correct. The intended expression should have been 1/(180*π) but a better idiom is Math.toRadians().