### PR TITLE
First pass at aligned depictions API.

### DIFF
--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -342,7 +342,7 @@ public class StructureDiagramGenerator {
     /**
      * Generate coordinates aligned, the atoms in substructure pattern is used to
      * cache/provide the coordinates. If no coordinates are present the
-     * substructure from the molecule is generated first and it's coordinates
+     * substructure from the molecule is generated first and its coordinates
      * cached. If an atom in the
      *
      * @param mol     molecule


### PR DESCRIPTION
A new method on the SDG "generateAlignedDepictions" provides a convenient way to align depictions to a common substructure.

# Default layouts

```java
SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
List<IAtomContainer> mols = new ArrayList<>();
for (String smi : new String[]{"C1CC(CO)CCC1",
                               "C1(NC(C)C)CC(CO)CCC1",
                               "C1CC(CO2CC2)CC(CCCC)C1"}) {
    mols.add(smipar.parseSmiles(smi));
}

new DepictionGenerator(new Font("Arial", Font.PLAIN, 24)).withZoom(1)
                                                         .depict(mols).writeTo("/tmp/tmp.svg");
```

![tmp](https://github.com/cdk/cdk/assets/983232/636a82f9-0021-499f-9ee3-f581e94873a5)


# Align to substructure

Before depiction we can manually generate the coordinates and provide a substructure/SMARTS pattern.

```java
StructureDiagramGenerator sdg = new StructureDiagramGenerator();
Pattern pat = SmartsPattern.create("OCC1CCCCC1");
for (IAtomContainer mol : mols) {
    sdg.generateAlignedCoordinates(mol, pat);
}
```

![tmp-1](https://github.com/cdk/cdk/assets/983232/213cfc47-9eb5-4445-95e0-ed2000441678)


# Align to common substructure (provide reference)

```java
IAtomContainer ref = new MDLV2000Reader(new StringReader("\n" +
                                                                 "  ChemDraw01192411162D\n" +
                                                                 "\n" +
                                                                 "  8  8  0  0  0  0  0  0  0  0999 V2000\n" +
                                                                 "   -1.0297    0.7162    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
                                                                 "   -0.2047    0.7127    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
                                                                 "    0.2047   -0.0035    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
                                                                 "    1.0297   -0.0069    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
                                                                 "    1.4452    0.7058    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" +
                                                                 "   -0.2108   -0.7162    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
                                                                 "   -1.0357   -0.7127    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
                                                                 "   -1.4452    0.0035    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" +
                                                                 "  1  2  1  0      \n" +
                                                                 "  2  3  1  0      \n" +
                                                                 "  3  4  1  0      \n" +
                                                                 "  4  5  1  0      \n" +
                                                                 "  3  6  1  0      \n" +
                                                                 "  6  7  1  0      \n" +
                                                                 "  7  8  1  0      \n" +
                                                                 "  1  8  1  0      \n" +
                                                                 "M  END\n")).read(builder.newAtomContainer());

StructureDiagramGenerator sdg = new StructureDiagramGenerator();
Pattern pat = SmartsPattern.create("OCC1CCCCC1");
for (IAtomContainer mol : mols) {
    sdg.generateAlignedCoordinates(mol, ref, pat);
}
```

![tmp-2](https://github.com/cdk/cdk/assets/983232/729e880f-485c-4853-9d18-751f8de9b681)

# Ring Alignment

If the substructure atom is acyclic and the molecule is cyclic you would get some weird results if you copied directly. Therefore the alignment ignores atoms which aren't in a ring in both. It would be nice if we could do some cleanup after and choose the orientation with lowest 2D RMSD but for now this is sufficent:

![tmp](https://github.com/cdk/cdk/assets/983232/7c3a5b9f-44ee-4ba1-a2d1-b56e4de398fd)

# Hybridisation

Different bonding can also cause strange results and may need some tweaking.

```java
for (String smi : new String[]{"C1CCCCC1CCC",
                                     "C1CCCCC1C=C=C"}) {
    mols.add(smipar.parseSmiles(smi));
}

StructureDiagramGenerator sdg = new StructureDiagramGenerator();
Pattern pat = SmartsPattern.create("C1CCCCC1[#6]~[#6]~[#6]");
```

![tmp](https://github.com/cdk/cdk/assets/983232/4d79845e-4034-497e-a74b-edf1b0d092bf)

