### PR TITLE
Bounds check before access the atoms for a bond, this is a fatal erro…

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV2000Reader.java
@@ -826,6 +826,12 @@ public class MDLV2000Reader extends DefaultChemObjectReader {
                 throw new CDKException("invalid line length: " + length + " " + line);
         }
 
+        if (u >= atoms.length || v >= atoms.length) {
+            // handleError("Bond references atom which does not exists: " + line, lineNum, 0, length);
+            // but we need this to be FATAL!
+            throw new CDKException("MOLfile bond uses atoms does not exists: " + line + " num_atoms=" + atoms.length);
+        }
+
         IBond bond = builder.newBond();
         bond.setAtoms(new IAtom[]{atoms[u], atoms[v]});
 


### PR DESCRIPTION
…r we can not recover from and should throw/stop parsing even in relaxed mode, handleError can not capture that yet.