### PR TITLE
Abbreviations rebased

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -526,18 +526,6 @@ public class Abbreviations implements Iterable<String> {
                 usedAtoms.addAll(sgroup.getAtoms());
         }
 
-        // ensure we don't abbreviate stereochemistry
-        for (IStereoElement<?,?> se : mol.stereoElements()) {
-            IChemObject chemObject = se.getFocus();
-            if (chemObject instanceof IAtom) {
-                usedAtoms.add((IAtom) chemObject);
-            }
-            else if (chemObject instanceof IBond) {
-                usedAtoms.add(((IBond) chemObject).getBegin());
-                usedAtoms.add(((IBond) chemObject).getEnd());
-            }
-        }
-
         final List<Sgroup> newSgroups = new ArrayList<>();
         final List<Sgroup> allSgroups = new ArrayList<>();
 
@@ -605,6 +593,18 @@ public class Abbreviations implements Iterable<String> {
                 }
 
             } catch (CDKException ignored) {
+            }
+        }
+
+        // ensure we don't abbreviate stereochemistry
+        for (IStereoElement<?,?> se : mol.stereoElements()) {
+            IChemObject chemObject = se.getFocus();
+            if (chemObject instanceof IAtom) {
+                usedAtoms.add((IAtom) chemObject);
+            }
+            else if (chemObject instanceof IBond) {
+                usedAtoms.add(((IBond) chemObject).getBegin());
+                usedAtoms.add(((IBond) chemObject).getEnd());
             }
         }
 

--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -35,8 +35,10 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
+import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.isomorphism.matchers.Expr;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtom;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
@@ -490,6 +492,18 @@ public class Abbreviations implements Iterable<String> {
         if (sgroups != null) {
             for (Sgroup sgroup : sgroups)
                 usedAtoms.addAll(sgroup.getAtoms());
+        }
+
+        // ensure we don't abbreviate stereochemistry
+        for (IStereoElement<?,?> se : mol.stereoElements()) {
+            IChemObject chemObject = se.getFocus();
+            if (chemObject instanceof IAtom) {
+                usedAtoms.add((IAtom) chemObject);
+            }
+            else if (chemObject instanceof IBond) {
+                usedAtoms.add(((IBond) chemObject).getBegin());
+                usedAtoms.add(((IBond) chemObject).getEnd());
+            }
         }
 
         final List<Sgroup> newSgroups = new ArrayList<>();

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -458,6 +458,32 @@ class AbbreviationsTest {
         assertThat(sgroups.get(1).getSubscript(), is("CHEtPh"));
     }
 
+    // Don't generate NiPr
+    @Test
+    void avoidAmbiguity() throws Exception {
+        String smi = "C1CCCCC1=NC(C)C";
+        Abbreviations factory = new Abbreviations();
+        factory.add("*C(C)C iPr");
+        IAtomContainer mol = smi(smi);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("iPr"));
+    }
+
+    // we need brackets here, so Ni (nickle) does not accidnetly come out
+    @Test
+    void testNiPr2_needBrackets() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("CCCCN(C(C)C)C(C)C");
+        factory.add("*C(C)C iPr");
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("N(iPr)2"));
+    }
+
     @Test
     void avoid_CHCH2() throws Exception {
         Abbreviations factory = new Abbreviations();
@@ -786,18 +812,6 @@ class AbbreviationsTest {
         List<Sgroup> sgroups = factory.generate(mol);
         assertThat(sgroups.size(), is(1));
         assertThat(sgroups.get(0).getSubscript(), is("Pd(dppf)Cl2"));
-    }
-
-    // Don't generate NiPr
-    @Test
-    void avoidAmbiguity() throws Exception {
-        String smi = "C1CCCCC1=NC(C)C";
-        Abbreviations factory = new Abbreviations();
-        factory.add("*C(C)C iPr");
-        IAtomContainer mol = smi(smi);
-        List<Sgroup> sgroups = factory.generate(mol);
-        assertThat(sgroups.size(), is(1));
-        assertThat(sgroups.get(0).getSubscript(), is("iPr"));
     }
 
     @Test

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -437,6 +437,26 @@ class AbbreviationsTest {
         assertThat(sgroups5.get(0).getSubscript(), is("Ph"));
     }
 
+    @Test
+    void testDoNotAbbreviateStereochemistry() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("C(C)[C@@H](C1=CC=CC=C1)NC(=O)C1=C(C(=NC2=CC=CC=C12)C1=CC=CC=C1)CN1CCC(CC1)O");
+        factory.add("*CC Et");
+        factory.add("*c1ccccc1 Ph");
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(3));
+        assertThat(sgroups.get(0).getSubscript(), is("Ph"));
+        assertThat(sgroups.get(1).getSubscript(), is("Ph"));
+        assertThat(sgroups.get(2).getSubscript(), is("Et"));
+
+        // removing stereo allows further contraction
+        mol.setStereoElements(Collections.emptyList());
+        sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(2));
+        assertThat(sgroups.get(0).getSubscript(), is("Ph"));
+        assertThat(sgroups.get(1).getSubscript(), is("CHEtPh"));
+    }
 
     @Test
     void avoid_CHCH2() throws Exception {

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -514,6 +514,18 @@ class AbbreviationsTest {
     }
 
     @Test
+    void testCOEt() throws Exception {
+        Abbreviations factory = new Abbreviations();
+        IAtomContainer mol = smi("C1CCCCC1C(=O)CC");
+        factory.add("*CC Et");
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+        assertThat(sgroups.get(0).getSubscript(), is("COEt"));
+    }
+
+
+    @Test
     void MeMgCl() throws Exception {
         Abbreviations factory = new Abbreviations();
         IAtomContainer mol = smi("C[Mg]Cl");


### PR DESCRIPTION
Two more minor tweaks/improvements to abbreviations.
- Do not contract on chiral atoms
- allow -N(iPr)2 and iPr2NH but not -NiPr (since it could be "Ni" "Pr").