### PR TITLE
Add transform/SMIRKS support to CDK.

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -216,7 +216,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
     private BondRef getBondRef(IBond bond) {
         BondRef ref = getBondRefUnsafe(bond);
         if (ref == null)
-            throw new NoSuchBondException("Atom is not a member of this AtomContainer");
+            throw new NoSuchBondException("Bond is not a member of this AtomContainer");
         return ref;
     }
 

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
@@ -228,7 +228,7 @@ public class Transform {
                     results.add(cpy);
             }
         }
-        return results;
+        return Collections.unmodifiableList(results);
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
@@ -27,7 +27,6 @@ import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
@@ -23,6 +23,7 @@ package org.openscience.cdk.isomorphism;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
@@ -76,8 +77,7 @@ import java.util.NoSuchElementException;
  */
 public class Transform {
 
-    private static final ILoggingTool LOGGER = LoggingToolFactory.createLoggingTool(Transform.class);
-    public static final String NO_TRANSFORM_DEFINED = "No transform defined";
+    private static final String NO_TRANSFORM_DEFINED = "No transform defined";
 
     public enum Mode {
         /**
@@ -329,7 +329,7 @@ public class Transform {
         for (int i = 0; i < match.length; i++)
             amap[i + 1] = mol.getAtom(match[i]);
         for (int i = 1; i <= match.length; i++)
-            amap[i].setFlag(CDKConstants.MAPPED, true);
+            amap[i].setFlag(IChemObject.MAPPED, true);
     }
 
     private static IAtomContainer copyOf(IAtomContainer mol) {

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2022 NextMove Software
+ *               2022 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
+import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Transform a molecule using a query pattern and a sequence of
+ * {@link TransformOp}s. The query pattern is matched against a given molecule
+ * and based on that mapping a series of additions/deletions/changes are made.
+ * Transformations can be used for both standardisation/normalisation and
+ * library generation. <br/>
+ * This base class provides the low level implementation needed to run a
+ * transformation, in practice you would use something like
+ * {@link org.openscience.cdk.smirks.Smirks} in the <code>cdk-smarts</code>
+ * module to parse a transform from a string representation.
+ * <br/>
+ * The simplest way to use a transform is the {@link #apply(org.openscience.cdk.interfaces.IAtomContainer)}
+ * method, this runs the transform in-place over non-overlapping matches.
+ * <pre>{@code
+ * Transform tform = new Transform();
+ * if (Smirks.parse(tform, "[*:1][NH2D1:2]>>[*:1]O amine to hydroxy")) {
+ *   IAtomContainer mol = ...;
+ *   tform.apply(mol); // replace all NH2 groups with OH
+ * }
+ * }</pre>
+ * Note that non-overlapping matches can depend on the order of the atoms in a
+ * query or molecule being transformed. A more verbose mode is to provide the
+ * optional second {@link org.openscience.cdk.isomorphism.Transform.Mode}
+ * argument, this results in a copy of the input molecule being made multiple
+ * results being returned:
+ *
+ * <pre>{@code
+ * Transform tform = new Transform();
+ * if (Smirks.parse(tform, "[*:1][NH2D1:2]>>[*:1]O amine to hydroxy")) {
+ *   IAtomContainer mol = ...;
+ *   // replace each NH2 groups with OH one at a time
+ *   for (IAtomContainer copy : tform.apply(mol, Mode.All)) {
+ *
+ *   }
+ * }
+ * }</pre>
+ *
+ * @author John Mayfield
+ * @see org.openscience.cdk.isomorphism.Pattern
+ * @see org.openscience.cdk.isomorphism.TransformOp
+ * @see org.openscience.cdk.smirks.Smirks
+ */
+public class Transform {
+
+    private static final ILoggingTool LOGGER = LoggingToolFactory.createLoggingTool(Transform.class);
+    public static final String NO_TRANSFORM_DEFINED = "No transform defined";
+
+    public enum Mode {
+        /**
+         * Run the transform at all places the query matches. A collection is
+         * returned.
+         */
+        All,
+        /**
+         * Run the transform at all (unique) places the query matches.
+         * {@link Mappings#uniqueAtoms()}
+         */
+        Unique,
+        /**
+         * Run the transform at all (exclusive) places the query matches.
+         * Note: A single result is returned or none.
+         * {@link Mappings#exclusiveAtoms()}
+         */
+        Exclusive
+    }
+
+    private enum Status {
+        OK,
+        WARNING,
+        ERROR
+    }
+
+    private Pattern pattern;
+    private TransformPlan plan;
+    private Status status;
+    private String message;
+
+    /**
+     * Create an empty transform.
+     */
+    public Transform() {
+        setError(NO_TRANSFORM_DEFINED);
+    }
+
+    Transform(Pattern substructure, List<TransformOp> ops) {
+        init(substructure, ops, null);
+    }
+
+    /**
+     * Initialize the transform.
+     *
+     * @param pattern the substructure pattern to match
+     * @param ops the ops to run on the atoms of the pattern
+     * @param warning the warning message (optional)
+     */
+    public void init(Pattern pattern, List<TransformOp> ops, String warning) {
+        if (pattern == null || ops == null)
+            throw new NoSuchElementException("Pattern and ops must be provided!");
+        this.pattern = pattern;
+        this.plan = new TransformPlan(ops);
+        if (warning != null && !warning.isEmpty())
+            setWarning(warning);
+        else
+            setOk();
+    }
+
+    /**
+     * Initialize the transform.
+     *
+     * @param pattern the substructure pattern to match
+     * @param ops the ops to run on the atoms of the pattern
+     */
+    public void init(Pattern pattern, List<TransformOp> ops) {
+        init(pattern, ops, null);
+    }
+
+    private void setOk() {
+        this.status = Status.OK;
+        this.message = null;
+    }
+
+    private void setWarning(String warning) {
+        this.status = Status.WARNING;
+        this.message = warning;
+    }
+
+    /**
+     * Indicate there is an error with this transform. This
+     * method will clear any existing message and status. Any attempt to call
+     * {@link #apply(org.openscience.cdk.interfaces.IAtomContainer)} will
+     * be ignored (no-op) and return false (did not apply).
+     * <br/>
+     * You can clear the error status by calling,
+     * {@link #init(Pattern, java.util.List)}.
+     *
+     * @param message the warning/error message
+     * @return returns false
+     */
+    public boolean setError(String message) {
+        this.status = Status.ERROR;
+        this.message = message;
+        return false;
+    }
+
+    /**
+     * Access the warning/error message on a problem found with the transform.
+     *
+     * @return the message (null if there are no warnings or errors)
+     */
+    public String message() {
+        return message;
+    }
+
+    /**
+     * Reset this transform so it can be reused. This will set the status to
+     * Error and indicate a message that the transform is not initialized.
+     */
+    public void reset() {
+        setError(NO_TRANSFORM_DEFINED);
+        pattern = null;
+        plan.clear();
+    }
+
+    /**
+     * Apply the transform to the provided molecule and obtain the results of
+     * applying the transform. The original molecule is <b>NOT</b> modified.
+     *
+     * @param mol  the molecule to transform
+     * @param mode how to transform the molecule
+     * @return an iterable which may be empty or contain copies of the molecule
+     * transformed
+     */
+    public Iterable<IAtomContainer> apply(IAtomContainer mol, Mode mode) {
+
+        if (status == Status.ERROR)
+            return Collections.emptyList();
+
+        // We can make this lazy
+        List<IAtomContainer> results = new ArrayList<>();
+
+        if (mode == Mode.Exclusive) {
+            IAtomContainer cpy = copyOf(mol);
+            if (apply(cpy))
+                results.add(cpy);
+        } else {
+            Mappings mappings = pattern.matchAll(mol);
+            if (mode == Mode.Unique)
+                mappings = mappings.uniqueAtoms();
+            IAtom[] amap = new IAtom[plan.requiredAtomCapacity(mol)];
+            for (int[] match : mappings) {
+                IAtomContainer cpy = copyOf(mol);
+                permute(amap, match, cpy);
+                if (plan.apply(cpy, amap))
+                    results.add(cpy);
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Applies the exclusive transform to the provided molecule modifying it as
+     * required.
+     *
+     * @param mol the molecule to modify
+     * @return the molecule was modified or not
+     */
+    public boolean apply(IAtomContainer mol) {
+        if (status == Status.ERROR)
+            return false;
+
+        // atoms may be deleted, so we need to the atoms by index separately
+        IAtom[] atoms = AtomContainerManipulator.getAtomArray(mol);
+        IAtom[] amap = new IAtom[plan.requiredAtomCapacity(mol)];
+
+        boolean changed = false;
+        for (int[] match : pattern.matchAll(mol).exclusiveAtoms().toArray()) {
+            permute(amap, match, atoms);
+            if (plan.apply(mol, amap))
+                changed = true;
+        }
+
+        return changed;
+    }
+
+    /* Internal Methods */
+
+    // important we store atoms at index +1 to make it easier to debug/compare
+    // to the labelled atom maps
+    private void permute(IAtom[] amap, int[] match, IAtom[] atoms) {
+        for (int i = 0; i < match.length; i++)
+            amap[i + 1] = atoms[match[i]];
+    }
+
+    // important we store atoms at index +1 to make it easier to debug/compare
+    // to the labelled atom maps
+    private void permute(IAtom[] amap, int[] match, IAtomContainer mol) {
+        for (int i = 0; i < match.length; i++)
+            amap[i + 1] = mol.getAtom(match[i]);
+        for (int i = 1; i <= match.length; i++)
+            amap[i].setFlag(CDKConstants.MAPPED, true);
+    }
+
+    private static IAtomContainer copyOf(IAtomContainer mol) {
+        return mol.getBuilder().newInstance(IAtomContainer.class, mol);
+    }
+}

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/Transform.java
@@ -275,6 +275,10 @@ public class Transform {
     }
 
     private static IAtomContainer copyOf(IAtomContainer mol) {
-        return mol.getBuilder().newInstance(IAtomContainer.class, mol);
+        try {
+            return mol.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException("Could not clone() molecule");
+        }
     }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -338,6 +338,7 @@ public final class TransformOp implements Comparable<TransformOp> {
                 return type + "{" + a + "-" + b + "}";
             case NewBond:
             case BondOrder:
+            case AromaticBond:
                 switch (c) {
                     case 1:
                         return type + "{" + a + "-" + b + "}";
@@ -358,7 +359,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DbTogether:
                 return type + "{" + c + "/" + a + "=" + b + "\\" + d + "}";
             default:
-                throw new IllegalStateException();
+                throw new IllegalStateException("Unknown op:" + type);
         }
     }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -304,6 +304,16 @@ public final class TransformOp implements Comparable<TransformOp> {
         int thisMaxIdx = this.getMaxAtomIdx();
         int thatMinIdx = that.getMinAtomIdx();
         int thatMaxIdx = that.getMaxAtomIdx();
+
+        // FIXME: better ordering needed, but priority=0 is creation
+        // and we want to ensure all the atoms are created before a bond
+        // is made
+        if (getPriority() == 0) {
+            cmp = Integer.compare(thisMaxIdx, thatMaxIdx);
+            if (cmp != 0)
+                return cmp;
+        }
+
         if (thisMaxIdx < thatMinIdx)
             return -1;
         if (thatMaxIdx < thisMinIdx)

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -95,10 +95,15 @@ public final class TransformOp implements Comparable<TransformOp> {
          */
         Element,
         /**
-         * Set the aromatic flag of an atom.
+         * Set or clear the aromatic flag of an atom.
          * {@code params: {idx, isarom}}
          */
         Aromatic,
+        /**
+         * Set or clear the aromatic flag of an bond.
+         * {@code params: {idx1, idx2, isarom}}
+         */
+        AromaticBond,
         /**
          * Set the formal charge of an atom.
          * {@code params: {idx, charg}}
@@ -231,6 +236,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case NewBond:
             case DeleteBond:
             case BondOrder:
+            case AromaticBond:
             case MoveH:
                 return Math.max(a, b);
             case DbOpposite:
@@ -257,6 +263,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case NewBond:
             case DeleteBond:
             case BondOrder:
+            case AromaticBond:
             case MoveH:
                 return Math.min(a, b);
             case DbOpposite:

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -120,6 +120,12 @@ public final class TransformOp implements Comparable<TransformOp> {
          */
         AdjustH,
         /**
+         * Move a hydrogen from one atom to another and create a new one at the
+         * given index.
+         * {@code params: {idx1, idx2}}
+         */
+        PromoteH,
+        /**
          * Move a hydrogen from one atom to another.
          * {@code params: {idx1, idx2}}
          */
@@ -214,7 +220,8 @@ public final class TransformOp implements Comparable<TransformOp> {
                 (type == Type.NewBond ||
                  type == Type.DeleteBond ||
                  type == Type.BondOrder ||
-                 type == Type.MoveH))
+                 type == Type.MoveH ||
+                 type == Type.PromoteH))
             return new TransformOp(type, a, to, c, d);
         return this;
     }
@@ -225,6 +232,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DeleteBond:
             case BondOrder:
             case MoveH:
+            case PromoteH:H:
                 if (x == a) return b;
                 else if (x == b) return a;
                 return -1;
@@ -250,6 +258,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case BondOrder:
             case AromaticBond:
             case MoveH:
+            case PromoteH:
                 return Math.max(a, b);
             case DbOpposite:
             case DbTogether:
@@ -277,6 +286,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case BondOrder:
             case AromaticBond:
             case MoveH:
+            case PromoteH:
                 return Math.min(a, b);
             case DbOpposite:
             case DbTogether:
@@ -294,6 +304,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case AdjustH:
                 return 0;
             case MoveH:
+            case PromoteH:
                 return 1;
             case DeleteAtom:
             case DeleteBond:
@@ -373,6 +384,7 @@ public final class TransformOp implements Comparable<TransformOp> {
                 }
 
             case MoveH:
+            case PromoteH:
                 return type + "{" + a + "=>" + b + "}";
             case Tetrahedral:
                 return type + "{" + a + ",@(" + b + "," + c + "," + d + "}";

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -115,6 +115,11 @@ public final class TransformOp implements Comparable<TransformOp> {
          */
         ImplH,
         /**
+         * Set the total hydrogen count of an atom.
+         * {@code params: {idx, hcnt}}
+         */
+        TotalH,
+        /**
          * Adjust the total hydrogen count (up or down) of an atom.
          * {@code params: {idx, hdelta}}
          */
@@ -223,6 +228,16 @@ public final class TransformOp implements Comparable<TransformOp> {
                  type == Type.MoveH ||
                  type == Type.PromoteH))
             return new TransformOp(type, a, to, c, d);
+        if (type == Type.Tetrahedral ||
+            type == Type.DbOpposite ||
+            type == Type.DbTogether) {
+            if (b == from)
+                return new TransformOp(type, a, to, c, d);
+            if (c == from)
+                return new TransformOp(type, a, b, to, d);
+            if (d == from)
+                return new TransformOp(type, a, b, c, to);
+        }
         return this;
     }
 
@@ -251,6 +266,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case Aromatic:
             case Charge:
             case ImplH:
+            case TotalH:
             case AdjustH:
                 return a;
             case NewBond:
@@ -279,6 +295,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case Aromatic:
             case Charge:
             case ImplH:
+            case TotalH:
             case AdjustH:
                 return a;
             case NewBond:
@@ -309,6 +326,8 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DeleteAtom:
             case DeleteBond:
                 return 2;
+            case TotalH:
+                return 4;
             case Tetrahedral:
             case DbOpposite:
             case DbTogether:
@@ -368,6 +387,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case Charge:
             case ImplH:
             case AdjustH:
+            case TotalH:
                 return type + "{" + b + "@" + a + "}";
             case DeleteBond:
                 return type + "{" + a + "-" + b + "}";

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -205,6 +205,26 @@ public final class TransformOp implements Comparable<TransformOp> {
         this(type, a, 0, 0);
     }
 
+    public Type type() {
+        return type;
+    }
+
+    public int argA() {
+        return a;
+    }
+
+    public int argB() {
+        return b;
+    }
+
+    public int argC() {
+        return c;
+    }
+
+    public int argD() {
+        return c;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -184,7 +184,14 @@ public final class TransformOp implements Comparable<TransformOp> {
          * {@code params: {idx1, idx2, elem, hcnt}}
          */
         ReplaceHydrogen,
-        RemoveUnmapped
+        /**
+         * Remove unmapped fragments.
+         */
+        RemoveUnmapped,
+        /**
+         * Recalculate hydrogens on changed atoms.
+         */
+        RecomputeHydrogens
     }
 
     final Type type;
@@ -316,6 +323,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case Tetrahedral:
                 return Math.max(Math.max(a, b), Math.max(c, d));
             case RemoveUnmapped:
+            case RecomputeHydrogens:
                 return 0;
             default:
                 throw new IllegalStateException(type + " atom index?");
@@ -348,6 +356,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case Tetrahedral:
                 return Math.min(Math.min(a, b), Math.min(c, d));
             case RemoveUnmapped:
+            case RecomputeHydrogens:
                 return 0;
             default:
                 throw new IllegalStateException();
@@ -374,7 +383,8 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DbTogether:
                 return 5;
             case RemoveUnmapped:
-                return 6;
+            case RecomputeHydrogens:
+                return 6; // post-processing
             default:
                 return 3;
         }
@@ -459,6 +469,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DbTogether:
                 return type + "{" + c + "/" + a + "=" + b + "\\" + d + "}";
             case RemoveUnmapped:
+            case RecomputeHydrogens:
                 return type.toString();
             default:
                 throw new IllegalStateException("Unknown op:" + type);

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright (C) 2022 NextMove Software
+ *               2022 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.openscience.cdk.config.Elements;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * A transform operation (TransformOp) describes a change to be made to some
+ * mapped set of indexed atoms (0 &le; <b>idx</b> &lt; N). An op-code has a
+ * type and then up to 4 additional integer parameters name a, b, c, d.
+ * <br/>
+ * What these parameters mean depend on the type and summarised below:
+ * <table summary="OpCode parameter types">
+ *     <thead>
+ *       <tr><th>Type</th><th>Param a</th><th>Param b</th><th>Param c</th><th>Param d</th></tr>
+ *     </thead>
+ *     <tbody>
+ *         <tr><th>NewAtom</th><td>idx</td><td>atomic number</td><td>impl H count</td><td>is aromatic?</td></tr>
+ *         <tr><th>NewBond</th><td>idx</td><td>idx</td><td>bond order</td><td></td></tr>
+ *         <tr><th>DeleteAtom</th><td>idx</td><td></td><td></td><td></td></tr>
+ *         <tr><th>DeleteBond</th><td>idx</td><td>idx</td><td></td><td></td></tr>
+ *         <tr><th>BondOrder</th><td>idx</td><td>idx</td><td>bond order</td><td></td></tr>
+ *         <tr><th>Mass</th><td>idx</td><td>isotope mass</td><td></td><td></td></tr>
+ *         <tr><th>Element</th><td>idx</td><td>atomic number</td><td></td><td></td></tr>
+ *         <tr><th>Aromatic</th><td>idx</td><td>is aromatic?</td><td></td><td></td></tr>
+ *         <tr><th>Charge</th><td>idx</td><td>formal charge</td><td></td><td></td></tr>
+ *         <tr><th>ImplH</th><td>idx</td><td>impl H</td><td></td><td></td></tr>
+ *         <tr><th>AdjustH</th><td>idx</td><td>+/- impl H change</td><td></td><td></td></tr>
+ *         <tr><th>MoveH</th><td>idx</td><td>idx</td><td></td><td></td></tr>
+ *         <tr><th>Tetrahedral</th><td>idx1</td><td>idx2</td><td>idx3</td><td>idx4</td></tr>
+ *         <tr><th>DbTogether</th><td>idx1</td><td>idx2</td><td>idx3</td><td>idx4</td></tr>
+ *         <tr><th>DbOpposite</th><td>idx1</td><td>idx2</td><td>idx3</td><td>idx4</td></tr>
+ *     </tbody>
+ * </table>
+ */
+public final class TransformOp implements Comparable<TransformOp> {
+
+    // note the ordering here is important, atoms must be created before bonds,
+    // bonds must be deleted before atoms.
+    public enum Type {
+        /**
+         * Create a new atom.
+         * {@code params: {idx, elem, hcnt, isarom}}
+         */
+        NewAtom,
+        /**
+         * Create a new bond with between the two atom indexes.
+         * {@code params: {idx1, idx2, order}}
+         */
+        NewBond,
+        /**
+         * Delete a bond.
+         * {@code params: {idx1, idx2}}
+         */
+        DeleteBond,
+        /**
+         * Delete an atom.
+         * {@code params: {idx}}
+         */
+        DeleteAtom,
+        /**
+         * Set the bond order.
+         * {@code params: {idx1, idx2, order}}
+         */
+        BondOrder,
+        /**
+         * Set the mass number (isotope) of an atom.
+         * {@code params: {idx, mass}}
+         */
+        Mass,
+        /**
+         * Set the atomic number (element) of an atom.
+         * {@code params: {idx, elem}}
+         */
+        Element,
+        /**
+         * Set the aromatic flag of an atom.
+         * {@code params: {idx, isarom}}
+         */
+        Aromatic,
+        /**
+         * Set the formal charge of an atom.
+         * {@code params: {idx, charg}}
+         */
+        Charge,
+        /**
+         * Set the implicit hydrogen count of an atom.
+         * {@code params: {idx, hcnt}}
+         */
+        ImplH,
+        /**
+         * Adjust the total hydrogen count (up or down) of an atom.
+         * {@code params: {idx, hdelta}}
+         */
+        AdjustH,
+        /**
+         * Move a hydrogen from one atom to another.
+         * {@code params: {idx1, idx2}}
+         */
+        MoveH,
+        /**
+         * Set the tetrahedral left-handed
+         * {@code params: {foci, nbr1, nbr2, nbr3}}
+         */
+        Tetrahedral,
+        /**
+         * Set the double bond (ndr1-idx1=idx2-nbr2) such that the
+         * neighbours are on together (cis) on the same side of the double
+         * bond.
+         * {@code params: {idx1, idx2, nbr1, nbr2}}
+         */
+        DbTogether,
+        /**
+         * Set the double bond (ndr1-idx1=idx2-nbr2) such that the
+         * neighbours are on opposite (trans) sides of the double bond.
+         * <p>
+         * {@code params: {idx1, idx2, nbr1, nbr2}}
+         */
+        DbOpposite,
+
+        /* Replace* Ops are put in by the optimization pass. */
+
+        /**
+         * Replace an existing atom, keep bonding to other mapped atoms intact
+         * but removing bonds to unmapped atoms. This is a convenient way to
+         * preserve stereochemistry when we delete and then add a atom/bond
+         * pair. Note this op-code is automatically put in by an
+         * optimisation pass.
+         * <p>
+         * {@code params: {idx, elem, hcnt, isarom}}
+         */
+        ReplaceAtom,
+        /**
+         * Replace an existing implicit or explicit atom, If it's an
+         * explicit hydrogen, and bond to unmapped atoms are removed. This
+         * is a convenient way to preserve stereochemistry when we delete
+         * a hydrogen then bond a new atom. Note this op-code is
+         * automatically put in by an optimisation pass.
+         * <p>
+         * {@code params: {idx1, idx2, elem, hcnt}}
+         */
+        ReplaceHydrogen
+    }
+
+    final Type type;
+    final int a;
+    final int b;
+    final int c;
+    final int d;
+
+    public TransformOp(Type type, int a, int b, int c, int d) {
+        this.type = type;
+        this.a = a;
+        this.b = b;
+        this.c = c;
+        this.d = d;
+    }
+
+    public TransformOp(Type type, int a, int b, int c) {
+        this(type, a, b, c, 0);
+    }
+
+    public TransformOp(Type type, int a, int b) {
+        this(type, a, b, 0);
+    }
+
+    public TransformOp(Type type, int a) {
+        this(type, a, 0, 0);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransformOp opCode = (TransformOp) o;
+        return a == opCode.a && b == opCode.b && c == opCode.c && d == opCode.d && type == opCode.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, a, b, c, d);
+    }
+
+    int getOtherIdx(int x) {
+        switch (type) {
+            case NewBond:
+            case DeleteBond:
+            case BondOrder:
+            case MoveH:
+                if (x == a) return b;
+                else if (x == b) return a;
+                return -1;
+            default:
+                return -1;
+        }
+    }
+
+    int getMaxAtomIdx() {
+        switch (type) {
+            case NewAtom:
+            case ReplaceAtom:
+            case DeleteAtom:
+            case Mass:
+            case Element:
+            case Aromatic:
+            case Charge:
+            case ImplH:
+            case AdjustH:
+                return a;
+            case NewBond:
+            case DeleteBond:
+            case BondOrder:
+            case MoveH:
+                return Math.max(a, b);
+            case DbOpposite:
+            case DbTogether:
+            case Tetrahedral:
+                return Math.max(Math.max(a, b), Math.max(c, d));
+            default:
+                throw new IllegalStateException(type + " atom index?");
+        }
+    }
+
+    private int getMinAtomIdx() {
+        switch (type) {
+            case NewAtom:
+            case DeleteAtom:
+            case ReplaceAtom:
+            case Mass:
+            case Element:
+            case Aromatic:
+            case Charge:
+            case ImplH:
+            case AdjustH:
+                return a;
+            case NewBond:
+            case DeleteBond:
+            case BondOrder:
+            case MoveH:
+                return Math.min(a, b);
+            case DbOpposite:
+            case DbTogether:
+            case Tetrahedral:
+                return Math.min(Math.min(a, b), Math.min(c, d));
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    private int getPriority() {
+        switch (type) {
+            case NewAtom:
+            case NewBond:
+            case AdjustH:
+                return 0;
+            case MoveH:
+                return 1;
+            case DeleteAtom:
+            case DeleteBond:
+                return 2;
+            case Tetrahedral:
+            case DbOpposite:
+            case DbTogether:
+                return 5;
+            default:
+                return 3;
+        }
+    }
+
+    @Override
+    public int compareTo(TransformOp that) {
+        int cmp = Integer.compare(this.getPriority(), that.getPriority());
+        if (cmp != 0)
+            return cmp;
+        int thisMinIdx = this.getMinAtomIdx();
+        int thisMaxIdx = this.getMaxAtomIdx();
+        int thatMinIdx = that.getMinAtomIdx();
+        int thatMaxIdx = that.getMaxAtomIdx();
+        if (thisMaxIdx < thatMinIdx)
+            return -1;
+        if (thatMaxIdx < thisMinIdx)
+            return +1;
+        return this.type.compareTo(that.type);
+    }
+
+    @Override
+    public String toString() {
+        switch (type) {
+            case ReplaceAtom:
+            case NewAtom:
+                String desc = Elements.ofNumber(b).symbol();
+                if (d != 0)
+                    desc = desc.toLowerCase(Locale.ROOT);
+                desc += "H" + c;
+                return type + "{[" + desc + "@" + a + "]}";
+            case ReplaceHydrogen:
+                desc = Elements.ofNumber(c).symbol();
+                desc += "H" + d;
+                return type + "{[" + desc + "@" + a + "=>" + b + "]}";
+            case DeleteAtom:
+                return type + "{" + a + "}";
+            case Mass:
+            case Element:
+            case Aromatic:
+            case Charge:
+            case ImplH:
+            case AdjustH:
+                return type + "{" + b + "@" + a + "}";
+            case DeleteBond:
+                return type + "{" + a + "-" + b + "}";
+            case NewBond:
+            case BondOrder:
+                switch (c) {
+                    case 1:
+                        return type + "{" + a + "-" + b + "}";
+                    case 2:
+                        return type + "{" + a + "=" + b + "}";
+                    case 3:
+                        return type + "{" + a + "#" + b + "}";
+                    default:
+                        return type + "{" + a + "," + b + ",order=" + c + "}";
+                }
+
+            case MoveH:
+                return type + "{" + a + "=>" + b + "}";
+            case Tetrahedral:
+                return type + "{" + a + ",@(" + b + "," + c + "," + d + "}";
+            case DbOpposite:
+                return type + "{" + c + "/" + a + "=" + b + "/" + d + "}";
+            case DbTogether:
+                return type + "{" + c + "/" + a + "=" + b + "\\" + d + "}";
+            default:
+                throw new IllegalStateException();
+        }
+    }
+}

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -65,10 +65,17 @@ public final class TransformOp implements Comparable<TransformOp> {
          */
         NewAtom,
         /**
-         * Create a new bond with between the two atom indexes.
+         * Create a new bond with between the two atom indexes. If the bond
+         * already exists the pattern will fail to apply.
          * {@code params: {idx1, idx2, order}}
          */
         NewBond,
+        /**
+         * Create a new bond with between the two atom indexes.
+         * If the bond already exists the order is updated.
+         * {@code params: {idx1, idx2, order}}
+         */
+        OverwriteBond,
         /**
          * Delete a bond.
          * {@code params: {idx1, idx2}}
@@ -205,6 +212,10 @@ public final class TransformOp implements Comparable<TransformOp> {
         this(type, a, 0, 0);
     }
 
+    public TransformOp(Type type, TransformOp op) {
+        this(type, op.a, op.b, op.c, op.d);
+    }
+
     public Type type() {
         return type;
     }
@@ -243,6 +254,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             return new TransformOp(type, to, b, c, d);
         if (b == from &&
                 (type == Type.NewBond ||
+                 type == Type.OverwriteBond ||
                  type == Type.DeleteBond ||
                  type == Type.BondOrder ||
                  type == Type.MoveH ||
@@ -264,6 +276,7 @@ public final class TransformOp implements Comparable<TransformOp> {
     int getOtherIdx(int x) {
         switch (type) {
             case NewBond:
+            case OverwriteBond:
             case DeleteBond:
             case BondOrder:
             case MoveH:
@@ -290,6 +303,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case AdjustH:
                 return a;
             case NewBond:
+            case OverwriteBond:
             case DeleteBond:
             case BondOrder:
             case AromaticBond:
@@ -319,6 +333,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case AdjustH:
                 return a;
             case NewBond:
+            case OverwriteBond:
             case DeleteBond:
             case BondOrder:
             case AromaticBond:
@@ -338,6 +353,7 @@ public final class TransformOp implements Comparable<TransformOp> {
         switch (type) {
             case NewAtom:
             case NewBond:
+            case OverwriteBond:
             case AdjustH:
                 return 0;
             case MoveH:
@@ -412,6 +428,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DeleteBond:
                 return type + "{" + a + "-" + b + "}";
             case NewBond:
+            case OverwriteBond:
             case BondOrder:
             case AromaticBond:
                 switch (c) {

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -81,7 +81,7 @@ public final class TransformOp implements Comparable<TransformOp> {
         DeleteAtom,
         /**
          * Set the bond order.
-         * {@code params: {idx1, idx2, order}}
+         * {@code params: {idx1, idx2, order, old-order}}
          */
         BondOrder,
         /**
@@ -222,7 +222,7 @@ public final class TransformOp implements Comparable<TransformOp> {
     }
 
     public int argD() {
-        return c;
+        return d;
     }
 
     @Override

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -183,7 +183,8 @@ public final class TransformOp implements Comparable<TransformOp> {
          * <p>
          * {@code params: {idx1, idx2, elem, hcnt}}
          */
-        ReplaceHydrogen
+        ReplaceHydrogen,
+        RemoveUnmapped
     }
 
     final Type type;
@@ -314,6 +315,8 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DbTogether:
             case Tetrahedral:
                 return Math.max(Math.max(a, b), Math.max(c, d));
+            case RemoveUnmapped:
+                return 0;
             default:
                 throw new IllegalStateException(type + " atom index?");
         }
@@ -344,6 +347,8 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DbTogether:
             case Tetrahedral:
                 return Math.min(Math.min(a, b), Math.min(c, d));
+            case RemoveUnmapped:
+                return 0;
             default:
                 throw new IllegalStateException();
         }
@@ -368,6 +373,8 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DbOpposite:
             case DbTogether:
                 return 5;
+            case RemoveUnmapped:
+                return 6;
             default:
                 return 3;
         }
@@ -451,6 +458,8 @@ public final class TransformOp implements Comparable<TransformOp> {
                 return type + "{" + c + "/" + a + "=" + b + "/" + d + "}";
             case DbTogether:
                 return type + "{" + c + "/" + a + "=" + b + "\\" + d + "}";
+            case RemoveUnmapped:
+                return type.toString();
             default:
                 throw new IllegalStateException("Unknown op:" + type);
         }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -232,7 +232,7 @@ public final class TransformOp implements Comparable<TransformOp> {
             case DeleteBond:
             case BondOrder:
             case MoveH:
-            case PromoteH:H:
+            case PromoteH:
                 if (x == a) return b;
                 else if (x == b) return a;
                 return -1;
@@ -348,16 +348,18 @@ public final class TransformOp implements Comparable<TransformOp> {
     public String toString() {
         switch (type) {
             case ReplaceAtom:
-            case NewAtom:
+            case NewAtom: {
                 String desc = Elements.ofNumber(b).symbol();
                 if (d != 0)
                     desc = desc.toLowerCase(Locale.ROOT);
                 desc += "H" + c;
                 return type + "{[" + desc + "@" + a + "]}";
-            case ReplaceHydrogen:
-                desc = Elements.ofNumber(c).symbol();
+            }
+            case ReplaceHydrogen: {
+                String desc = Elements.ofNumber(c).symbol();
                 desc += "H" + d;
                 return type + "{[" + desc + "@" + a + "=>" + b + "]}";
+            }
             case DeleteAtom:
                 return type + "{" + a + "}";
             case Mass:

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformOp.java
@@ -207,6 +207,18 @@ public final class TransformOp implements Comparable<TransformOp> {
         return Objects.hash(type, a, b, c, d);
     }
 
+    TransformOp remap(int from, int to) {
+        if (a == from)
+            return new TransformOp(type, to, b, c, d);
+        if (b == from &&
+                (type == Type.NewBond ||
+                 type == Type.DeleteBond ||
+                 type == Type.BondOrder ||
+                 type == Type.MoveH))
+            return new TransformOp(type, a, to, c, d);
+        return this;
+    }
+
     int getOtherIdx(int x) {
         switch (type) {
             case NewBond:

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -296,6 +296,11 @@ final class TransformPlan {
             case Aromatic:
                 amap[op.a].setIsAromatic(op.b != 0);
                 break;
+            case AromaticBond:
+                amap[op.a].getBond(amap[op.b]).setIsAromatic(op.c != 0);
+                amap[op.a].setIsAromatic(op.c != 0); // questionable semantics
+                amap[op.b].setIsAromatic(op.c != 0);
+                break;
             case Charge:
                 amap[op.a].setFormalCharge(op.b);
                 break;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -271,6 +271,8 @@ final class TransformPlan {
             case NewBond:
                 if (amap[op.a].getBond(amap[op.b]) != null)
                     return false;
+                if (amap[op.a] == null || amap[op.b] == null)
+                    throw new IllegalStateException(op + " atoms={null=" + (amap[op.a]==null) + ",null=" + (amap[op.b]==null) + "}");
                 mol.addBond(amap[op.a].getIndex(), amap[op.b].getIndex(),
                             BOND_ORDERS[op.c]);
                 if (op.c == 5 && amap[op.a].isAromatic() && amap[op.b].isAromatic())
@@ -298,8 +300,8 @@ final class TransformPlan {
                 break;
             case AromaticBond:
                 amap[op.a].getBond(amap[op.b]).setIsAromatic(op.c != 0);
-                amap[op.a].setIsAromatic(op.c != 0); // questionable semantics
-                amap[op.b].setIsAromatic(op.c != 0);
+                // amap[op.a].setIsAromatic(op.c != 0); // only for aromatic!
+                // amap[op.b].setIsAromatic(op.c != 0);
                 break;
             case Charge:
                 amap[op.a].setFormalCharge(op.b);

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -71,7 +71,6 @@ final class TransformPlan {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Optimizes op-codes:" + this.ops);
         }
-        System.err.println(this.ops);
     }
 
     /**

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -612,6 +612,15 @@ final class TransformPlan {
         IBond endNBor = amap[op.b].getBond(amap[op.d]);
         if (begNbor == null || endNBor == null)
             throw new IllegalStateException();
+
+        // swap order
+        if (dbBond.getEnd().equals(amap[op.a]) &&
+            dbBond.getBegin().equals(amap[op.b])) {
+            IBond tmp = begNbor;
+            begNbor = endNBor;
+            endNBor = tmp;
+        }
+
         List<IStereoElement<?,?>> newStereo = mol.getProperty(SMIRKS_NEWSTEREO);
         if (newStereo == null)
             mol.setProperty(SMIRKS_NEWSTEREO, newStereo = new ArrayList<>());

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -51,7 +51,7 @@ final class TransformPlan {
 
     private static final ILoggingTool LOGGER
             = LoggingToolFactory.createLoggingTool(TransformPlan.class);
-    public static final String SMIRKS_NEWSTEREO = "smirks.newstereo";
+    private static final String SMIRKS_NEWSTEREO = "smirks.newstereo";
 
     private final List<TransformOp> ops;
     private final int maxNewAtomIdx;

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -304,14 +304,29 @@ final class TransformPlan {
                     return false;
                 break;
             case NewBond:
-                if (amap[op.a].getBond(amap[op.b]) != null)
-                    return false;
                 if (amap[op.a] == null || amap[op.b] == null)
                     throw new IllegalStateException(op + " atoms={null=" + (amap[op.a] == null) + ",null=" + (amap[op.b] == null) + "}");
+                if (amap[op.a].getBond(amap[op.b]) != null)
+                    return false;
                 mol.addBond(amap[op.a].getIndex(), amap[op.b].getIndex(),
                             BOND_ORDERS[op.c]);
-                if (op.c == 5 && amap[op.a].isAromatic() && amap[op.b].isAromatic())
-                    amap[op.a].getBond(amap[op.b]).setIsAromatic(true);
+                if (op.c == 5)
+                    mol.getBond(mol.getBondCount()-1).setIsAromatic(true);
+                markBondingChanged(amap[op.a], amap[op.b]);
+                break;
+            case OverwriteBond:
+                if (amap[op.a] == null || amap[op.b] == null)
+                    throw new IllegalStateException(op + " atoms={null=" + (amap[op.a] == null) + ",null=" + (amap[op.b] == null) + "}");
+                IBond tmpBond = amap[op.a].getBond(amap[op.b]);
+                if (tmpBond == null) {
+                    mol.addBond(amap[op.a].getIndex(), amap[op.b].getIndex(),
+                                BOND_ORDERS[op.c]);
+                    tmpBond = mol.getBond(mol.getBondCount()-1);
+                } else {
+                    tmpBond.setOrder(BOND_ORDERS[op.c]);
+                }
+                if (op.c == 5)
+                    tmpBond.setIsAromatic(true);
                 markBondingChanged(amap[op.a], amap[op.b]);
                 break;
             case DeleteAtom:

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -1,0 +1,624 @@
+/*
+ * Copyright (C) 2022 NextMove Software
+ *               2022 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObject;
+import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.interfaces.ITetrahedralChirality;
+import org.openscience.cdk.stereo.DoubleBondStereochemistry;
+import org.openscience.cdk.stereo.ExtendedCisTrans;
+import org.openscience.cdk.stereo.ExtendedTetrahedral;
+import org.openscience.cdk.stereo.TetrahedralChirality;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Internal - Optimize and run a series of op-codes over a set of matched atoms.
+ */
+final class TransformPlan {
+
+    private static final ILoggingTool LOGGER
+            = LoggingToolFactory.createLoggingTool(TransformPlan.class);
+
+    private final List<TransformOp> ops;
+    private final int maxNewAtomIdx;
+    private final int fstNewAtomIdx;
+    private final int numNewAtoms;
+
+    TransformPlan(List<TransformOp> ops) {
+        // determine strategy/plan params
+        this.numNewAtoms = numNewAtoms(ops);
+        this.fstNewAtomIdx = firstNewAtom(ops);
+        this.maxNewAtomIdx = maxAtomIdx(ops);
+        this.ops = new ArrayList<>(ops);
+
+        // ensure op-codes are run in a specific order, bonds must be deleted
+        // before atoms, atoms must be created before bonds. We also prioritize
+        // the op-codes that can be trivially undo (and might fail) so we can
+        // roll them back if needed
+        Collections.sort(this.ops);
+        optimize(this.ops);
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Optimizes op-codes:" + this.ops);
+        }
+        System.err.println(this.ops);
+    }
+
+    /**
+     * The required atom capacity is the number atoms in the query + any new
+     * atoms + 1 (since we index from 1 rather than 0). In practice we use
+     * number of atoms in the target molecule since this is more readily to
+     * hand and the number of atoms in the query must be less-than-or-equal to
+     * this.
+     */
+    int requiredAtomCapacity(IAtomContainer mol) {
+        return mol.getAtomCount() + numNewAtoms + 1;
+    }
+
+    /**
+     * Apply the plan a molecule with the atoms index in the {@code amap} array.
+     *
+     * @param mol the molecule
+     * @param amap atom-mapping
+     * @return if the operations were applied successfully or not
+     */
+    boolean apply(IAtomContainer mol, IAtom[] amap) {
+        prepare(mol, amap);
+        for (int i = 0; i < ops.size(); i++) {
+            TransformOp op = ops.get(i);
+            if (!apply(mol, amap, op)) {
+                undo(mol, amap, i);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Clear the ops.
+     */
+    void clear() {
+        ops.clear();
+    }
+
+    @Override
+    public String toString() {
+        return ops.toString();
+    }
+
+    /* Internal Methods */
+
+    private static void resetFlags(IAtom atom) {
+        atom.setFlag(CDKConstants.MAPPED, false);
+        atom.setFlag(CDKConstants.REACTIVE_CENTER, false);
+    }
+
+    private void prepare(IAtomContainer mol, IAtom[] amap) {
+        for (IAtom atom : mol.atoms())
+            resetFlags(atom);
+        for (int i = 1; i < amap.length; i++) {
+            if (amap[i] != null)
+                amap[i].setFlag(CDKConstants.MAPPED, true);
+        }
+    }
+
+    private void optimize(List<TransformOp> ops) {
+        // if we delete an atom after remove one of it's bonds we
+        // can better run this just by deleting the atom
+        for (int i = ops.size() - 1; i > 2; i--)
+            if (canDoReplaceAtom(ops.get(i - 3), ops.get(i - 2),
+                                 ops.get(i - 1), ops.get(i)))
+                i = optimizeReplaceAtom(ops, i);
+
+        // if we add a single bonded atom on then remove a single hydrogen
+        // special case this to preserve stereochemistry
+        for (int i = ops.size() - 1; i > 1; i--)
+            if (canDoReplaceH(ops.get(i - 2), ops.get(i - 1), ops.get(i)))
+                i = optimizeReplaceHydrogen(ops, i);
+
+        // if we delete an atom after remove one of it's bonds we
+        // can better run this just by deleting the atom
+        for (int i = ops.size() - 1; i > 0; i--)
+            if (deleteBondedAtom(ops.get(i - 1), ops.get(i)))
+                ops.remove(i - 1);
+    }
+
+    private int optimizeReplaceHydrogen(List<TransformOp> ops, int i) {
+        // adjH i-2, newAtom i-1, newBond i
+        ops.set(i - 2, new TransformOp(TransformOp.Type.ReplaceHydrogen,
+                                       ops.get(i - 2).a,
+                                       ops.get(i - 1).a,
+                                       ops.get(i - 1).b,
+                                       ops.get(i - 1).c));
+        if (ops.get(i - 1).d != 0)
+            ops.set(i - 1, new TransformOp(TransformOp.Type.Aromatic, ops.get(i - 1).a, 1));
+        else
+            ops.remove(i--);
+        ops.remove(i--);
+        return i;
+    }
+
+    private int optimizeReplaceAtom(List<TransformOp> ops, int i) {
+        ops.set(i - 3, new TransformOp(TransformOp.Type.ReplaceAtom,
+                                       ops.get(i).a,
+                                       ops.get(i - 3).b,
+                                       ops.get(i - 3).c,
+                                       ops.get(i - 3).d));
+        if (ops.get(i - 1).c != ops.get(i - 2).c) {
+            ops.set(i - 2, new TransformOp(TransformOp.Type.BondOrder,
+                                           ops.get(i - 1).a,
+                                           ops.get(i - 1).b,
+                                           ops.get(i - 2).c));
+        } else {
+            ops.remove(i--);
+        }
+        ops.remove(i--);
+        ops.remove(i--);
+        return i;
+    }
+
+    private boolean deleteBondedAtom(TransformOp fst, TransformOp snd) {
+        return snd.type == TransformOp.Type.DeleteAtom &&
+                fst.type == TransformOp.Type.DeleteBond &&
+                (snd.a == fst.a || snd.a == fst.b);
+    }
+
+    private boolean canReuseBond(TransformOp newBnd, TransformOp delBnd) {
+        if (newBnd.type != TransformOp.Type.NewBond)
+            return false;
+        if (delBnd.type != TransformOp.Type.DeleteBond)
+            return false;
+        // is there an atom index overlap?
+        return newBnd.a == delBnd.a ||
+                newBnd.a == delBnd.b ||
+                newBnd.b == delBnd.a ||
+                newBnd.b == delBnd.b;
+    }
+
+    private boolean canDoReplaceAtom(TransformOp op1, TransformOp op2, TransformOp op3, TransformOp op4) {
+        // NewAtm, NewBnd, DelBnd, DelAtm
+        return op1.type == TransformOp.Type.NewAtom &&
+                canReuseBond(op2, op3) &&
+                op4.type == TransformOp.Type.DeleteAtom;
+    }
+
+    private boolean canDoReplaceH(TransformOp adjH, TransformOp newAtm, TransformOp newBnd) {
+        // NewAtm, NewBnd, AdjustH
+        return newAtm.type == TransformOp.Type.NewAtom &&
+                newBnd.type == TransformOp.Type.NewBond &&
+                adjH.type == TransformOp.Type.AdjustH &&
+                adjH.b == -1 &&
+                newAtm.a == newBnd.getOtherIdx(adjH.a) &&
+                (newBnd.c == 1 || newBnd.c == 5);
+    }
+
+
+    private int numNewAtoms(List<TransformOp> ops) {
+        int count = 0;
+        for (TransformOp op : ops)
+            if (op.type == TransformOp.Type.NewAtom)
+                count++;
+        return count;
+    }
+
+    private int maxAtomIdx(List<TransformOp> ops) {
+        int max = 0;
+        for (TransformOp op : ops)
+            max = Math.max(op.getMaxAtomIdx(), max);
+        return max;
+    }
+
+    private int firstNewAtom(List<TransformOp> ops) {
+        int min = Integer.MAX_VALUE;
+        for (TransformOp op : ops)
+            if (op.type == TransformOp.Type.NewAtom)
+                min = Math.min(op.a, min);
+        return min;
+    }
+
+    private static final IBond.Order[] BOND_ORDERS = new IBond.Order[]{
+            IBond.Order.UNSET,
+            IBond.Order.SINGLE,
+            IBond.Order.DOUBLE,
+            IBond.Order.TRIPLE,
+            IBond.Order.QUADRUPLE,
+            IBond.Order.SINGLE // aromatic also set
+    };
+
+
+    private static boolean apply(IAtomContainer mol,
+                                 IAtom[] amap,
+                                 TransformOp op) {
+        switch (op.type) {
+            case NewAtom:
+                amap[op.a] = newAtom(mol, op.b, op.c, op.d);
+                break;
+            case ReplaceAtom:
+                replaceAtom(mol, amap, op);
+                break;
+            case ReplaceHydrogen:
+                replaceHydrogen(mol, amap, op);
+                break;
+            case NewBond:
+                if (amap[op.a].getBond(amap[op.b]) != null)
+                    return false;
+                mol.addBond(amap[op.a].getIndex(), amap[op.b].getIndex(),
+                            BOND_ORDERS[op.c]);
+                if (op.c == 5 && amap[op.a].isAromatic() && amap[op.b].isAromatic())
+                    amap[op.a].getBond(amap[op.b]).setIsAromatic(true);
+                markBondingChanged(amap[op.a], amap[op.b]);
+                break;
+            case DeleteAtom:
+                // mark and sweep would be more optimal but require API changes
+                mol.removeAtom(amap[op.a]);
+                markBondingChanged(amap[op.a]);
+                break;
+            case DeleteBond:
+                mol.removeBond(amap[op.a].getBond(amap[op.b]));
+                markBondingChanged(amap[op.a], amap[op.b]);
+                break;
+            case BondOrder:
+                amap[op.a].getBond(amap[op.b]).setOrder(BOND_ORDERS[op.c]);
+                markBondingChanged(amap[op.a], amap[op.b]);
+                break;
+            case Element:
+                amap[op.a].setAtomicNumber(op.b);
+                break;
+            case Aromatic:
+                amap[op.a].setIsAromatic(op.b != 0);
+                break;
+            case Charge:
+                amap[op.a].setFormalCharge(op.b);
+                break;
+            case ImplH:
+                amap[op.a].setImplicitHydrogenCount(op.b);
+                markBondingChanged(amap[op.a]);
+                break;
+            case AdjustH:
+                if (!adjustHydrogenCount(mol, amap[op.a], op.b))
+                    return false;
+                markBondingChanged(amap[op.a]);
+                break;
+            case MoveH:
+                if (!moveHydrogen(mol, amap[op.a], amap[op.b]))
+                    return false;
+                markBondingChanged(amap[op.a], amap[op.b]);
+                break;
+            case Mass:
+                amap[op.a].setMassNumber(op.b);
+                break;
+            case Tetrahedral:
+                setLeftHandedTetrahedral(mol, amap, op);
+                break;
+            case DbTogether:
+            case DbOpposite:
+                setDbStereo(mol, amap, op);
+                break;
+            default:
+                return false;
+        }
+
+        resyncStereo(mol);
+        return true;
+    }
+
+    /**
+     * Synchronize stereochemistry, remove any stereochemistry where the bonding
+     * around the central atom/bond (the focus) changed during the transform.
+     *
+     * @param mol the molecule to synchronised
+     */
+    private static void resyncStereo(IAtomContainer mol) {
+        if (mol.stereoElements().iterator().hasNext()) {
+            boolean removed = false;
+            List<IStereoElement> updatedStereo = new ArrayList<>();
+            for (IStereoElement<?, ?> se : mol.stereoElements()) {
+                switch (se.getConfigClass()) {
+                    case IStereoElement.Tetrahedral:
+                    case IStereoElement.SquarePlanar:
+                    case IStereoElement.TrigonalBipyramidal:
+                    case IStereoElement.Octahedral:
+                        if (!bondingChanged(se.getFocus()))
+                            updatedStereo.add(se);
+                        else
+                            removed = true;
+                        break;
+                    case IStereoElement.Atropisomeric:
+                    case IStereoElement.CisTrans:
+                        if (!bondingChanged(((IBond) se.getFocus()).getBegin()) &&
+                                !bondingChanged(((IBond) se.getFocus()).getEnd()))
+                            updatedStereo.add(se);
+                        else
+                            removed = true;
+                        break;
+                    case IStereoElement.Allenal:
+                        IAtom[] ends = ExtendedTetrahedral.findTerminalAtoms(mol, (IAtom)se.getFocus());
+                        if (!bondingChanged(se.getFocus()) &&
+                            !bondingChanged(ends[0]) && !bondingChanged(ends[1]))
+                            updatedStereo.add(se);
+                        else
+                            removed = true;
+                        break;
+                    case IStereoElement.Cumulene:
+                        ends = ExtendedCisTrans.findTerminalAtoms(mol, (IBond) se.getFocus());
+                        if (!bondingChanged(((IBond) se.getFocus()).getBegin()) &&
+                                !bondingChanged(((IBond) se.getFocus()).getEnd()) &&
+                                ends != null && !bondingChanged(ends[0]) && !bondingChanged(ends[1]))
+                            updatedStereo.add(se);
+                        else
+                            removed = true;
+                        break;
+                    default:
+                        throw new IllegalStateException("Unhandled stereochemistry type");
+                }
+            }
+            if (removed)
+                mol.setStereoElements(updatedStereo);
+        }
+    }
+
+    // this is inefficient, need better AtomContainer API points but OK for now
+    private static void removeStereo(IAtomContainer mol, IChemObject atom) {
+        List<IStereoElement> stereo = new ArrayList<>();
+        for (IStereoElement<?,?> se : mol.stereoElements())
+            if (!se.getFocus().equals(atom))
+                stereo.add(se);
+        mol.setStereoElements(stereo);
+    }
+
+    private static void setLeftHandedTetrahedral(IAtomContainer mol, IAtom[] amap, TransformOp op) {
+        IAtom focus = amap[op.a];
+        removeStereo(mol, focus);
+        IAtom[] carriers = new IAtom[]{amap[op.b], amap[op.c], amap[op.d], focus};
+        // replace the placeholder atom if this atom has 4 atoms
+        if (focus.getBondCount() == 4) {
+            for (IBond bond : focus.bonds()) {
+                IAtom nbor = bond.getOther(focus);
+                if (!nbor.equals(amap[op.b]) && !nbor.equals(amap[op.c]) && !nbor.equals(amap[op.d]))
+                    carriers[3] = nbor;
+            }
+        }
+        mol.addStereoElement(new TetrahedralChirality(focus,
+                                                      carriers,
+                                                      ITetrahedralChirality.Stereo.ANTI_CLOCKWISE));
+    }
+
+    private static void setDbStereo(IAtomContainer mol, IAtom[] amap, TransformOp op) {
+        IBond dbBond = amap[op.a].getBond(amap[op.b]);
+        if (dbBond == null)
+            throw new IllegalStateException();
+        removeStereo(mol, dbBond);
+        IBond begNbor = amap[op.a].getBond(amap[op.c]);
+        IBond endNBor = amap[op.b].getBond(amap[op.d]);
+        if (begNbor == null || endNBor == null)
+            throw new IllegalStateException();
+        if (op.type == TransformOp.Type.DbTogether)
+            mol.addStereoElement(new DoubleBondStereochemistry(dbBond,
+                                                               new IBond[]{begNbor, endNBor},
+                                                               IDoubleBondStereochemistry.Conformation.TOGETHER));
+        else {
+            mol.addStereoElement(new DoubleBondStereochemistry(dbBond,
+                                                               new IBond[]{begNbor, endNBor},
+                                                               IDoubleBondStereochemistry.Conformation.OPPOSITE));
+        }
+    }
+
+    private static void replaceAtom(IAtomContainer mol, IAtom[] amap, TransformOp op) {
+        amap[op.a].setMassNumber(null);
+        amap[op.a].setAtomicNumber(op.b);
+        amap[op.a].setImplicitHydrogenCount(op.c);
+        amap[op.a].setIsAromatic(op.d != 0);
+        removeUnmappedBonds(amap[op.a], mol);
+    }
+
+    private static boolean replaceHydrogen(IAtomContainer mol, IAtom[] amap, TransformOp op) {
+        IAtom atom = amap[op.a];
+        IAtom hAtm = null;
+        int hcnt = atom.getImplicitHydrogenCount();
+        if (hcnt == 0) {
+            for (IBond bond : atom.bonds()) {
+                if (bond.getOrder() != IBond.Order.SINGLE)
+                    continue;
+                IAtom nbor = bond.getOther(atom);
+                if (isUnmappedExplH(nbor)) {
+                    hAtm = nbor;
+                    break;
+                }
+            }
+            if (hAtm == null)
+                return false;
+        } else {
+            amap[op.a].setImplicitHydrogenCount(hcnt - 1);
+        }
+        if (hAtm != null) {
+            removeUnmappedBonds(hAtm, mol);
+            hAtm.setMassNumber(null);
+            hAtm.setAtomicNumber(op.c);
+            hAtm.setImplicitHydrogenCount(op.d);
+            hAtm.setFormalCharge(0);
+            hAtm.setIsAromatic(false);
+            amap[op.b] = hAtm;
+        } else {
+            IAtom newAtom = mol.getBuilder().newAtom();
+            newAtom.setAtomicNumber(op.c);
+            newAtom.setImplicitHydrogenCount(op.d);
+            mol.addAtom(newAtom);
+            amap[op.b] = mol.getAtom(mol.getAtomCount() - 1);
+            mol.addBond(atom.getIndex(), amap[op.b].getIndex(),
+                        IBond.Order.SINGLE);
+        }
+        return true;
+    }
+
+    private static void removeUnmappedBonds(IAtom hAtm, IAtomContainer mol) {
+        List<IBond> bondsToDelete = new ArrayList<>();
+        for (IBond bond : hAtm.bonds())
+            if (isUnmapped(bond.getOther(hAtm)))
+                bondsToDelete.add(bond);
+        for (IBond bond : bondsToDelete)
+            mol.removeBond(bond);
+    }
+
+    private static IAtom newAtom(IAtomContainer mol, int elem, int hnct, int arom) {
+        IAtom atom = mol.getBuilder().newAtom();
+        atom.setAtomicNumber(elem);
+        atom.setImplicitHydrogenCount(hnct);
+        atom.setIsAromatic(arom != 0);
+        mol.addAtom(atom);
+        return mol.getAtom(mol.getAtomCount() - 1);
+    }
+
+    // important!! this operation is atomic, the atom is not updated unless the operation is possible
+    private static boolean adjustHydrogenCount(IAtomContainer mol, IAtom atom, int adjustment) {
+        int updatedHcnt = atom.getImplicitHydrogenCount() + adjustment;
+        if (updatedHcnt >= 0) {
+            atom.setImplicitHydrogenCount(updatedHcnt);
+        } else {
+            if (!removeExplH(mol, atom, -updatedHcnt))
+                return false;
+            atom.setImplicitHydrogenCount(0);
+        }
+        return true;
+    }
+
+    private static boolean removeExplH(IAtomContainer mol,
+                                       IAtom atom,
+                                       int required) {
+        Set<IAtom> deleted = new HashSet<>();
+        for (IBond bond : atom.bonds()) {
+            if (bond.getOrder() != IBond.Order.SINGLE)
+                continue;
+            IAtom nbor = bond.getOther(atom);
+            if (isUnmappedExplH(nbor)) {
+                deleted.add(nbor);
+                if (deleted.size() == required)
+                    break;
+            }
+        }
+        if (deleted.size() != required)
+            return false;
+        for (IAtom a : deleted)
+            mol.removeAtom(a);
+        return true;
+    }
+
+    // important !! this operation is atomic, the atoms are not updated unless the operation is possible
+    private static boolean moveHydrogen(IAtomContainer mol, IAtom from, IAtom to) {
+        // if possible we move an implicit hydrogen (cheap)
+        if (from.getImplicitHydrogenCount() != 0) {
+            from.setImplicitHydrogenCount(from.getImplicitHydrogenCount() - 1);
+            to.setImplicitHydrogenCount(to.getImplicitHydrogenCount() + 1);
+            return true;
+        } else {
+            return moveExplH(mol, from, to);
+        }
+    }
+
+    private static boolean moveExplH(IAtomContainer mol,
+                                     IAtom src, IAtom dst) {
+        IAtom hAtm = null;
+        IBond hBnd = null;
+        for (IBond bond : src.bonds()) {
+            if (bond.getOrder() != IBond.Order.SINGLE)
+                continue;
+            IAtom nbor = bond.getOther(src);
+            if (isUnmappedExplH(nbor)) {
+                hBnd = bond;
+                hAtm = nbor;
+                break;
+            }
+        }
+
+        if (hAtm == null)
+            return false;
+
+        mol.removeBond(hBnd);
+        mol.addBond(dst.getIndex(), hAtm.getIndex(), IBond.Order.SINGLE);
+        return true;
+    }
+
+    private static boolean isUnmappedExplH(IAtom atom) {
+        if (atom.getAtomicNumber() != 1)
+            return false;
+        return isUnmapped(atom);
+    }
+
+    private static boolean isUnmapped(IAtom atom) {
+        return !atom.getFlag(CDKConstants.MAPPED);
+    }
+
+    private static void markBondingChanged(IAtom atom) {
+        atom.setFlag(CDKConstants.REACTIVE_CENTER, true);
+    }
+
+    private static void markBondingChanged(IAtom beg, IAtom end) {
+        end.setFlag(CDKConstants.REACTIVE_CENTER, true);
+    }
+
+    private static boolean bondingChanged(IChemObject chemobj) {
+        return chemobj.getFlag(CDKConstants.REACTIVE_CENTER);
+    }
+
+    private void undo(IAtomContainer mol, IAtom[] amap, TransformOp op) {
+        switch (op.type) {
+            case NewAtom:
+                mol.removeAtom(amap[op.a]);
+                break;
+            case NewBond:
+                mol.removeBond(amap[op.a].getBond(amap[op.b]));
+                break;
+            case AdjustH:
+                if (!adjustHydrogenCount(mol, amap[op.a], -op.b))
+                    throw new IllegalStateException("Was not able to undo AdjustH");
+                break;
+            case MoveH:
+                if (!moveHydrogen(mol, amap[op.b], amap[op.a]))
+                    throw new IllegalStateException("Was not able to undo MoveH");
+                break;
+            default:
+                throw new IllegalStateException("OpCode cannot be undone: " + op);
+        }
+    }
+
+    /**
+     * Undo the OpCodes (0 .. n)
+     *
+     * @param mol  the molecule
+     * @param amap the atom map
+     * @param n    undo operations before this op idx
+     */
+    private void undo(IAtomContainer mol, IAtom[] amap, int n) {
+        for (int i = n - 1; i >= 0; i--)
+            undo(mol, amap, ops.get(i));
+    }
+}

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -36,6 +36,7 @@ import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -100,6 +101,7 @@ final class TransformPlan {
                 return false;
             }
         }
+        resyncStereo(mol);
         return true;
     }
 
@@ -342,7 +344,6 @@ final class TransformPlan {
                 return false;
         }
 
-        resyncStereo(mol);
         return true;
     }
 
@@ -398,8 +399,9 @@ final class TransformPlan {
                         throw new IllegalStateException("Unhandled stereochemistry type");
                 }
             }
-            if (removed)
-                mol.setStereoElements((List)updatedStereo);
+            if (removed) {
+                mol.setStereoElements((List) updatedStereo);
+            }
         }
     }
 
@@ -618,6 +620,7 @@ final class TransformPlan {
     }
 
     private static void markBondingChanged(IAtom beg, IAtom end) {
+        beg.setFlag(CDKConstants.REACTIVE_CENTER, true);
         end.setFlag(CDKConstants.REACTIVE_CENTER, true);
     }
 

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/TransformPlan.java
@@ -168,6 +168,8 @@ final class TransformPlan {
     }
 
     private int optimizeReplaceAtom(List<TransformOp> ops, int i) {
+        int from = ops.get(i-3).a;
+        int to   = ops.get(i).a;
         ops.set(i - 3, new TransformOp(TransformOp.Type.ReplaceAtom,
                                        ops.get(i).a,
                                        ops.get(i - 3).b,
@@ -183,6 +185,8 @@ final class TransformPlan {
         }
         ops.remove(i--);
         ops.remove(i--);
+        for (int j=i; j<ops.size(); j++)
+            ops.set(j, ops.get(j).remap(from, to));
         return i;
     }
 

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformOpTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformOpTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TransformOpTest {
+
+    @Test
+    void testToString() {
+        Assertions.assertEquals("Mass{13@1}", new TransformOp(TransformOp.Type.Mass, 1, 13).toString());
+        Assertions.assertEquals("MoveH{1=>2}", new TransformOp(TransformOp.Type.MoveH, 1, 2).toString());
+        Assertions.assertEquals("NewAtom{[CH3@1]}", new TransformOp(TransformOp.Type.NewAtom, 1, 6, 3).toString());
+        Assertions.assertEquals("NewAtom{[cH1@1]}", new TransformOp(TransformOp.Type.NewAtom, 1, 6, 1, 1).toString());
+        Assertions.assertEquals("NewBond{1-2}", new TransformOp(TransformOp.Type.NewBond, 1, 2, 1).toString());
+        Assertions.assertEquals("NewBond{1=2}", new TransformOp(TransformOp.Type.NewBond, 1, 2, 2).toString());
+        Assertions.assertEquals("NewBond{1#2}", new TransformOp(TransformOp.Type.NewBond, 1, 2, 3).toString());
+        Assertions.assertEquals("NewBond{1,2,order=4}", new TransformOp(TransformOp.Type.NewBond, 1, 2, 4).toString());
+    }
+}

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
@@ -28,6 +28,9 @@ import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class TransformTest {
 
     @Test
@@ -38,12 +41,9 @@ class TransformTest {
                 Arrays.asList(new TransformOp(Type.NewAtom, 6, 17, 0),
                               new TransformOp(Type.NewBond, 1, 5, 1),
                               new TransformOp(Type.BondOrder, 1, 2, 2)));
-        transform.apply(pentane2);
-        System.err.println(pentane2.getBondCount());
-        for  (IAtom atom : pentane2.atoms())
-            System.err.println(atom.getSymbol());
-        for (IBond bond : pentane2.bonds())
-            System.err.println(bond.getBegin().getIndex() + " " + bond.getEnd().getIndex() + " " + bond.getOrder());
+        assertTrue(transform.apply(pentane2));
+        assertEquals(pentane2.getBondCount(), 5);
+        assertEquals(pentane2.getBond(5).getOrder(), IBond.Order.DOUBLE);
     }
 
 }

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.isomorphism;
+
+import org.junit.jupiter.api.Test;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.isomorphism.TransformOp.Type;
+import org.openscience.cdk.templates.TestMoleculeFactory;
+
+import java.util.Arrays;
+
+class TransformTest {
+
+    @Test
+    void testSimpleRingForming() {
+        IAtomContainer pentane1 = TestMoleculeFactory.makeAlkane(5);
+        IAtomContainer pentane2 = TestMoleculeFactory.makeAlkane(5);
+        Transform transform = new Transform(Pattern.findSubstructure(pentane1),
+                Arrays.asList(new TransformOp(Type.NewAtom, 6, 17, 0),
+                              new TransformOp(Type.NewBond, 1, 5, 1),
+                              new TransformOp(Type.BondOrder, 1, 2, 2)));
+        transform.apply(pentane2);
+        System.err.println(pentane2.getBondCount());
+        for  (IAtom atom : pentane2.atoms())
+            System.err.println(atom.getSymbol());
+        for (IBond bond : pentane2.bonds())
+            System.err.println(bond.getBegin().getIndex() + " " + bond.getEnd().getIndex() + " " + bond.getOrder());
+    }
+
+}

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
@@ -42,7 +42,7 @@ class TransformTest {
                               new TransformOp(Type.NewBond, 1, 5, 1),
                               new TransformOp(Type.BondOrder, 1, 2, 2)));
         assertTrue(transform.apply(pentane2));
-        assertEquals(6, pentane2.getBondCount());
+        assertEquals(5, pentane2.getBondCount());
         assertEquals(IBond.Order.DOUBLE, pentane2.getBond(0).getOrder());
     }
 

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
@@ -43,7 +43,7 @@ class TransformTest {
                               new TransformOp(Type.BondOrder, 1, 2, 2)));
         assertTrue(transform.apply(pentane2));
         assertEquals(pentane2.getBondCount(), 5);
-        assertEquals(pentane2.getBond(5).getOrder(), IBond.Order.DOUBLE);
+        assertEquals(pentane2.getBond(0).getOrder(), IBond.Order.DOUBLE);
     }
 
 }

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/TransformTest.java
@@ -42,8 +42,8 @@ class TransformTest {
                               new TransformOp(Type.NewBond, 1, 5, 1),
                               new TransformOp(Type.BondOrder, 1, 2, 2)));
         assertTrue(transform.apply(pentane2));
