### PR TITLE
Propogating molecule id in svg to the corresponding title element 

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
@@ -682,8 +682,10 @@ public final class DepictionGenerator {
         if (title == null || title.isEmpty())
             return new Bounds();
         scale = 1 / scale * getParameterValue(RendererModel.TitleFontScale.class);
+        String refId = chemObj.getProperty(MarkedElement.ID_KEY);
+        String classStr = refId != null ? ("title " + refId) : "title";
         return new Bounds(MarkedElement.markup(StandardGenerator.embedText(font, title, getParameterValue(RendererModel.TitleColor.class), scale),
-                                               "title"));
+                                               classStr));
     }
 
     private Bounds generateReactionConditions(IReaction chemObj, Color fg, double scale) {


### PR DESCRIPTION
While drawing a reaction from a smiles string, we can set the depiction generator to add titles for each participant. The resulting svg generated has id attribute on each participant for ex: "mol1", by default on the first reactant. The corresponding title `<g>` has no correspondence with the molecule mol1. Therefore using javascript it is impossible to find out which title corresponds to which molecule in the svg. This is important if we need to fetch the metadata for the molecule (from a third service) when someone hover's over it's title.  
As way around would be to propagate the id attribute on the molecule as a class name in the title. This patch does this. Please feel free to review.

Following this would be to allow data-* attributes on each molecule to add metadata in the resulting svg but that would be a different pull request.

 