### PR TITLE
Remove redundant convention from the CML, there is a CDKConvention wh…

### DIFF
--- a/storage/pdb/src/main/resources/org/openscience/cdk/templates/data/list_aminoacids.cml
+++ b/storage/pdb/src/main/resources/org/openscience/cdk/templates/data/list_aminoacids.cml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<list title="List of amino acids" convention="cdk:substructureList"
+<list title="List of amino acids"
         xmlns="http://www.xml-cml.org/schema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.xml-cml.org/schema ../../org/openscience/cdk/io/cml/data/cmlAll.xsd">


### PR DESCRIPTION
…ich is not used but it does nothing with the substructureList.

Should fix #930 