-        assertEquals(pentane2.getBondCount(), 5);
-        assertEquals(pentane2.getBond(0).getOrder(), IBond.Order.DOUBLE);
+        assertEquals(6, pentane2.getBondCount());
+        assertEquals(IBond.Order.DOUBLE, pentane2.getBond(0).getOrder());
     }
 
 }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
@@ -218,7 +218,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
     private BondRef getBondRef(IBond bond) {
         BondRef ref = getBondRefUnsafe(bond);
         if (ref == null)
-            throw new NoSuchBondException("Atom is not a member of this AtomContainer");
+            throw new NoSuchBondException("Bond is not a member of this AtomContainer");
         return ref;
     }
 

--- a/tool/smarts/pom.xml
+++ b/tool/smarts/pom.xml
@@ -72,6 +72,19 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-atomtype</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- benchmark only -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-inchi</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-test</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
@@ -303,8 +303,9 @@ public final class Smarts {
             if (peek() == ':') {
                 next();
                 int num = nextUnsignedInt();
-                if (num < 0) {
+                if (num <= 0) {
                     pos = mark;
+                    error = "map idx should >0";
                     return false;
                 }
                 atom.setProperty(CDKConstants.ATOM_ATOM_MAPPING, num);
@@ -1352,10 +1353,11 @@ public final class Smarts {
                         if (expr == null)
                             return false;
                         num = nextUnsignedInt();
-                        if (num < 0)
+                        if (num <= 0) {
+                            error = "map idx should >0";
                             return false;
-                        if (num != 0)
-                            atom.setProperty(CDKConstants.ATOM_ATOM_MAPPING, num);
+                        }
+                        atom.setProperty(CDKConstants.ATOM_ATOM_MAPPING, num);
                         // should be add end of expr
                         if (lastOp != 0)
                             return peek() == ']';
@@ -1511,7 +1513,10 @@ public final class Smarts {
             atom.setExpression(expr);
             if (!parseExplicitHydrogen(atom, expr) &&
                 !parseAtomExpr(atom, expr, '\0')) {
-                error = "Invalid atom expression";
+                if (error != null)
+                    error = "Invalid atom expression: " + error;
+                else
+                    error = "Invalid atom expression";
                 return false;
             }
             append(atom);
@@ -2979,7 +2984,7 @@ public final class Smarts {
                         throw new IllegalArgumentException();
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("Unsupported type" + expr.type());
             }
         }
 
@@ -3114,6 +3119,8 @@ public final class Smarts {
                     return generateAtom(atom, expr.right());
                 if (expr.right().type() == Expr.Type.REACTION_ROLE)
                     return generateAtom(atom, expr.left());
+            } else if (expr.type() == REACTION_ROLE) {
+                return generateAtom(atom, new Expr(TRUE));
             }
 
             int mapidx = atom != null ? mapidx(atom) : 0;

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/Smarts.java
@@ -1584,8 +1584,12 @@ public final class Smarts {
                 bond.setExpression(null);
                 bondPos = aoffset[mol.getAtomCount()-1];
             }
-            bond.setAtom(prev, 0);
+
+            if (mol.getBondCount() == boffset.length)
+                boffset = Arrays.copyOf(boffset, boffset.length + (boffset.length>>>1));
             boffset[mol.getBondCount()] = bondPos;
+
+            bond.setAtom(prev, 0);
             rings[rnum] = addBond(prev, bond);
             numRingOpens++;
             bond = null;
@@ -1606,6 +1610,9 @@ public final class Smarts {
                     return false;
                 }
                 this.bond = null;
+
+                if (mol.getBondCount() == boffset.length)
+                    boffset = Arrays.copyOf(boffset, boffset.length + (boffset.length>>>1));
                 boffset[mol.indexOf(bond)] = bondPos;
             } else if (openExpr == null) {
                 ((QueryBond) BondRef.deref(bond)).setExpression(new Expr(SINGLE_OR_AROMATIC));
@@ -1831,9 +1838,9 @@ public final class Smarts {
                     Expr expr = ((QueryBond) BondRef.deref(bond)).getExpression();
                     expr = strip(expr, Expr.Type.STEREOCHEMISTRY);
                     if (expr == null)
-                        expr = new Expr(SINGLE_OR_AROMATIC);
+                        expr = new Expr(ORDER, 1);
                     else
-                        expr.and(new Expr(SINGLE_OR_AROMATIC));
+                        expr.and(new Expr(ORDER, 1));
                     ((QueryBond) bond).setExpression(expr);
                 }
             }
@@ -3095,7 +3102,7 @@ public final class Smarts {
                         case BSTEREO_UPU: bdir = BSTEREO_DNU; break;
                     }
                 }
-                if (bexpr.isEmpty())
+                if (bexpr.isEmpty() || bexpr.equals("-"))
                     bexpr = bdir;
                 else
                     bexpr += ';' + bdir;

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsResult.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsResult.java
@@ -34,6 +34,8 @@ public class SmartsResult {
     private final String str;
     private final int pos;
     private final String mesg;
+    private final int[] aoffsets;
+    private final int[] boffsets;
     private final boolean status;
 
     SmartsResult(String str, int pos, String mesg) {
@@ -41,13 +43,17 @@ public class SmartsResult {
         this.pos = pos;
         this.mesg = mesg;
         this.status = false;
+        this.aoffsets = null;
+        this.boffsets = null;
     }
 
-    SmartsResult(String str) {
+    SmartsResult(String str, int[] aoffsets, int[] boffsets) {
         this.str = str;
         this.pos = str.length();
         this.mesg = "OK";
         this.status = true;
+        this.aoffsets = aoffsets;
+        this.boffsets = boffsets;
     }
 
     /**
@@ -59,20 +65,47 @@ public class SmartsResult {
         return this.mesg;
     }
 
+    public int getAtomLocation(int idx) {
+        if (idx < 0)
+            return 0;
+        if (idx >= aoffsets.length)
+            return str.length();
+        return aoffsets[idx];
+    }
+
+    public int getBondLocation(int idx) {
+        if (idx < 0)
+            return 0;
+        if (idx >= boffsets.length)
+            return str.length();
+        return boffsets[idx];
+    }
+
+    public String displayErrorLocation() {
+        return displayErrorLocation(pos-1);
+    }
+
     /**
      * Displays where the error occurred on the input string.
      *
      * @return the error location
      */
-    public String displayErrorLocation() {
+    public String displayErrorLocation(int pos) {
         StringBuilder sb = new StringBuilder();
         sb.append(str);
         sb.append('\n');
-        char[] cs = new char[pos - 1];
-        Arrays.fill(cs, ' ');
-        sb.append(cs);
-        sb.append('^');
-        sb.append('\n');
+        if (pos <= str.length()) {
+            char[] cs = new char[pos];
+            Arrays.fill(cs, ' ');
+            sb.append(cs);
+            sb.append('^');
+            if (str.charAt(pos) == '[') {
+                int end = str.indexOf(']', pos);
+                while (pos++ < end)
+                    sb.append('^');
+            }
+            sb.append('\n');
+        }
         return sb.toString();
     }
 

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/BinaryExprValue.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/BinaryExprValue.java
@@ -33,6 +33,8 @@ import java.util.Objects;
  */
 final class BinaryExprValue {
 
+    public static final BinaryExprValue ZERO = new BinaryExprValue(0, Type.Integer);
+
     enum Type {
         Integer,
         Boolean,

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/BinaryExprValue.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/BinaryExprValue.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2022 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.smirks;
+
+import java.util.Objects;
+
+/**
+ * Internal.
+ *
+ * A helper utility to assist in evaluating binary expressions that may have
+ * an undefined or invalid result. Consider a SMARTS atom like this: {@code
+ * [CH2,NH2] => OR(AND(elem=C,H=2),AND(elem=N,H=2))} we can deduce that the
+ * element is "conflicting" but the hydrogen count must be "2".
+ *
+ * @author John Mayfield
+ */
+final class BinaryExprValue {
+
+    enum Type {
+        Integer,
+        Boolean,
+        Conflict,
+        Undefined
+    }
+
+    final int val;
+    final Type type;
+
+    static final BinaryExprValue UNDEF = new BinaryExprValue(0, Type.Undefined);
+    static final BinaryExprValue CONFLICTING = new BinaryExprValue(0, Type.Conflict);
+    static final BinaryExprValue FALSE = new BinaryExprValue(0, Type.Boolean);
+    static final BinaryExprValue TRUE = new BinaryExprValue(1, Type.Boolean);
+
+    BinaryExprValue(int x, Type t) {
+        this.val = x;
+        this.type = t;
+    }
+
+    BinaryExprValue(int x) {
+        this.val = x;
+        this.type = Type.Integer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BinaryExprValue that = (BinaryExprValue) o;
+        return val == that.val && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(val, type);
+    }
+
+    BinaryExprValue and(BinaryExprValue that) {
+        if (this.type == Type.Undefined)
+            return that;
+        if (that.type == Type.Undefined)
+            return this;
+        if (this.type == Type.Conflict || that.type == Type.Conflict)
+            return CONFLICTING;
+        if (this.val == that.val)
+            return this;
+        return CONFLICTING;
+    }
+
+    BinaryExprValue or(BinaryExprValue that) {
+        if (this.type == Type.Conflict || that.type == Type.Conflict)
+            return CONFLICTING;
+        if (this.type == Type.Undefined && that.type == Type.Undefined)
+            return UNDEF;
+        if (this.type == that.type && this.val == that.val)
+            return this;
+        return CONFLICTING;
+    }
+
+    BinaryExprValue not() {
+        if (this.type == Type.Undefined)
+            return UNDEF;
+        // !true => false etc
+        if (this.type == Type.Boolean)
+            return this.val != 0 ? FALSE : TRUE;
+        return CONFLICTING;
+    }
+
+    public boolean ok() {
+        return type == Type.Integer || type == Type.Boolean;
+    }
+
+    public boolean invalid() {
+        return type == Type.Conflict;
+    }
+
+    public boolean undef() {
+        return type == Type.Undefined;
+    }
+
+    @Override
+    public String toString() {
+        if (type == Type.Undefined)
+            return "{undefined}";
+        if (type == Type.Conflict)
+            return "{conflict}";
+        if (type == Type.Boolean)
+            return val != 0 ? "(true)" : "(false)";
+        else
+            return "(" + val + ")";
+    }
+
+}

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -568,8 +568,8 @@ public class Smirks {
         }
     }
 
-    private static void determineBondChanges(List<TransformOp> ops,
-                                             SmirksState state) {
+    private static boolean determineBondChanges(List<TransformOp> ops,
+                                                SmirksState state) {
         for (IBond[] pair : state.bondPairs) {
             int begIdx = pair[0] == null ? state.atomidx.get(pair[1].getBegin()) : state.atomidx.get(pair[0].getBegin());
             int endIdx = pair[0] == null ? state.atomidx.get(pair[1].getEnd()) : state.atomidx.get(pair[0].getEnd());
@@ -595,14 +595,16 @@ public class Smirks {
                     if (!rgt.ok()) {
                         if (IsAnyBond(pair[1]))
                             continue;
-                        throw new IllegalArgumentException();
+                        state.warnings.add("Ignored query bond, consider using '~'");
+                    } else {
+                        if (changed(lft, rgt))
+                            ops.add(new TransformOp(TransformOp.Type.BondOrder,
+                                                    begIdx, endIdx, rgt.val));
                     }
-                    if (changed(lft, rgt))
-                        ops.add(new TransformOp(TransformOp.Type.BondOrder,
-                                                begIdx, endIdx, rgt.val));
                 }
             }
         }
+        return true;
     }
 
     private static void determineStereoChanges(List<TransformOp> ops, SmirksState state) {

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -318,8 +318,6 @@ public class Smirks {
         // build the query pattern based on the left-hand side of the reaction
         prepareQuery(state);
 
-        System.err.println(ops);
-
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(Smarts.generate(query));
             LOGGER.debug(ops);

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -273,10 +273,14 @@ public class Smirks {
             }
         }
 
+        if (state.opts.contains(SmirksOption.REMOVED_UNMAPPED_FRAGMENTS))
+            ops.add(new TransformOp(TransformOp.Type.RemoveUnmapped, 0));
+
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(Smarts.generate(query));
             LOGGER.debug(ops);
         }
+
 
         transform.init(DfPattern.findSubstructure(query), ops, state.getMessage());
 

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -1,0 +1,882 @@
+/*
+ * Copyright (C) 2022 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.smirks;
+
+import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.ReactionRole;
+import org.openscience.cdk.config.Elements;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.isomorphism.DfPattern;
+import org.openscience.cdk.isomorphism.Transform;
+import org.openscience.cdk.isomorphism.TransformOp;
+import org.openscience.cdk.isomorphism.matchers.Expr;
+import org.openscience.cdk.isomorphism.matchers.QueryAtom;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
+import org.openscience.cdk.isomorphism.matchers.QueryBond;
+import org.openscience.cdk.smarts.Smarts;
+import org.openscience.cdk.smarts.SmartsResult;
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Support for parsing a SMIRKS transform and utilities to parse/apply in one
+ * step.
+ *
+ * <pre>{@code
+ * if (Smirks.apply(mol, "[*:1][H]>>[*:1]Cl")) {
+ *     System.err.println("Success!");
+ * }
+ * }</pre>
+ *
+ * If the SMIRKS is invalid a runtime exception is thrown. If you expect
+ * to be processing possibly invalid inputs consider using the more verbose
+ * {@link #parse(org.openscience.cdk.isomorphism.Transform, String)}
+ * function and apply it separately. Note you can parse in either the
+ * low-level {@link org.openscience.cdk.isomorphism.Transform} or the
+ * higher-level {@link org.openscience.cdk.smirks.SmirksTransform}.
+ *
+ * <pre>
+ * {@code
+ * Transform transform = new SmirksTransform();
+ * if (!Smirks.parse(transform, "[*:1][H]>>[*:1]Cl"))
+ *   System.err.println("BAD SMIRKS: " + transform.message());
+ *
+ * IAtomContainer mol = ...;
+ * transform.apply(mol);
+ * }
+ * </pre>
+ *
+ * @see org.openscience.cdk.isomorphism.Transform
+ * @see org.openscience.cdk.smirks.SmirksTransform
+ */
+public class Smirks {
+
+    private static final ILoggingTool LOGGER = LoggingToolFactory.createLoggingTool(Smirks.class);
+
+    private Smirks() {
+    }
+
+    private static final class BondKey {
+        int beg;
+        int end;
+
+        BondKey(int beg, int end) {
+            this.beg = beg;
+            this.end = end;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            BondKey key = (BondKey) o;
+            return beg == key.beg && end == key.end;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(beg, end);
+        }
+    }
+
+    /**
+     * Convenience function to compile a SMIRKS string into a transform.
+     *
+     * <pre>{@code
+     * Smirks.compile("[*:1][H]>>[*:1]Cl")
+     *       .apply(mol);
+     * }</pre>
+     *
+     * If the SMIRKS is invalid a runtime exception is thrown. If you expect
+     * to be processing possibly invalid inputs consider using the more verbose
+     * {@link #parse(org.openscience.cdk.isomorphism.Transform, String)}
+     * function.
+     *
+     * @param smirks the SMIRKS string
+     * @return a SmirksTransform
+     */
+    public static SmirksTransform compile(String smirks) {
+        SmirksTransform transform = new SmirksTransform();
+        if (!Smirks.parse(transform, smirks))
+            throw new IllegalStateException("Invalid SMIRKS: " + transform.message());
+        return transform;
+    }
+
+    /**
+     * Convenience function to compile and apply a SMIRKS string on a molecule
+     * to all non-overlapping (exclusive) matches.
+     *
+     * <pre>{@code
+     * if (Smirks.apply(mol, "[*:1][H]>>[*:1]Cl")) {
+     *     System.err.println("Success!");
+     * }
+     * }</pre>
+     *
+     * If the SMIRKS is invalid a runtime exception is thrown. If you expect
+     * to be processing possibly invalid inputs consider using the more verbose
+     * {@link #parse(org.openscience.cdk.isomorphism.Transform, String)}
+     * function and apply it separately.
+     *
+     * @param mol the molecule to apply the SMIRKS to
+     * @param smirks the SMIRKS string
+     * @return the pattern was applied or not
+     * @see org.openscience.cdk.isomorphism.Transform#apply(org.openscience.cdk.interfaces.IAtomContainer)
+     */
+    public static boolean apply(IAtomContainer mol, String smirks) {
+        return compile(smirks).apply(mol);
+    }
+
+    /**
+     * Convenience function to compile and apply a SMIRKS string on a copy of
+     * the molecule returning the places the transform matched and applied.
+     *
+     * <pre>{@code
+     * for (IAtomContainer res : Smirks.apply(mol, "[*:1][H]>>[*:1]Cl")) {
+     *    // ... further process result molecule
+     * }
+     * }</pre>
+     *
+     * If the SMIRKS is invalid a runtime exception is thrown. If you expect
+     * to be processing possibly invalid inputs consider using the more verbose
+     * {@link #parse(org.openscience.cdk.isomorphism.Transform, String)}
+     * function and apply it separately.
+     *
+     * @param mol the molecule to apply the SMIRKS to
+     * @param smirks the SMIRKS string
+     * @return the pattern was applied or not
+     * @see org.openscience.cdk.isomorphism.Transform#apply(org.openscience.cdk.interfaces.IAtomContainer, org.openscience.cdk.isomorphism.Transform.Mode)
+     */
+    public static Iterable<IAtomContainer> apply(IAtomContainer mol,
+                                                 String smirks,
+                                                 Transform.Mode mode) {
+        return compile(smirks).apply(mol, mode);
+    }
+
+    /**
+     * Parse a SMIRKS string into a transform.
+     *
+     * <pre>
+     * {@code
+     * Transform transform = new SmirksTransform();
+     * if (!Smirks.parse(transform, "[*:1][H]>>[*:1]Cl")) {
+     *   System.err.println("BAD SMIRKS: " + transform.message());
+     *   return;
+     * }
+     *
+     * IAtomContainer mol = ...;
+     * transform.apply(mol);
+     * }
+     * </pre>
+     *
+     * If the SMIRKS could not be interpreted or was invalid this method returns
+     * <b>false</b> and sets the transform into an error state meaning calling
+     * {@code apply()} will do nothing. The {@link Transform#message()} may
+     * still be set if there were warnings generated when interpreting the
+     * SMIRKS.
+     *
+     * @param transform the transform to load into
+     * @param smirks    the SMIRKS string
+     * @return the SMIRKS interpretable or not (there was an error)
+     * @see org.openscience.cdk.isomorphism.Transform
+     * @see org.openscience.cdk.smirks.SmirksTransform
+     */
+    public static boolean parse(Transform transform,
+                                String smirks) {
+
+        if (transform == null)
+            throw new NullPointerException("No transform provided");
+        if (smirks == null)
+            throw new NullPointerException("No SMIRKS string provided");
+
+        QueryAtomContainer query = new QueryAtomContainer(null);
+        SmartsResult result = Smarts.parseToResult(query, smirks,
+                                                   Smarts.FLAVOR_LOOSE);
+        if (!result.ok())
+            return transform.setError(result.getMessage());
+
+        SmirksState state = new SmirksState(query);
+
+        // based on the atom mapping pair up the atoms/bonds from the left side
+        // of the reaction to the right side
+        if (!collectAtomPairs(state))
+            return transform.setError(state.getMessage());
+        if (!collectBondPairs(state))
+            return transform.setError(state.getMessage());
+
+        // now we have the pairs of atoms/bonds we need to work out which were
+        // added/removed/changed. For the changes we detect we insert Op-codes
+        // that will be run to carry out the transform
+        List<TransformOp> ops = new ArrayList<>();
+        determineHydrogenMovement(ops, state);
+        determineAtomChanges(ops, state);
+        determineBondChanges(ops, state);
+        determineStereoChanges(ops, state);
+
+        // build the query pattern based on the left-hand side of the reaction
+        prepareQuery(state);
+
+        System.err.println(Smarts.generate(query));
+        System.err.println(ops);
+        transform.init(DfPattern.findSubstructure(query), ops, state.getMessage());
+
+        return true;
+    }
+
+    private static final class SmirksState {
+        List<String> errors = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+
+        QueryAtomContainer query;
+
+        int numAtoms = 1; // start numbering from one to we line up with atom maps.
+        int numPairs = 0;
+        Map<IAtom, Integer> atomidx = new HashMap<>();
+        Map<Integer, Integer> remap = new HashMap<>();
+
+        List<IAtom[]> atomPairs = new ArrayList<>();
+        List<IBond[]> bondPairs = new ArrayList<>();
+
+        int[] hcount;
+        int[] hmin;
+
+        SmirksState(QueryAtomContainer query) {
+            this.query = query;
+            this.hcount = new int[query.getAtomCount() + 1];
+            this.hmin = new int[query.getAtomCount() + 1];
+        }
+
+        private int calcImplH(IAtom atom) {
+            // if the atom is not in square brackets [C:1][O] vs [C:1]O
+            // "iscomplex" is not defined
+            if (atom.getProperty("cdk.smarts.iscomplex") == null) {
+                // guaranteed to be defined since it is not an expression
+                int elem = GetAtomicNumber(atom).val;
+                Integer valence = GetExplValence(query, atom);
+                if (valence == null) {
+                    warnings.add("Created (right hand side) unbracketed " + Elements.ofNumber(elem)
+                                                                                    .symbol() + " atom was connected with bond expressions");
+                    return 0;
+                }
+                if (IsAromatic(atom).val == 1)
+                    valence++;
+                switch (elem) {
+                    case IAtom.Wildcard:
+                        return 0;
+                    case IAtom.B:
+                        if (valence < 3) return 3 - valence;
+                        break;
+                    case IAtom.C:
+                        if (valence < 4) return 4 - valence;
+                        break;
+                    case IAtom.N:
+                    case IAtom.P:
+                        if (valence < 3) return 3 - valence;
+                        else if (valence < 5) return 5 - valence;
+                        break;
+                    case IAtom.O:
+                        if (valence < 2) return 2 - valence;
+                        break;
+                    case IAtom.S:
+                        if (valence < 2) return 2 - valence;
+                        else if (valence < 4) return 4 - valence;
+                        else if (valence < 6) return 6 - valence;
+                        break;
+                }
+            }
+            return 0;
+        }
+
+        public boolean error(String s) {
+            errors.add(s);
+            return false;
+        }
+
+        public void warning(String s) {
+            warnings.add(s);
+        }
+
+        public String getMessage() {
+            if (errors.isEmpty() && warnings.isEmpty())
+                return null;
+            StringBuilder sb = new StringBuilder();
+            for (String e : errors) {
+                if (sb.length() != 0) sb.append(", ");
+                sb.append(e);
+            }
+            if (sb.length() == 0) {
+                for (String w : warnings) {
+                    if (sb.length() != 0) sb.append(", ");
+                    sb.append(w);
+                }
+            }
+            return sb.toString();
+        }
+    }
+
+    private static boolean collectAtomPairs(SmirksState state) {
+        for (IAtom atom : state.query.atoms()) {
+            ReactionRole role = atom.getProperty(CDKConstants.REACTION_ROLE);
+            if (role == null)
+                return state.error("SMIRKS was not a reaction!");
+            boolean maybeImplH = isExplH(state.query, atom);
+
+            int mapidx = getMapIdx(atom);
+            Integer pairidx = state.remap.get(mapidx);
+            if (pairidx == null) {
+                pairidx = state.numPairs++;
+                if (mapidx != 0)
+                    state.remap.put(mapidx, pairidx);
+            }
+            while (state.atomPairs.size() <= pairidx)
+                state.atomPairs.add(new IAtom[2]);
+
+            IAtom[] atoms = state.atomPairs.get(pairidx);
+            switch (role) {
+                case Reactant:
+                case Agent:
+                    if (atoms[0] != null)
+                        return duplicateAtomMap(state, atoms[0], atom);
+                    atoms[0] = atom;
+                    if (maybeImplH)
+                        break;
+                    state.atomidx.put(atom, state.numAtoms++);
+                    break;
+                case Product:
+                    if (atoms[1] != null)
+                        return duplicateAtomMap(state, atoms[1], atom);
+                    atoms[1] = atom;
+                    if ((maybeImplH || isExplH(state.query, atoms[0])) &&
+                            (atoms[0] == null || !state.atomidx.containsKey(atoms[0])))
+                        break;
+                    int aidx = atoms[0] != null ? state.atomidx.get(atoms[0]) : state.numAtoms++;
+                    state.atomidx.put(atom, aidx);
+                    state.hcount[aidx] = state.calcImplH(atom);
+                    break;
+            }
+        }
+        return true;
+    }
+
+    private static boolean collectBondPairs(SmirksState state) {
+        Map<BondKey, IBond[]> bondMap = new HashMap<>();
+        for (IBond bond : state.query.bonds()) {
+            IAtom beg = bond.getBegin();
+            IAtom end = bond.getEnd();
+
+            int begIdx = getMapIdx(beg);
+            int endIdx = getMapIdx(end);
+
+            // suppressed hydrogen
+            if (!state.atomidx.containsKey(beg)) {
+                if (!state.atomidx.containsKey(end))
+                    throw new IllegalStateException();
+                state.hcount[state.atomidx.get(end)] += isProduct(end) ? +1 : -1;
+                if (!isProduct(end))
+                    state.hmin[state.atomidx.get(end)]++;
+                continue;
+            }
+            if (!state.atomidx.containsKey(end)) {
+                state.hcount[state.atomidx.get(beg)] += isProduct(beg) ? +1 : -1;
+                if (!isProduct(beg))
+                    state.hmin[state.atomidx.get(beg)]++;
+                continue;
+            }
+
+            IBond[] bondPair = null;
+            if (begIdx != 0 && endIdx != 0)
+                bondPair = bondMap.get(new BondKey(getMapIdx(beg), getMapIdx(end)));
+            if (bondPair == null) {
+                state.bondPairs.add(bondPair = new IBond[2]);
+                if (begIdx != 0 && endIdx != 0)
+                    bondMap.put(new BondKey(getMapIdx(beg), getMapIdx(end)), bondPair);
+            }
+            ReactionRole role = beg.getProperty(CDKConstants.REACTION_ROLE);
+            switch (role) {
+                case Reactant:
+                case Agent:
+                    bondPair[0] = bond;
+                    break;
+                case Product:
+                    bondPair[1] = bond;
+                    break;
+            }
+        }
+        return true;
+    }
+
+
+    private static boolean determineHydrogenMovement(List<TransformOp> ops,
+                                                     SmirksState state) {
+        Iterator<IAtom[]> iter = state.atomPairs.iterator();
+        while (iter.hasNext()) {
+            IAtom[] pair = iter.next();
+            if (isExplH(state.query, pair[0])) {
+                if (isExplH(state.query, pair[1])) {
+                    IAtom begNbor = state.query.getConnectedBondsList(pair[0]).get(0).getOther(pair[0]);
+                    IAtom endNbor = state.query.getConnectedBondsList(pair[1]).get(0).getOther(pair[1]);
+                    int begNborIdx = state.atomidx.get(begNbor);
+                    int endNborIdx = state.atomidx.get(endNbor);
+                    if (begNborIdx != endNborIdx) {
+                        state.hcount[begNborIdx]++;
+                        state.hcount[endNborIdx]--;
+                        ops.add(new TransformOp(TransformOp.Type.MoveH, begNborIdx, endNborIdx));
+                    }
+                    iter.remove();
+                } else if (pair[1] == null) {
+                    iter.remove();
+                }
+            } else if (isExplH(state.query, pair[1])) {
+                iter.remove();
+            }
+        }
+        return true;
+    }
+
+    private static String generateAtom(IAtom atom) {
+        return "[" + Smarts.generateAtom(((QueryAtom) atom).getExpression())
+                           .replaceAll("^\\[|\\]$", "") + ":" + getMapIdx(atom) + "]";
+    }
+
+    private static void checkAtomMap(SmirksState state, IAtom atom) {
+        if (getMapIdx(atom) != 0)
+            state.warning("Warning - added/removed atoms do not need to be mapped: " + generateAtom(atom));
+    }
+
+    private static boolean duplicateAtomMap(SmirksState state, IAtom atom1, IAtom atom2) {
+        return state.error("Duplicate atom map " + generateAtom(atom1) + " and " + generateAtom(atom2));
+    }
+
+    private static void determineAtomChanges(List<TransformOp> ops,
+                                             SmirksState state) {
+        for (IAtom[] pair : state.atomPairs) {
+            int aidx = pair[0] != null ? state.atomidx.get(pair[0]) : state.atomidx.get(pair[1]);
+            if (pair[0] != null && pair[1] == null) {
+                checkAtomMap(state, pair[0]);
+                ops.add(new TransformOp(TransformOp.Type.DeleteAtom, aidx));
+            } else if (pair[0] == null && pair[1] != null) {
+                checkAtomMap(state, pair[1]);
+                ops.addAll(atomTypeOps(state.atomidx.get(pair[1]), null, pair[1], state.hcount[aidx]));
+            } else {
+                ops.addAll(atomTypeOps(aidx, pair[0], pair[1], state.hcount[aidx]));
+            }
+        }
+    }
+
+    private static void determineBondChanges(List<TransformOp> ops,
+                                             SmirksState state) {
+        for (IBond[] pair : state.bondPairs) {
+            int begIdx = pair[0] == null ? state.atomidx.get(pair[1].getBegin()) : state.atomidx.get(pair[0].getBegin());
+            int endIdx = pair[0] == null ? state.atomidx.get(pair[1].getEnd()) : state.atomidx.get(pair[0].getEnd());
+            BinaryExprValue lft = GetBondOrder(pair[0]);
+            BinaryExprValue rgt = GetBondOrder(pair[1]);
+            if (pair[0] != null && pair[1] == null) {
+                ops.add(new TransformOp(TransformOp.Type.DeleteBond, begIdx, endIdx, GetBondOrder(pair[0]).val));
+            } else {
+                if (pair[0] == null && pair[1] != null) {
+                    if (!rgt.ok())
+                        throw new IllegalArgumentException();
+                    ops.add(new TransformOp(TransformOp.Type.NewBond, begIdx, endIdx, GetBondOrder(pair[1]).val, 0));
+                } else {
+                    if (!rgt.ok()) {
+                        if (IsAnyBond(pair[1]))
+                            continue;
+                        throw new IllegalArgumentException();
+                    }
+                    if (changed(lft, rgt))
+                        ops.add(new TransformOp(TransformOp.Type.BondOrder,
+                                                begIdx, endIdx, rgt.val));
+                }
+            }
+        }
+    }
+
+    private static void determineStereoChanges(List<TransformOp> ops, SmirksState state) {
+        List<IStereoElement> stereoElements = new ArrayList<>();
+        for (IStereoElement se : state.query.stereoElements()) {
+            switch (se.getConfigClass()) {
+                case IStereoElement.Tetrahedral:
+                    if (isProduct((IAtom) se.getFocus())) {
+                        IStereoElement<IAtom, IAtom> th = (IStereoElement<IAtom, IAtom>) se;
+                        BinaryExprValue val = GetProperty(th.getFocus(), Expr.Type.STEREOCHEMISTRY);
+                        if (val.val == 1) {
+                            ops.add(new TransformOp(TransformOp.Type.Tetrahedral,
+                                                    state.atomidx.get(th.getFocus()),
+                                                    state.atomidx.get(th.getCarriers().get(0)),
+                                                    state.atomidx.get(th.getCarriers().get(1)),
+                                                    state.atomidx.get(th.getCarriers().get(2))));
+                        } else if (val.val == 2) {
+                            ops.add(new TransformOp(TransformOp.Type.Tetrahedral,
+                                                    state.atomidx.get(th.getFocus()),
+                                                    state.atomidx.get(th.getCarriers().get(0)),
+                                                    state.atomidx.get(th.getCarriers().get(2)),
+                                                    state.atomidx.get(th.getCarriers().get(1))));
+                        }
+                    } else {
+                        stereoElements.add(se);
+                    }
+                    break;
+                case IStereoElement.CisTrans:
+                    if (isProduct(((IBond) se.getFocus()).getBegin()) &&
+                            isProduct(((IBond) se.getFocus()).getEnd())) {
+                        IStereoElement<IBond, IBond> db = (IStereoElement<IBond, IBond>) se;
+                        BinaryExprValue val = GetProperty(db.getFocus(), Expr.Type.STEREOCHEMISTRY);
+                        IAtom a = db.getFocus().getBegin();
+                        IAtom b = db.getFocus().getEnd();
+                        IAtom c = db.getCarriers().get(0).getOther(a);
+                        IAtom d = db.getCarriers().get(1).getOther(b);
+                        if (val.val == 1) {
+                            ops.add(new TransformOp(TransformOp.Type.DbOpposite,
+                                                    state.atomidx.get(a),
+                                                    state.atomidx.get(b),
+                                                    state.atomidx.get(c),
+                                                    state.atomidx.get(d)));
+                        } else {
+                            ops.add(new TransformOp(TransformOp.Type.DbTogether,
+                                                    state.atomidx.get(a),
+                                                    state.atomidx.get(b),
+                                                    state.atomidx.get(c),
+                                                    state.atomidx.get(d)));
+                        }
+                    } else {
+                        stereoElements.add(se);
+                    }
+                    break;
+                case IStereoElement.SquarePlanar:
+                case IStereoElement.TrigonalBipyramidal:
+                case IStereoElement.Octahedral:
+                case IStereoElement.Allenal:
+                    if (isProduct((IAtom) se.getFocus()))
+                        state.warning("Ignored setting atom stereo on right hand side - unsupported stereo class: " + se.getConfigClass());
+                    else
+                        stereoElements.add(se);
+                    break;
+                case IStereoElement.Atropisomeric:
+                case IStereoElement.Cumulene:
+                    if (isProduct(((IBond) se.getFocus()).getBegin()) &&
+                            isProduct(((IBond) se.getFocus()).getEnd()))
+                        state.warning("Ignored setting bond stereo on right hand side - unsupported stereo class: " + se.getConfigClass());
+                    else
+                        stereoElements.add(se);
+                    break;
+            }
+        }
+
+        // only reactant/query stereo will be kept
+        state.query.setStereoElements(stereoElements);
+    }
+
+    private static void prepareQuery(SmirksState state) {
+        Set<IAtom> toremove = new HashSet<>();
+        for (IAtom atom : state.query.atoms()) {
+            if (isProduct(atom) || isExplH(state.query, atom)) {
+                toremove.add(atom);
+            } else {
+                // clear the role and renumber the maps
+                atom.setProperty(CDKConstants.REACTION_ROLE, null);
+                atom.setProperty(CDKConstants.ATOM_ATOM_MAPPING, state.atomidx.get(atom));
+                stripRxnRole(atom);
+                constrainMinHydrogenCount(atom, state.hmin[state.atomidx.get(atom)]);
+            }
+        }
+        for (IAtom atom : toremove)
+            state.query.removeAtom(atom);
+    }
+
+
+    private static Integer GetExplValence(QueryAtomContainer query, IAtom atom) {
+        int count = 0;
+        for (IBond bond : query.getConnectedBondsList(atom)) {
+            BinaryExprValue result = GetBondOrder(bond, true);
+            if (!result.ok())
+                return null;
+            count += result.val;
+        }
+        return count;
+    }
+
+    private static void constrainMinHydrogenCount(IAtom atom, int hcount) {
+        if (hcount <= 0)
+            return;
+        QueryAtom qatom = (QueryAtom) atom;
+        Expr expr = qatom.getExpression();
+        for (int i = 0; i < hcount; i++)
+            expr.and(new Expr(Expr.Type.TOTAL_H_COUNT, i).negate());
+        qatom.setExpression(expr);
+    }
+
+    private static void stripRxnRole(IAtom atom) {
+        QueryAtom qatom = (QueryAtom) atom;
+        qatom.setExpression(stripRxnRole(qatom.getExpression()));
+    }
+
+    private static Expr stripRxnRole(Expr e) {
+        switch (e.type()) {
+            case REACTION_ROLE:
+                return new Expr(Expr.Type.TRUE);
+            case OR:
+                return stripRxnRole(e.left()).or(stripRxnRole(e.right()));
+            case AND:
+                return stripRxnRole(e.left()).and(stripRxnRole(e.right()));
+            default:
+                // n.b. REACTION_ROLE should not be negated so don't handle that
+                return e;
+        }
+    }
+
+    private static boolean isProduct(IAtom end) {
+        return end.getProperty(CDKConstants.REACTION_ROLE) == ReactionRole.Product;
+    }
+
+    private static boolean isExplH(Expr e) {
+        return (e.type() == Expr.Type.ELEMENT ||
+                e.type() == Expr.Type.ALIPHATIC_ELEMENT) &&
+                e.value() == 1;
+    }
+
+    // is a suppressible explicit H, 2H etc. is not suppressible
+    private static boolean isExplHWithOptRole(Expr e) {
+        if (e.type() == Expr.Type.AND) {
+            Expr l = e.left();
+            Expr r = e.right();
+            return (isExplH(l) && r.type() == Expr.Type.REACTION_ROLE) ||
+                    (isExplH(r) && l.type() == Expr.Type.REACTION_ROLE);
+        }
+        return isExplH(e);
+    }
+
+    private static boolean isExplH(IAtomContainer mol, IAtom a) {
+        if (a == null)
+            return false;
+        if (!isExplHWithOptRole(((QueryAtom) a).getExpression()))
+            return false;
+        List<IBond> bonds = mol.getConnectedBondsList(a);
+        return bonds.size() == 1 && GetAtomicNumber(bonds.get(0).getOther(a)).val != 1;
+    }
+
+    private static boolean isWildCard(IAtomContainer mol, IAtom a) {
+        if (a == null)
+            return false;
+        if (!isExplHWithOptRole(((QueryAtom) a).getExpression()))
+            return false;
+        List<IBond> bonds = mol.getConnectedBondsList(a);
+        return bonds.size() == 1; // + single acyclic?
+    }
+
+    private static boolean changed(BinaryExprValue lft, BinaryExprValue rgt) {
+        return rgt.ok() && !lft.equals(rgt);
+    }
+
+    private static Integer getMapIdx(IAtom atom) {
+        Integer x = atom.getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+        return x != null ? x : 0;
+    }
+
+    private static BinaryExprValue GetAtomicNumber(IAtom atom) {
+        return atom == null ? BinaryExprValue.UNDEF : GetAtomicNumber(((QueryAtom) atom).getExpression());
+    }
+
+    private static BinaryExprValue GetAtomicNumber(Expr expr) {
+        switch (expr.type()) {
+            case ELEMENT:
+            case ALIPHATIC_ELEMENT:
+            case AROMATIC_ELEMENT:
+                return new BinaryExprValue(expr.value());
+            case AND:
+                return GetAtomicNumber(expr.left()).and(GetAtomicNumber(expr.right()));
+            case OR:
+                return GetAtomicNumber(expr.left()).or(GetAtomicNumber(expr.right()));
+            case NOT:
+                return GetAtomicNumber(expr.left()).not();
+            default:
+                return BinaryExprValue.UNDEF;
+        }
+    }
+
+    private static BinaryExprValue IsAromatic(Expr expr) {
+        int lft, rgt;
+        switch (expr.type()) {
+            case ELEMENT:
+                switch (expr.value()) {
+                    case IAtom.B:
+                    case IAtom.C:
+                    case IAtom.N:
+                    case IAtom.O:
+                    case IAtom.Al:
+                    case IAtom.Si:
+                    case IAtom.P:
+                    case IAtom.S:
+                    case IAtom.Ge:
+                    case IAtom.As:
+                    case IAtom.Se:
+                    case IAtom.Sb:
+                    case IAtom.Te:
+                        return BinaryExprValue.UNDEF; // these 'might' be aromatic
+                    default:
+                        return BinaryExprValue.FALSE;
+                }
+            case AROMATIC_ELEMENT:
+            case IS_AROMATIC:
+                return BinaryExprValue.TRUE;
+            case ALIPHATIC_ELEMENT:
+            case IS_ALIPHATIC:
+            case IS_IN_CHAIN:
+            case IS_ALIPHATIC_HETERO:
+                return BinaryExprValue.FALSE;
+            case AND:
+                return IsAromatic(expr.left()).and(IsAromatic(expr.right()));
+            case OR:
+                return IsAromatic(expr.left()).or(IsAromatic(expr.right()));
+            case NOT:
+                return IsAromatic(expr.left()).not();
+            default:
+                return BinaryExprValue.UNDEF;
+        }
+    }
+
+    private static BinaryExprValue IsAromatic(IAtom atom) {
+        return IsAromatic(((QueryAtom) atom).getExpression());
+    }
+
+    private static BinaryExprValue GetProperty(Expr expr, Expr.Type type) {
+        switch (expr.type()) {
+            case AND:
+                return GetProperty(expr.left(), type).and(GetProperty(expr.right(), type));
+            case OR:
+                return GetProperty(expr.left(), type).or(GetProperty(expr.right(), type));
+            case NOT:
+                return BinaryExprValue.CONFLICTING;
+            default:
+                if (type == Expr.Type.ISOTOPE && expr.type() == Expr.Type.HAS_UNSPEC_ISOTOPE)
+                    return new BinaryExprValue(0);
+                if (type == Expr.Type.TOTAL_H_COUNT && expr.type() == Expr.Type.IMPL_H_COUNT)
+                    return new BinaryExprValue(expr.value());
+                if (expr.type() == type)
+                    return new BinaryExprValue(expr.value());
+                return BinaryExprValue.UNDEF;
+        }
+    }
+
+    private static BinaryExprValue GetProperty(IAtom atom, Expr.Type type) {
+        return atom == null ? BinaryExprValue.UNDEF
+                : GetProperty(((QueryAtom) atom).getExpression(), type);
+    }
+
+    private static BinaryExprValue GetProperty(IBond bond, Expr.Type type) {
+        return bond == null ? BinaryExprValue.UNDEF
+                : GetProperty(((QueryBond) bond).getExpression(), type);
+    }
+
+    private static boolean IsAnyBond(IBond bond) {
+        return bond != null && IsAnyBond(((QueryBond) bond).getExpression());
+    }
+
+    private static boolean IsAnyBond(Expr expr) {
+        return expr.type() == Expr.Type.TRUE;
+    }
+
+    private static BinaryExprValue GetBondOrder(IBond bond) {
+        if (bond == null)
+            return BinaryExprValue.UNDEF;
+        BinaryExprValue begIsArom = IsAromatic(bond.getBegin());
+        BinaryExprValue endIsArom = IsAromatic(bond.getEnd());
+        boolean mustBeAlip = begIsArom.equals(BinaryExprValue.FALSE) ||
+                endIsArom.equals(BinaryExprValue.FALSE);
+        return GetBondOrder(bond, mustBeAlip);
+    }
+
+    private static BinaryExprValue GetBondOrder(IBond bond, boolean mustBeAlip) {
+        if (bond == null)
+            return BinaryExprValue.UNDEF;
+        return GetBondOrder(((QueryBond) bond).getExpression(), mustBeAlip);
+    }
+
+    private static BinaryExprValue GetBondOrder(Expr expr, boolean alipEndPoint) {
+        BinaryExprValue lft, rgt;
+        switch (expr.type()) {
+            case IS_AROMATIC:
+                return new BinaryExprValue(5);
+            case SINGLE_OR_AROMATIC:
+                if (alipEndPoint)
+                    return new BinaryExprValue(1);
+                return new BinaryExprValue(5);
+            case DOUBLE_OR_AROMATIC:
+                if (alipEndPoint)
+                    return new BinaryExprValue(2);
+                return new BinaryExprValue(5);
+            case SINGLE_OR_DOUBLE:
+                return BinaryExprValue.CONFLICTING;
+            case ALIPHATIC_ORDER:
+                return new BinaryExprValue(expr.value());
+            case AND:
+                return GetBondOrder(expr.left(), alipEndPoint).and(GetBondOrder(expr.right(), alipEndPoint));
+            case OR:
+                return GetBondOrder(expr.left(), alipEndPoint).or(GetBondOrder(expr.right(), alipEndPoint));
+            case NOT:
+                return GetBondOrder(expr.left(), alipEndPoint).not();
+            default:
+                return BinaryExprValue.UNDEF;
+        }
+    }
+
+    static List<TransformOp> atomTypeOps(IAtom before, IAtom after) {
+        return atomTypeOps(0, before, after, 0);
+    }
+
+
+    private static List<TransformOp> atomTypeOps(int aidx, IAtom before, IAtom after, int hAdjust) {
+        List<TransformOp> ops = new ArrayList<>(4);
+        BinaryExprValue lft = GetAtomicNumber(before);
+        BinaryExprValue rgt = GetAtomicNumber(after);
+        if (before == null) {
+            ops.add(new TransformOp(TransformOp.Type.NewAtom, aidx, rgt.val, hAdjust, IsAromatic(after).val));
+        } else if (changed(lft, rgt))
+            ops.add(new TransformOp(TransformOp.Type.Element, aidx, rgt.val));
+        lft = GetProperty(before, Expr.Type.FORMAL_CHARGE);
+        rgt = GetProperty(after, Expr.Type.FORMAL_CHARGE);
+        if (changed(lft, rgt))
+            ops.add(new TransformOp(TransformOp.Type.Charge, aidx, rgt.val));
+        lft = GetProperty(before, Expr.Type.TOTAL_H_COUNT);
+        rgt = GetProperty(after, Expr.Type.TOTAL_H_COUNT);
+        if (changed(lft, rgt))
+            ops.add(new TransformOp(TransformOp.Type.ImplH, aidx, rgt.val));
+        else if (before != null && hAdjust != 0) {
+            ops.add(new TransformOp(TransformOp.Type.AdjustH, aidx, hAdjust));
+        }
+        lft = GetProperty(before, Expr.Type.ISOTOPE);
+        rgt = GetProperty(after, Expr.Type.ISOTOPE);
+        if (changed(lft, rgt))
+            ops.add(new TransformOp(TransformOp.Type.Mass, aidx, rgt.val));
+        // hcnt delta and implH
+        return ops;
+    }
+}

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -804,8 +804,8 @@ public class Smirks {
     }
 
     private static void checkValence(SmirksState state, List<TransformOp> ops) {
-//        if (!state.opts.contains(SmirksOption.PEDANTIC))
-//            return;
+        if (!state.opts.contains(SmirksOption.PEDANTIC))
+            return;
         Map<Integer,Integer> valence  = new HashMap<>();
         Set<Integer>         unknown  = new HashSet<>();
         Map<Integer,Integer> hcnts    = new HashMap<>();

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -257,7 +257,7 @@ public class Smirks {
         determineHydrogenMovement(ops, state);
         determineAtomChanges(ops, state);
         if (!determineBondChanges(ops, state))
-            return false;
+            return transform.setError(state.getMessage());
         determineStereoChanges(ops, state);
 
         checkValence(state, ops);
@@ -718,6 +718,7 @@ public class Smirks {
 
     private static boolean determineBondChanges(List<TransformOp> ops,
                                                 SmirksState state) {
+
         for (IBond[] pair : state.bondPairs) {
             int begIdx = pair[0] == null ? state.atomidx.get(pair[1].getBegin()) : state.atomidx.get(pair[0].getBegin());
             int endIdx = pair[0] == null ? state.atomidx.get(pair[1].getEnd()) : state.atomidx.get(pair[0].getEnd());

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -101,12 +101,12 @@ public class Smirks {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             BondKey key = (BondKey) o;
-            return beg == key.beg && end == key.end;
+            return beg == key.beg && end == key.end || beg == key.end && end == key.beg;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(beg, end);
+            return Objects.hash(Math.min(beg, end), Math.max(beg, end));
         }
     }
 

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -318,10 +318,10 @@ public class Smirks {
         // build the query pattern based on the left-hand side of the reaction
         prepareQuery(state);
 
-        //if (LOGGER.isDebugEnabled()) {
-        System.err.println(Smarts.generate(query));
-        System.err.println(ops);
-        //}
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(Smarts.generate(query));
+            LOGGER.debug(ops);
+        }
 
         transform.init(DfPattern.findSubstructure(query), ops, state.getMessage());
 
@@ -574,13 +574,13 @@ public class Smirks {
             int begIdx = pair[0] == null ? state.atomidx.get(pair[1].getBegin()) : state.atomidx.get(pair[0].getBegin());
             int endIdx = pair[0] == null ? state.atomidx.get(pair[1].getEnd()) : state.atomidx.get(pair[0].getEnd());
 
-            if (pair[0] != null && pair[1] != null) {
-                System.err.println(begIdx + "-" + endIdx + " changed?");
-            } else if (pair[0] != null && pair[1] == null) {
-                System.err.println(begIdx + "-" + endIdx + " deleted");
-            } else if (pair[1] != null && pair[0] == null) {
-                System.err.println(begIdx + "-" + endIdx + " new bond");
-            }
+//            if (pair[0] != null && pair[1] != null) {
+//                System.err.println(begIdx + "-" + endIdx + " changed?");
+//            } else if (pair[0] != null && pair[1] == null) {
+//                System.err.println(begIdx + "-" + endIdx + " deleted");
+//            } else if (pair[1] != null && pair[0] == null) {
+//                System.err.println(begIdx + "-" + endIdx + " new bond");
+//            }
 
             BinaryExprValue lft = GetBondOrder(pair[0]);
             BinaryExprValue rgt = GetBondOrder(pair[1]);
@@ -808,7 +808,6 @@ public class Smirks {
     }
 
     private static BinaryExprValue IsAromatic(Expr expr) {
-        int lft, rgt;
         switch (expr.type()) {
             case ELEMENT:
                 switch (expr.value()) {
@@ -906,7 +905,6 @@ public class Smirks {
     }
 
     private static BinaryExprValue GetBondOrder(Expr expr, boolean alipEndPoint) {
-        BinaryExprValue lft, rgt;
         switch (expr.type()) {
             case IS_AROMATIC:
                 return new BinaryExprValue(5);

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -598,7 +598,8 @@ public class Smirks {
     }
 
     private static void checkAtomMap(SmirksState state, IAtom atom) {
-        if (state.opts.contains(SmirksOption.PEDANTIC))
+        if (!state.opts.contains(SmirksOption.PEDANTIC))
+            return;
         if (getMapIdx(atom) != 0)
             state.warning("Added/removed atoms do not need to be mapped", atom);
     }

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -392,16 +392,16 @@ public class Smirks {
             return 0;
         }
 
-        public boolean error(String s) {
+        boolean error(String s) {
             errors.add(s);
             return false;
         }
 
-        public void warning(String s) {
+        void warning(String s) {
             warnings.add(s);
         }
 
-        public String getMessage() {
+        String getMessage() {
             if (errors.isEmpty() && warnings.isEmpty())
                 return null;
             StringBuilder sb = new StringBuilder();
@@ -510,7 +510,7 @@ public class Smirks {
         return true;
     }
 
-    private static boolean determineHydrogenMovement(List<TransformOp> ops,
+    private static void determineHydrogenMovement(List<TransformOp> ops,
                                                      SmirksState state) {
         Iterator<IAtom[]> iter = state.atomPairs.iterator();
         while (iter.hasNext()) {
@@ -540,7 +540,6 @@ public class Smirks {
                 iter.remove();
             }
         }
-        return true;
     }
 
     private static String generateAtom(IAtom atom) {

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -481,7 +481,7 @@ public class Smirks {
 
     private static String generateAtom(IAtom atom) {
         return "[" + Smarts.generateAtom(((QueryAtom) atom).getExpression())
-                           .replaceAll("^\\[|]", "") + ":" + getMapIdx(atom) + "]";
+                           .replaceAll("(?:^\\[)|(?:]$)", "") + ":" + getMapIdx(atom) + "]";
     }
 
     private static void checkAtomMap(SmirksState state, IAtom atom) {

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -273,8 +273,10 @@ public class Smirks {
             }
         }
 
-        if (state.opts.contains(SmirksOption.REMOVED_UNMAPPED_FRAGMENTS))
+        if (state.opts.contains(SmirksOption.REMOVE_UNMAPPED_FRAGMENTS))
             ops.add(new TransformOp(TransformOp.Type.RemoveUnmapped, 0));
+        if (state.opts.contains(SmirksOption.RECOMPUTE_HYDROGENS))
+            ops.add(new TransformOp(TransformOp.Type.RecomputeHydrogens, 0));
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(Smarts.generate(query));

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -296,29 +296,32 @@ public class Smirks {
                     case IElement.Wildcard:
                         return 0;
                     case IElement.B:
-                        if (valence < 3) return 3 - valence;
+                        if (valence <= 3) return 3 - valence;
                         break;
                     case IElement.C:
-                        if (valence < 4) return 4 - valence;
+                        if (valence <= 4) return 4 - valence;
                         break;
                     case IElement.N:
                     case IElement.P:
-                        if (valence < 3) return 3 - valence;
-                        else if (valence < 5) return 5 - valence;
+                        if (valence <= 3) return 3 - valence;
+                        else if (valence <= 5) return 5 - valence;
                         break;
                     case IElement.O:
-                        if (valence < 2) return 2 - valence;
+                        if (valence <= 2) return 2 - valence;
                         break;
                     case IElement.S:
-                        if (valence < 2) return 2 - valence;
-                        else if (valence < 4) return 4 - valence;
-                        else if (valence < 6) return 6 - valence;
+                        if (valence <= 2) return 2 - valence;
+                        else if (valence <= 4) return 4 - valence;
+                        else if (valence <= 6) return 6 - valence;
                         break;
                     case IElement.F:
                     case IElement.Cl:
                     case IElement.Br:
                     case IElement.I:
-                        if (valence < 1) return 1 - valence;
+                        if (valence <= 1) return 1 - valence;
+                        else if (valence <= 3) return 3 - valence;
+                        else if (valence <= 5) return 5 - valence;
+                        else if (valence <= 7) return 7 - valence;
                         break;
                     default:
                         throw new IllegalStateException("No default valence for element=" + elem);
@@ -867,8 +870,6 @@ public class Smirks {
             default:
                 if (type == Expr.Type.ISOTOPE && expr.type() == Expr.Type.HAS_UNSPEC_ISOTOPE)
                     return new BinaryExprValue(0);
-                if (type == Expr.Type.TOTAL_H_COUNT && expr.type() == Expr.Type.IMPL_H_COUNT)
-                    return new BinaryExprValue(expr.value());
                 if (expr.type() == type)
                     return new BinaryExprValue(expr.value());
                 return BinaryExprValue.UNDEF;
@@ -979,6 +980,10 @@ public class Smirks {
             ops.add(new TransformOp(TransformOp.Type.Charge, aidx, rgt.val));
         lft = getProperty(before, Expr.Type.TOTAL_H_COUNT);
         rgt = getProperty(after, Expr.Type.TOTAL_H_COUNT);
+        if (changed(lft, rgt))
+            ops.add(new TransformOp(TransformOp.Type.TotalH, aidx, rgt.val));
+        lft = getProperty(before, Expr.Type.IMPL_H_COUNT);
+        rgt = getProperty(after, Expr.Type.IMPL_H_COUNT);
         if (changed(lft, rgt))
             ops.add(new TransformOp(TransformOp.Type.ImplH, aidx, rgt.val));
         else if (before != null && hAdjust != 0) {

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -672,7 +672,7 @@ public class Smirks {
 
     private static String generateAtom(IAtom atom) {
         return "[" + Smarts.generateAtom(((QueryAtom) atom).getExpression())
-                           .replaceAll("^\\[|]$", "") + ":" + getMapIdx(atom) + "]";
+                           .replaceAll("(?:^\\[)|(?:]$)", "") + ":" + getMapIdx(atom) + "]";
     }
 
     private static void checkAtomMap(SmirksState state, IAtom atom) {

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/Smirks.java
@@ -25,6 +25,7 @@ import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.isomorphism.DfPattern;
 import org.openscience.cdk.isomorphism.Transform;
@@ -245,8 +246,11 @@ public class Smirks {
         // build the query pattern based on the left-hand side of the reaction
         prepareQuery(state);
 
-        System.err.println(Smarts.generate(query));
-        System.err.println(ops);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(Smarts.generate(query));
+            LOGGER.debug(ops);
+        }
+
         transform.init(DfPattern.findSubstructure(query), ops, state.getMessage());
 
         return true;
@@ -290,23 +294,23 @@ public class Smirks {
                 if (IsAromatic(atom).val == 1)
                     valence++;
                 switch (elem) {
-                    case IAtom.Wildcard:
+                    case IElement.Wildcard:
                         return 0;
-                    case IAtom.B:
+                    case IElement.B:
                         if (valence < 3) return 3 - valence;
                         break;
-                    case IAtom.C:
+                    case IElement.C:
                         if (valence < 4) return 4 - valence;
                         break;
-                    case IAtom.N:
-                    case IAtom.P:
+                    case IElement.N:
+                    case IElement.P:
                         if (valence < 3) return 3 - valence;
                         else if (valence < 5) return 5 - valence;
                         break;
-                    case IAtom.O:
+                    case IElement.O:
                         if (valence < 2) return 2 - valence;
                         break;
-                    case IAtom.S:
+                    case IElement.S:
                         if (valence < 2) return 2 - valence;
                         else if (valence < 4) return 4 - valence;
                         else if (valence < 6) return 6 - valence;
@@ -464,7 +468,7 @@ public class Smirks {
 
     private static String generateAtom(IAtom atom) {
         return "[" + Smarts.generateAtom(((QueryAtom) atom).getExpression())
-                           .replaceAll("^\\[|\\]$", "") + ":" + getMapIdx(atom) + "]";
+                           .replaceAll("(?:^\\[)|(?:]$)", "") + ":" + getMapIdx(atom) + "]";
     }
 
     private static void checkAtomMap(SmirksState state, IAtom atom) {
@@ -727,19 +731,19 @@ public class Smirks {
         switch (expr.type()) {
             case ELEMENT:
                 switch (expr.value()) {
-                    case IAtom.B:
-                    case IAtom.C:
-                    case IAtom.N:
-                    case IAtom.O:
-                    case IAtom.Al:
-                    case IAtom.Si:
-                    case IAtom.P:
-                    case IAtom.S:
-                    case IAtom.Ge:
-                    case IAtom.As:
-                    case IAtom.Se:
-                    case IAtom.Sb:
-                    case IAtom.Te:
+                    case IElement.B:
+                    case IElement.C:
+                    case IElement.N:
+                    case IElement.O:
+                    case IElement.Al:
+                    case IElement.Si:
+                    case IElement.P:
+                    case IElement.S:
+                    case IElement.Ge:
+                    case IElement.As:
+                    case IElement.Se:
+                    case IElement.Sb:
+                    case IElement.Te:
                         return BinaryExprValue.UNDEF; // these 'might' be aromatic
                     default:
                         return BinaryExprValue.FALSE;

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
@@ -67,7 +67,11 @@ public enum SmirksOption {
      * If a bond already exists where a new one is to be created update the bond
      * order as required.
      */
-    OVERWRITE_BOND;
+    OVERWRITE_BOND,
+    /**
+     * Remove any disconnected fragments
+     */
+    REMOVED_UNMAPPED_FRAGMENTS;
 
     /**
      * Align closer with RDKit's "Reaction SMARTS" semantics.
@@ -76,5 +80,6 @@ public enum SmirksOption {
     public static final Set<SmirksOption> RDKIT = unmodifiableSet(EnumSet.of(DIFF_PART,
                                                                              IGNORE_IMPL_H,
                                                                              IGNORE_TOTAL_H0,
-                                                                             OVERWRITE_BOND));
+                                                                             OVERWRITE_BOND,
+                                                                             REMOVED_UNMAPPED_FRAGMENTS));
 }

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
@@ -69,17 +69,33 @@ public enum SmirksOption {
      */
     OVERWRITE_BOND,
     /**
-     * Remove any disconnected fragments
+     * Postprocessing - Remove any disconnected fragments that were not matched
+     * by the transformed.
      */
-    REMOVED_UNMAPPED_FRAGMENTS;
+    REMOVE_UNMAPPED_FRAGMENTS,
+    /**
+     * Postprocessing - Recompute the implicit hydrogen count on changed atoms
+     * that has not had its hydrogen count explicitly set.
+     */
+    RECOMPUTE_HYDROGENS,
+    /**
+     * Preprocessing - Automatically convert implicit hydrogens to explicit
+     * hydrogens when the pattern contains a '*'.
+     */
+    EXPAND_HYDROGENS;
 
     /**
      * Align closer with RDKit's "Reaction SMARTS" semantics.
-     * WIP - need to handle the floating valence
      */
     public static final Set<SmirksOption> RDKIT = unmodifiableSet(EnumSet.of(DIFF_PART,
                                                                              IGNORE_IMPL_H,
                                                                              IGNORE_TOTAL_H0,
                                                                              OVERWRITE_BOND,
-                                                                             REMOVED_UNMAPPED_FRAGMENTS));
+                                                                             REMOVE_UNMAPPED_FRAGMENTS,
+                                                                             RECOMPUTE_HYDROGENS));
+
+    public static final Set<SmirksOption> DAYLIGHT = unmodifiableSet(EnumSet.of(IGNORE_SET_ELEM,
+                                                                                IGNORE_IMPL_H,
+                                                                                IGNORE_TOTAL_H,
+                                                                                EXPAND_HYDROGENS));
 }

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
@@ -19,9 +19,20 @@
 
 package org.openscience.cdk.smirks;
 
+import java.util.EnumSet;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableSet;
+
 public enum SmirksOption {
     /**
      * Additional check and warnings when parsing SMIRKS.
      */
-    PEDANTIC
+    PEDANTIC,
+    /**
+     * Run the reaction backwards (retro synthesis), the right-hand-side is now
+     * matched as a query. Note that not all SMIRKS are reversible and good
+     * form is usually write separate forward/backwards transformations.
+     */
+    REVERSE
 }

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
@@ -30,9 +30,51 @@ public enum SmirksOption {
      */
     PEDANTIC,
     /**
-     * Run the reaction backwards (retro synthesis), the right-hand-side is now
+     * Run the reaction backwards (retro synthesis). The right-hand-side is now
      * matched as a query. Note that not all SMIRKS are reversible and good
      * form is usually write separate forward/backwards transformations.
      */
-    REVERSE
+    REVERSE,
+    /**
+     * Do not allow '[*:1].[*:2]' to match the same fragment.
+     * The preferred way to do this component grouping '([*:1]).([*:2])' but if
+     * you are only performing reactions it is reasonable that you expect the
+     * parts to be different and some toolkits only have this as an option.
+     */
+    DIFF_PART,
+    /**
+     * Do not allow the atomic number to be changed. {@code [Pb:1]>>[Au:1]}
+     * will do nothing.
+     */
+    IGNORE_SET_ELEM,
+    /**
+     * Do not allow the implicit hydrogen count to be set.
+     * {@code [Ch4:1]>>[Ch3:1]} does nothing.
+     */
+    IGNORE_IMPL_H,
+    /**
+     * Do not allow the total hydrogen count to be set.
+     * {@code [CH4:1]>>[CH3:1]} does nothing.
+     */
+    IGNORE_TOTAL_H,
+    /**
+     * Do not allow the total hydrogen count to be set if it is 0.
+     * {@code [CH4:1]>>[CH3:1]} works but {@code [CH4:1]>>[CH0:1]} does
+     * not.
+     */
+    IGNORE_TOTAL_H0,
+    /**
+     * If a bond already exists where a new one is to be created update the bond
+     * order as required.
+     */
+    OVERWRITE_BOND;
+
+    /**
+     * Align closer with RDKit's "Reaction SMARTS" semantics.
+     * WIP - need to handle the floating valence
+     */
+    public static final Set<SmirksOption> RDKIT = unmodifiableSet(EnumSet.of(DIFF_PART,
+                                                                             IGNORE_IMPL_H,
+                                                                             IGNORE_TOTAL_H0,
+                                                                             OVERWRITE_BOND));
 }

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksOption.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.smirks;
+
+public enum SmirksOption {
+    /**
+     * Additional check and warnings when parsing SMIRKS.
+     */
+    PEDANTIC
+}

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksTransform.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksTransform.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 NextMove Software
+ *               2022 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.smirks;
+
+import org.openscience.cdk.aromaticity.Aromaticity;
+import org.openscience.cdk.aromaticity.ElectronDonation;
+import org.openscience.cdk.graph.Cycles;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.isomorphism.Transform;
+import org.openscience.cdk.smarts.SmartsPattern;
+
+/**
+ * A SMIRKS transform, is a {@link Transform} which can optionally (on by
+ * default) perform ring and aromaticity (Daylight) perception. Before applying
+ * the transform the molecule is matched it is passed to
+ * {@link SmartsPattern#prepare}. The prepare function ensures ring and aromatic
+ * flags are consistent. You can turn off by setting {@link #setPrepare(boolean)} to
+ * false.
+ * <br/>
+ * Basic usage:
+ * <pre>
+ * {@code
+ * SmirksTransform smirks = Smirks.compile("[C:1][H]>>[C:1]Cl");
+ * smirks.apply(mol);
+ * }
+ * </pre>
+ *
+ * @see org.openscience.cdk.isomorphism.Transform
+ * @see org.openscience.cdk.isomorphism.Pattern
+ * @see org.openscience.cdk.smarts.SmartsPattern
+ */
+public final class SmirksTransform extends Transform {
+
+    /**
+     * Prepare the target molecule (i.e. detect rings, aromaticity) before
+     * matching the SMARTS.
+     */
+    private boolean doPrep = true;
+
+    /** Aromaticity model. */
+    private static final Aromaticity arom = new Aromaticity(ElectronDonation.daylight(),
+                                                            Cycles.or(Cycles.all(), Cycles.relevant()));
+
+    // package private!
+    SmirksTransform() {
+        super();
+    }
+
+    /**
+     * Sets whether the molecule should be "prepared" for a SMIRKS transform,
+     * including set ring flags and perceiving aromaticity. The main reason
+     * to skip preparation (via {@link SmartsPattern#prepare(IAtomContainer)})
+     * is if it has already been done, for example when matching multiple
+     * SMIRKS transforms.
+     *
+     * @param doPrep whether preparation should be done
+     * @return self for inline calling
+     */
+    public SmirksTransform setPrepare(boolean doPrep) {
+        this.doPrep = doPrep;
+        return this;
+    }
+
+    @Override
+    public Iterable<IAtomContainer> apply(IAtomContainer mol, Mode mode) {
+        if (doPrep)
+            SmartsPattern.prepare(mol);
+        return super.apply(mol, mode);
+    }
+
+    @Override
+    public boolean apply(IAtomContainer mol) {
+        if (doPrep)
+            SmartsPattern.prepare(mol);
+        return super.apply(mol);
+    }
+}

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksTransform.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksTransform.java
@@ -55,10 +55,6 @@ public final class SmirksTransform extends Transform {
      */
     private boolean doPrep = true;
 
-    /** Aromaticity model. */
-    private static final Aromaticity arom = new Aromaticity(ElectronDonation.daylight(),
-                                                            Cycles.or(Cycles.all(), Cycles.relevant()));
-
     // package private!
     SmirksTransform() {
         super();

--- a/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksTransform.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smirks/SmirksTransform.java
@@ -20,9 +20,6 @@
 
 package org.openscience.cdk.smirks;
 
-import org.openscience.cdk.aromaticity.Aromaticity;
-import org.openscience.cdk.aromaticity.ElectronDonation;
-import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.isomorphism.Transform;
 import org.openscience.cdk.smarts.SmartsPattern;

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1032,4 +1032,21 @@ class SmirksTest {
         final String smirks = "[c;r6:1](-[SH1:2]):[c;r6:3](-[NH2:4]).[#6:6]-[CH1;R0:5](=[OD1])>>[c:3]2:[c:1]:[s:2]:[c:5](-[#6:6]):[n:4]@2";
         assertWarningMesg(smirks, "Ignored query bond, consider using '~'");
     }
+
+    @Test
+    void testRetroWittigLike() throws Exception {
+        final String smiles = "CCC=Cc1ccccc1";
+        final String smirks = "[CH1:1]=[CH1+0:2]>>[CH1:1]=O.[CH2+0:2][P+](c1ccccc1)(C)C";
+        final String expected = "CCC=O.C(c1ccccc1)[P+](c2ccccc2)(C)C";
+
+        assertTransform(smiles, smirks, new SmirksTransform(), expected);
+        assertTransform(smiles, smirks, new SmirksTransform(),
+                        new String[] {expected},
+                        Transform.Mode.Unique);
+        assertTransform(smiles, smirks, new SmirksTransform(),
+                        new String[] {
+                                "CCC=O.C(c1ccccc1)[P+](c2ccccc2)(C)C",
+                                "CCC[P+](c1ccccc1)(C)C.C(c1ccccc1)=O"},
+                        Transform.Mode.All);
+    }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1055,6 +1055,23 @@ class SmirksTest {
                         Transform.Mode.All);
     }
 
+    @Test
+    void testRetroWittigLikeTriPhenyl() throws Exception {
+        final String smiles = "CCC=Cc1ccccc1";
+        final String smirks = "[CH1:1]=[CH1+0:2]>>[CH1:1]=O.[CH2+0:2][P+](c1ccccc1)(c2ccccc2)c3ccccc3";
+        final String expected = "CCC=O.C(c1ccccc1)[P+](c2ccccc2)(c3ccccc3)c4ccccc4";
+
+        assertTransform(smiles, smirks, new SmirksTransform(), expected);
+        assertTransform(smiles, smirks, new SmirksTransform(),
+                        new String[] {expected},
+                        Transform.Mode.Unique);
+        assertTransform(smiles, smirks, new SmirksTransform(),
+                        new String[] {
+                                "CCC=O.C(c1ccccc1)[P+](c2ccccc2)(c3ccccc3)c4ccccc4",
+                                "CCC[P+](c1ccccc1)(c2ccccc2)c3ccccc3.C(c1ccccc1)=O"},
+                        Transform.Mode.All);
+    }
+
     // need to check the atoms of a bond to see if the implicit bond definition
     // is aliphatic or aromatic
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -555,8 +555,13 @@ class SmirksTest {
     // correctly
     @Test
     void testReplaceH_2() throws Exception {
+        assertWarningMesg("[CH1:1][H]>>[*:1]c1ccccc1",
+                          "Not enough context to determine bond order of newly created bond!");
+        // * is both aliphatic and aromatic! so we can't know until we run
+        // the pattern if the new bond is aromatic or aliphatic, it must be
+        // knowable from the pattern
         assertTransform("C[C@H](O)CC",
-                        "[CH1:1][H]>>[*:1]c1ccccc1",
+                        "[CH1:1][H]>>[*:1]-c1ccccc1",
                         "C[C@](O)(CC)c1ccccc1");
     }
 
@@ -1048,5 +1053,14 @@ class SmirksTest {
                                 "CCC=O.C(c1ccccc1)[P+](c2ccccc2)(C)C",
                                 "CCC[P+](c1ccccc1)(C)C.C(c1ccccc1)=O"},
                         Transform.Mode.All);
+    }
+
+    // need to check the atoms of a bond to see if the implicit bond definition
+    // is aliphatic or aromatic
+    @Test
+    public void testAromaticContext() throws Exception {
+        assertTransform("FC(F)(F)c1nn(c(c1)C)C",
+                        "[cH0X3v4+0:1]1[cH1X3v4+0:3][cH0X3v4+0:4][nH0X2v3+0:11][nH0X3v3+0:10]1>>[CH0+0:1]([CH2+0:3][CH0+0:4]=O)=O.[NH1+0:10][NH2+0:11]",
+                        "FC(F)(F)C(CC(C)=O)=O.NNC");
     }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1087,4 +1087,18 @@ class SmirksTest {
                         "[c;H0v4X3;+0:1]1[c;H1v4X3;+0:3][c;H1v4X3;+0:4][c;H0v4X3;+0:5][n;H0v3X3;+0:13]1>>[H][#6;AH1:3]([#6;AH0;+0:1]=O)[#6;AH1:4]([H])[#6;AH0;+0:5]=O.[H][#7;A:13][H]",
                         "n1c(cccc1C)N.C(CCC(C)=O)(C)=O");
     }
+
+    @Test
+    public void testAromatic6() throws Exception {
+        assertTransform("CCn1c(CCl)nc2cc(C)ccc12",
+                        "[cH0+0:1]1[nH0+0:6][cH0+0:7][cH0+0:13][nD2H0+0:14]1>>[CH0+0:1](O)=O.[NH1+0:6][cH0+0:7][cH0+0:13][NH2+0:14]",
+                        "CCNc1ccc(cc1N)C.C(CCl)(O)=O");
+    }
+
+    @Test
+    public void testFischerIndole() throws Exception {
+        assertTransform("CCOC(=O)c1[nH]c2ccccc2c1Cc1ccccc1",
+                        "[#8:9]-[C:8](=[O;D1;H0:10])-[c;H0;D3;+0:5]1:[nH;D2;+0:1]:[c:2]:[c;H0;D3;+0:3](:[c:4]):[c;H0;D3;+0:6]:1-[C:7]>>N-[NH;D2;+0:1]-[c:2]:[cH;D2;+0:3]:[c:4].O=[C;H0;D3;+0:5](-[CH2;D2;+0:6]-[C:7])-[C:8](-[#8:9])=[O;D1;H0:10]",
+                        "CCOC(=O)C(CCc1ccccc1)=O.N(c1ccccc1)N");
+    }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1080,4 +1080,11 @@ class SmirksTest {
                         "[cH0X3v4+0:1]1[cH1X3v4+0:3][cH0X3v4+0:4][nH0X2v3+0:11][nH0X3v3+0:10]1>>[CH0+0:1]([CH2+0:3][CH0+0:4]=O)=O.[NH1+0:10][NH2+0:11]",
                         "FC(F)(F)C(CC(C)=O)=O.NNC");
     }
+
+    @Test
+    public void testImplicitValenceAromatic5() throws Exception {
+        assertTransform("n1c(cccc1C)-n2c(ccc2C)C",
+                        "[c;H0v4X3;+0:1]1[c;H1v4X3;+0:3][c;H1v4X3;+0:4][c;H0v4X3;+0:5][n;H0v3X3;+0:13]1>>[H][#6;AH1:3]([#6;AH0;+0:1]=O)[#6;AH1:4]([H])[#6;AH0;+0:5]=O.[H][#7;A:13][H]",
+                        "n1c(cccc1C)N.C(CCC(C)=O)(C)=O");
+    }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -68,8 +68,11 @@ class SmirksTest {
             actualSmiles.add(SMIGEN.create(actual));
         }
 
-        assertEquals(expected.length, actualSmiles.size(), "The number of expected transforms " + expected.length +
-                " and actual transforms " + actualSmiles.size() + " is different.");
+        assertEquals(expected.length,
+                     actualSmiles.size(),
+                     "The number of expected transforms " + expected.length +
+                     " and actual transforms " + actualSmiles.size() + " is different:" +
+                     actualSmiles);
 
         for (int i = 0; i < expected.length; i++) {
             Assertions.assertEquals(

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -59,6 +59,8 @@ class SmirksTest {
     static void assertTransform(String smiles, String smirks, Transform transform, String[] expected, Transform.Mode mode) throws Exception {
         IAtomContainer mol = SMIPAR.parseSmiles(smiles);
         assertTrue(Smirks.parse(transform, smirks), transform.message());
+        if (transform.message() != null)
+            System.err.println("Warning: " + transform.message());
         Iterable<IAtomContainer> iterable = transform.apply(mol, mode);
 
         List<String> actualSmiles = new ArrayList<>();

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -998,7 +998,7 @@ class SmirksTest {
     @Test
     void testBenzoxazoleCarboxylicAcid() throws Exception {
         final String smiles = "c1cc(O)c(N)cc1.CC(=O)O";
-        final String smirks = "[c;r6:1](-[OH1:2]):[c;r6:3](-[NH2:4]).[#6:6]-[C;R0:5](=[OD1])-[OH1]>>[C:3]2:[C:1]:[OH0:2]:[CH1:5](-[#6:6]):[NH1:4]2";
+        final String smirks = "[c;r6:1](-[OH1:2]):[c;r6:3](-[NH2:4]).[#6:6]-[C;R0:5](=[OD1])-[OH1]>>[c:3]2[c:1][OH0:2][CH1:5]([#6:6])[NH1:4]2";
         final String expected = "c1cc2OC(C)Nc2cc1";
 
         assertTransform(smiles, smirks, new SmirksTransform(), expected);
@@ -1011,7 +1011,7 @@ class SmirksTest {
     @Test
     void testBenzothiazole() throws Exception {
         final String smiles = "CC=O.Nc1ccccc1S";
-        final String smirks = "[c;r6:1](-[SH1:2]):[c;r6:3](-[NH2:4]).[#6:6]-[CH1;R0:5](=[OD1])>>[c:3]2:[c:1]:[sH0:2]:[c:5](-[#6:6]):[nH1:4]2";
+        final String smirks = "[c;r6:1](-[SH1:2]):[c;r6:3](-[NH2:4]).[#6:6]-[CH1;R0:5](=[OD1])>>[c:3]2[c:1][SH0:2][C:5]([#6:6])[NH1:4]2";
         final String expected = "CC1Sc2ccccc2N1";
 
         assertTransform(smiles, smirks, new SmirksTransform(), expected);
@@ -1109,6 +1109,7 @@ class SmirksTest {
                         "[CH2+]C(=O)C1=CC=CC=C1");
     }
 
+    @Disabled
     @Test
     public void testAddOMe() throws Exception {
         Assertions.fail("ToDo: Should use ReplaceAtom op-code");

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1109,4 +1109,11 @@ class SmirksTest {
                         "[CH2+]C(=O)C1=CC=CC=C1");
     }
 
+    @Test
+    public void testAddOMe() throws Exception {
+        Assertions.fail("ToDo: Should use ReplaceAtom op-code");
+        assertTransform("ClC(=O)C1=CC=CC=C1",
+                        "[#6:1]Cl>>[#6:1]OC",
+                        "C(=O)(C1=CC=CC=C1)O");
+    }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1083,43 +1083,73 @@ class SmirksTest {
     // need to check the atoms of a bond to see if the implicit bond definition
     // is aliphatic or aromatic
     @Test
-    public void testAromaticContext() throws Exception {
+    void testAromaticContext() throws Exception {
         assertTransform("FC(F)(F)c1nn(c(c1)C)C",
                         "[cH0X3v4+0:1]1[cH1X3v4+0:3][cH0X3v4+0:4][nH0X2v3+0:11][nH0X3v3+0:10]1>>[CH0+0:1]([CH2+0:3][CH0+0:4]=O)=O.[NH1+0:10][NH2+0:11]",
                         "FC(F)(F)C(CC(C)=O)=O.NNC");
     }
 
     @Test
-    public void testImplicitValenceAromatic5() throws Exception {
+    void testImplicitValenceAromatic5() throws Exception {
         assertTransform("n1c(cccc1C)-n2c(ccc2C)C",
                         "[c;H0v4X3;+0:1]1[c;H1v4X3;+0:3][c;H1v4X3;+0:4][c;H0v4X3;+0:5][n;H0v3X3;+0:13]1>>[H][#6;AH1:3]([#6;AH0;+0:1]=O)[#6;AH1:4]([H])[#6;AH0;+0:5]=O.[H][#7;A:13][H]",
                         "n1c(cccc1C)N.C(CCC(C)=O)(C)=O");
     }
 
     @Test
-    public void testAromatic6() throws Exception {
+    void testAromatic6() throws Exception {
         assertTransform("CCn1c(CCl)nc2cc(C)ccc12",
                         "[cH0+0:1]1[nH0+0:6][cH0+0:7][cH0+0:13][nD2H0+0:14]1>>[CH0+0:1](O)=O.[NH1+0:6][cH0+0:7][cH0+0:13][NH2+0:14]",
                         "CCNc1ccc(cc1N)C.C(CCl)(O)=O");
     }
 
     @Test
-    public void testFischerIndole() throws Exception {
+    void testFischerIndole() throws Exception {
         assertTransform("CCOC(=O)c1[nH]c2ccccc2c1Cc1ccccc1",
                         "[#8:9]-[C:8](=[O;D1;H0:10])-[c;H0;D3;+0:5]1:[nH;D2;+0:1]:[c:2]:[c;H0;D3;+0:3](:[c:4]):[c;H0;D3;+0:6]:1-[C:7]>>N-[NH;D2;+0:1]-[c:2]:[cH;D2;+0:3]:[c:4].O=[C;H0;D3;+0:5](-[CH2;D2;+0:6]-[C:7])-[C:8](-[#8:9])=[O;D1;H0:10]",
                         "CCOC(=O)C(CCc1ccccc1)=O.N(c1ccccc1)N");
     }
 
     @Test
-    public void testChargeChange() throws Exception {
+    void testChargeNewAtom() throws Exception {
         assertTransform("ClC(=O)C1=CC=CC=C1",
                         "[#6:1]Cl>>[#6:1][CH2+]",
                         "[CH2+]C(=O)C1=CC=CC=C1");
     }
 
+
+
+    @Test
+    void testDeleteAtom() throws Exception {
+        assertTransform("Cl.c1ccccc1",
+                        "Cl>>",
+                        "c1ccccc1");
+    }
+
+    @Test
+    void testDeleteBond() throws Exception {
+        assertTransform("BrBr",
+                        "[Br:1][Br:2]>>[Br:1].[Br:2]",
+                        "[Br].[Br]");
+    }
+
+    @Test
+    void testSetChange() throws Exception {
+        assertTransform("c1ccccc1O",
+                        "[OH:1]>>[OH0-:1]",
+                        "c1ccccc1[O-]");
+    }
+
+    @Test
+    void testSetMass() throws Exception {
+        assertTransform("c1ccccc1[H]",
+                        "[H:1]>>[2H:1]",
+                        "c1ccccc1[2H]");
+    }
+
     @Disabled
     @Test
-    public void testAddOMe() throws Exception {
+    void testAddOMe() throws Exception {
         Assertions.fail("ToDo: Should use ReplaceAtom op-code");
         assertTransform("ClC(=O)C1=CC=CC=C1",
                         "[#6:1]Cl>>[#6:1]OC",

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -20,7 +20,6 @@
 package org.openscience.cdk.smirks;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1099,7 +1099,7 @@ class SmirksTest {
     @Test
     void testThiazole() throws Exception {
         final String smiles = "CC(N)=S.CC(I)C(C)=O";
-        final String smirks = "[#6:6]-[C;R0:1](=[OD1])-[CH1;R0:5](-[#6:7])-[*;#17,#35,#53].[NH2:2]-[C:3]=[SD1:4]>>[CH1:1]2(-[#6:6])[NH1:2][CH1:3][S:4][C:5]([#6:7])2";
+        final String smirks = "[#6:6]-[CH0R0:1](=[OD1])-[CH1;R0:5](-[#6:7])-[*;#17,#35,#53].[NH2:2]-[CH0:3]=[SD1:4]>>[CH1:1]2(-[#6:6])[NH1:2][CH1:3][S:4][C:5]([#6:7])2";
         final String expected = "CC1NC(C(C)S1)C";
 
         assertTransform(smiles, smirks, expected);
@@ -1112,7 +1112,7 @@ class SmirksTest {
     @Test
     void testBenzoxazoleCarboxylicAcid() throws Exception {
         final String smiles = "c1cc(O)c(N)cc1.CC(=O)O";
-        final String smirks = "[c;r6:1](-[OH1:2]):[c;r6:3](-[NH2:4]).[#6:6]-[C;R0:5](=[OD1])-[OH1]>>[c:3]2[c:1][OH0:2][CH1:5]([#6:6])[NH1:4]2";
+        final String smirks = "[c;r6:1](-[OH1:2]):[c;r6:3](-[NH2:4]).[#6:6]-[CH0R0:5](=[OD1])-[OH1]>>[c:3]2[c:1][OH0:2][CH1:5]([#6:6])[NH1:4]2";
         final String expected = "c1cc2OC(C)Nc2cc1";
 
         assertTransform(smiles, smirks, new SmirksTransform(), expected);

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1388,10 +1388,10 @@ class SmirksTest {
     @Test
     void testValenceWarning() {
         assertWarningMesg("[C:1]>>[C:1]O",
-                          "Atom valence change detected");
+                          "Possible valence change");
         assertNoWarningMesg("[C:1][H]>>[C:1]O");
         assertWarningMesg("[C:1][H]>>[C:1]=O",
-                          "Atom valence change detected");
+                          "Possible valence change");
         assertNoWarningMesg("[CH4:1]>>[CH3:1]O");
     }
 

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -724,6 +724,17 @@ class SmirksTest {
         assertTransform("CC=CC",
                         "[*:1][*:2]=[*:3][*:4]>>[*:1]/-[*:2]=[*:3]/-[*:4]",
                         "C/C=C/C");
+        assertTransform("CC=CC",
+                        "[*:1][*:2]=[*:3][*:4]>>[*:1]/[*:2]=[*:3]/[*:4]",
+                        "C/C=C/C");
+        assertTransform("CC=CC",
+                        "[*:1][*:2]=[*:3][*:4]>>[*:1]/[*:2]=[*:3]/[*:4]",
+                        new String[]{"C/C=C/C"},
+                        Transform.Mode.Unique);
+        assertTransform("CC=CC",
+                        "[*:1][*:2]=[*:3][*:4]>>[*:1]/[*:2]=[*:3]/[*:4]",
+                        new String[]{"C/C=C/C", "C/C=C/C"},
+                        Transform.Mode.All);
     }
 
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -469,6 +469,20 @@ class SmirksTest {
     }
 
     @Test
+    void testKeepStereo_7() throws Exception {
+        assertTransform("CC=[C@]=CCl",
+                        "[C:1]Cl>>[C:1]Br",
+                        "CC=[C@]=CBr");
+    }
+
+    @Test
+    void testKeepStereo_8() throws Exception {
+        assertTransform("Cl/C=C=C=C/Cl",
+                        "[C:1]Cl>>[C:1]Br",
+                        "Br/C=C=C=C/Br");
+    }
+
+    @Test
     void testKeepStereo_Split1() throws Exception {
         // TODO stereo should be kept
         assertTransform("C/C=C/C=C/C",
@@ -1162,6 +1176,13 @@ class SmirksTest {
         assertTransform("c1ccccc1[H]",
                         "[H:1]>>[2H:1]",
                         "c1ccccc1[2H]");
+    }
+
+    @Test
+    void testSetElem() throws Exception {
+        assertTransform("[Pb]",
+                        "[Pb:1]>>[Au:1]",
+                        "[Au]");
     }
 
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -525,18 +525,28 @@ class SmirksTest {
 
     @Test
     void testKeepStereo_Split1() throws Exception {
-        // TODO stereo should be kept
         assertTransform("C/C=C/C=C/C",
                         "[CD2H:1]-[CD2H:2]>>[C:1]O.[C:2]O",
-                        "CC=CO.C(=CC)O");
+                        "C/C=C/O.C(=C/C)\\O");
+        assertTransform("C/C=C/C=C\\C",
+                        "[CD2H:1]-[CD2H:2]>>[C:1]O.[C:2]O",
+                        "C/C=C/O.C(=C\\C)\\O");
+        assertTransform("C/C=C/C=C\\C",
+                        "[CD2H:1]-[CD2H:2]>>[CH2:1].[CH2:2]",
+                        "CC=C.C=CC");
+        assertTransform("C/C=C/C=C\\C",
+                        "[CD2H:1]-[CD2H:2]>>[C:1][H].[C:2][H]",
+                        "CC=C.C=CC");
+        assertTransform("C/C=C/C=C\\C",
+                        "[CD2H:1]-[CD2H:2]>>[C:1][2H].[C:2][2H]",
+                        "C/C=C/[2H].C(=C\\C)\\[2H]");
     }
 
     @Test
     void testKeepStereo_Split2() throws Exception {
-        // TODO stereo should be kept
         assertTransform("Br[C@H](Cl)[C@H](Cl)Br",
                         "[CD3H:1]-[CD3H:2]>>[C:1]O.[C:2]O",
-                        "BrC(Cl)O.C(Cl)(Br)O");
+                        "Br[C@H](Cl)O.[C@@H](Cl)(Br)O");
     }
 
     // swapping two atoms we should lose stereochemistry because no information

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -286,7 +286,7 @@ class SmirksTest {
     }
 
     @Test
-    public void testImplicitValenceAromatic() throws Exception {
+    void testImplicitValenceAromatic() throws Exception {
         assertTransform("c1ccccc1C(=O)O",
                         "[OD1:1][H]>>[O:1]Cc1ccccc1",
                         "c1ccccc1C(=O)OCc2ccccc2");
@@ -341,7 +341,7 @@ class SmirksTest {
     }
 
     // https://www.daylight.com/dayhtml/doc/theory/theory.smirks.html
-    // but atom map 0 => 5, 0 is undef, think this is a bug in Daylight doc (TODO Roger)
+    // but atom map 0 => 5, 0 is undef, think this is a bug in Daylight doc
     // the implicit hydrogens are moved as needed
     @Test
     void testHydrogenMovement_1() throws Exception {

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -219,6 +219,7 @@ class SmirksTest {
     }
 
     @Disabled("TODO aromatic flags on atoms/bonds")
+    @Test
     public void testImplicitValenceAromatic() throws Exception {
         assertTransform("c1ccccc1C(=O)O",
                         "[OD1:1][H]>>[O:1]Cc1ccccc1",
@@ -551,4 +552,20 @@ class SmirksTest {
 
     // To Test:
     // [H:1]C>>C[*:1]
+
+    @Test
+    void testBondOrderingSwapping_1() throws Exception {
+        assertTransform("[Li+:30].[Al+3:32].[O:28]=[C:27]1[O:31][C:2](=[O:29])[CH:3]2[CH2:26][C:17]" +
+                "(=[C:8]([C:9]3=[CH:10][CH:11]=[C:12]([O:13][CH3:14])[CH:15]=[CH:16]3)[CH2:7][CH:4]12)[C:18]=4" +
+                "[CH:19]=[CH:20][C:21]([O:22][CH3:23])=[CH:24][CH:25]4",
+                 "[Al+3;h0X0:32].[C+0;h1:3]1[C+0;h1:4][C+0;h0X3v4:27](=[O+0;h0:28])[O+0;h0X2v2:31][C+0;h0X3v4:2]1=[O+0;h0:29].[Li+;h0X0:30]>>[CH2+0:2]([OH1+0:29])[CH1+0:3][CH1+0:4][CH2+0:27][O+0;h1:28]",
+                "OCC1CC(=C(CC1CO)C=2C=CC(OC)=CC2)C3=CC=C(OC)C=C3");
+    }
+
+    @Test
+    void testBondOrderingSwapping_2() throws Exception {
+        assertTransform("CCC(C)O",
+                "[H][C:1]-[O:2][H]>>[O:2]=[C:1]",
+                "CCC(C)=O");
+    }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -764,12 +764,20 @@ class SmirksTest {
         assertTransform(smiles, smirks, expected);
     }
 
-    @Disabled("throws an IllegalArgumentException in org.openscience.cdk.smirks.Smirks.collectBondPairs with the mapped Hs")
+    // @Disabled("throws an IllegalArgumentException in org.openscience.cdk.smirks.Smirks.collectBondPairs with the mapped Hs")
     @Test
     void testSwernOxidationMappedHydrogens() throws Exception {
         final String smiles = "C1CC(O)C(O)CC1";
         final String smirks = "[*:1][C:2]([H:3])([O:4][H:5])[C:6]([H:7])([O:8][H:9])[*:10]>>[*:1][C:2](=[O:4])[C:6](=[O:8])[*:10].[H:3][H:5].[H:7][H:9]";
-        final String expected = "C1CC(=O)C(=O)CC1";
+        final String expected = "C1CC(=O)C(=O)CC1.[H][H].[H][H]";
+        assertTransform(smiles, smirks, expected);
+    }
+
+    @Test
+    void testSwernOxidationMappedHydrogens_ExplH() throws Exception {
+        final String smiles = "C1CC(O[2H])C(O[2H])CC1";
+        final String smirks = "[*:1][C:2]([H:3])([O:4][H:5])[C:6]([H:7])([O:8][H:9])[*:10]>>[*:1][C:2](=[O:4])[C:6](=[O:8])[*:10].[H:3][H:5].[H:7][H:9]";
+        final String expected = "C1CC(=O)C(=O)CC1.[2H][H].[2H][H]";
         assertTransform(smiles, smirks, expected);
     }
 

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -222,12 +222,12 @@ class SmirksTest {
         Transform transform = new Transform();
         assertTrue(Smirks.parse(transform, ">>c1ccccc~1"));
         assertThat(transform.message(),
-                   containsString("Cannot determine bond order for newly created bond (presumed aromatic single)\n" +
+                   containsString("Cannot determine bond order for newly created bond (presumed aromatic single due to attached atoms)\n" +
                                           ">>c1ccccc~1\n" +
                                           "         ^\n"));
         assertTrue(Smirks.parse(transform, ">>c~1ccccc1"));
         assertThat(transform.message(),
-                   containsString("Cannot determine bond order for newly created bond (presumed aromatic single)\n" +
+                   containsString("Cannot determine bond order for newly created bond (presumed aromatic single due to attached atoms)\n" +
                                           ">>c~1ccccc1\n" +
                                           "   ^\n"));
     }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -38,6 +38,8 @@ import org.openscience.cdk.smiles.SmilesParser;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openscience.cdk.isomorphism.TransformOp.Type.*;
@@ -128,7 +130,7 @@ class SmirksTest {
     private void assertWarningMesg(String smirks, String expected) {
         Transform transform = new Transform();
         Smirks.parse(transform, smirks);
-        MatcherAssert.assertThat(transform.message(), startsWith(expected));
+        assertThat(transform.message(), startsWith(expected));
         // System.err.println("Warning: " + transform.message());
     }
 
@@ -195,15 +197,15 @@ class SmirksTest {
     void warnOnWildCardBond() {
         Transform transform = new Transform();
         assertTrue(Smirks.parse(transform, ">>c1ccccc~1"));
-        assertEquals(transform.message(),
-                     "Cannot determine bond order for newly created bond\n" +
-                     ">>c1ccccc~1\n" +
-                     "         ^\n");
+        assertThat(transform.message(),
+                   containsString("Cannot determine bond order for newly created bond (presumed aromatic single)\n" +
+                                  ">>c1ccccc~1\n" +
+                                  "         ^\n"));
         assertTrue(Smirks.parse(transform, ">>c~1ccccc1"));
-        assertEquals(transform.message(),
-                     "Cannot determine bond order for newly created bond\n" +
-                     ">>c~1ccccc1\n" +
-                     "   ^\n");
+        assertThat(transform.message(),
+                   containsString("Cannot determine bond order for newly created bond (presumed aromatic single)\n" +
+                                  ">>c~1ccccc1\n" +
+                                  "   ^\n"));
     }
 
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -985,7 +985,7 @@ class SmirksTest {
     @Test
     void testThiazole() throws Exception {
         final String smiles = "CC(N)=S.CC(I)C(C)=O";
-        final String smirks = "[#6:6]-[C;R0:1](=[OD1])-[CH1;R0:5](-[#6:7])-[*;#17,#35,#53].[NH2:2]-[C:3]=[SD1:4]>>[CH1:1]2(-[#6:6]):[NH1:2]:[CH1:3]:[S:4][C:5]([#6:7]):2";
+        final String smirks = "[#6:6]-[C;R0:1](=[OD1])-[CH1;R0:5](-[#6:7])-[*;#17,#35,#53].[NH2:2]-[C:3]=[SD1:4]>>[CH1:1]2(-[#6:6])[NH1:2][CH1:3][S:4][C:5]([#6:7])2";
         final String expected = "CC1NC(C(C)S1)C";
 
         assertTransform(smiles, smirks, expected);

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -37,10 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openscience.cdk.isomorphism.TransformOp.Type.*;
 
 class SmirksTest {
@@ -78,6 +75,17 @@ class SmirksTest {
         Collections.sort(actual);
         Arrays.sort(expected);
         assertArrayEquals(expected, actual.toArray());
+    }
+
+    @Test
+    void testNullArgument_Transform() {
+        assertThrows(NullPointerException.class, () -> Smirks.parse(null, "[C:3]>>[C:3][O:3]"), "NullPointerException expected when passing null as an argument for transform.");
+    }
+
+    @Test
+    void testNullArgument_Smirks() {
+        Transform transform = new Transform();
+        assertThrows(NullPointerException.class, () -> Smirks.parse(transform, null), "NullPointerException expected when passing null as an argument for smirks.");
     }
 
     @Test
@@ -568,4 +576,103 @@ class SmirksTest {
                 "[H][C:1]-[O:2][H]>>[O:2]=[C:1]",
                 "CCC(C)=O");
     }
+
+    @Test
+    void testReaction_1() throws Exception {
+        assertTransform("[O:1]=[C:2]([OH:17])[C:8]=1[NH:16][C:15]=2[CH:14]=[CH:13][CH:12]=[CH:11][C:10]2[CH:9]1.[OH:7][CH2:6][CH2:5][CH2:4][NH2:3]",
+                "[CH0D3v4:2][OH1D1v2:17].[NH2D1v3:3]>>[CH0:2][NH1:3]",
+                "O=C(C=1NC=2C=CC=CC2C1)NCCCO");
+    }
+
+    @Test
+    void testReaction_2() throws Exception {
+        assertTransform("[O:1]=[C:2]([OH:17])[C:8]=1[NH:16][C:15]=2[CH:14]=[CH:13][CH:12]=[CH:11][C:10]2[CH:9]1.[OH:7][CH2:6][CH2:5][CH2:4][NH2:3]",
+                "[N+0;h2D1v3:3][C+0;h2:4].[O+0;h0:1]=[C+0;h0D3v4:2]([O+0;h1D1v2:17])[C+0;h0:8]>>[OH0:1]=[CH0:2]([NH1:3][CH2:4])[CH0:8]",
+                "O=C(C=1NC=2C=CC=CC2C1)NCCCO");
+    }
+
+    // uses atom properties h, D and v; should the usage of these yield an exception or a warning message?
+    @Test
+    void testReaction_3() throws Exception {
+        assertTransform("[O:21]=[C:20]([NH:29][NH2:28])[C:22]1=[CH:23][CH:24]=[CH:25][N:26]=[CH:27]1." +
+                        "[OH:19][CH2:18][CH2:17][CH2:16][CH2:15][CH2:14][CH2:13][CH2:12][CH2:11][CH2:10][CH2:9][CH2:8][CH2:7][CH2:6][CH2:5][CH2:4][CH:2]([CH3:1])[CH3:3]",
+                "[N+0;h2D1v3:28][N+0;h1D2v3:29][C+0;h0D3v4:20].[O+0;h1D1v2:19]>>[O+0;h0D2v2:19][C+0;h0D3v4:20]",
+                "O=C(C1=CC=CN=C1)OCCCCCCCCCCCCCCCC(C)C");
+    }
+
+    @Test
+    void testReaction_4() throws Exception {
+        assertTransform("[O:21]=[C:20]([NH:29][NH2:28])[C:22]1=[CH:23][CH:24]=[CH:25][N:26]=[CH:27]1." +
+                        "[OH:19][CH2:18][CH2:17][CH2:16][CH2:15][CH2:14][CH2:13][CH2:12][CH2:11][CH2:10][CH2:9][CH2:8][CH2:7][CH2:6][CH2:5][CH2:4][CH:2]([CH3:1])[CH3:3]",
+                "[N+0;h2D1v3:28][N+0;h1D2v3:29][C+0;h0D3v4:20].[O+0;h1D1v2:19]>>[OH0:19][C:20]",
+                "O=C(C1=CC=CN=C1)OCCCCCCCCCCCCCCCC(C)C");
+    }
+
+    @Test
+    void testReaction_5_Transform() throws Exception {
+        final String smiles = "[O:21]=[C:20]([NH:29][NH2:28])[C:22]1=[CH:23][CH:24]=[CH:25][N:26]=[CH:27]1." +
+                "[OH:19][CH2:18][CH2:17][CH2:16][CH2:15][CH2:14][CH2:13][CH2:12][CH2:11][CH2:10][CH2:9][CH2:8][CH2:7][CH2:6][CH2:5][CH2:4][CH:2]([CH3:1])[CH3:3]";
+        final String smirks = "[C+0;h2:18][O+0;h1D1v2:19].[N+0;h2D1v3:28][N+0;h1D2v3:29][C+0;h0D3v4:20](=[O+0;h0:21])[c+0;h0:22]>>[CH2:18][OH0:19][CH0:20](=[OH0:21])[cH0:22]";
+
+        IAtomContainer atomContainer = SMIPAR.parseSmiles(smiles);
+        Transform transform = new Transform();
+        assertTrue(Smirks.parse(transform, smirks), transform.message());
+
+        // does not match and thus does not modify the molecule because there are aromatic atoms in the smirks
+        // successfully matching the smiles would require aromaticity perception to be carried out on the smiles
+        assertFalse(transform.apply(atomContainer));
+    }
+
+    @Test
+    void testReaction_5_SmirksTransform() throws Exception {
+        final String smiles = "[O:21]=[C:20]([NH:29][NH2:28])[C:22]1=[CH:23][CH:24]=[CH:25][N:26]=[CH:27]1." +
+                "[OH:19][CH2:18][CH2:17][CH2:16][CH2:15][CH2:14][CH2:13][CH2:12][CH2:11][CH2:10][CH2:9][CH2:8][CH2:7][CH2:6][CH2:5][CH2:4][CH:2]([CH3:1])[CH3:3]";
+        final String smirks = "[C+0;h2:18][O+0;h1D1v2:19].[N+0;h2D1v3:28][N+0;h1D2v3:29][C+0;h0D3v4:20](=[O+0;h0:21])[c+0;h0:22]>>[CH2:18][OH0:19][CH0:20](=[OH0:21])[cH0:22]";
+        final String expected = "O=C(c1cccnc1)OCCCCCCCCCCCCCCCC(C)C";
+
+        IAtomContainer atomContainer = SMIPAR.parseSmiles(smiles);
+        SmirksTransform transform = new SmirksTransform();
+        assertTrue(Smirks.parse(transform, smirks), transform.message());
+        assertTrue(transform.apply(atomContainer));
+        String actual = SMIGEN.create(atomContainer);
+
+        Assertions.assertEquals(
+                expected,
+                actual,
+                "Applying the transform did not generate the expected molecule");
+    }
+
+    @Test
+    void testReaction_5_SmirksTransform_setPrepareFalse() throws Exception {
+        final String smiles = "[O:21]=[C:20]([NH:29][NH2:28])[C:22]1=[CH:23][CH:24]=[CH:25][N:26]=[CH:27]1." +
+                "[OH:19][CH2:18][CH2:17][CH2:16][CH2:15][CH2:14][CH2:13][CH2:12][CH2:11][CH2:10][CH2:9][CH2:8][CH2:7][CH2:6][CH2:5][CH2:4][CH:2]([CH3:1])[CH3:3]";
+        final String smirks = "[C+0;h2:18][O+0;h1D1v2:19].[N+0;h2D1v3:28][N+0;h1D2v3:29][C+0;h0D3v4:20](=[O+0;h0:21])[c+0;h0:22]>>[CH2:18][OH0:19][CH0:20](=[OH0:21])[cH0:22]";
+
+        IAtomContainer atomContainer = SMIPAR.parseSmiles(smiles);
+        SmirksTransform transform = new SmirksTransform();
+        transform.setPrepare(false);
+        assertTrue(Smirks.parse(transform, smirks), transform.message());
+
+        // does not match and thus does not modify the molecule because there are aromatic atoms in the smirks
+        // successfully matching the smiles would require aromaticity perception to be carried out on the smiles
+        assertFalse(transform.apply(atomContainer));
+    }
+
+    @Test
+    void testReaction_6() throws Exception {
+        assertTransform("[O:17]=[C:6]1[CH2:10][CH2:9][CH2:8]1.[F:15][C:12]([F:14])([F:13])[c:11]1[cH:16][c:2]([Br:1])[cH:3][cH:4][c:5]1[I:18]",
+                "[C+0;h0D3v4:6](=[O+0;h0:17])([C+0;h2:8])[C+0;h2:10].[c+0;h1:4]:[c+0;h0D3v4:5]([I+0;h0D1v1:18]):[c+0;h0:11]" +
+                        ">>[cH1:4]:[cH0:5]([CH0:6]([OH1:17])([CH2:8])[CH2:10]):[cH0:11]",
+                "OC1(CCC1)c2ccc(cc2C(F)(F)F)Br");
+    }
+
+    @Test
+    void invalidSmirks_1() {
+        final String smirks = "[*:1][N:2](=[O:3])=[O:4]";
+        SmirksTransform transform = new SmirksTransform();
+        transform.setPrepare(false);
+        assertFalse(Smirks.parse(transform, smirks), transform.message());
+        assertEquals("SMIRKS was not a reaction!", transform.message());
+    }
+
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1,0 +1,554 @@
+/*
+ * Copyright (C) 2022 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.smirks;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.isomorphism.Transform;
+import org.openscience.cdk.isomorphism.TransformOp;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smarts.Smarts;
+import org.openscience.cdk.smiles.SmiFlavor;
+import org.openscience.cdk.smiles.SmilesGenerator;
+import org.openscience.cdk.smiles.SmilesParser;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openscience.cdk.isomorphism.TransformOp.Type.*;
+
+class SmirksTest {
+
+    private static final IChemObjectBuilder BUILDER = SilentChemObjectBuilder.getInstance();
+    private static final SmilesParser SMIPAR = new SmilesParser(BUILDER);
+    private static final SmilesGenerator SMIGEN = new SmilesGenerator(SmiFlavor.Default | SmiFlavor.UseAromaticSymbols);
+
+    static void assertTransform(String smiles, String smirks, String expected) throws Exception {
+        IAtomContainer mol = SMIPAR.parseSmiles(smiles);
+        Transform transform = new Transform();
+        assertTrue(Smirks.parse(transform, smirks), transform.message());
+        assertTrue(transform.apply(mol));
+        String actual = SMIGEN.create(mol);
+        Assertions.assertEquals(
+                expected,
+                actual,
+                "Applying the transform did not generate the expected molecule");
+    }
+
+    static void assertNoMatch(String smiles, String smirks) throws Exception {
+        IAtomContainer mol = SMIPAR.parseSmiles(smiles);
+        Transform transform = new Transform();
+        Smirks.parse(transform, smirks);
+        String actual = SMIGEN.create(mol);
+        assertFalse(transform.apply(mol), "Transform should not apply but did, result=" + actual);
+    }
+
+    static void assertAtomTypeOps(String lft, String rgt, TransformOp... expected) {
+        IAtomContainer qlft = new QueryAtomContainer(null);
+        IAtomContainer qrgt = new QueryAtomContainer(null);
+        assertTrue(Smarts.parse(qlft, lft), "Invalid SMARTS " + lft);
+        assertTrue(Smarts.parse(qrgt, rgt), "Invalid SMARTS " + rgt);
+        List<TransformOp> actual = Smirks.atomTypeOps(qlft.getAtom(0), qrgt.getAtom(0));
+        Collections.sort(actual);
+        Arrays.sort(expected);
+        assertArrayEquals(expected, actual.toArray());
+    }
+
+    @Test
+    void testDuplicateMapIdx_Product() {
+        Transform transform = new Transform();
+        assertFalse(Smirks.parse(transform, "[C:3]>>[C:3][O:3]"));
+        assertEquals(transform.message(), "Duplicate atom map [C:3] and [O:3]");
+    }
+
+    @Test
+    void testDuplicateMapIdx_Reactant() {
+        Transform transform = new Transform();
+        assertFalse(Smirks.parse(transform, "[C:4][O:4]>>[C:4]"));
+        assertEquals(transform.message(), "Duplicate atom map [C:4] and [O:4]");
+    }
+
+    @Test
+    void warnOnUnpairedAtomMap() {
+        Transform transform = new Transform();
+        assertTrue(Smirks.parse(transform, "[C:3]>>[C:3][O:4]"));
+        assertEquals(transform.message(), "Warning - added/removed atoms do not need to be mapped: [O:4]");
+    }
+
+    @Test
+    void atomTypeHChanges_1() {
+        assertAtomTypeOps("[CH1]", "[C]"); // no-op
+        assertAtomTypeOps("[CH1]", "[CH0]", new TransformOp(ImplH, 0, 0));
+        assertAtomTypeOps("[CH1]", "[CH1]"); // no-op
+        assertAtomTypeOps("[CH1]", "[CH2]", new TransformOp(ImplH, 0, 2));
+    }
+
+    @Test
+    void atomTypeImplHChanges_1() {
+        assertAtomTypeOps("[CH1]", "[C]"); // no-op
+        assertAtomTypeOps("[CH1]", "[Ch0]", new TransformOp(ImplH, 0, 0));
+        assertAtomTypeOps("[CH1]", "[Ch1]"); // no-op
+        assertAtomTypeOps("[CH1]", "[Ch2]", new TransformOp(ImplH, 0, 2));
+        assertAtomTypeOps("[CH1]", "[C;h2,H3]");
+        assertAtomTypeOps("[CH1]", "[C;h3,H3]", new TransformOp(ImplH, 0, 3));
+    }
+
+    @Test
+    void atomTypeHChanges_2() {
+        assertAtomTypeOps("[C;H0,H1]", "[C]"); // no-op
+        assertAtomTypeOps("[C;H0,H1]", "[CH0]", new TransformOp(ImplH, 0, 0));
+        assertAtomTypeOps("[C;H0,H1]", "[CH1]", new TransformOp(ImplH, 0, 1));
+        assertAtomTypeOps("[C;H0,H1]", "[CH2]", new TransformOp(ImplH, 0, 2));
+    }
+
+    @Test
+    void atomTypeHChanges_3() {
+        assertAtomTypeOps("[C;H0,H1]", "[C;H0,H1]"); // no-op
+        assertAtomTypeOps("[C;H0,H1]", "[C,H0]"); // conflicting
+        assertAtomTypeOps("[C;H0,H1]", "[C;H0]", new TransformOp(ImplH, 0, 0));
+        assertAtomTypeOps("[C;H0,H1]", "[C;H1]", new TransformOp(ImplH, 0, 1));
+        assertAtomTypeOps("[C;H0,H1]", "[C;H2]", new TransformOp(ImplH, 0, 2));
+    }
+
+    @Test
+    void atomTypeMassChange() {
+        assertAtomTypeOps("[12C]", "[12C]");
+        assertAtomTypeOps("[13C]", "[13C]");
+        assertAtomTypeOps("[12,13;C]", "[12,13;C]");
+        assertAtomTypeOps("[12C]", "[C]");
+        assertAtomTypeOps("[C]", "[12C]", new TransformOp(Mass, 0, 12));
+        assertAtomTypeOps("[C]", "[13C]", new TransformOp(Mass, 0, 13));
+        assertAtomTypeOps("[12,13;C]", "[13;C]", new TransformOp(Mass, 0, 13));
+        assertAtomTypeOps("[12C]", "[12,13;C]");
+        assertAtomTypeOps("[12C]", "[0C]", new TransformOp(Mass, 0, 0));
+    }
+
+    @Test
+    void atomTypeChargeChange() {
+        assertAtomTypeOps("[C+]", "[C+]");
+        assertAtomTypeOps("[C+]", "[C]");
+        assertAtomTypeOps("[C+]", "[C+0]", new TransformOp(Charge, 0, 0));
+        assertAtomTypeOps("[C+]", "[C+1]");
+        assertAtomTypeOps("[C+]", "[C+2]", new TransformOp(Charge, 0, 2));
+        assertAtomTypeOps("[C]", "[C+]", new TransformOp(Charge, 0, 1));
+        assertAtomTypeOps("[C]", "[C+1]", new TransformOp(Charge, 0, 1));
+    }
+
+    @Test
+    void atomTypeElemChange() {
+        assertAtomTypeOps("[C]", "[*]");
+        assertAtomTypeOps("[C]", "[C]");
+        assertAtomTypeOps("[C]", "[C,N]");
+        assertAtomTypeOps("[C]", "[N]", new TransformOp(Element, 0, 7));
+        assertAtomTypeOps("[C,N]", "[C]", new TransformOp(Element, 0, 6));
+        assertAtomTypeOps("[C,N]", "[N]", new TransformOp(Element, 0, 7));
+        assertAtomTypeOps("[C,N]", "[#7]", new TransformOp(Element, 0, 7));
+        assertAtomTypeOps("[C,N]", "C", new TransformOp(Element, 0, 6));
+        // assertAtomTypeOps("[C,N]", "c", new OpCode(Element, 0, 6, 0, 1));
+    }
+
+    // https://www.daylight.com/dayhtml/doc/theory/theory.smirks.html
+    @Test
+    void testNitroNorm_1() throws Exception {
+        assertTransform("c1ccccc1N(=O)=O",
+                        "[*:1][N:2](=[O:3])=[O:4]>>[*:1][N+:2](=[O:3])[O-:4]",
+                        "c1ccccc1[N+](=O)[O-]");
+    }
+
+    @Test
+    void testNitroNorm_2() throws Exception {
+        assertTransform("c1ccccc1[N]([O-])=O",
+                        "[N:1](-[O-:2])=[O:3]>>[N:1](=[O+0:2])=[O:3]",
+                        "c1ccccc1N(=O)=O");
+    }
+
+    // The C here is [CH2][CH3]
+    @Test
+    void testImplicitValence() throws Exception {
+        assertTransform("c1ccccc1C(=O)O",
+                        "[OD1:1][H]>>[O:1]CC",
+                        "c1ccccc1C(=O)OCC");
+    }
+
+    @Test
+    void testImplicitValence_ExplH() throws Exception {
+        assertTransform("c1ccccc1C(=O)O",
+                        "[OD1:1][H]>>[OD1:1]C([H])([H])C([H])([H])[H]",
+                        "c1ccccc1C(=O)OCC");
+    }
+
+    @Test
+    void testImplicitValence_VirtH() throws Exception {
+        assertTransform("c1ccccc1C(=O)O",
+                        "[OD1:1][H]>>[OD1:1][CH2][CH3]",
+                        "c1ccccc1C(=O)OCC");
+    }
+
+    // explicit hydrogens in SMIRKS, but we remove implicit hydrogens
+    @Test
+    void testHydrogenAdjustment_1() throws Exception {
+        assertTransform("c1ccccc1N(=O)=O",
+                        "[c:1][H]>>[*:1]Cl",
+                        "c1(c(c(c(c(c1N(=O)=O)Cl)Cl)Cl)Cl)Cl");
+    }
+
+    @Disabled("TODO aromatic flags on atoms/bonds")
+    public void testImplicitValenceAromatic() throws Exception {
+        assertTransform("c1ccccc1C(=O)O",
+                        "[OD1:1][H]>>[O:1]Cc1ccccc1",
+                        "c1ccccc1C(=O)OCc1ccccc1");
+    }
+
+    // explicit hydrogens in SMIRKS, but we remove (one) implicit hydrogens
+    @Test
+    void testHydrogenAdjustment_2() throws Exception {
+        assertTransform("C1CCCCC1N(=O)=O",
+                        "[C:1][H]>>[*:1]Cl",
+                        "C1(C(C(C(C(C1(N(=O)=O)Cl)Cl)Cl)Cl)Cl)Cl");
+    }
+
+    // explicit hydrogens in SMIRKS, but we add implicit hydrogens
+    @Test
+    void testHydrogenAdjustment_3() throws Exception {
+        assertTransform("c1(c(c(c(c(c1N(=O)=O)Cl)Cl)Cl)Cl)Cl",
+                        "[c:1][Cl]>>[*:1][H]",
+                        "c1ccccc1N(=O)=O");
+    }
+
+    // remove explicit hydrogens
+    @Test
+    void testHydrogenAdjustment_4() throws Exception {
+        assertTransform("[H]c1c([H])c([H])c([H])c([H])c1N(=O)=O",
+                        "[c:1][H]>>[*:1]Cl",
+                        "Clc1c(Cl)c(Cl)c(Cl)c(Cl)c1N(=O)=O");
+    }
+
+    // each carbon has two explicit atoms, only one should be removed
+    @Test
+    void testHydrogenAdjustment_5() throws Exception {
+        assertTransform("[H]C1([H])C([H])([H])C([H])([H])C([H])([H])C([H])([H])C([H])1N(=O)=O",
+                        "[C:1][H]>>[*:1]Cl",
+                        "ClC1([H])C(Cl)([H])C(Cl)([H])C(Cl)([H])C(Cl)([H])C1(Cl)N(=O)=O");
+    }
+
+    // the deuterium or other H should be removed
+    @Test
+    void testHydrogenAdjustment_6() throws Exception {
+        assertTransform("[2H]c1c([H])c([H])c([H])c([H])c1N(=O)=O",
+                        "[c:1][H]>>[*:1]Cl",
+                        "Clc1c(Cl)c(Cl)c(Cl)c(Cl)c1N(=O)=O");
+    }
+
+    // only the deuterium should be removed
+    @Test
+    void testHydrogenAdjustment_7() throws Exception {
+        assertTransform("[2H]c1c([H])c([H])c([H])c([H])c1N(=O)=O",
+                        "[c:1][2#1]>>[*:1]Cl",
+                        "Clc1c([H])c([H])c([H])c([H])c1N(=O)=O");
+    }
+
+    // https://www.daylight.com/dayhtml/doc/theory/theory.smirks.html
+    // but atom map 0 => 5, 0 is undef, think this is a bug in Daylight doc (TODO Roger)
+    // the implicit hydrogens are moved as needed
+    @Test
+    void testHydrogenMovement_1() throws Exception {
+        assertTransform("c1ccccc1C(=O)Cl.NCCC",
+                        "[C:1](=[O:2])[Cl:3].[H:99][N:4]([H:100])[C:5]>>[C:1](=[O:2])[N:4]([H:100])[C:5].[Cl:3][H:99]",
+                        "c1ccccc1C(=O)NCCC.Cl");
+    }
+
+    // the deuterium is moved from one atom to another
+    @Test
+    void testHydrogenMovement_2() throws Exception {
+        assertTransform("c1ccccc1C(=O)Cl.[2H]N([H])CCC",
+                        "[C:1](=[O:2])[Cl:3].[H:99][N:4]([H:100])[C:5]>>[C:1](=[O:2])[N:4]([H:100])[C:5].[Cl:3][H:99]",
+                        "c1ccccc1C(=O)N([H])CCC.Cl[2H]");
+    }
+
+    // it is possible to move the implicit hydrogen and keep the 2H in place
+    @Test
+    void testHydrogenMovement_3() throws Exception {
+        assertTransform("c1ccccc1C(=O)Cl.[2H]NCCC",
+                        "[C:1](=[O:2])[Cl:3].[H:99][N:4]([H:100])[C:5]>>[C:1](=[O:2])[N:4]([H:100])[C:5].[Cl:3][H:99]",
+                        "c1ccccc1C(=O)N([2H])CCC.Cl");
+    }
+
+    // if we want we can force the implicit Hydrogen to move even if there is an implicit hydrogen
+    @Test
+    void testHydrogenMovement_4() throws Exception {
+        assertTransform("c1ccccc1C(=O)Cl.[2H]NCCC",
+                        "[C:1](=[O:2])[Cl:3].[2#1:99][N:4]([H:100])[C:5]>>[C:1](=[O:2])[N:4]([H:100])[C:5].[Cl:3][H:99]",
+                        "c1ccccc1C(=O)NCCC.Cl[2H]");
+    }
+
+    // hydrogen moves to a new atom (made up) but make sure ops are done in
+    // correct order
+    @Test
+    void testHydrogenMovement_5() throws Exception {
+        assertTransform("Cl[2H]",
+                        "[Cl:1][H:2]>>[Cl:1].[H:2]Br",
+                        "[Cl].[2H]Br");
+    }
+
+    // hydrogens swap
+    @Test
+    void testHydrogenMovement_6() throws Exception {
+        assertTransform("Cl[2H].Br[3H]",
+                        "[Cl:1][H:2].[Br:3][H:4]>>[Cl:1][H:4].[Br:3][H:2]",
+                        "Cl[3H].[2H]Br");
+    }
+
+    // hydrogens swap (implicit)
+    @Test
+    void testHydrogenMovement_7() throws Exception {
+        assertTransform("Cl.Br",
+                        "[Cl:1][H:2].[Br:3][H:4]>>[Cl:1][H:4].[Br:3][H:2]",
+                        "Cl.Br");
+    }
+
+    // @Ignore("when is the XOR filter applied? after match or after changes are successful")
+    @Test
+    void testMultiEdges() throws Exception {
+        assertNoMatch(
+                "CC",
+                "[*:1].[*:2]>>[*:1]-[*:2]");
+//        assertTransform("C1CCCCC1",
+//                        "[*:1].[*:2]>>[*:1]-[*:2]",
+//                        "[CH2]12[CH2]3[CH2]2[CH2]3CC1");
+    }
+
+    @Test
+    void testBreakBond() throws Exception {
+        assertTransform("C=CC=CC=C",
+                        "[CH:1]=[CH:2]>>[CH3:1].[CH3:2]",
+                        "C=CC.CC=C");
+        assertTransform("C=CC=CC=C",
+                        "[C:1]=[C:2]>>[C:1]([H])[H].[C:2]([H])[H]",
+                        "C.CC.CC.C");
+    }
+
+    // removing one and then adding an atom from a tetrahedral it is desirable
+    // to keep the configuration intact
+    @Test
+    void testKeepStereo_1() throws Exception {
+        assertTransform("C[C@](CC)(N)Cl",
+                        "[C:1]Cl>>[C:1]Br",
+                        "C[C@](CC)(N)Br");
+    }
+
+    // removing one and then adding an atom from a tetrahedral it is desirable
+    // to keep the configuration intact... even if there is an implicit hydrogen
+    @Test
+    void testKeepStereo_2() throws Exception {
+        assertTransform("C[C@H](CC)Cl",
+                        "[C:1]Cl>>[C:1]Br",
+                        "C[C@H](CC)Br");
+    }
+
+    @Test
+    void testKeepStereo_3() throws Exception {
+        assertTransform("C/C=C(/C)Cl",
+                        "[C:1]Cl>>[C:1]Br",
+                        "C/C=C(/C)\\Br");
+    }
+
+    @Test
+    void testKeepStereo_4() throws Exception {
+        assertTransform("C/C=C(C)\\Cl",
+                        "[C:1]Cl>>[C:1]Br",
+                        "C/C=C(/C)\\Br");
+    }
+
+    @Test
+    void testKeepStereo_5() throws Exception {
+        assertTransform("O=[S@](C)CC",
+                        "[S:1]C>>[S:1]Cl",
+                        "O=[S@](Cl)CC");
+    }
+
+    @Test
+    void testKeepStereo_6() throws Exception {
+        assertTransform("C[C@H](CC)Cl",
+                        "[CH1:1][H]>>[C:1]Br",
+                        "C[C@](CC)(Cl)Br");
+    }
+
+    // swapping two atoms we should lose stereochemistry because no information
+    // has been given about the order in which these attach
+    @Test
+    void testRemoveStereo_1() throws Exception {
+        assertTransform("C[C@](CC)(N)Cl",
+                        "[C:1](N)Cl>>[C:1]([H])Br",
+                        "CC(CC)Br");
+    }
+
+    @Test
+    void testRemoveStereo_2() throws Exception {
+        assertTransform("C/C=C(C)\\Cl",
+                        "[C:1](C)Cl>>[C:1](N)Br",
+                        "CC=C(N)Br");
+    }
+
+    @Test
+    void testRemoveStereo_3() throws Exception {
+        assertTransform("C/C=C(C)\\Cl",
+                        "[CH0:1](C)Cl>>[CH2:1]",
+                        "CC=C");
+    }
+
+    @Test
+    void testRemoveStereo_4() throws Exception {
+        assertTransform("O=[S@](C)CC",
+                        "[S:1](=[O:2])C>>[S:1]([OH:2])([H])Cl",
+                        "OS(Cl)CC");
+    }
+
+    @Test
+    void testRemoveStereo_5() throws Exception {
+        assertTransform("O[C@H](C)CC",
+                        "[H][CH:1][O:2]>>[C:1]=[OH0:2]",
+                        "O=C(C)CC");
+    }
+
+    @Test
+    void testRemoveStereo_6() throws Exception {
+        assertTransform("O[C@H](C)CC",
+                        "[CH:1][OH:2]>>[CH0:1]=[OH0:2]",
+                        "O=C(C)CC");
+    }
+
+    @Test
+    void testRemoveStereo_7() throws Exception {
+        assertTransform("C/C=C/C",
+                        "[CH:1]=[CH:2]>>[CH2:1]-[CH2:2]",
+                        "CCCC");
+    }
+
+    @Test
+    void testRemoveStereo_8() throws Exception {
+        assertTransform("C/C=C/O",
+                        "[OH:1]-[CH:2]>>[OH0:1]=[CH0:2]",
+                        "CC=C=O");
+        // but stereo kept here
+        assertTransform("C/C=C/O",
+                        "[OH:1]-[CH:2]>>C[OH0:1]-[CH:2]",
+                        "C/C=C/OC");
+    }
+
+    @Test
+    void testAtomReuseOptimisation_1() throws Exception {
+        assertTransform("COC",
+                        "[C:1]O>>[C:1]N",
+                        "CN.[CH3]");
+    }
+
+    @Test
+    void testAtomReuseOptimisation_2() throws Exception {
+        assertTransform("COC",
+                        "[CH3:1]O>>[CH2:1]=N",
+                        "C=N.[CH3]");
+    }
+
+    // make sure with the replace H optimisation the bonds to other
+    // atoms get broken
+    @Test
+    void testReplaceH_1() throws Exception {
+        assertTransform("[C][H][C]",
+                        "[C:1][#1]>>[*:1]Cl",
+                        "[C]Cl.[C]");
+    }
+
+    // make sure with the replace H optimisation the aromaticity gets set
+    // correctly
+    @Test
+    void testReplaceH_2() throws Exception {
+        assertTransform("C[C@H](O)CC",
+                        "[CH1:1][H]>>[*:1]c1ccccc1",
+                        "C[C@](O)(CC)c1ccccc1");
+    }
+
+    @Test
+    void testReplaceH_3() throws Exception {
+        assertTransform("[C][H][C].[BH][H][B]",
+                        "[H][C,B:1][#1:2]>>[*:1]([H:2])Cl",
+                        "[C][H][C].[B]([H][B])Cl");
+    }
+
+    @Test
+    void testInvertStereo_1() throws Exception {
+        assertTransform("C[C@](Br)(Cl)N",
+                        "[C:1][C@:2]([Br:3])([Cl:4])[N:5]>>[C:1][C@@:2]([Br:3])([Cl:4])[N:5]",
+                        "C[C@@](Br)(Cl)N");
+    }
+
+    @Test
+    void testInvertStereo_2() throws Exception {
+        assertTransform("C[C@@](Br)(Cl)N",
+                        "[C:1][C@@:2]([Br:3])([Cl:4])[N:5]>>[C:1][C@:2]([Br:3])([Cl:4])[N:5]",
+                        "C[C@](Br)(Cl)N");
+    }
+
+    @Test
+    void testInvertStereo_3() throws Exception {
+        assertTransform("C[C@@](Br)(Cl)N",
+                        "[C:1][C@@:2]([Br:3])([Cl:4])[N:5]>>[C:1][C@@:2]([Cl:4])([Br:3])[N:5]",
+                        "C[C@](Br)(Cl)N");
+    }
+
+    @Test
+    void testInvertStereo_4() throws Exception {
+        assertTransform("C[C@@](Br)(Cl)N",
+                        "[*:1][*@@:2]([*:3])([*:4])[*:5]>>[*:1][*@:2]([*:3])([*:4])[*:5]",
+                        "C[C@](Br)(Cl)N");
+    }
+
+    @Test
+    void testSetStereo_1() throws Exception {
+        assertTransform("CC=CC",
+                        "[*:1][*:2]=[*:3][*:4]>>[*:1]/[*:2]=[*:3]/[*:4]",
+                        "C/C=C/C");
+    }
+
+    @Test
+    void testSetStereo_2() throws Exception {
+        assertTransform("CC=CC",
+                        "[*:1][*:2]=[*:3][*:4]>>[*:1]/[*:2]=[*:3]\\[*:4]",
+                        "C/C=C\\C");
+    }
+
+    @Test
+    void testMolecularHydrogen() throws Exception {
+        assertTransform("[H][H].c1ccccc1",
+                        "[H][H:1]>>[H+:1]",
+                        "[H+].c1ccccc1");
+    }
+
+    // To Test:
+    // [H:1]C>>C[*:1]
+}

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1301,7 +1301,7 @@ class SmirksTest {
     }
 
     @Test
-    @Timeout(value = 100, unit = TimeUnit.MILLISECONDS)
+//    @Timeout(value = 100, unit = TimeUnit.MILLISECONDS)
     void testLazyTransform() throws Exception {
         IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
         SmilesParser smipar = new SmilesParser(bldr);
@@ -1312,12 +1312,16 @@ class SmirksTest {
         IAtomContainer mol = smipar.parseSmiles(sucrose);
         Transform tform = Smirks.compile(smirks);
 
+        long t0 = System.nanoTime();
         int i = 0;
         for (IAtomContainer container : tform.apply(mol, Transform.Mode.All)) {
-            if (++i >= 10)
-                break;
+//            if (++i >= 10)
+//                break;
+            ++i;
         }
-        Assertions.assertEquals(10, i);
+        long t1 = System.nanoTime();
+        System.err.println(TimeUnit.NANOSECONDS.toMillis(t1-t0) + " ms");
+        //Assertions.assertEquals(10, i);
     }
 
     @Test
@@ -1438,6 +1442,21 @@ class SmirksTest {
         assertWarningMesg("[C:1][H]>>[C:1]=O",
                           "Possible valence change");
         assertNoWarningMesg("[CH4:1]>>[CH3:1]O");
+    }
+
+    @Test
+    void shouldRemoveUnmapped() throws Exception {
+        assertTransform("c1ccccc1OCC",
+                        "[c:1]O>>[c:1][H]",
+                        "c1ccccc1.[CH2]C");
+        assertTransform("c1ccccc1OCC",
+                        "[c:1]O>>[c:1][H]",
+                        "c1ccccc1",
+                        SmirksOption.REMOVED_UNMAPPED_FRAGMENTS);
+        assertTransform("c1ccccc1OCC",
+                        "[C:1]O>>[C:1][H]",
+                        "CC",
+                        SmirksOption.REMOVED_UNMAPPED_FRAGMENTS);
     }
 
     @Disabled

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -674,7 +674,11 @@ class SmirksTest {
     @Test
     void testSetStereo_1() throws Exception {
         assertTransform("CC=CC",
-                        "[*:1][*:2]=[*:3][*:4]>>[*:1]/[*:2]=[*:3]/[*:4]",
+                        "[*:1]-[*:2]=[*:3]-[*:4]>>[*:1]/[*:2]=[*:3]/[*:4]",
+                        "C/C=C/C");
+        // need to add new Stereo after sorting out old stereo
+        assertTransform("CC=CC",
+                        "[*:1][*:2]=[*:3][*:4]>>[*:1]/-[*:2]=[*:3]/-[*:4]",
                         "C/C=C/C");
     }
 

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -466,6 +466,22 @@ class SmirksTest {
                         "C[C@](CC)(Cl)Br");
     }
 
+    @Test
+    void testKeepStereo_Split1() throws Exception {
+        // TODO stereo should be kept
+        assertTransform("C/C=C/C=C/C",
+                        "[CD2H:1]-[CD2H:2]>>[C:1]O.[C:2]O",
+                        "CC=CO.C(=CC)O");
+    }
+
+    @Test
+    void testKeepStereo_Split2() throws Exception {
+        // TODO stereo should be kept
+        assertTransform("Br[C@H](Cl)[C@H](Cl)Br",
+                        "[CD3H:1]-[CD3H:2]>>[C:1]O.[C:2]O",
+                        "BrC(Cl)O.C(Cl)(Br)O");
+    }
+
     // swapping two atoms we should lose stereochemistry because no information
     // has been given about the order in which these attach
     @Test
@@ -1116,7 +1132,6 @@ class SmirksTest {
                         "[#6:1]Cl>>[#6:1][CH2+]",
                         "[CH2+]C(=O)C1=CC=CC=C1");
     }
-
 
 
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1224,6 +1224,30 @@ class SmirksTest {
         Assertions.assertEquals(10, i);
     }
 
+    @Test
+    void testExclusiveApplyLimit() throws Exception {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        SmilesParser smipar = new SmilesParser(bldr);
+        SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.Isomeric | SmiFlavor.UseAromaticSymbols);
+        String smirks = "[#8H1:1]>>[#8H0-:1]";
+        String sucrose = "OC[C@H]1O[C@@](CO)(O[C@H]2O[C@H](CO)[C@@H](O)[C@H](O)[C@H]2O)[C@@H](O)[C@@H]1O";
+        IAtomContainer mol = smipar.parseSmiles(sucrose);
+        Transform tform = Smirks.compile(smirks);
+        tform.apply(mol, 5);
+        String smi = smigen.create(mol);
+        Assertions.assertEquals(5, countOccurrences(smi, "[O-]"));
+    }
+
+    private static int countOccurrences(String smi, String key) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = smi.indexOf(key, idx)) >= 0) {
+            idx += key.length();
+            count++;
+        }
+        return count;
+    }
+
     @Disabled
     @Test
     void testAddOMe() throws Exception {

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1533,12 +1533,11 @@ class SmirksTest {
                                            SmirksOption.PEDANTIC));
     }
 
-    @Disabled
+    // Note: not perfect - should use the replace atom op-code
     @Test
     void testAddOMe() throws Exception {
-        Assertions.fail("ToDo: Should use ReplaceAtom op-code");
         assertTransform("ClC(=O)C1=CC=CC=C1",
                         "[#6:1]Cl>>[#6:1]OC",
-                        "C(=O)(C1=CC=CC=C1)O");
+                        "C(=O)(C1=CC=CC=C1)OC");
     }
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -62,15 +62,15 @@ class SmirksTest {
     private static final SmilesParser SMIPAR = new SmilesParser(BUILDER);
     private static final SmilesGenerator SMIGEN = new SmilesGenerator(SmiFlavor.Default | SmiFlavor.UseAromaticSymbols);
 
-    static void assertTransform(String smiles, String smirks, String expected, SmirksOption ... options) throws Exception {
+    static void assertTransform(String smiles, String smirks, String expected, SmirksOption... options) throws Exception {
         assertTransform(smiles, smirks, new String[]{expected}, Transform.Mode.Exclusive, options);
     }
 
-    static void assertTransform(String smiles, String smirks, Transform transform, String expected, SmirksOption ... options) throws Exception {
+    static void assertTransform(String smiles, String smirks, Transform transform, String expected, SmirksOption... options) throws Exception {
         assertTransform(smiles, smirks, transform, new String[]{expected}, Transform.Mode.Exclusive, options);
     }
 
-    static void assertTransform(String smiles, String smirks, String[] expected, Transform.Mode mode, SmirksOption ... options) throws Exception {
+    static void assertTransform(String smiles, String smirks, String[] expected, Transform.Mode mode, SmirksOption... options) throws Exception {
         assertTransform(smiles, smirks, new Transform(), expected, mode, options);
     }
 
@@ -79,7 +79,7 @@ class SmirksTest {
                                 Transform transform,
                                 String[] expected,
                                 Transform.Mode mode,
-                                SmirksOption ... options) throws Exception {
+                                SmirksOption... options) throws Exception {
         IAtomContainer mol = SMIPAR.parseSmiles(smiles);
         assertTrue(Smirks.parse(transform, smirks, options), transform.message());
         if (transform.message() != null) {
@@ -116,8 +116,8 @@ class SmirksTest {
         StackTraceElement entry = null;
         for (StackTraceElement e : elems) {
             if (e.getMethodName().equals("getStackTrace") ||
-                e.getMethodName().equals("assertTransform") ||
-                e.getMethodName().equals("findEntryPoint"))
+                    e.getMethodName().equals("assertTransform") ||
+                    e.getMethodName().equals("findEntryPoint"))
                 continue;
             entry = e;
             break;
@@ -223,13 +223,13 @@ class SmirksTest {
         assertTrue(Smirks.parse(transform, ">>c1ccccc~1"));
         assertThat(transform.message(),
                    containsString("Cannot determine bond order for newly created bond (presumed aromatic single)\n" +
-                                  ">>c1ccccc~1\n" +
-                                  "         ^\n"));
+                                          ">>c1ccccc~1\n" +
+                                          "         ^\n"));
         assertTrue(Smirks.parse(transform, ">>c~1ccccc1"));
         assertThat(transform.message(),
                    containsString("Cannot determine bond order for newly created bond (presumed aromatic single)\n" +
-                                  ">>c~1ccccc1\n" +
-                                  "   ^\n"));
+                                          ">>c~1ccccc1\n" +
+                                          "   ^\n"));
     }
 
     @Test
@@ -1520,6 +1520,18 @@ class SmirksTest {
                         SmirksOption.RECOMPUTE_HYDROGENS);
     }
 
+    @Test
+    void testPedanticUndefinedBondErrors() throws Exception {
+        Transform transform = new Transform();
+        Assertions.assertFalse(Smirks.parse(transform,
+                                            "[*D1:1].[*D1:2]>>[*:1][*:2]",
+                                            SmirksOption.PEDANTIC));
+        Assertions.assertEquals("Cannot determine bond order for newly created bond",
+                                transform.message());
+        Assertions.assertTrue(Smirks.parse(transform,
+                                           "[*D1:1].[*D1:2]>>[*:1]-[*:2]",
+                                           SmirksOption.PEDANTIC));
+    }
 
     @Disabled
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1101,4 +1101,12 @@ class SmirksTest {
                         "[#8:9]-[C:8](=[O;D1;H0:10])-[c;H0;D3;+0:5]1:[nH;D2;+0:1]:[c:2]:[c;H0;D3;+0:3](:[c:4]):[c;H0;D3;+0:6]:1-[C:7]>>N-[NH;D2;+0:1]-[c:2]:[cH;D2;+0:3]:[c:4].O=[C;H0;D3;+0:5](-[CH2;D2;+0:6]-[C:7])-[C:8](-[#8:9])=[O;D1;H0:10]",
                         "CCOC(=O)C(CCc1ccccc1)=O.N(c1ccccc1)N");
     }
+
+    @Test
+    public void testChargeChange() throws Exception {
+        assertTransform("ClC(=O)C1=CC=CC=C1",
+                        "[#6:1]Cl>>[#6:1][CH2+]",
+                        "[CH2+]C(=O)C1=CC=CC=C1");
+    }
+
 }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1301,7 +1301,7 @@ class SmirksTest {
     }
 
     @Test
-//    @Timeout(value = 100, unit = TimeUnit.MILLISECONDS)
+    @Timeout(value = 100, unit = TimeUnit.MILLISECONDS)
     void testLazyTransform() throws Exception {
         IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
         SmilesParser smipar = new SmilesParser(bldr);
@@ -1315,13 +1315,10 @@ class SmirksTest {
         long t0 = System.nanoTime();
         int i = 0;
         for (IAtomContainer container : tform.apply(mol, Transform.Mode.All)) {
-//            if (++i >= 10)
-//                break;
-            ++i;
+            if (++i >= 10)
+                break;
         }
-        long t1 = System.nanoTime();
-        System.err.println(TimeUnit.NANOSECONDS.toMillis(t1-t0) + " ms");
-        //Assertions.assertEquals(10, i);
+        Assertions.assertEquals(10, i);
     }
 
     @Test
@@ -1452,12 +1449,77 @@ class SmirksTest {
         assertTransform("c1ccccc1OCC",
                         "[c:1]O>>[c:1][H]",
                         "c1ccccc1",
-                        SmirksOption.REMOVED_UNMAPPED_FRAGMENTS);
+                        SmirksOption.REMOVE_UNMAPPED_FRAGMENTS);
         assertTransform("c1ccccc1OCC",
                         "[C:1]O>>[C:1][H]",
                         "CC",
-                        SmirksOption.REMOVED_UNMAPPED_FRAGMENTS);
+                        SmirksOption.REMOVE_UNMAPPED_FRAGMENTS);
     }
+
+    @Test
+    void shouldRecomputeHydrogenCount() throws Exception {
+        assertTransform("c1ccccc1C",
+                        "[C:1]>>[C:1][O]",
+                        "c1ccccc1[CH3][O]");
+        assertTransform("c1ccccc1C",
+                        "[C:1]>>[C:1][O]",
+                        "c1ccccc1CO",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+        assertTransform("c1ccccc1C",
+                        "[C:1]>>[C:1]=[O]",
+                        "c1ccccc1C=O",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+        assertTransform("[CH]c1ccccc1C",
+                        "[CH3:1]>>[C:1]=[O]",
+                        "[CH]c1ccccc1C=O",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+        assertTransform("C",
+                        "[C:1]>>[C+:1]",
+                        "[CH3+]",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+        assertTransform("C",
+                        "[C:1]>>[N-:1]",
+                        "[NH2-]",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+    }
+
+    @Test
+    void shouldRecomputeHydrogenCount_Charges() throws Exception {
+        assertTransform("C",
+                        "[C:1]>>[C+:1]",
+                        "[CH3+]",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+        assertTransform("C",
+                        "[C:1]>>[N-:1]",
+                        "[NH2-]",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+    }
+
+    @Test
+    void shouldRecomputeHydrogenCount_LeaveUnmapped() throws Exception {
+        assertTransform("[CH]c1ccccc1C",
+                        "[CH3:1]>>[C:1]=[O]",
+                        "[CH]c1ccccc1C=O",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+    }
+
+    @Test
+    void shouldRecomputeHydrogenCount_ExplictH() throws Exception {
+        assertTransform("c1ccccc1C",
+                        "[CH3:1]>>[C:1][OH0]",
+                        "c1ccccc1C[O]",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+        assertTransform("c1ccccc1C",
+                        "[CH3:1]>>[C:1][OH0]",
+                        "c1ccccc1CO",
+                        SmirksOption.RECOMPUTE_HYDROGENS,
+                        SmirksOption.IGNORE_TOTAL_H0);
+        assertTransform("c1ccccc1C",
+                        "[CH3:1]>>[C:1][OH2]",
+                        "c1ccccc1C[OH2]",
+                        SmirksOption.RECOMPUTE_HYDROGENS);
+    }
+
 
     @Disabled
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -173,36 +173,39 @@ class SmirksTest {
     @Test
     void atomTypeHChanges_1() {
         assertAtomTypeOps("[CH1]", "[C]"); // no-op
-        assertAtomTypeOps("[CH1]", "[CH0]", new TransformOp(ImplH, 0, 0));
+        assertAtomTypeOps("[CH1]", "[CH0]", new TransformOp(TotalH, 0, 0));
         assertAtomTypeOps("[CH1]", "[CH1]"); // no-op
-        assertAtomTypeOps("[CH1]", "[CH2]", new TransformOp(ImplH, 0, 2));
+        assertAtomTypeOps("[CH1]", "[CH2]", new TransformOp(TotalH, 0, 2));
     }
 
     @Test
     void atomTypeImplHChanges_1() {
         assertAtomTypeOps("[CH1]", "[C]"); // no-op
         assertAtomTypeOps("[CH1]", "[Ch0]", new TransformOp(ImplH, 0, 0));
-        assertAtomTypeOps("[CH1]", "[Ch1]"); // no-op
+        assertAtomTypeOps("[Ch1]", "[Ch1]"); // no-op
+        assertAtomTypeOps("[CH1]", "[Ch1]", new TransformOp(ImplH, 0, 1));
         assertAtomTypeOps("[CH1]", "[Ch2]", new TransformOp(ImplH, 0, 2));
         assertAtomTypeOps("[CH1]", "[C;h2,H3]");
-        assertAtomTypeOps("[CH1]", "[C;h3,H3]", new TransformOp(ImplH, 0, 3));
+        assertAtomTypeOps("[CH1]", "[C;h3H3]", new TransformOp(TotalH, 0, 3), new TransformOp(ImplH, 0, 3));
+        assertAtomTypeOps("[CH1]", "[C;h3H4]", new TransformOp(ImplH, 0, 3), new TransformOp(TotalH, 0, 4));
+        assertAtomTypeOps("[CH1]", "[C;h3,H3]"); // conflicting
     }
 
     @Test
     void atomTypeHChanges_2() {
         assertAtomTypeOps("[C;H0,H1]", "[C]"); // no-op
-        assertAtomTypeOps("[C;H0,H1]", "[CH0]", new TransformOp(ImplH, 0, 0));
-        assertAtomTypeOps("[C;H0,H1]", "[CH1]", new TransformOp(ImplH, 0, 1));
-        assertAtomTypeOps("[C;H0,H1]", "[CH2]", new TransformOp(ImplH, 0, 2));
+        assertAtomTypeOps("[C;H0,H1]", "[CH0]", new TransformOp(TotalH, 0, 0));
+        assertAtomTypeOps("[C;H0,H1]", "[CH1]", new TransformOp(TotalH, 0, 1));
+        assertAtomTypeOps("[C;H0,H1]", "[CH2]", new TransformOp(TotalH, 0, 2));
     }
 
     @Test
     void atomTypeHChanges_3() {
         assertAtomTypeOps("[C;H0,H1]", "[C;H0,H1]"); // no-op
         assertAtomTypeOps("[C;H0,H1]", "[C,H0]"); // conflicting
-        assertAtomTypeOps("[C;H0,H1]", "[C;H0]", new TransformOp(ImplH, 0, 0));
-        assertAtomTypeOps("[C;H0,H1]", "[C;H1]", new TransformOp(ImplH, 0, 1));
-        assertAtomTypeOps("[C;H0,H1]", "[C;H2]", new TransformOp(ImplH, 0, 2));
+        assertAtomTypeOps("[C;H0,H1]", "[C;H0]", new TransformOp(TotalH, 0, 0));
+        assertAtomTypeOps("[C;H0,H1]", "[C;H1]", new TransformOp(TotalH, 0, 1));
+        assertAtomTypeOps("[C;H0,H1]", "[C;H2]", new TransformOp(TotalH, 0, 2));
     }
 
     @Test
@@ -1246,6 +1249,61 @@ class SmirksTest {
             count++;
         }
         return count;
+    }
+
+    @Test
+    void setHydrogenCount() throws Exception {
+        assertTransform("[H]C", "[#6:1]>>[#6H0:1]", "[C]");
+        assertTransform("[H]C", "[#6:1]>>[#6H1:1]", "[H][C]");
+        assertTransform("[H]C", "[#6:1]>>[#6H2:1]", "[H][CH]");
+        assertTransform("[H]C", "[#6:1]>>[#6H3:1]", "[H][CH2]");
+        assertTransform("[H]C", "[#6:1]>>[#6H4:1]", "[H]C");
+        assertTransform("[H]C", "[#6:1]>>[#6H5:1]", "[H][CH4]");
+
+        assertTransform("[H]C[H]", "[#6:1]>>[#6H0:1]", "[C]");
+        assertTransform("[H]C[H]", "[#6:1]>>[#6H1:1]", "[C][H]");
+        assertTransform("[H]C[H]", "[#6:1]>>[#6H2:1]", "[H][C][H]");
+        assertTransform("[H]C[H]", "[#6:1]>>[#6H3:1]", "[H][CH][H]");
+        assertTransform("[H]C[H]", "[#6:1]>>[#6H4:1]", "[H]C[H]");
+        assertTransform("[H]C[H]", "[#6:1]>>[#6H5:1]", "[H][CH3][H]");
+
+        assertTransform("[H]C", "[#6:1]>>[#6h0:1]", "[H][C]");
+        assertTransform("[H]C", "[#6:1]>>[#6h1:1]", "[H][CH]");
+        assertTransform("[H]C", "[#6:1]>>[#6h2:1]", "[H][CH2]");
+        assertTransform("[H]C", "[#6:1]>>[#6h3:1]", "[H]C");
+        assertTransform("[H]C", "[#6:1]>>[#6h4:1]", "[H][CH4]");
+        assertTransform("[H]C", "[#6:1]>>[#6h5:1]", "[H][CH5]");
+    }
+
+    @Test
+    void setHydrogenCountIsotope() throws Exception {
+        assertTransform("[2H]C", "[#6:1]>>[#6h0:1]", "[2H][C]");
+        assertTransform("[2H]C", "[#6:1]>>[#6h1:1]", "[2H][CH]");
+        assertTransform("[2H]C", "[#6:1]>>[#6h2:1]", "[2H][CH2]");
+        assertTransform("[2H]C", "[#6:1]>>[#6h3:1]", "[2H]C");
+        assertTransform("[2H]C", "[#6:1]>>[#6h4:1]", "[2H][CH4]");
+        assertTransform("[2H]C", "[#6:1]>>[#6h5:1]", "[2H][CH5]");
+    }
+
+    @Test
+    void setHydrogenCountBridging() throws Exception {
+        // we can not delete bridging hydrogens by setting the hcnt since this affects
+        // the other atoms
+        assertNoMatch("[H]B1([H]B([H]1)[H])", "[#5:1]>>[#5H0:1]");
+        assertNoMatch("[H]B1([H]B([H]1)[H])", "[#5:1]>>[#5H1:1]");
+        assertTransform("[H]B1([H]B([H]1)[H])", "[#5:1]>>[#5H2:1]", "[B]1[H][B][H]1");
+        assertTransform("[H]B1([H]B([H]1)[H])", "[#5:1]>>[#5H3:1]", "[H]B1[H]B([H]1)[H]");
+        assertTransform("[H]B1([H]B([H]1)[H])", "[#5:1]>>[#5H4:1]", "[H][BH]1[H][BH]([H]1)[H]");
+    }
+
+    @Test
+    void defaultValences() throws Exception {
+        assertTransform("C", "[#6:1]>>[#6H3:1]ClO", "C[ClH]O");
+        assertTransform("C", "[#6:1]>>[#6H3:1]Cl=O", "CCl=O");
+        assertTransform("C", "[#6:1]>>[#6H3:1]Cl(=O)=O", "CCl(=O)=O");
+        assertTransform("C", "[#6:1]>>[#6H3:1]S=O", "CS=O");
+        assertTransform("C", "[#6:1]>>[#6H3:1]N(O)O", "CN(O)O");
+        assertTransform("C", "[#6:1]>>[#6H3:1]N(O)=O", "CN(O)=O");
     }
 
     @Disabled

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -1270,6 +1270,23 @@ class SmirksTest {
         assertTransform("[Pb]",
                         "[Pb:1]>>[Au:1]",
                         "[Au]");
+        assertTransform("[Pb]",
+                        "[Pb:1]>>[Au:1]",
+                        "[Pb]",
+                        SmirksOption.IGNORE_SET_ELEM);
+    }
+
+    @Test
+    void shouldHaveOneSingleBond() throws Exception {
+        assertTransform("CC",
+                        "([CH3:1].[CH3:2])>>[cH1:1]cccc[cH1:2]",
+                        "c1-ccccc1");
+        assertNoMatch("CC",
+                      "([CH3:1].[CH3:2])>>[cH1:1]1cccc[cH1:2]1");
+        assertTransform("CC",
+                        "([CH3:1].[CH3:2])>>[cH1:1]1cccc[cH1:2]1",
+                        "c1ccccc1",
+                        SmirksOption.OVERWRITE_BOND);
     }
 
     @Test
@@ -1338,8 +1355,12 @@ class SmirksTest {
     @Test
     void setHydrogenCount() throws Exception {
         assertTransform("[H]C", "[#6:1]>>[#6H0:1]", "[C]");
+        assertTransform("[H]C", "[#6:1]>>[#6H0:1]", "[H]C", SmirksOption.IGNORE_TOTAL_H0);
+        assertTransform("[H]C", "[#6:1]>>[#6H1:1]", "[H][C]");
         assertTransform("[H]C", "[#6:1]>>[#6H1:1]", "[H][C]");
         assertTransform("[H]C", "[#6:1]>>[#6H2:1]", "[H][CH]");
+        assertTransform("[H]C", "[#6:1]>>[#6H2:1]", "[H][CH]", SmirksOption.IGNORE_TOTAL_H0);
+        assertTransform("[H]C", "[#6:1]>>[#6H2:1]", "[H]C", SmirksOption.IGNORE_TOTAL_H);
         assertTransform("[H]C", "[#6:1]>>[#6H3:1]", "[H][CH2]");
         assertTransform("[H]C", "[#6:1]>>[#6H4:1]", "[H]C");
         assertTransform("[H]C", "[#6:1]>>[#6H5:1]", "[H][CH4]");

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -172,14 +172,14 @@ class SmirksTest {
     void testDuplicateMapIdx_Product() {
         Transform transform = new Transform();
         assertFalse(Smirks.parse(transform, "[C:3]>>[C:3][O:3]"));
-        assertEquals(transform.message(), "Duplicate atom map [C:3] and [O:3]");
+        assertEquals("Duplicate atom map [C:3] and [O:3]", transform.message());
     }
 
     @Test
     void testDuplicateMapIdx_Reactant() {
         Transform transform = new Transform();
         assertFalse(Smirks.parse(transform, "[C:4][O:4]>>[C:4]"));
-        assertEquals(transform.message(), "Duplicate atom map [C:4] and [O:4]");
+        assertEquals("Duplicate atom map [C:4] and [O:4]", transform.message());
     }
 
     @Test

--- a/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smirks/SmirksTest.java
@@ -62,21 +62,26 @@ class SmirksTest {
     private static final SmilesParser SMIPAR = new SmilesParser(BUILDER);
     private static final SmilesGenerator SMIGEN = new SmilesGenerator(SmiFlavor.Default | SmiFlavor.UseAromaticSymbols);
 
-    static void assertTransform(String smiles, String smirks, String expected) throws Exception {
-        assertTransform(smiles, smirks, new String[]{expected}, Transform.Mode.Exclusive);
+    static void assertTransform(String smiles, String smirks, String expected, SmirksOption ... options) throws Exception {
+        assertTransform(smiles, smirks, new String[]{expected}, Transform.Mode.Exclusive, options);
     }
 
-    static void assertTransform(String smiles, String smirks, Transform transform, String expected) throws Exception {
-        assertTransform(smiles, smirks, transform, new String[]{expected}, Transform.Mode.Exclusive);
+    static void assertTransform(String smiles, String smirks, Transform transform, String expected, SmirksOption ... options) throws Exception {
+        assertTransform(smiles, smirks, transform, new String[]{expected}, Transform.Mode.Exclusive, options);
     }
 
-    static void assertTransform(String smiles, String smirks, String[] expected, Transform.Mode mode) throws Exception {
-        assertTransform(smiles, smirks, new Transform(), expected, mode);
+    static void assertTransform(String smiles, String smirks, String[] expected, Transform.Mode mode, SmirksOption ... options) throws Exception {
+        assertTransform(smiles, smirks, new Transform(), expected, mode, options);
     }
 
-    static void assertTransform(String smiles, String smirks, Transform transform, String[] expected, Transform.Mode mode) throws Exception {
+    static void assertTransform(String smiles,
+                                String smirks,
+                                Transform transform,
+                                String[] expected,
+                                Transform.Mode mode,
+                                SmirksOption ... options) throws Exception {
         IAtomContainer mol = SMIPAR.parseSmiles(smiles);
-        assertTrue(Smirks.parse(transform, smirks), transform.message());
+        assertTrue(Smirks.parse(transform, smirks, options), transform.message());
         if (transform.message() != null) {
             StackTraceElement entry = findEntryPoint();
             if (entry != null) {
@@ -308,6 +313,14 @@ class SmirksTest {
         assertTransform("c1ccccc1N(=O)=O",
                         "[*:1][N:2](=[O:3])=[O:4]>>[*:1][N+:2](=[O:3])[O-:4]",
                         "c1ccccc1[N+](=O)[O-]");
+    }
+
+    @Test
+    void shouldReverseNitroNorm() throws Exception {
+        assertTransform("c1ccccc1[N+]([O-])=O",
+                        "[*:1][N+0:2](=[O:3])=[O+0:4]>>[*:1][N+:2](=[O:3])[O-:4]",
+                        "c1ccccc1N(=O)=O",
+                        SmirksOption.REVERSE);
     }
 
     @Test


### PR DESCRIPTION
This patch provides the generic/low-level data structures and representations to describe a molecular transform. A conveient way of describing transforms is the SMIRKS syntax which is supported via functionality in the 'cdk-smarts' module.

Transforms are useful for standardisation, library generation, and retro synthesis.

# Quick start

1. Include ``cdk-smarts`` module
2. Parse and apply in-place to all non-overlapping matches

```java
if (Smirks.apply(mol, "[*:1][H]>>[*:1]Cl")) {
    System.err.println("Success!");
}
```
3. A transform can be compiled and reused:

```java
Transform transform = Smirks.compile("[*:1][H]>>[*:1]Cl");
for (IAtomContainer mol : mols) {
    if (transform.apply(mol))
       System.err.println("Success!");
}
```
4. If you expect to handle invalid inputs, please use the parse method which returns true/false. You can provide a ``Transform`` or ``SmirksTransform`` depending on if you want it to automatically ensure correct aromaticity/ring flags.

```java
Transform transform = new SmirksTransform();
if (!Smirks.parse(transform, "[*:1][H]>>[*:1]Cl")) {
  System.err.println("BAD SMIRKS - " + transform.message());
  return;
}

for (IAtomContainer mol : mols) {
    if (transform.apply(mol))
       System.err.println("Success!");
}
```

# Features

The atomic number, hydrogen count, charge, and mass can be modified on mapped atoms

```
[SH2:1]>>[SH4:1] set hcnt to 4
[O:1]>>[O-:1] set the charge to -1
[C:1]>>[13C:1] set the isotope 
[Pb:1]>>[Au:1] set the element to gold
```

There is inconsistency in other implementations about how/when these properties get removed. For example ``[OH1:1]>>[O:1]`` may remove the hydrogen count. CDK's implementation follows a simpler system where by you must explicitly specify you want something removed (zero'd).

```
[SH2:1]>>[S:1] leave hnct unset (no-op)
[SH2:1]>>[SHO:1] set hcnt to 0
[O-:1]>>[O+0:1] set the charge to 0
[13C:1]>>[0C:1] remove the isotope 
[Pb:1]>>[#0:1] set atomic num 0, note '*' is treated as no-op
```

If the right-hand side has an expression it is examined to see if the property being modified is consistent. The safer portable SMIRKS it is recommend you stick to SMILES ``[<mass>?<symbol><hcnt>?<chg>?:<map>]`` on the right-hand side.

```
[S,O;H2:1]>>[S,O;HO:1] set hcnt to 0
[S,O;H2:1]>>[SH0,OHO:1] set hcnt to 0
[SH1,OH2:1]>>[SH0,OH1:1] inconsistent hcnt (so leave unset)
```

Hydrogens are **not** automatically adjusted, so if you change a property like charge or add/remove bonds you should adjust the hydrogen count accordingly. Subset atoms (B, C, N, O, P, S, F, Cl, Br, I) that are added (unmapped on right-hand side) not in square brackets will automatically set the implicit hydrogen count.

Although it is possible to explicitly set the number of hydrogens with ``H<cnt>`` it is more portable/powerful to use explicit hydrogens in the SMIRKS to *adjust* the hydrogen count.

```
[OH1:1]>>[O-:1] wrong
[OH1:1]>>[OH0-:1] acceptable
[H][O:1]>>[O-:1] preferred 

[C:1]>>[C:1]Cl wrong
[CH1:1]>>[CH0:1]Cl acceptable (but only matches [CH]!)
[H][C:1]>>[C:1]Cl preferred
```

Note SMIRKS transform does **not** need the hydrogens to be explicit in the molecule being modified, the transform is compiled and works on either hydrogen counts or explicit hydrogens.

Stereochemistry on atoms with a single point change will persist their stereochemistry.

```
[C:1]Br>>[C:1]Cl (smirks):

  C/C=C/Br (input)     C/C=C/Cl (output)
  Br[C@H](N)O (input)  Cl[C@H](N)O (output)
```

Multiple changes will result in the stereochemistry being lost

```
[C:1](Br)N>>[C:1](Cl)I (smirks):

  Br[C@H](N)O (input)  ClC(N)O (output)
```

# API Overview

The low-level API in the 'cdk-isomorphism' module works with a *substructure pattern* and *ops* which change the atoms matched by the pattern. We therefore run a transform by matching the pattern to the molecule, then running the ops over the atoms matched by the pattern. The atoms in the molecule being transformed are permuted/ordering to be the same as the query (actually idx+1) such that the op-code parameters are consistent.

```java
// [CD1:1][C:2][CD1:3]>>[C:1]1[C:2][C:3]1
// 
// in this example we create a query pattern (the maps are included for clarity)
// the ops then select atoms at index 1 (atoms[0+1]) and 3 (atoms[2+1]) and create a
// new bond with order=1 (single).
Transform tform = new Transform();
tform.init(SmartsPattern.create("[CD1:1]C[CD1:3]"), // [CD1]C[CD1] will work the same
           Arrays.asList(new TransformOp(Type.NewBond, 1, 3, 1)));
```

# Future additions

## Options

Testing other implementations there are some options that may be useful and flags on how things could be interpreted. I've put in the most sensible defaults in (IMO) and the flags would therefore change the behaviour away from that. A nice feature is we can then say "parse this as RDKIT compatibility mode". Although I am planning an ACS talk next spring which will highlight some of the existing behaviours of other implementations are inconsistent/ambiguous.

I've mainly not decided whether to do this via integer bitmaps or enums or another mechanism. Here is the enum option I was toying with:

```java
public enum Option {
        /** The transform will be run right-to-left instead of left-to-right. */
        Reverse,
        /** Ignore attempts to set the hydrogen count with properties. */
        IgnoreHCnt,
        /**
         * Unless specified, zero the hydrogen count on a mapped atom if it's
         * counterpart had a hydrogen count specified.
         */
        ZeroHCntIfChanged,
        /** Interpret [CH0] the same as [C] */
        ZeroHIsUnset,
        /** Ignore attempts to set the isotopic mass of an atom. */
        IgnoreIso,
        /** Ignores attempts to change the element of an atom. */
        IgnoreTransmutation,
        /**
         * Unless specified, zero the charge on a mapped atom if it's
         * counterpart had a charge specified.
         */
        ZeroChargeIfChanged,
        /** Unless a charge is specified, default to zero. */
        ZeroCharge,

        UnpairedMaps,

        // where does this option go
        RECALCULATE_H,

        // options of the plan

        /**
         * Automatically add explicit hydrogens to a pattern before matching/
         * running the transform.
         */
        AutoExplH,
        /**
         * Remove stereo chemistry even when a single neighbour changes.
         */
        RemoveStereoOnSinglePointChange,
        /** If a bond already exists between two atoms and a new one  */
        OverwriteExistingBond,
        /** LillyMol - Not supported yet. */
        DeleteUnmapped
    }

    public final Set<Option> Daylight = EnumSet.of(Option.IgnoreHCnt,
                                                   Option.IgnoreIso,
                                                   Option.IgnoreTransmutation,
                                                   Option.ZeroCharge,
                                                   Option.AutoExplH,
                                                   Option.RemoveStereoOnSinglePointChange);

    public final Set<Option> OEChem = EnumSet.of(Option.IgnoreIso,
                                                 Option.ZeroHCntIfChanged);
```
