### PR TITLE
Reaction arrows

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/ReactionDepiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/ReactionDepiction.java
@@ -557,7 +557,8 @@ final class ReactionDepiction extends Depiction {
             final int nSideCol = xOffsetSide.length - 1;
             final int nSideRow = yOffsetSide.length - 1;
 
-            double mainCompOffset = sideRequired.h + (nSideRow * padding) - (firstRowHeight / 2);
+            double mainCompOffset = sideRequired.h + 4*margin +
+                                    (nSideRow * padding) - (firstRowHeight / 2);
             if (mainCompOffset < 0)
                 mainCompOffset = 0;
 

--- a/app/depict/src/main/java/org/openscience/cdk/depict/ReactionDepiction.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/ReactionDepiction.java
@@ -649,7 +649,7 @@ final class ReactionDepiction extends Depiction {
                 arrow.add(GeneralPath.outlineOf(path, strokeWidth, fgcol));
                 break;
             case RESONANCE:
-                arrow.add(new LineElement(0, 0, minWidth - 0.5 * headLength, 0, strokeWidth, fgcol));
+                arrow.add(new LineElement(0.5 * headLength, 0, minWidth - 0.5 * headLength, 0, strokeWidth, fgcol));
                 path.moveTo(minWidth, 0);
                 path.lineTo(minWidth - headLength, +headThickness);
                 path.lineTo(minWidth - inset * headLength, 0);

--- a/base/core/src/main/java/org/openscience/cdk/CDKConstants.java
+++ b/base/core/src/main/java/org/openscience/cdk/CDKConstants.java
@@ -434,6 +434,11 @@ public class CDKConstants {
      */
     public static final String      REACTION_CONDITIONS          = "cdk:ReactionConditions";
 
+    /**
+     * Arrow display type
+     */
+    public static final String      REACTION_ARROW                = "cdk:Arrow";
+
 
     /* **************************************
      * Some predefined property names for * AtomTypes *

--- a/display/render/src/main/java/org/openscience/cdk/renderer/color/IAtomColorer.java
+++ b/display/render/src/main/java/org/openscience/cdk/renderer/color/IAtomColorer.java
@@ -44,5 +44,8 @@ public interface IAtomColorer {
      * @param defaultColor the color to use if the atom type of this atom cannot be identified
      * @return the color of the specified atom
      */
-    Color getAtomColor(IAtom atom, Color defaultColor);
+    default Color getAtomColor(IAtom atom, Color defaultColor) {
+        Color color = getAtomColor(atom);
+        return color != null ? color : defaultColor;
+    }
 }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesParser.java
@@ -230,7 +230,12 @@ final class CxSmilesParser {
         int beg = iter.pos;
         while (iter.hasNext() && !isSgroupDelim(iter.curr()))
             iter.next();
-        final String field = unescape(iter.substr(beg, iter.pos));
+        String field = unescape(iter.substr(beg, iter.pos));
+
+        // cdk.Arrow => cdk:Arrow to align with CDKConstants, ':' needs encoding
+        // in CXSMILES
+        if (field.startsWith("cdk."))
+            field = field.replace("cdk.", "cdk:");
 
         if (!iter.nextIf(':'))
             return false;

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -370,6 +370,17 @@ public final class SmilesParser {
 
                 assignCxSmilesInfo(rxn.getBuilder(), rxn, atoms, atomToMol, cxstate);
             }
+
+            String arrowType = rxn.getProperty(CDKConstants.REACTION_ARROW);
+            if (arrowType != null && !arrowType.isEmpty()) {
+                switch (arrowType) {
+                    case "RES": rxn.setDirection(IReaction.Direction.RESONANCE); break;
+                    case "EQU": rxn.setDirection(IReaction.Direction.BIDIRECTIONAL); break;
+                    case "RET": rxn.setDirection(IReaction.Direction.RETRO_SYNTHETIC); break;
+                    case "NGO": rxn.setDirection(IReaction.Direction.NO_GO); break;
+                }
+
+            }
         }
     }
 

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesParserTest.java
@@ -218,7 +218,25 @@ class CxSmilesParserTest {
         CxSmilesState state = new CxSmilesState();
         assertThat(CxSmilesParser.processCx("|SgD::cdk&#58;ReactionConditions:Heat&#10;Hv|", state), is(not(-1)));
         assertThat(state.mysgroups,
-                   hasItem(new CxSmilesState.CxDataSgroup(new ArrayList<>(), "cdk:ReactionConditions", "Heat\nHv", "", "", "")));
+                   hasItem(new CxSmilesState.CxDataSgroup(new ArrayList<>(),  CDKConstants.REACTION_CONDITIONS, "Heat\nHv", "", "", "")));
+    }
+
+    @Test
+    void dataSgroupsArrow() {
+        CxSmilesState state = new CxSmilesState();
+        assertThat(CxSmilesParser.processCx("|SgD::cdk&#58;Arrow:RES|", state), is(not(-1)));
+        assertThat(state.mysgroups,
+                   hasItem(new CxSmilesState.CxDataSgroup(new ArrayList<>(), CDKConstants.REACTION_ARROW, "RES", "", "", "")));
+    }
+
+    // a ':' needs to be escaped in CXSMILES, if we "cdk." as a Data prop, convert this to cdk:
+    // which then also gets picked up and set in the porperties
+    @Test
+    void dataSgroupsArrowWithDot() {
+        CxSmilesState state = new CxSmilesState();
+        assertThat(CxSmilesParser.processCx("|SgD::cdk.Arrow:RES|", state), is(not(-1)));
+        assertThat(state.mysgroups,
+                   hasItem(new CxSmilesState.CxDataSgroup(new ArrayList<>(), CDKConstants.REACTION_ARROW, "RES", "", "", "")));
     }
 
     @Test


### PR DESCRIPTION
Some extra pieces related to arrow styles. We had a lesser known mechanism for putting reaction conditions below and arrow (e.g. "Heat 2h"). We use the same mechanism for specifying the reaction arrow.

```
[CH3:9][CH:8]([CH3:10])[c:7]1[cH:11][cH:12][cH:13][cH:14][cH:15]1.[CH2:3]([CH2:4][C:5](=[O:6])Cl)[CH2:2][Cl:1]>[Al+3].[Cl-].[Cl-].[Cl-].C(Cl)Cl>[CH3:9][CH:8]([CH3:10])[c:7]1[cH:11][cH:12][c:13]([cH:14][cH:15]1)[C:5](=[O:6])[CH2:4][CH2:3][CH2:2][Cl:1] |SgD::cdk.Arrow:NGO|
```