### PR TITLE
Query bond funcs

### DIFF
--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/matchers/QueryAtomContainer.java
@@ -897,17 +897,9 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     public double getBondOrderSum(IAtom atom) {
         double count = 0;
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i].contains(atom)) {
-                if (bonds[i].getOrder() == IBond.Order.SINGLE) {
-                    count += 1;
-                } else if (bonds[i].getOrder() == IBond.Order.DOUBLE) {
-                    count += 2;
-                } else if (bonds[i].getOrder() == IBond.Order.TRIPLE) {
-                    count += 3;
-                } else if (bonds[i].getOrder() == IBond.Order.QUADRUPLE) {
-                    count += 4;
-                }
-            }
+            IBond bond = bonds[i];
+            if (bond.contains(atom) && bond.getOrder() != null)
+                count += bond.getOrder().numeric();
         }
         return count;
     }
@@ -923,8 +915,11 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     public Order getMaximumBondOrder(IAtom atom) {
         IBond.Order max = IBond.Order.SINGLE;
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i].contains(atom) && bonds[i].getOrder().ordinal() > max.ordinal()) {
-                max = bonds[i].getOrder();
+            IBond bond = bonds[i];
+            if (bond.contains(atom) &&
+                    bond.getOrder() != null &&
+                    bond.getOrder().numeric() > max.numeric()) {
+                max = bond.getOrder();
             }
         }
         return max;
@@ -941,8 +936,11 @@ public class QueryAtomContainer extends QueryChemObject implements IQueryAtomCon
     public Order getMinimumBondOrder(IAtom atom) {
         IBond.Order min = IBond.Order.QUADRUPLE;
         for (int i = 0; i < bondCount; i++) {
-            if (bonds[i].contains(atom) && bonds[i].getOrder().ordinal() < min.ordinal()) {
-                min = bonds[i].getOrder();
+            IBond bond = bonds[i];
+            if (bond.contains(atom) &&
+                    bond.getOrder() != null &&
+                    bond.getOrder().numeric() < min.numeric()) {
+                min = bond.getOrder();
             }
         }
         return min;


### PR DESCRIPTION
At some point these went out of sync with the main AtomContainer, the order.numeric() should be compared and not the ordinal() since "unset" has the largest enum in the ordinal. We also make this function null safe since it's highly likely Query molecules have unset bond order.

Fixes #920.

I then was pondering an exception for providing a query molecule to the atom type matcher, but since we have the fall-back "X" atom type I think logging a warning makes most sense. If a caller wants to avoid the warning they should check if the molecule is a query before hand.