### PR TITLE
Additional reaction arrow types.

### DIFF
--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IReaction.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IReaction.java
@@ -44,12 +44,24 @@ public interface IReaction extends IChemObject {
      * Permissible reaction directions.
      */
     enum Direction {
-        /** Reaction equilibrium which is (almost) fully on the product side. Often denoted with a forward arrow. */
+        /** Reaction equilibrium which is (almost) fully on the product side.
+         *  Often denoted with a forward arrow. */
         FORWARD,
-        /** Reaction equilibrium which is (almost) fully on the reactant side. Often denoted with a backward arrow. */
+        /** Reaction equilibrium which is (almost) fully on the reactant side.
+         *  Often denoted with a backward arrow. */
         BACKWARD,
-        /** Reaction equilibrium state. Often denoted by a double arrow. */
-        BIDIRECTIONAL
+        /** Reaction equilibrium state. Often denoted by a stacked arrows, one
+         *  forwards, one backwards. */
+        BIDIRECTIONAL,
+        /** Reaction is a no-go, Often denoted by a cross or hash arrow. */
+        NO_GO,
+        /** Indicate the precursors for a given molecule,
+         *  note this will make swap where reactant/products appear.
+         *  Usually denoted with an open arrow. */
+        RETRO_SYNTHETIC,
+        /** Reaction shows interconversion between resonance forms. Usually
+         *  denoted by a double-headed arrow. */
+        RESONANCE
     }
 
     /**


### PR DESCRIPTION
Here we add in some extra arrow types which are controlled by the "direction" attribution on the reaction. I was considering a separate enum (ArrowDisplay?) but it fits more or less into the existing direction attribute.

To paraphrase Oprah, *"You get an arrow, you get an arrow, you get an arrow!"*

<img src="https://i.kym-cdn.com/entries/icons/original/000/012/809/oprah-free-car.gif" alt="drawing" width="200"/>

Note the **RETERO_SYNTHETIC** arrow swaps the sense of reactant/product. I think that makes sense but happy to discuss.

# SVG

**NO_GO**
![nogo](https://user-images.githubusercontent.com/983232/199610839-7410a473-37ab-4422-a3ec-a7dd8561cfc9.svg)
**RETRO_SYNTHETIC**
![retro](https://user-images.githubusercontent.com/983232/199610849-2109d757-1399-4ff1-923c-22403dd16ff6.svg)
**BIDIRECTIONAL** (restyled)
![bidirectional](https://user-images.githubusercontent.com/983232/199610855-0b1c5501-6e9a-483b-9059-43f8fdb58649.svg)
**RESONANCE**
![resonance](https://user-images.githubusercontent.com/983232/199610862-f2408d5b-facd-4ba3-b879-fd3e36f00b8a.svg)

# PNG

**NO_GO**
![nogo](https://user-images.githubusercontent.com/983232/199610948-7f8974f2-9549-4a60-bc33-4d828bc1ec3f.png)
**RETRO_SYNTHETIC**
![retro](https://user-images.githubusercontent.com/983232/199610957-c5027a89-2c8b-4a11-9a79-cb644044a36d.png)
**BIDIRECTIONAL** (restyled)
![bidirectional](https://user-images.githubusercontent.com/983232/199610899-323163ab-8b61-4ec4-b95e-1cb36379a71f.png)
**RESONANCE**
![resonance](https://user-images.githubusercontent.com/983232/199610911-427a530a-f4ea-4175-b7de-8a4c59e4ed18.png)

# Demo Code

```java
SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
IReaction reaction = smipar.parseReactionSmiles("[CH3:9][CH:8]([CH3:10])[c:7]1[cH:11][cH:12][cH:13][cH:14][cH:15]1.[CH2:3]([CH2:4][C:5](=[O:6])Cl)[CH2:2][Cl:1]>[Al+3].[Cl-].[Cl-].[Cl-].C(Cl)Cl>[CH3:9][CH:8]([CH3:10])[c:7]1[cH:11][cH:12][c:13]([cH:14][cH:15]1)[C:5](=[O:6])[CH2:4][CH2:3][CH2:2][Cl:1] |f:2.3.4.5| Friedel-Crafts acylation [3.10.1]");

Abbreviations abbreviations = new Abbreviations();
abbreviations.add("[Al+3].[Cl-].[Cl-].[Cl-] AlCl3");
abbreviations.add("ClCCl DCM");
abbreviations.setContractToSingleLabel(true);
for (IAtomContainer mol : ReactionManipulator.getAllAtomContainers(reaction))
    abbreviations.apply(mol);

reaction.setDirection(IReaction.Direction.NO_GO);
new DepictionGenerator().depict(reaction)
                        .writeTo("/tmp/nogo.svg");

reaction = smipar.parseReactionSmiles("[CH3:9][CH:8]([CH3:10])[c:7]1[cH:11][cH:12][cH:13][cH:14][cH:15]1.[CH2:3]([CH2:4][C:5](=[O:6])Cl)[CH2:2][Cl:1]>>[CH3:9][CH:8]([CH3:10])[c:7]1[cH:11][cH:12][c:13]([cH:14][cH:15]1)[C:5](=[O:6])[CH2:4][CH2:3][CH2:2][Cl:1] |f:2.3.4.5| Friedel-Crafts acylation [3.10.1]");
reaction.setDirection(IReaction.Direction.RETRO_SYNTHETIC);
new DepictionGenerator().depict(reaction)
                        .writeTo("/tmp/retro.svg");

reaction.setDirection(IReaction.Direction.BIDIRECTIONAL);
new DepictionGenerator().depict(reaction)
                        .writeTo("/tmp/bidirectional.svg");

reaction = smipar.parseReactionSmiles("c1c(Cl)cccc1[N-][N+]#N>>c1c(Cl)cccc1N=[N+]=[N-]");
reaction.setDirection(IReaction.Direction.RESONANCE);
new DepictionGenerator().depict(reaction)
                        .writeTo("/tmp/resonance.svg");
```

