### PR TITLE
Added auto-generated OSGi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,6 +518,11 @@
                 <version>1.3.7</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>2.18.0</version>
@@ -594,6 +599,7 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>
@@ -693,6 +699,25 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.8</version>
+                <configuration>
+                    <instructions>
+                        <Export-Package>org.openscience.*</Export-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>3.6</version>
@@ -728,7 +753,7 @@
                         <groupId>org.openscience.cdk</groupId>
                         <artifactId>cdk-build-utils</artifactId>
                         <version>1.0.2.9-jdk11</version>
-                    </dependency>                    
+                    </dependency>
                 </dependencies>
             </plugin>
             <plugin>


### PR DESCRIPTION
I want to get rid of [net.openchrom.thirdpartylibraries.cdk](https://github.com/OpenChrom/openchrom3rdpl/tree/develop/openchrom/plugins/net.openchrom.thirdpartylibraries.cdk) and this seems to be a requirement.