### PR TITLE
Improved Abbreviation Handling

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -523,6 +523,10 @@ public class Abbreviations implements Iterable<String> {
                 newbonds.size() > 2)
                 continue;
 
+            // avoid contracting completely unless requested to
+            if (newbonds.size() == 0 && !contractSingleFragments)
+                continue;
+
             // create the symbol
             StringBuilder sb = new StringBuilder();
             sb.append(newSymbol(attach.getAtomicNumber(), hcount, newbonds.size() == 0));
@@ -683,7 +687,7 @@ public class Abbreviations implements Iterable<String> {
         for (Sgroup sgroup : newSgroups) {
             double coverage = sgroup.getAtoms().size() / (double) mol.getAtomCount();
             // update javadoc if changed!
-            if (sgroup.getBonds().isEmpty() || coverage < 0.4d)
+            if (sgroup.getBonds().isEmpty() || coverage < 0.8d)
                 sgroups.add(sgroup);
         }
         mol.setProperty(CDKConstants.CTAB_SGROUPS, Collections.unmodifiableList(sgroups));

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -302,10 +302,10 @@ public class Abbreviations implements Iterable<String> {
         int numAtoms = mol.getAtomCount();
         for (int i = 0; i < numAtoms; i++) {
             final IAtom atom = mol.getAtom(i);
-            int deg = adjlist[i].length;
+            int deg  = adjlist[i].length;
             int elem = atom.getAtomicNumber();
 
-            if (elem == 6 && deg <= 2 || deg < 2)
+            if (elem == 6 && deg <= 2)
                 continue;
 
             for (int w : adjlist[i]) {
@@ -724,7 +724,8 @@ public class Abbreviations implements Iterable<String> {
                 first++;
             }
 
-            sb.append(newSymbol(attach.getAtomicNumber(), hcount, newbonds.size() == 0));
+            sb.append(newSymbol(attach.getAtomicNumber(), hcount,
+                                newbonds.size() == 0 && first == 0));
             for (int i = first; i < adjGroups.size(); i++) {
                 AdjacentGroup group = adjGroups.get(i);
                 boolean useParen =

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -396,9 +396,9 @@ public class Abbreviations implements Iterable<String> {
         }
 
         List<IAtomContainer> res = new ArrayList<>();
-        if (!bfrag.isEmpty())
+        if (bfrag.getAtomCount() > 1)
             res.add(bfrag);
-        if (!efrag.isEmpty())
+        if (efrag.getAtomCount() > 1)
             res.add(efrag);
         return res;
     }

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -994,19 +994,16 @@ public class Abbreviations implements Iterable<String> {
     private boolean shouldContract(Sgroup sgroup, int nAtoms, int nRingAtoms) {
         if (sgroup.getBonds().isEmpty())
             return true; // no crossing bonds, normally an agent etc
-        int nAbbrChainAtoms = 0;
         int nAbbrRingAtoms  = 0;
         for (IAtom atom : sgroup.getAtoms()) {
             if (atom.isInRing())
-                nAbbrRingAtoms++;
-            else
-                nAbbrChainAtoms++;
+                nAbbrRingAtoms++;;
         }
         int nOtherRingAtoms = nRingAtoms - nAbbrRingAtoms;
         if (nAbbrRingAtoms != 0)
             return nOtherRingAtoms > nAbbrRingAtoms;
-        int nOtherChainAtoms = nAtoms - nRingAtoms - nAbbrChainAtoms;
-        return nOtherChainAtoms > nAbbrChainAtoms;
+        int nOtherAtoms = nAtoms - sgroup.getAtoms().size();
+        return nOtherAtoms > sgroup.getAtoms().size();
     }
 
     /**

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -51,7 +51,7 @@ class AbbreviationsTest {
         IAtomContainer mol = smi("[K+].[O-]C(=O)[O-].[K+]");
         Abbreviations factory = new Abbreviations();
         factory.add("[K+].[O-]C(=O)[O-].[K+] K2CO3");
-        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("K2CO3"));
@@ -101,6 +101,31 @@ class AbbreviationsTest {
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("NMe2"));
+    }
+
+    @Test
+    void autoContractCEt2() throws Exception {
+        IAtomContainer mol = smi("CCC(CC)CC");
+        Abbreviations factory = new Abbreviations();
+        factory.add("*CC Et");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("CHEt3"));
+        assertThat(sgroups.get(0).getAtoms().size(), is(7));
+    }
+
+    @Test
+    void autoContractCEt2_NonTerminal() throws Exception {
+        IAtomContainer mol = smi("CCCCCCCC(CC)CC");
+        Abbreviations factory = new Abbreviations();
+        factory.add("*CC Et");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("CHEt2"));
     }
 
     @Test

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -24,7 +24,6 @@
 package org.openscience.cdk.depict;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -39,7 +38,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AbbreviationsTest {
 
@@ -286,16 +285,25 @@ class AbbreviationsTest {
         assertThat(sgroups.size(), is(0));
     }
 
-    @Disabled
+    @Test
     void avoidPhContraction() throws Exception {
         Abbreviations factory = new Abbreviations();
         factory.add("*c1ccccc1 Ph");
         IAtomContainer mol = smi("c1ccccc1CCc1cscc1");
         factory.apply(mol);
-        assertNull(mol.getProperty(CDKConstants.CTAB_SGROUPS));
+        List<Sgroup> sgroups = mol.getProperty(CDKConstants.CTAB_SGROUPS);
+        assertEquals(0, sgroups.size());
     }
 
-    // TestCase [OH:1][CH2:2][c:3]1[cH:4][cH:5][cH:6][s:7]1.Br[CH2:8][c:9]1[cH:10][cH:11][cH:12][cH:13][cH:14]1>C1CCOC1.[NaH]>[cH:12]1[cH:13][cH:14][c:9]([cH:10][cH:11]1)[CH2:8][O:1][CH2:2][c:3]1[cH:4][cH:5][cH:6][s:7]1
+    @Test
+    void avoidPhContraction2() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*c1ccccc1 Ph");
+        IAtomContainer mol = smi("c1ccccc1CBr");
+        factory.apply(mol);
+        List<Sgroup> sgroups = mol.getProperty(CDKConstants.CTAB_SGROUPS);
+        assertEquals(0, sgroups.size());
+    }
 
     @Test
     void MeMgCl() throws Exception {

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -51,7 +51,7 @@ class AbbreviationsTest {
         IAtomContainer mol = smi("[K+].[O-]C(=O)[O-].[K+]");
         Abbreviations factory = new Abbreviations();
         factory.add("[K+].[O-]C(=O)[O-].[K+] K2CO3");
-        factory.setContractToSingleLabel(true);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("K2CO3"));
@@ -63,8 +63,8 @@ class AbbreviationsTest {
         IAtomContainer mol = smi("CCP(CC)CC");
         Abbreviations factory = new Abbreviations();
         factory.add("*CC Et");
-        factory.setContractToSingleLabel(true);
-        factory.setContractOnHetero(true);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON)
+               .with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("PEt3"));
@@ -76,20 +76,31 @@ class AbbreviationsTest {
         IAtomContainer mol = smi("CCP(CC)CC");
         Abbreviations factory = new Abbreviations();
         factory.add("*CC Et");
-        factory.setContractToSingleLabel(false);
-        factory.setContractOnHetero(true);
+        factory.without(Abbreviations.Option.ALLOW_SINGLETON)
+               .with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(3));
         assertThat(sgroups.get(0).getSubscript(), is("Et"));
         assertThat(sgroups.get(1).getSubscript(), is("Et"));
         assertThat(sgroups.get(2).getSubscript(), is("Et"));
-        factory.setContractToSingleLabel(true);
-        factory.setContractOnHetero(false);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON)
+               .without(Abbreviations.Option.AUTO_CONTRACT_HETERO);
         sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(3));
         assertThat(sgroups.get(0).getSubscript(), is("Et"));
         assertThat(sgroups.get(1).getSubscript(), is("Et"));
         assertThat(sgroups.get(2).getSubscript(), is("Et"));
+    }
+
+    @Test
+    void autoContractNMe2() throws Exception {
+        IAtomContainer mol = smi("CCCCCCN(C)C");
+        // no abbreviations define but cal still contract
+        Abbreviations factory = new Abbreviations();
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("NMe2"));
     }
 
     @Test
@@ -154,7 +165,7 @@ class AbbreviationsTest {
         IAtomContainer mol = smi("ClCCl.FC(F)(F)C(=O)O");
         factory.add("ClCCl DCM");
         factory.add("FC(F)(F)C(=O)O TFA");
-        factory.setContractToSingleLabel(true);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("TFA·DCM"));
@@ -166,7 +177,7 @@ class AbbreviationsTest {
         IAtomContainer mol = smi("ClCCl.FC(F)(F)C(=O)O");
         factory.add("ClCCl DCM");
         factory.add("FC(F)(F)C(=O)O TFA");
-        factory.setContractToSingleLabel(false);
+        factory.without(Abbreviations.Option.ALLOW_SINGLETON);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("DCM"));
@@ -345,7 +356,7 @@ class AbbreviationsTest {
     void hclSaltOfEdci() throws Exception {
         Abbreviations factory = new Abbreviations();
         factory.add("CCN=C=NCCCN(C)C EDCI");
-        factory.setContractToSingleLabel(true);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
         IAtomContainer mol = smi("CCN=C=NCCCN(C)C.Cl");
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
@@ -356,7 +367,7 @@ class AbbreviationsTest {
     void SnCl2() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("Cl[Sn]Cl");
-        factory.setContractToSingleLabel(true);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("SnCl2"));
@@ -366,7 +377,7 @@ class AbbreviationsTest {
     void HOOH() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("OO");
-        factory.setContractToSingleLabel(true);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("HOOH"));
@@ -378,7 +389,7 @@ class AbbreviationsTest {
         Abbreviations factory = new Abbreviations();
         factory.add("ClCCl DCM");
         factory.add("Cl[Pd]Cl.[Fe+2].c1ccc(P([c-]2cccc2)c2ccccc2)cc1.c1ccc(P([c-]2cccc2)c2ccccc2)cc1 Pd(dppf)Cl2");
-        factory.setContractToSingleLabel(true);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
         IAtomContainer mol = smi(smi);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
@@ -391,7 +402,7 @@ class AbbreviationsTest {
         Abbreviations factory = new Abbreviations();
         factory.add("Cl[Pd]Cl.[Fe+2].c1ccc(P([c-]2cccc2)c2ccccc2)cc1.c1ccc(P([c-]2cccc2)c2ccccc2)cc1 Pd(dppf)Cl2");
         factory.add("Cl[Pd]Cl PdCl2");
-        factory.setContractToSingleLabel(true);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
         IAtomContainer mol = smi(smi);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -207,6 +207,45 @@ class AbbreviationsTest {
     }
 
     @Test
+    void PhMgCl() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("c1ccccc1[Mg]Cl");
+        factory.add("*c1ccccc1 Ph");
+        factory.add("*[Mg]Cl MgCl");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("PhMgCl"));
+    }
+
+
+    @Test
+    void PhNnBu3() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("c1ccccc1[Sn](CCCC)(CCCC)CCCC");
+        factory.add("*c1ccccc1 Ph");
+        factory.add("*CCCC nBu");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("Sn(Ph)nBu3"));
+    }
+
+    @Test
+    void MeMgCl() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("C[Mg]Cl");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        // could be better
+        assertThat(sgroups.get(0).getSubscript(), is("Mg(Cl)Me"));
+    }
+
+    @Test
     void phenylShouldNotMatchBenzene() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("c1ccccc1");

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -24,8 +24,10 @@
 package org.openscience.cdk.depict;
 
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupType;
@@ -274,6 +276,34 @@ class AbbreviationsTest {
         assertThat(sgroups.size(), is(1));
         sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
         assertThat(sgroups.get(0).getSubscript(), is("PhCl"));
+    }
+
+    @Test
+    void PhCl_keepCl() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("Clc1ccccc1");
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
+        assertThat(sgroups.get(0).getSubscript(), is("PhCl"));
+
+        // block the chlorine atom
+        IAtom chlorineAtom = mol.getAtom(0);
+        assertEquals(IAtom.Cl, chlorineAtom.getAtomicNumber());
+        List<Sgroup> sgroups2 = factory.generate(mol,
+                                                 Collections.singleton(chlorineAtom));
+        assertThat(sgroups2.size(), is(1));
+        assertThat(sgroups2.get(0).getSubscript(), is("Ph"));
+
+        // block the Ph contraction
+        IAtom carbonAtom = mol.getAtom(5);
+        assertEquals(IAtom.C, carbonAtom.getAtomicNumber());
+        List<Sgroup> sgroups3 = factory.generate(mol,
+                                                 Collections.singleton(carbonAtom));
+        assertThat(sgroups3.size(), is(0));
     }
 
     @Test

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -59,6 +59,40 @@ class AbbreviationsTest {
     }
 
     @Test
+    void autoContractPEt3() throws Exception {
+        IAtomContainer mol = smi("CCP(CC)CC");
+        Abbreviations factory = new Abbreviations();
+        factory.add("*CC Et");
+        factory.setContractToSingleLabel(true);
+        factory.setContractOnHetero(true);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("PEt3"));
+        assertThat(sgroups.get(0).getAtoms().size(), is(7));
+    }
+
+    @Test
+    void autoContractPEt3_off() throws Exception {
+        IAtomContainer mol = smi("CCP(CC)CC");
+        Abbreviations factory = new Abbreviations();
+        factory.add("*CC Et");
+        factory.setContractToSingleLabel(false);
+        factory.setContractOnHetero(true);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(3));
+        assertThat(sgroups.get(0).getSubscript(), is("Et"));
+        assertThat(sgroups.get(1).getSubscript(), is("Et"));
+        assertThat(sgroups.get(2).getSubscript(), is("Et"));
+        factory.setContractToSingleLabel(true);
+        factory.setContractOnHetero(false);
+        sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(3));
+        assertThat(sgroups.get(0).getSubscript(), is("Et"));
+        assertThat(sgroups.get(1).getSubscript(), is("Et"));
+        assertThat(sgroups.get(2).getSubscript(), is("Et"));
+    }
+
+    @Test
     void phenyl() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("CCCCCCC(c1ccccc1)(c1ccccc1)c1ccccc1");
@@ -322,6 +356,7 @@ class AbbreviationsTest {
     void SnCl2() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("Cl[Sn]Cl");
+        factory.setContractToSingleLabel(true);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("SnCl2"));
@@ -331,6 +366,7 @@ class AbbreviationsTest {
     void HOOH() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("OO");
+        factory.setContractToSingleLabel(true);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("HOOH"));

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -33,6 +33,7 @@ import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -67,7 +68,7 @@ class AbbreviationsTest {
                .with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
-        assertThat(sgroups.get(0).getSubscript(), is("PEt3"));
+        assertThat(sgroups.get(0).getSubscript(), is("Et3P"));
         assertThat(sgroups.get(0).getAtoms().size(), is(7));
     }
 
@@ -104,7 +105,7 @@ class AbbreviationsTest {
     }
 
     @Test
-    void autoContractCEt2() throws Exception {
+    void autoContractCHEt3() throws Exception {
         IAtomContainer mol = smi("CCC(CC)CC");
         Abbreviations factory = new Abbreviations();
         factory.add("*CC Et");
@@ -112,8 +113,21 @@ class AbbreviationsTest {
         factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
-        assertThat(sgroups.get(0).getSubscript(), is("CHEt3"));
+        assertThat(sgroups.get(0).getSubscript(), is("Et3CH"));
         assertThat(sgroups.get(0).getAtoms().size(), is(7));
+    }
+
+    @Test
+    void autoContractEt2CO() throws Exception {
+        IAtomContainer mol = smi("C(=O)(CC)CC");
+        Abbreviations factory = new Abbreviations();
+        factory.add("*CC Et");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("Et2CO"));
+        assertThat(sgroups.get(0).getAtoms().size(), is(6));
     }
 
     @Test
@@ -230,8 +244,26 @@ class AbbreviationsTest {
         factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
-        assertThat(sgroups.get(0).getSubscript(), is("Sn(Ph)nBu3"));
+        assertThat(sgroups.get(0).getSubscript(), is("nBu3SnPh"));
     }
+
+    @Test
+    void PhNnBu3_noSingleton() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("c1ccccc1[Sn](CCCC)(CCCC)CCCC");
+        factory.add("*c1ccccc1 Ph");
+        factory.add("*CCCC nBu");
+        factory.without(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(2));
+        sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
+        assertThat(sgroups.get(0).getSubscript(), is("Ph"));
+        assertThat(sgroups.get(1).getSubscript(), is("SnnBu3"));
+    }
+
+    // C=CH2 test case
+    // TestCase [OH:1][CH2:2][c:3]1[cH:4][cH:5][cH:6][s:7]1.Br[CH2:8][c:9]1[cH:10][cH:11][cH:12][cH:13][cH:14]1>C1CCOC1.[NaH]>[cH:12]1[cH:13][cH:14][c:9]([cH:10][cH:11]1)[CH2:8][O:1][CH2:2][c:3]1[cH:4][cH:5][cH:6][s:7]1
 
     @Test
     void MeMgCl() throws Exception {
@@ -242,7 +274,7 @@ class AbbreviationsTest {
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         // could be better
-        assertThat(sgroups.get(0).getSubscript(), is("Mg(Cl)Me"));
+        assertThat(sgroups.get(0).getSubscript(), is("MeMgCl"));
     }
 
     @Test

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -129,6 +129,66 @@ class AbbreviationsTest {
     }
 
     @Test
+    void testBiphenyl() throws Exception {
+        IAtomContainer mol = smi("c1ccccc1c1ccccc1");
+        Abbreviations factory = new Abbreviations();
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("Ph2"));
+        assertThat(sgroups.get(0).getAtoms().size(), is(12));
+        factory.without(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(2));
+        assertThat(sgroups.get(0).getSubscript(), is("Ph"));
+        assertThat(sgroups.get(1).getSubscript(), is("Ph"));
+    }
+
+    @Test
+    void testNEt2() throws Exception {
+        IAtomContainer mol = smi("CCN(CC)N(CC)CC");
+        Abbreviations factory = new Abbreviations();
+        factory.add("*CC Et");
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("(NEt2)2"));
+        assertThat(sgroups.get(0).getAtoms().size(), is(10));
+        factory.without(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(2));
+        assertThat(sgroups.get(0).getSubscript(), is("NEt2"));
+        assertThat(sgroups.get(1).getSubscript(), is("NEt2"));
+    }
+
+    @Test
+    void testNMe2() throws Exception {
+        IAtomContainer mol = smi("CN(C)N(C)C");
+        Abbreviations factory = new Abbreviations();
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("(NMe2)2"));
+        assertThat(sgroups.get(0).getAtoms().size(), is(6));
+        factory.without(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(2));
+        assertThat(sgroups.get(0).getSubscript(), is("NMe2"));
+        assertThat(sgroups.get(1).getSubscript(), is("NMe2"));
+    }
+
+    @Test
     void phenyl() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("CCCCCCC(c1ccccc1)(c1ccccc1)c1ccccc1");

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -24,6 +24,7 @@
 package org.openscience.cdk.depict;
 
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -38,6 +39,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class AbbreviationsTest {
 
@@ -262,7 +264,24 @@ class AbbreviationsTest {
         assertThat(sgroups.get(1).getSubscript(), is("SnnBu3"));
     }
 
-    // C=CH2 test case
+    @Test
+    void avoid_CHCH2() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("c1ccccc1C=C");
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(0));
+    }
+
+    @Disabled
+    void avoidPhContraction() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        factory.add("*c1ccccc1 Ph");
+        IAtomContainer mol = smi("c1ccccc1CCc1cscc1");
+        factory.apply(mol);
+        assertNull(mol.getProperty(CDKConstants.CTAB_SGROUPS));
+    }
+
     // TestCase [OH:1][CH2:2][c:3]1[cH:4][cH:5][cH:6][s:7]1.Br[CH2:8][c:9]1[cH:10][cH:11][cH:12][cH:13][cH:14]1>C1CCOC1.[NaH]>[cH:12]1[cH:13][cH:14][c:9]([cH:10][cH:11]1)[CH2:8][O:1][CH2:2][c:3]1[cH:4][cH:5][cH:6][s:7]1
 
     @Test
@@ -486,9 +505,10 @@ class AbbreviationsTest {
     }
 
     @Test
-    void NBocFromHeteroCollapseExplicitH() throws Exception {
+    void NBocFromHeteroCollapse() throws Exception {
         Abbreviations factory = new Abbreviations();
         factory.add("*C(=O)OC(C)(C)C Boc");
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_LINKERS);
         IAtomContainer mol = smi("c1cc2ccccc2ccn1C(=O)OC(C)(C)C");
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -265,6 +265,19 @@ class AbbreviationsTest {
     }
 
     @Test
+    void PhCl() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("Clc1ccccc1");
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
+        assertThat(sgroups.get(0).getSubscript(), is("PhCl"));
+    }
+
+    @Test
     void avoid_CHCH2() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("c1ccccc1C=C");

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -36,7 +36,9 @@ import org.openscience.cdk.smiles.SmilesParser;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -294,17 +296,147 @@ class AbbreviationsTest {
         IAtom chlorineAtom = mol.getAtom(0);
         assertEquals(IAtom.Cl, chlorineAtom.getAtomicNumber());
         List<Sgroup> sgroups2 = factory.generate(mol,
-                                                 Collections.singleton(chlorineAtom));
+                                                 Collections.singletonMap(chlorineAtom, 1));
         assertThat(sgroups2.size(), is(1));
         assertThat(sgroups2.get(0).getSubscript(), is("Ph"));
+    }
+
+    @Test
+    void PhCl_keepOneC() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("Clc1ccccc1");
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
+        assertThat(sgroups.get(0).getSubscript(), is("PhCl"));
 
         // block the Ph contraction
         IAtom carbonAtom = mol.getAtom(5);
         assertEquals(IAtom.C, carbonAtom.getAtomicNumber());
         List<Sgroup> sgroups3 = factory.generate(mol,
-                                                 Collections.singleton(carbonAtom));
+                                                 Collections.singletonMap(carbonAtom, 1));
         assertThat(sgroups3.size(), is(0));
+
+        // all carbon atoms in same group, only Ph comes out
+        Map<IAtom,Integer> atomSets = new HashMap<>();
+        for (IAtom atom : mol.atoms()) {
+            if (atom.getAtomicNumber() == IAtom.C)
+                atomSets.put(atom, 1);
+        }
+        List<Sgroup> sgroups4 = factory.generate(mol,
+                                                 atomSets);
+        assertThat(sgroups4.size(), is(1));
+        assertThat(sgroups4.get(0).getSubscript(), is("Ph"));
+
+        // all atoms in same group, PhCl comes out
+        for (IAtom atom : mol.atoms())
+            atomSets.put(atom, 1);
+        List<Sgroup> sgroups5 = factory.generate(mol,
+                                                 atomSets);
+        assertThat(sgroups5.size(), is(1));
+        assertThat(sgroups5.get(0).getSubscript(), is("PhCl"));
     }
+
+    @Test
+    void PhCl_keepAllC() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("Clc1ccccc1");
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
+        assertThat(sgroups.get(0).getSubscript(), is("PhCl"));
+
+        // all carbon atoms in same group, only Ph comes out
+        Map<IAtom,Integer> atomSets = new HashMap<>();
+        for (IAtom atom : mol.atoms()) {
+            if (atom.getAtomicNumber() == IAtom.C)
+                atomSets.put(atom, 1);
+        }
+        List<Sgroup> sgroups4 = factory.generate(mol,
+                                                 atomSets);
+        assertThat(sgroups4.size(), is(1));
+        assertThat(sgroups4.get(0).getSubscript(), is("Ph"));
+
+        // all atoms in same group, PhCl comes out
+        for (IAtom atom : mol.atoms())
+            atomSets.put(atom, 1);
+        List<Sgroup> sgroups5 = factory.generate(mol,
+                                                 atomSets);
+        assertThat(sgroups5.size(), is(1));
+        assertThat(sgroups5.get(0).getSubscript(), is("PhCl"));
+    }
+
+    @Test
+    void PhCl_keepAll() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("Clc1ccccc1");
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
+        assertThat(sgroups.get(0).getSubscript(), is("PhCl"));
+
+        // all atoms in same group, PhCl comes out
+        Map<IAtom,Integer> atomSets = new HashMap<>();
+        for (IAtom atom : mol.atoms())
+            atomSets.put(atom, 1);
+        List<Sgroup> sgroups5 = factory.generate(mol,
+                                                 atomSets);
+        assertThat(sgroups5.size(), is(1));
+        assertThat(sgroups5.get(0).getSubscript(), is("PhCl"));
+    }
+
+    @Test
+    void Ph2_keepAll() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("c1ccccc1c1ccccc1");
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
+        assertThat(sgroups.get(0).getSubscript(), is("Ph2"));
+
+        // all atoms in same group, Ph2 still comes out
+        Map<IAtom,Integer> atomSets = new HashMap<>();
+        for (IAtom atom : mol.atoms())
+            atomSets.put(atom, 1);
+        List<Sgroup> sgroups5 = factory.generate(mol,
+                                                 atomSets);
+        assertThat(sgroups5.size(), is(1));
+        assertThat(sgroups5.get(0).getSubscript(), is("Ph2"));
+    }
+
+    @Test
+    void Ph2_keepOne() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("c1ccccc1c1ccccc1");
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        sgroups.sort(Comparator.comparing(sgroup -> sgroup.getAtoms().size()));
+        assertThat(sgroups.get(0).getSubscript(), is("Ph2"));
+
+        // all atoms in same group, only one Ph comes out
+        Map<IAtom,Integer> atomSets = new HashMap<>();
+        atomSets.put(mol.getAtom(0), 1);
+        List<Sgroup> sgroups5 = factory.generate(mol,
+                                                 atomSets);
+        assertThat(sgroups5.size(), is(1));
+        assertThat(sgroups5.get(0).getSubscript(), is("Ph"));
+    }
+
 
     @Test
     void avoid_CHCH2() throws Exception {


### PR DESCRIPTION
Improvements to the Abbreviation algorithm, options, and functionality.

- We can now generate more (and better) abbreviations than before, for example. ``Et3P`` and ``Ph2``
- Rather than some true/false flags, there is now some enum options to tune how things work: ```java
factory.with(Abbreviations.Option.ALLOW_SINGLETON);
factory.without(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
```
- When abbreviations are applied has be tweaked, previously if <40% of the atoms were in the contraction it was applied. Now it does <50% but splits out ring atoms. This means if there is a single ring in a structure or two rings of the same sizes it does not get contracted.
- It is also now possible to provide an indication that atoms should be keep together and not have an abbreviation split them. This is most useful to substructure highlighting.