### PR TITLE
Fix for non-deterministic CIP designation bug

### DIFF
--- a/descriptor/cip/pom.xml
+++ b/descriptor/cip/pom.xml
@@ -75,6 +75,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-ctab</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-io</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/rules/CIPLigandRule.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/rules/CIPLigandRule.java
@@ -88,7 +88,7 @@ public class CIPLigandRule implements ISequenceSubRule<ILigand> {
         ILigand[] newLigands = new ILigand[ligands.length];
         System.arraycopy(ligands, 0, newLigands, 0, ligands.length);
 
-        //Should sort based on full CIP rule, not just based on atom number/mass
+        //Now sorts based on full CIP rule, not just based on atom number/mass
         Arrays.sort(newLigands, this);
         // this above list is from low to high precendence, so we need to revert the array
         ILigand[] reverseLigands = new ILigand[newLigands.length];

--- a/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/rules/CIPLigandRule.java
+++ b/descriptor/cip/src/main/java/org/openscience/cdk/geometry/cip/rules/CIPLigandRule.java
@@ -88,7 +88,8 @@ public class CIPLigandRule implements ISequenceSubRule<ILigand> {
         ILigand[] newLigands = new ILigand[ligands.length];
         System.arraycopy(ligands, 0, newLigands, 0, ligands.length);
 
-        Arrays.sort(newLigands, numberRule);
+        //Should sort based on full CIP rule, not just based on atom number/mass
+        Arrays.sort(newLigands, this);
         // this above list is from low to high precendence, so we need to revert the array
         ILigand[] reverseLigands = new ILigand[newLigands.length];
         for (int i = 0; i < newLigands.length; i++) {

--- a/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/CIPToolTest.java
+++ b/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/CIPToolTest.java
@@ -766,4 +766,101 @@ class CIPToolTest extends CDKTestCase {
 
         Assertions.assertEquals(CIP_CHIRALITY.NONE, CIPTool.getCIPChirality(mol, tetraStereo));
     }
+
+
+    /**
+     * Tests if permuting the bond order in an input molfile will modify the
+     * CIP designations. Order of input bonds should not change CIP R/S designation.
+     */
+    @Test
+    public void testPermutingBondOrderingDoesNotChangeCIPDesignation() throws Exception {
+    	String read1 = "\n"
+    			+ "   JSDraw212042315552D\n"
+    			+ "\n"
+    			+ " 12 11  0  0  1  0              0 V2000\n"
+    			+ "   10.7120   -5.6160    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   12.0630   -6.3960    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   13.4140   -5.6160    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   14.7650   -6.3960    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   16.1160   -5.6160    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   17.4670   -6.3960    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   18.8180   -5.6160    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   20.1690   -6.3960    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   12.0630   -7.9560    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   13.4140   -4.0560    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   14.7650   -7.9560    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "   16.1160   -4.0560    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+    			+ "  1  2  1  0  0  0  0\n"
+    			+ "  3  4  1  0  0  0  0\n"
+    			+ "  4  5  1  0  0  0  0\n"
+    			+ "  6  7  1  0  0  0  0\n"
+    			+ "  7  8  1  0  0  0  0\n"
+    			+ "  2  9  1  0  0  0  0\n"
+    			+ "  4 11  1  6  0  0  0\n";
+    	
+    	String read2 = "M  END";
+    			
+    	String[] bondLines = new String[] {
+    			"  2  3  1  0  0  0  0  \n",
+    			"  5 12  1  0  0  0  0  \n",
+    			"  5  6  1  0  0  0  0  \n",
+    			"  3 10  1  0  0  0  0  \n",
+    	};
+    	int[][] order= new int[][] {
+    		
+    			new int[] {0,1,2,3},
+    			new int[] {0,3,1,2},
+    			new int[] {0,2,3,1},
+    			
+    			new int[] {0,2,1,3},
+    			new int[] {0,3,2,1},
+    			new int[] {0,1,3,2},
+    			
+    			new int[] {1,0,2,3},
+    			new int[] {1,3,0,2},
+    			new int[] {1,2,3,0},
+    			
+    			new int[] {1,2,0,3},
+    			new int[] {1,3,2,0},
+    			new int[] {1,0,3,2},
+    			
+    			new int[] {2,0,1,3},
+    			new int[] {2,3,0,1},
+    			new int[] {2,1,3,0},
+    			
+    			new int[] {2,1,0,3},
+    			new int[] {2,3,1,0},
+    			new int[] {2,0,3,1},
+
+    			new int[] {3,0,1,2},
+    			new int[] {3,2,0,1},
+    			new int[] {3,1,2,0},
+    			
+    			new int[] {3,1,0,2},
+    			new int[] {3,2,1,0},
+    			new int[] {3,0,2,1},
+    			
+    	};
+    	
+    	for(int[] ord:order) {
+    		StringBuilder full = new StringBuilder(read1);
+    		for(int k:ord) {
+    			full.append(bondLines[k]);    			
+    		}
+    		full.append(read2); 
+    		IAtomContainer mol;
+        	try(IteratingSDFReader reader = new IteratingSDFReader(new BufferedReader(new StringReader(full.toString())),SilentChemObjectBuilder.getInstance())){
+    			mol = reader.next();			
+    		}
+
+            CIPTool.label(mol);
+            
+            for (IAtom atom : mol.atoms()) {
+            	Object p = atom.getProperty(CDKConstants.CIP_DESCRIPTOR);
+            	if(p!=null) {
+            		Assertions.assertEquals(CIP_CHIRALITY.S.toString(),p);
+            	}
+            }
+    	}
+    }
 }


### PR DESCRIPTION
This PR is to correct a CIP bug in CDK. CDK's default CIP rule works well, but has a bug in the recursive part where, if there's a tie between 2 ligands based on atomic number/mass, it will then get all sub-ligands and compare them. The issue is that each set of sub-ligands is sorted by a mass+atomic number priority ONLY, and each sub-ligand from the parent ligand is compared only to its matched counterpart, not to all potentially higher priority ligands. This can lead to wrongly assigning CIP designations.

Consider this case below (4S)-2,3,4,5-tetramethyloctane:  
```
  
     3'    5'
     M     C
     |  4  | 
 M-C-C-[C]-C-C-C-M
   | 3  :  5
   M    M
        4'
 
 M = Methyl
 C = Carbon
 : = Dashed bond
 # = Locant 
```

The 4 postion [C] is a stereo center with S configuration (as demonstrated with the : dashed bond to the methyl group below). The carbon atoms at 3, 4 and 5 positions are tied for priority based on first pass CIP rules (atom number and mass). However, 3 and 5 are quickly seen as higher priority than 4' in the first tie-break as 4' has no sub-ligands. 3 and 5, however, both have 2 sub-ligands. 3 has [3',2] and 5 has [5',6] as sub-ligands. The next step CDK CIP rules do is to ORDER these sub-ligands and then compare them. In this case, we need to order [3',2] and [5',6] individually. For [3',2], this is done by comparing only the ATOMIC NUMBER+MASS between 3' and 2, and since they are both carbon atoms, this will result in a tie. This means  that if the starting order of [3',2] was [3',2] it will remain that way. If the starting order is [2,3'] it will remain [2,3']. Since the input order of the ligands is based on read-order (order of bonds in the bond table in the CTAB, for example), this means the ordering of the sub-ligands is effectively non-deterministic. 2 is certainly higher priority than 3' in full CIP rules, and 6 is higher priority than 5' as well. In the above cases there are 4 ways the ligand ordering can go:

```
 Possibility 1: both sub-ligands in right order
    3 vs 5 =>
    [2,3'] vs [6,5'] => 
    2 vs 6 => 2 is higher priority
    therefore 3 is higher priority (correct)
 
 Possibility 2: 3 sub-ligands wrong order, 5 right order
    3 vs 5 =>
    [3',2] vs [6,5'] => 
    3' vs 6 => 6 is higher priority
    therefore 5 is higher priority (incorrect)
 
 Possibility 3: 3 sub-ligands RIGHT order, 5 wrong order
    3 vs 5 =>
    [2,3'] vs [5',6] => 
    2 vs 5' => 2 is higher priority
    therefore 3 is higher priority (correct)
 
 Possibility 4: both sub-ligands in WRONG order
    3 vs 5 =>
    [3',2] vs [5',6] => 
    3' vs 5' => TIE, go to next
    2 vs 6 => 2 is higher priority
    therefore 3 is higher priority (correct)
```
Notice here that 3 of the 4 possibilities above will give the correct CIP ordering. This is indeed typical. The bug only applies in circumstances where 2 or more "principal" ligands are tied for CIP priority based on atom number and atomic weight AND those 2 ligands both have sub-ligands  (non-hydrogens) AND at least 2 sub-ligands of those ligands are tied for atomic weight and atomic mass. Even still, the majority of the time the criteria is met, CDK will still produce the correct CIP labeling. Nevertheless, wrong stereo assignments are very possible and have been observed fairly regularly due to this bug.

The fix present in this PR is simply to have sub-ligands sorted by the full CIP rules. A test was added which permutes the order of the bonds in the case above, and ensures that no matter what order the bonds come in, the CIP designations are always the same. This test did not pass before the fix.
