### PR TITLE
AtomContainer2 Phase 2

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/DepictionGenerator.java
@@ -48,7 +48,6 @@ import org.openscience.cdk.renderer.generators.standard.StandardGenerator.Deloca
 import org.openscience.cdk.renderer.generators.standard.StandardGenerator.ForceDelocalisedBondDisplay;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.ReactionManipulator;
-import org.openscience.cdk.tools.manipulator.ReactionSetManipulator;
 
 import javax.vecmath.Point2d;
 import java.awt.Color;

--- a/app/depict/src/main/java/org/openscience/cdk/depict/ReactionBounds.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/ReactionBounds.java
@@ -25,7 +25,6 @@ import org.openscience.cdk.renderer.elements.Bounds;
 
 import java.awt.Dimension;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -130,7 +130,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     /**
      * Constructs an empty AtomContainer.
      */
-    public AtomContainer() {
+    protected AtomContainer() {
         this(0, 0, 0, 0);
     }
 
@@ -141,7 +141,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
      *
      * @param container An AtomContainer to copy the atoms and electronContainers from
      */
-    public AtomContainer(IAtomContainer container) {
+    protected AtomContainer(IAtomContainer container) {
         this.atomCount = container.getAtomCount();
         this.bondCount = container.getBondCount();
         this.lonePairCount = container.getLonePairCount();
@@ -185,8 +185,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
      * @param lpCount   Number of lone pairs to be in this container
      * @param seCount   Number of single electrons to be in this container
      */
-    public AtomContainer(int atomCount, int bondCount, int lpCount,
-                         int seCount) {
+    protected AtomContainer(int atomCount, int bondCount, int lpCount, int seCount) {
         this.atomCount = 0;
         this.bondCount = 0;
         this.lonePairCount = 0;

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer2.java
@@ -164,7 +164,8 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
     }
 
     private BaseAtomRef getAtomRefUnsafe(IAtom atom) {
-        if (atom.getContainer() == this &&
+        if (atom == null ||
+            atom.getContainer() == this &&
             atoms[atom.getIndex()] == atom)
             return (BaseAtomRef) atom;
         atom = unbox(atom);

--- a/base/data/src/test/java/org/openscience/cdk/ChangeEventPropagationTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/ChangeEventPropagationTest.java
@@ -46,7 +46,7 @@ class ChangeEventPropagationTest extends CDKTestCase {
         ChemSequence cs = new ChemSequence();
         ChemModel cm = new ChemModel();
         IAtomContainerSet som = new AtomContainerSet();
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom a1 = new Atom("C");
         Atom a2 = new Atom("C");
         Bond b1 = new Bond(a1, a2);

--- a/base/data/src/test/java/org/openscience/cdk/ChemModelTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/ChemModelTest.java
@@ -54,7 +54,7 @@ class ChemModelTest extends AbstractChemModelTest {
         Assertions.assertTrue(chemModel.isEmpty());
 
         IAtom atom = new Atom("N");
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtomContainerSet mset = new AtomContainerSet();
         mol.addAtom(atom);
         mset.addAtomContainer(mol);

--- a/base/data/src/test/java/org/openscience/cdk/RingTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/RingTest.java
@@ -65,7 +65,7 @@ class RingTest extends AbstractRingTest {
 
     @Test
     void testRing_IAtomContainer() {
-        IAtomContainer container = new org.openscience.cdk.AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
         container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
 

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ComponentGroupingTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ComponentGroupingTest.java
@@ -32,6 +32,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 /**
  * @author John May
@@ -76,7 +77,7 @@ class ComponentGroupingTest {
 
     /** @cdk.inchi InChI=1/O2/c1-2 */
     static IAtomContainer oxidanone() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("O"));
         m.addAtom(new Atom("O"));
         m.addBond(0, 1, IBond.Order.DOUBLE);
@@ -85,7 +86,7 @@ class ComponentGroupingTest {
 
     /** @cdk.inchi InChI=1/C2H6O2/c3-1-2-4/h3-4H,1-2H2 */
     static IAtomContainer ethyleneGlycol() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("O"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
@@ -98,7 +99,7 @@ class ComponentGroupingTest {
 
     /** InChI=1/C2H6O.H2O/c1-2-3;/h3H,2H2,1H3;1H2 */
     static IAtomContainer ethylAlcoholHydrate() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("O"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ComponentGroupingTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/ComponentGroupingTest.java
@@ -31,7 +31,6 @@ import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 /**

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/StereoMatchTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/StereoMatchTest.java
@@ -32,7 +32,6 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.stereo.TetrahedralChirality;

--- a/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/StereoMatchTest.java
+++ b/base/isomorphism/src/test/java/org/openscience/cdk/isomorphism/StereoMatchTest.java
@@ -33,6 +33,7 @@ import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.stereo.TetrahedralChirality;
 
@@ -179,7 +180,7 @@ class StereoMatchTest {
     }
 
     static IAtomContainer dimethylpropane() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("C", 0));
         container.addAtom(atom("C", 3));
         container.addAtom(atom("C", 3));
@@ -193,7 +194,7 @@ class StereoMatchTest {
     }
 
     static IAtomContainer but2ene() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("C", 1));
         container.addAtom(atom("C", 1));
         container.addAtom(atom("C", 3));

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
@@ -131,7 +131,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
     /**
      * Constructs an empty AtomContainer.
      */
-    public AtomContainer() {
+    AtomContainer() {
         this(0, 0, 0, 0);
     }
 
@@ -142,7 +142,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
      *
      * @param container An AtomContainer to copy the atoms and electronContainers from
      */
-    public AtomContainer(IAtomContainer container) {
+    AtomContainer(IAtomContainer container) {
         this.atomCount = container.getAtomCount();
         this.bondCount = container.getBondCount();
         this.lonePairCount = container.getLonePairCount();
@@ -182,8 +182,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer, IChemOb
      * @param lpCount   Number of lone pairs to be in this container
      * @param seCount   Number of single electrons to be in this container
      */
-    public AtomContainer(int atomCount, int bondCount, int lpCount,
-                         int seCount) {
+    AtomContainer(int atomCount, int bondCount, int lpCount, int seCount) {
         this.atomCount = 0;
         this.bondCount = 0;
         this.lonePairCount = 0;

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer2.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer2.java
@@ -167,7 +167,8 @@ final class AtomContainer2 extends ChemObject implements IAtomContainer {
     }
 
     private BaseAtomRef getAtomRefUnsafe(IAtom atom) {
-        if (atom.getContainer() == this &&
+        if (atom == null ||
+            atom.getContainer() == this &&
             atoms[atom.getIndex()] == atom)
             return (BaseAtomRef) atom;
         atom = unbox(atom);

--- a/base/test-atomtype/src/test/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcherTest.java
+++ b/base/test-atomtype/src/test/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcherTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.PseudoAtom;

--- a/base/test-atomtype/src/test/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcherTest.java
+++ b/base/test-atomtype/src/test/java/org/openscience/cdk/atomtype/SybylAtomTypeMatcherTest.java
@@ -92,7 +92,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
         String filename = "atomtyping.mol2";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         Mol2Reader reader = new Mol2Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         // just check consistency; other methods do perception testing
         SybylAtomTypeMatcher matcher = SybylAtomTypeMatcher.getInstance(DefaultChemObjectBuilder.getInstance());
@@ -108,7 +108,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
         String filename = "atomtyping.mol2";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         Mol2Reader reader = new Mol2Reader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertNotNull(molecule);
         IAtomContainer reference = molecule.clone();
 
@@ -169,7 +169,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
         String filename = "atomtyping4.mol2";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         Mol2Reader reader = new Mol2Reader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertNotNull(molecule);
         IAtomContainer reference = molecule.clone();
 
@@ -189,7 +189,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
      */
     @Test
     void testNonExistingType() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom();
         mol.addAtom(atom);
         SybylAtomTypeMatcher matcher = SybylAtomTypeMatcher.getInstance(mol.getBuilder());
@@ -203,7 +203,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
         String filename = "atomtyping2.mol2";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         Mol2Reader reader = new Mol2Reader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertNotNull(molecule);
         IAtomContainer reference = molecule.clone();
 
@@ -223,7 +223,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
         String filename = "atomtyping3.mol2";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         Mol2Reader reader = new Mol2Reader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertNotNull(molecule);
         IAtomContainer reference = molecule.clone();
 
@@ -255,7 +255,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testDummy() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new PseudoAtom("R");
         mol.addAtom(atom);
 
@@ -265,7 +265,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testEthene() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -278,7 +278,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testImine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("N");
         mol.addAtom(atom);
@@ -291,7 +291,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testPropyne() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("C");
@@ -307,7 +307,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
     
     @Test
     void testAllene() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("C");
@@ -323,7 +323,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testHalogenatedMethane() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("F"));
         mol.addAtom(new Atom("Cl"));
@@ -340,7 +340,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testMnF4() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("F");
         IAtom atom2 = new Atom("Mn");
         IAtom atom3 = new Atom("F");
@@ -363,7 +363,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testAmide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("N");
@@ -379,7 +379,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testCarboxylicAcid() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("O");
@@ -395,7 +395,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testCarboxylate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("O");
@@ -412,7 +412,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testMethylAmine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -425,7 +425,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testMethylNitro_Charged() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         mol.addAtom(atom);
         IAtom atom2 = new Atom("N");
@@ -446,7 +446,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testAmmonia() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom atom2 = new Atom("N");
         IAtom atom3 = new Atom("H");
@@ -469,7 +469,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testMethanol() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -482,7 +482,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testDMSO() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("S");
         IAtom atom3 = new Atom("C");
@@ -501,7 +501,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testDMSOO() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom1 = new Atom("O");
         IAtom atom2 = new Atom("S");
@@ -523,7 +523,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testCarbokation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom atom2 = new Atom("C");
         atom2.setFormalCharge(+1);
@@ -543,7 +543,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testSilicon() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "Si");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "O");
@@ -618,7 +618,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testThioAmide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("S");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("N");
@@ -634,7 +634,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testSalts() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom = new Atom("Na");
         atom.setFormalCharge(+1);
@@ -642,35 +642,35 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
         String[] expectedTypes = new String[]{"Na"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("K");
         atom.setFormalCharge(+1);
         mol.addAtom(atom);
         expectedTypes = new String[]{"K"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Ca");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Ca"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Mg");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Mg"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Cu");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Cu"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Al");
         atom.setFormalCharge(+3);
         mol.addAtom(atom);
@@ -701,7 +701,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testFerrocene() throws Exception {
-        IAtomContainer ferrocene = new AtomContainer();
+        IAtomContainer ferrocene = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ferrocene.addAtom(new Atom("C"));
         ferrocene.addAtom(new Atom("C"));
         ferrocene.addAtom(new Atom("C"));
@@ -734,7 +734,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testHCN() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -763,7 +763,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testLithiumMethanoxide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("Li");
@@ -779,7 +779,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testTinCompound() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("Sn");
         IAtom atom3 = new Atom("C");
@@ -801,7 +801,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testZincChloride() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Zn"));
         mol.addAtom(new Atom("Cl"));
         mol.addAtom(new Atom("Cl"));
@@ -838,7 +838,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testPhosphate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("P");
         IAtom atom3 = new Atom("O");
@@ -860,7 +860,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void test_Mo_4() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("Mo");
         mol.addAtom(a1);
         IAtom a2 = new Atom("C");
@@ -882,7 +882,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testCrth() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         // this is made up
         IAtom a1 = new Atom("Cr");
         mol.addAtom(a1);
@@ -898,7 +898,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testCroh() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         // this is made up, and may be wrong; info on the web is sparse, and PubChem has no
         // octa-coordinate structure; lone pairs involved?
         IAtom a1 = new Atom("Cr");
@@ -915,7 +915,7 @@ class SybylAtomTypeMatcherTest extends AbstractSybylAtomTypeTest {
 
     @Test
     void testCooh() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         // this is made up, and may be wrong; info on the web is sparse, and PubChem has no
         // octa-coordinate structure; lone pairs involved?
         IAtom a1 = new Atom("Co");

--- a/base/test-core/src/test/java/org/openscience/cdk/CDKConstantsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/CDKConstantsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.test.CDKTestCase;
 
@@ -43,7 +44,7 @@ class CDKConstantsTest extends CDKTestCase {
 
     @Test
     void testSingleOrDoubleFlag() throws Exception {
-        AtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom(Elements.CARBON);
         atom1.setFlag(CDKConstants.SINGLE_OR_DOUBLE, true);

--- a/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTest.java
@@ -80,7 +80,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testFindMatchingAtomType_IAtomContainer_IAtom() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         final IAtomType.Hybridization thisHybridization = IAtomType.Hybridization.SP3;
         atom.setHybridization(thisHybridization);
@@ -92,7 +92,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testFindMatchingAtomType_IAtomContainer() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         final IAtomType.Hybridization thisHybridization = IAtomType.Hybridization.SP3;
         atom.setHybridization(thisHybridization);
@@ -109,7 +109,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testDummy() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new PseudoAtom("R");
         mol.addAtom(atom);
 
@@ -122,7 +122,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testNonExistingType() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom();
         mol.addAtom(atom);
         CDKAtomTypeMatcher matcher = CDKAtomTypeMatcher.getInstance(DefaultChemObjectBuilder.getInstance());
@@ -133,7 +133,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testEthene() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -146,7 +146,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testEthyneKation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         atom2.setFormalCharge(+1);
@@ -160,7 +160,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testEthyneRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -174,7 +174,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testImine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("N");
         mol.addAtom(atom);
@@ -187,7 +187,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testImineRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("N");
         mol.addAtom(atom);
@@ -201,7 +201,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testEtheneRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -215,7 +215,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testGuanineMethyl() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("N");
         IAtom atom3 = new Atom("C");
@@ -261,7 +261,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPropyne() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("C");
@@ -277,7 +277,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testFormaldehyde() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -290,7 +290,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testCarboxylate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("O");
@@ -310,7 +310,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testFormaldehydeRadicalKation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         atom.setFormalCharge(+1);
         IAtom atom2 = new Atom("C");
@@ -329,7 +329,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testPartialMethane() throws Exception {
-        IAtomContainer methane = new AtomContainer();
+        IAtomContainer methane = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom carbon = new Atom("C");
         methane.addAtom(carbon);
 
@@ -351,7 +351,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethanol() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -364,7 +364,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testLithiumMethanoxide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("Li");
@@ -380,7 +380,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHCN() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -393,7 +393,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHNO2() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("O");
         IAtom atom3 = new Atom("O");
@@ -414,7 +414,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testNitromethane() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("O");
         IAtom atom3 = new Atom("O");
@@ -433,7 +433,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethylAmine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -446,7 +446,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethylAmineRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -461,7 +461,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethyleneImine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("C");
         mol.addAtom(atom);
@@ -474,7 +474,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testEthene_withHybridInfo() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         final IAtomType.Hybridization thisHybridization = IAtomType.Hybridization.SP2;
@@ -643,7 +643,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testDMSOCharged() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         atom.setFormalCharge(-1);
         IAtom atom2 = new Atom("S");
@@ -664,7 +664,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testDMSO() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("S");
         IAtom atom3 = new Atom("C");
@@ -683,7 +683,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testDMSOO() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom1 = new Atom("O");
         IAtom atom2 = new Atom("S");
@@ -705,7 +705,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testStrioxide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom1 = new Atom("O");
         IAtom atom2 = new Atom("S");
@@ -724,7 +724,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAmide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("N");
@@ -740,7 +740,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAmineOxide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("N");
         IAtom atom3 = new Atom("C");
@@ -762,7 +762,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testThioAmide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("S");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("N");
@@ -786,7 +786,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAmide2() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("N");
@@ -805,7 +805,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAmide3() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("N");
@@ -827,7 +827,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testLactam() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("N");
@@ -853,7 +853,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testThioAcetone() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("S");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("C");
@@ -872,7 +872,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testSulphuricAcid() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("S");
         IAtom atom3 = new Atom("O");
@@ -924,7 +924,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testSulphuricAcid_Charged() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("S");
         IAtom atom3 = new Atom("O");
@@ -949,7 +949,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testSF6() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("F");
         IAtom atom2 = new Atom("S");
         IAtom atom3 = new Atom("F");
@@ -977,7 +977,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMnF4() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("F");
         IAtom atom2 = new Atom("Mn");
         IAtom atom3 = new Atom("F");
@@ -1000,7 +1000,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testCrF6() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("F");
         IAtom atom2 = new Atom("Cr");
         IAtom atom3 = new Atom("F");
@@ -1028,7 +1028,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testXeF4() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("F");
         IAtom atom2 = new Atom("Xe");
         IAtom atom3 = new Atom("F");
@@ -1050,7 +1050,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPhosphate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("P");
         IAtom atom3 = new Atom("O");
@@ -1075,7 +1075,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testHydroxyTriMethylPhophanium() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("P");
         atom2.setFormalCharge(+1);
@@ -1098,7 +1098,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPhosphateCharged() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         atom.setFormalCharge(-1);
         IAtom atom2 = new Atom("P");
@@ -1122,7 +1122,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPhosphorusTriradical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("P");
         mol.addAtom(atom);
         mol.addSingleElectron(0);
@@ -1135,7 +1135,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAmmonia() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom atom2 = new Atom("N");
         IAtom atom3 = new Atom("H");
@@ -1158,7 +1158,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testNitrogenRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom atom2 = new Atom("N");
         IAtom atom3 = new Atom("H");
@@ -1175,7 +1175,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testTMS() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("Si");
         IAtom atom3 = new Atom("C");
@@ -1197,7 +1197,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testTinCompound() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("Sn");
         IAtom atom3 = new Atom("C");
@@ -1219,7 +1219,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testArsenicPlus() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("As");
         atom2.setFormalCharge(+1);
@@ -1242,7 +1242,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPhosphine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom atom2 = new Atom("P");
         IAtom atom3 = new Atom("H");
@@ -1264,7 +1264,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testPhosphorousAcid() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IChemObjectBuilder builder = mol.getBuilder();
         IAtom a1 = builder.newInstance(IAtom.class, "P");
         a1.setFormalCharge(1);
@@ -1296,7 +1296,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testDiethylPhosphine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("P");
         IAtom atom3 = new Atom("C");
@@ -1315,7 +1315,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testPhosphorCompound() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("P");
         IAtom atom3 = new Atom("C");
@@ -1331,7 +1331,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testCarbokation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom atom2 = new Atom("C");
         atom2.setFormalCharge(+1);
@@ -1351,7 +1351,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testCarbokation_implicitHydrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom2 = new Atom("C");
         atom2.setFormalCharge(+1);
         mol.addAtom(atom2);
@@ -1362,7 +1362,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHydrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         mol.addAtom(atom);
 
@@ -1372,7 +1372,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHydroxyl() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom oxygen = new Atom("O");
         oxygen.setFormalCharge(-1);
@@ -1386,7 +1386,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHydroxyl2() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom oxygen = new Atom("O");
         oxygen.setFormalCharge(-1);
         mol.addAtom(oxygen);
@@ -1397,7 +1397,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHydroxonium() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom atom1 = new Atom("H");
         IAtom atom2 = new Atom("H");
@@ -1417,7 +1417,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPositiveCarbonyl() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         IAtom atom1 = new Atom("H");
         IAtom atom2 = new Atom("H");
@@ -1440,7 +1440,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testProton() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         atom.setFormalCharge(1);
         mol.addAtom(atom);
@@ -1451,7 +1451,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHalides() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom = new Atom("Cl");
         atom.setFormalCharge(-1);
@@ -1459,21 +1459,21 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
         String[] expectedTypes = {"Cl.minus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("F");
         atom.setFormalCharge(-1);
         mol.addAtom(atom);
         expectedTypes = new String[]{"F.minus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Br");
         atom.setFormalCharge(-1);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Br.minus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("I");
         atom.setFormalCharge(-1);
         mol.addAtom(atom);
@@ -1483,7 +1483,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHalogens() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom = new Atom("Cl");
         IAtom hydrogen = new Atom("H");
@@ -1493,7 +1493,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
         String[] expectedTypes = new String[]{"Cl", "H"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("I");
         mol.addAtom(atom);
         mol.addAtom(hydrogen);
@@ -1501,7 +1501,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
         expectedTypes = new String[]{"I", "H"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Br");
         mol.addAtom(atom);
         mol.addAtom(hydrogen);
@@ -1509,7 +1509,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
         expectedTypes = new String[]{"Br", "H"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("F");
         mol.addAtom(atom);
         mol.addAtom(hydrogen);
@@ -1520,7 +1520,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testFluorRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("F");
         mol.addAtom(atom);
         mol.addSingleElectron(0);
@@ -1531,7 +1531,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testChlorRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("Cl");
         mol.addAtom(atom);
         mol.addSingleElectron(0);
@@ -1542,7 +1542,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testBromRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("Br");
         mol.addAtom(atom);
         mol.addSingleElectron(0);
@@ -1553,7 +1553,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testIodRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("I");
         mol.addAtom(atom);
         mol.addSingleElectron(0);
@@ -1564,7 +1564,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testIMinusF2() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("F");
         IAtom atom2 = new Atom("I");
         IAtom atom3 = new Atom("F");
@@ -1581,7 +1581,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHydride() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         atom.setFormalCharge(-1);
         mol.addAtom(atom);
@@ -1592,7 +1592,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHydrogenRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("H");
         mol.addAtom(atom);
         mol.addSingleElectron(0);
@@ -1603,7 +1603,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAzide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("N");
         atom2.setFormalCharge(-1);
@@ -1624,7 +1624,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAllene() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("C");
@@ -1640,7 +1640,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAzide2() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("N");
         IAtom atom3 = new Atom("N");
@@ -1661,7 +1661,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMercuryComplex() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom = new Atom("Hg");
         atom.setFormalCharge(-1);
@@ -1766,7 +1766,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPoloniumComplex() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom = new Atom("O");
         IAtom atom1 = new Atom("Po");
@@ -1785,7 +1785,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testStronglyBoundKations() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("O"));
         mol.getAtom(1).setFormalCharge(+1);
@@ -1800,20 +1800,20 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMetallics() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom = new Atom("W");
         mol.addAtom(atom);
         String[] expectedTypes = new String[]{"W.metallic"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("K");
         mol.addAtom(atom);
         expectedTypes = new String[]{"K.metallic"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Co");
         mol.addAtom(atom);
         expectedTypes = new String[]{"Co.metallic"};
@@ -1822,7 +1822,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testSalts() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom = new Atom("Na");
         atom.setFormalCharge(+1);
@@ -1830,63 +1830,63 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
         String[] expectedTypes = new String[]{"Na.plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("K");
         atom.setFormalCharge(+1);
         mol.addAtom(atom);
         expectedTypes = new String[]{"K.plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Ca");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Ca.2plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Mg");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Mg.2plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Ni");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Ni.2plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Pt");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Pt.2plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Co");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Co.2plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Co");
         atom.setFormalCharge(+3);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Co.3plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Cu");
         atom.setFormalCharge(+2);
         mol.addAtom(atom);
         expectedTypes = new String[]{"Cu.2plus"};
         assertAtomTypes(testedAtomTypes, expectedTypes, mol);
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom = new Atom("Al");
         atom.setFormalCharge(+3);
         mol.addAtom(atom);
@@ -1937,7 +1937,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testCyclopentadienyl() throws Exception {
-        IAtomContainer cp = new AtomContainer();
+        IAtomContainer cp = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         cp.addAtom(new Atom("C"));
         cp.getAtom(0).setHybridization(IAtomType.Hybridization.SP2);
         cp.getAtom(0).setImplicitHydrogenCount(1);
@@ -1967,7 +1967,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testFerrocene() throws Exception {
-        IAtomContainer ferrocene = new AtomContainer();
+        IAtomContainer ferrocene = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ferrocene.addAtom(new Atom("C"));
         ferrocene.addAtom(new Atom("C"));
         ferrocene.addAtom(new Atom("C"));
@@ -2000,7 +2000,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testFuran() throws Exception {
-        IAtomContainer furan = new AtomContainer();
+        IAtomContainer furan = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         furan.addAtom(new Atom("C"));
         furan.addAtom(new Atom("C"));
         furan.addAtom(new Atom("C"));
@@ -2017,7 +2017,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPerchlorate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("Cl");
         IAtom atom3 = new Atom("O");
@@ -2042,7 +2042,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testGallate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         atom.setFormalCharge(-1);
         IAtom atom2 = new Atom("Ga");
@@ -2068,7 +2068,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testGallateCovalent() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("Ga");
         IAtom atom3 = new Atom("O");
@@ -2087,7 +2087,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPerchlorate_ChargedBonds() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("Cl");
         IAtom atom3 = new Atom("O");
@@ -2113,7 +2113,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testChlorate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("Cl");
         IAtom atom3 = new Atom("O");
@@ -2132,7 +2132,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testOxide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         atom.setFormalCharge(-2);
         mol.addAtom(atom);
@@ -2172,7 +2172,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     void testBenzene() throws Exception {
         String[] expectedTypes = {"C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.add(new Ring(6, "C"));
         for (IBond bond : molecule.bonds()) {
             bond.setFlag(CDKConstants.ISAROMATIC, true);
@@ -2186,7 +2186,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     void testBenzene_SingleOrDouble() throws Exception {
         String[] expectedTypes = {"C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.add(new Ring(6, "C"));
         for (IBond bond : molecule.bonds()) {
             bond.setOrder(IBond.Order.UNSET);
@@ -2319,7 +2319,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     void testPyridineDirect() throws Exception {
         String[] expectedTypes = {"N.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("N"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -2341,7 +2341,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     void testPyridineWithSP2() throws Exception {
         String[] expectedTypes = {"N.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2", "C.sp2"};
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "N");
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "C");
         IAtom a3 = mol.getBuilder().newInstance(IAtom.class, "C");
@@ -2393,7 +2393,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPyridineOxide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -2416,7 +2416,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPyridineOxide_SP2() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.getAtom(0).setHybridization(Hybridization.SP2);
         mol.addAtom(new Atom("N")); // 1
@@ -2491,7 +2491,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     void testNiCovalentlyBound() throws Exception {
         String[] expectedTypes = {"C.sp3", "C.sp3", "S.3", "Ni", "S.3"};
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -2507,7 +2507,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHaloniumsF() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom carbon1 = new Atom("C");
         IAtom carbon2 = new Atom("C");
@@ -2526,7 +2526,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHaloniumsCl() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom carbon1 = new Atom("C");
         IAtom carbon2 = new Atom("C");
@@ -2545,7 +2545,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHaloniumsBr() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom carbon1 = new Atom("C");
         IAtom carbon2 = new Atom("C");
@@ -2564,7 +2564,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testHaloniumsI() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom carbon1 = new Atom("C");
         IAtom carbon2 = new Atom("C");
@@ -2583,7 +2583,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testRearrangementCarbokation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom carbon1 = new Atom("C");
         carbon1.setFormalCharge(+1);
@@ -2602,7 +2602,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testChargedSpecies() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         atom1.setFormalCharge(-1);
@@ -2620,7 +2620,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     //    [O+]=C-[C-]
     @Test
     void testChargedSpecies2() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("O");
         atom1.setFormalCharge(1);
@@ -2641,7 +2641,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     //    [C-]=C-C
     @Test
     void testChargedSpecies3() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         atom1.setFormalCharge(-1);
@@ -2661,7 +2661,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     // [C-]#[N+]C
     @Test
     void testIsonitrile() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("N");
@@ -2682,7 +2682,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testNobleGases() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         mol.addAtom(new Atom("He"));
         mol.addAtom(new Atom("Ne"));
@@ -2697,7 +2697,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testZincChloride() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Zn"));
         mol.addAtom(new Atom("Cl"));
         mol.addAtom(new Atom("Cl"));
@@ -2710,7 +2710,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testZinc() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Zn"));
         mol.getAtom(0).setFormalCharge(+2);
 
@@ -2720,7 +2720,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testSilicon() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "Si");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "O");
@@ -2795,7 +2795,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testScandium() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Sc"));
         mol.getAtom(0).setFormalCharge(-3);
         mol.addAtom(new Atom("O"));
@@ -2830,7 +2830,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testVanadium() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("V"));
         mol.getAtom(0).setFormalCharge(-3);
         mol.addAtom(new Atom("C"));
@@ -2865,7 +2865,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testTitanium() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Ti"));
         mol.getAtom(0).setFormalCharge(-3);
         mol.addAtom(new Atom("C"));
@@ -2900,7 +2900,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testBoronTetraFluoride() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("B"));
         mol.getAtom(0).setFormalCharge(-1);
         mol.addAtom(new Atom("F"));
@@ -2918,7 +2918,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testBerylliumTetraFluoride() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Be"));
         mol.getAtom(0).setFormalCharge(-2);
         mol.addAtom(new Atom("F"));
@@ -2936,7 +2936,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testArsine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("As"));
         mol.addAtom(new Atom("H"));
         mol.addAtom(new Atom("H"));
@@ -2951,7 +2951,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testBoron() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("B"));
         mol.addAtom(new Atom("H"));
         mol.addAtom(new Atom("H"));
@@ -2966,7 +2966,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testCarbonMonoxide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setFormalCharge(-1);
         mol.addAtom(new Atom("O"));
@@ -2979,7 +2979,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testTitaniumFourCoordinate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Ti"));
         mol.addAtom(new Atom("Cl"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -2999,7 +2999,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void bug1872969() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("S"));
         mol.addAtom(new Atom("O"));
@@ -3043,7 +3043,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAssumeExplicitHydrogens() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKAtomTypeMatcher atm = CDKAtomTypeMatcher.getInstance(mol.getBuilder(),
                 CDKAtomTypeMatcher.REQUIRE_EXPLICIT_HYDROGENS);
 
@@ -3068,7 +3068,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testCarbonRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("C");
@@ -3091,7 +3091,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testCarbonDiradical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         mol.addAtom(atom);
         mol.addSingleElectron(0);
@@ -3104,7 +3104,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testEthoxyEthaneRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("C");
@@ -3122,7 +3122,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethylFluorRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("F");
         mol.addAtom(atom);
@@ -3137,7 +3137,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethylChloroRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("Cl");
         mol.addAtom(atom);
@@ -3152,7 +3152,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethylBromoRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("Br");
         mol.addAtom(atom);
@@ -3167,7 +3167,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethylIodoRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("I");
         mol.addAtom(atom);
@@ -3182,7 +3182,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethyleneFluorKation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("F");
         mol.addAtom(atom);
@@ -3196,7 +3196,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethyleneChlorKation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("Cl");
         mol.addAtom(atom);
@@ -3210,7 +3210,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethyleneBromKation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("Br");
         mol.addAtom(atom);
@@ -3224,7 +3224,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethyleneIodKation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("I");
         mol.addAtom(atom);
@@ -3238,7 +3238,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethanolRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         IAtom atom2 = new Atom("O");
         mol.addAtom(atom);
@@ -3252,7 +3252,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testMethylMethylimineRadical() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         IAtom atom2 = new Atom("C");
         IAtom atom3 = new Atom("C");
@@ -3270,7 +3270,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testChargeSeparatedFluoroEthane() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("F");
         IAtom atom2 = new Atom("C");
         atom2.setFormalCharge(+1);
@@ -3291,7 +3291,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testSulphurCompound() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "S");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "N");
@@ -3313,7 +3313,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testAluminumChloride() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "Cl");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "Cl");
@@ -3338,7 +3338,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void cid1145() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "O");
         mol.addAtom(a1);
         a1.setFormalCharge(-1);
@@ -3403,7 +3403,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testChiPathFail() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "C");
@@ -3491,7 +3491,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testDimethylThiirane() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
@@ -3512,7 +3512,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testSulphonylLookalike() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
@@ -3527,7 +3527,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testNOxide() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "C");
         IAtom a3 = mol.getBuilder().newInstance(IAtom.class, "N");
@@ -3551,7 +3551,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testGermaniumFourCoordinate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Ge"));
         mol.addAtom(new Atom("Cl"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -3568,7 +3568,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPlatinumFourCoordinate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Pt"));
         mol.addAtom(new Atom("Cl"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -3585,7 +3585,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
 
     @Test
     void testPlatinumSixCoordinate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Pt"));
         mol.addAtom(new Atom("Cl"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -3609,7 +3609,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testWeirdNitrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("N"));
         mol.addAtom(new Atom("C"));
@@ -3628,7 +3628,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testAnotherNitrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setHybridization(Hybridization.SP2);
         mol.addAtom(new Atom("C"));
@@ -3669,7 +3669,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testFormalChargeRepresentation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         final IAtomType.Hybridization thisHybridization = IAtomType.Hybridization.SP3;
         atom.setHybridization(thisHybridization);
@@ -3695,7 +3695,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
     @Test
     void testP() throws Exception {
         IAtom atomP = new Atom("P");
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atomP);
         String[] expectedTypes = {"P.ine"};
 
@@ -4889,7 +4889,7 @@ class CDKAtomTypeMatcherTest extends AbstractCDKAtomTypeTest {
      */
     @Test
     void testAzoCompound() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "N");
         a1.setFormalCharge(1);
         mol.addAtom(a1);

--- a/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTestFileReposTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/atomtype/CDKAtomTypeMatcherTestFileReposTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.DefaultChemObjectBuilder;
@@ -153,7 +154,7 @@ class CDKAtomTypeMatcherTestFileReposTest extends CDKTestCase {
         reader.setReader(ins);
         IAtomContainer mol = null;
         if (reader.accepts(AtomContainer.class)) {
-            mol = reader.read(new AtomContainer());
+            mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         } else if (reader.accepts(ChemFile.class)) {
             IChemFile cf = reader.read(new ChemFile());
             mol = DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class);

--- a/base/test-core/src/test/java/org/openscience/cdk/config/IsotopesTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/config/IsotopesTest.java
@@ -22,7 +22,6 @@ package org.openscience.cdk.config;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.test.CDKTestCase;

--- a/base/test-core/src/test/java/org/openscience/cdk/config/IsotopesTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/config/IsotopesTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.Element;
 import org.openscience.cdk.interfaces.IAtom;
@@ -139,7 +141,7 @@ class IsotopesTest extends CDKTestCase {
 
     @Test
     void testConfigureAtoms_IAtomContainer() throws Exception {
-        AtomContainer container = new org.openscience.cdk.AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("C"));
         container.addAtom(new Atom("H"));
         container.addAtom(new Atom("N"));

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/AllPairsShortestPathsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/AllPairsShortestPathsTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/AllPairsShortestPathsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/AllPairsShortestPathsTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -51,7 +52,7 @@ class AllPairsShortestPathsTest {
     @Test
     void testConstruction_Empty() {
 
-        AllPairsShortestPaths asp = new AllPairsShortestPaths(new AtomContainer());
+        AllPairsShortestPaths asp = new AllPairsShortestPaths(SilentChemObjectBuilder.getInstance().newAtomContainer());
 
         // all vs all fro -10 -> 10
         for (int i = -10; i < 10; i++) {

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/CyclesTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/CyclesTest.java
@@ -2,7 +2,6 @@ package org.openscience.cdk.graph;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.interfaces.IAtom;

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/CyclesTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/CyclesTest.java
@@ -3,6 +3,7 @@ package org.openscience.cdk.graph;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -260,7 +261,7 @@ class CyclesTest {
         String path = "boronBuckyBall.mol";
         MDLV2000Reader mdl = new MDLV2000Reader(getClass().getResourceAsStream(path));
         try {
-            return mdl.read(new AtomContainer());
+            return mdl.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         } finally {
             mdl.close();
         }

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/GraphUtilTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/GraphUtilTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -158,7 +159,7 @@ class GraphUtilTest {
     @Test
     void testToAdjList_resize() throws Exception {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom a = new Atom("C");
         container.addAtom(a);
@@ -201,7 +202,7 @@ class GraphUtilTest {
 
     @Test
     void testToAdjList_Empty() throws Exception {
-        int[][] adjacent = GraphUtil.toAdjList(new AtomContainer());
+        int[][] adjacent = GraphUtil.toAdjList(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         assertThat(adjacent.length, is(0));
     }
 
@@ -219,7 +220,7 @@ class GraphUtilTest {
      */
     private static IAtomContainer simple() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom a = new Atom("C");
         IAtom b = new Atom("C");

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/GraphUtilTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/GraphUtilTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/PathToolsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/PathToolsTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IElement;

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/PathToolsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/PathToolsTest.java
@@ -70,7 +70,7 @@ class PathToolsTest extends CDKTestCase {
 
     @Test
     void testResetFlags_IAtomContainer() throws Exception {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom1 = new Atom("C");
         atom1.setFlag(CDKConstants.VISITED, true);
         IAtom atom2 = new Atom("C");
@@ -122,7 +122,7 @@ class PathToolsTest extends CDKTestCase {
         String filename = "shortest_path_test.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer testMolecule = new AtomContainer();
+        IAtomContainer testMolecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reader.read(testMolecule);
 
         List<IAtom> path = PathTools.getShortestPath(testMolecule, testMolecule.getAtom(0), testMolecule.getAtom(9));

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/ShortestPathsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/ShortestPathsTest.java
@@ -30,7 +30,6 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.templates.TestMoleculeFactory;

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/ShortestPathsTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/ShortestPathsTest.java
@@ -50,7 +50,7 @@ class ShortestPathsTest {
     @Test
     void testConstructor_Container_Empty() {
 
-        ShortestPaths sp = new ShortestPaths(new AtomContainer(), new Atom());
+        ShortestPaths sp = new ShortestPaths(SilentChemObjectBuilder.getInstance().newAtomContainer(), new Atom());
 
         Assertions.assertArrayEquals(new int[0], sp.pathTo(1));
         Assertions.assertArrayEquals(new int[0][0], sp.pathsTo(1));
@@ -1249,7 +1249,7 @@ class ShortestPathsTest {
      */
     private static IAtomContainer simple() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom a = new Atom("C");
         IAtom b = new Atom("C");
@@ -1329,7 +1329,7 @@ class ShortestPathsTest {
      * @cdk.inchi InChI=1S/C81H132/c1-3-7-67(8-4-1)11-15-69(16-12-67)19-23-71(24-20-69)27-31-73(32-28-71)35-39-75(40-36-73)43-47-77(48-44-75)51-55-79(56-52-77)59-63-81(64-60-79)65-61-80(62-66-81)57-53-78(54-58-80)49-45-76(46-50-78)41-37-74(38-42-76)33-29-72(30-34-74)25-21-70(22-26-72)17-13-68(14-18-70)9-5-2-6-10-68/h1-66H2
      */
     IAtomContainer pentadecaspiro() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         mol.addAtom(a1);
         IAtom a2 = new Atom("C");
@@ -1694,7 +1694,7 @@ class ShortestPathsTest {
      */
     private static IAtomContainer spiroundecane() {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         mol.addAtom(a1);
         IAtom a2 = new Atom("C");

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/SpanningTreeTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/SpanningTreeTest.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-core/src/test/java/org/openscience/cdk/graph/SpanningTreeTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/graph/SpanningTreeTest.java
@@ -76,7 +76,7 @@ class SpanningTreeTest extends CDKTestCase {
 
     @Test
     void testSpanningTree_IAtomContainer() {
-        SpanningTree sTree = new SpanningTree(new AtomContainer());
+        SpanningTree sTree = new SpanningTree(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertNotNull(sTree);
     }
 

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/DoubleBondStereochemistryTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/DoubleBondStereochemistryTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/DoubleBondStereochemistryTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/DoubleBondStereochemistryTest.java
@@ -58,7 +58,7 @@ class DoubleBondStereochemistryTest extends CDKTestCase {
      */
     @BeforeAll
     static void setup() throws Exception {
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molecule.addAtom(new Atom("C"));
         molecule.addAtom(new Atom("C"));

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/ExtendedTetrahedralTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/ExtendedTetrahedralTest.java
@@ -30,7 +30,6 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/ExtendedTetrahedralTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/ExtendedTetrahedralTest.java
@@ -31,6 +31,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -75,7 +76,7 @@ final class ExtendedTetrahedralTest {
     void nonCumulatedAtomThrowsException() {
         Assertions.assertThrows(IllegalArgumentException.class,
                                 () -> {
-                                    IAtomContainer ac = new AtomContainer();
+                                    IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
                                     ac.addAtom(new Atom("C"));
                                     ac.addAtom(new Atom("C"));
                                     ac.addAtom(new Atom("C"));
@@ -87,7 +88,7 @@ final class ExtendedTetrahedralTest {
 
     @Test
     void terminalAtomsAreFoundUnordered() {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
@@ -101,7 +102,7 @@ final class ExtendedTetrahedralTest {
 
     @Test
     void terminalAtomsAreFoundOrdered() {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/TetrahedralChiralityTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/TetrahedralChiralityTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/base/test-core/src/test/java/org/openscience/cdk/stereo/TetrahedralChiralityTest.java
+++ b/base/test-core/src/test/java/org/openscience/cdk/stereo/TetrahedralChiralityTest.java
@@ -54,7 +54,7 @@ class TetrahedralChiralityTest extends CDKTestCase {
 
     @BeforeAll
     static void setup() throws Exception {
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("Cl"));
         molecule.addAtom(new Atom("C"));
         molecule.addAtom(new Atom("Br"));

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/KekulizationTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/KekulizationTest.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -49,7 +50,7 @@ class KekulizationTest {
 
     @Test
     void benzene() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -68,7 +69,7 @@ class KekulizationTest {
     // when a double bond is already set, it is not moved
     @Test
     void benzeneWithExistingDoubleBond() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -86,7 +87,7 @@ class KekulizationTest {
 
     @Test
     void pyrrole() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("N", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -102,7 +103,7 @@ class KekulizationTest {
 
     @Test
     void pyrroleWithExplicitHydrogen() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("N", 0, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -122,7 +123,7 @@ class KekulizationTest {
     @Test
     void pyrroleWithMissingHydrogen() throws Exception {
         Assertions.assertThrows(CDKException.class, () -> {
-            IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+            IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             m.addAtom(atom("N", 0, true));
             m.addAtom(atom("C", 1, true));
             m.addAtom(atom("C", 1, true));
@@ -140,7 +141,7 @@ class KekulizationTest {
     /** @cdk.inchi InChI=1S/C10H8/c1-2-5-9-7-4-8-10(9)6-3-1/h1-8H */
     @Test
     void azulene() throws Exception {
-        IAtomContainer m = new AtomContainer(10, 11, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 0, true));
@@ -168,7 +169,7 @@ class KekulizationTest {
     /** @cdk.inchi InChI=1S/C5H5NO/c7-6-4-2-1-3-5-6/h1-5H */
     @Test
     void pyridineOxide() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 7, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 0, false));
         m.addAtom(atom("N", 0, true));
         m.addAtom(atom("C", 1, true));
@@ -191,7 +192,7 @@ class KekulizationTest {
     /** @cdk.inchi InChI=1S/C5H5NO/c7-6-4-2-1-3-5-6/h1-5H */
     @Test
     void pyridineOxideNonChargeSeparated() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 7, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 0, false));
         m.addAtom(atom("N", 0, true));
         m.addAtom(atom("C", 1, true));
@@ -211,7 +212,7 @@ class KekulizationTest {
 
     @Test
     void furane() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 0, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -232,7 +233,7 @@ class KekulizationTest {
      */
     @Test
     void tellurophene() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("Te", 0, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -251,7 +252,7 @@ class KekulizationTest {
      */
     @Test
     void carbonAnion() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -271,7 +272,7 @@ class KekulizationTest {
      */
     @Test
     void tropylium() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -297,7 +298,7 @@ class KekulizationTest {
      */
     @Test
     void seleniumCation() throws Exception {
-        IAtomContainer m = new AtomContainer(6, 6, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -321,7 +322,7 @@ class KekulizationTest {
      */
     @Test
     void sixValentSulphur() throws Exception {
-        IAtomContainer m = new AtomContainer(18, 20, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, false));
         m.addAtom(atom("S", 0, true));
         m.addAtom(atom("O", 0, false));
@@ -369,7 +370,7 @@ class KekulizationTest {
      */
     @Test
     void biphenyl() throws Exception {
-        IAtomContainer m = new AtomContainer(12, 13, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -404,7 +405,7 @@ class KekulizationTest {
      */
     @Test
     void quinone() throws Exception {
-        IAtomContainer m = new AtomContainer(8, 8, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 0, true));
         m.addAtom(atom("C", 0, true));
         m.addAtom(atom("C", 1, true));
@@ -429,7 +430,7 @@ class KekulizationTest {
      */
     @Test
     void fluorene() throws Exception {
-        IAtomContainer m = new AtomContainer(13, 15, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 2, false));
         m.addAtom(atom("C", 0, true));
         m.addAtom(atom("C", 1, true));
@@ -465,7 +466,7 @@ class KekulizationTest {
     /** @cdk.inchi InChI=1S/C5H5B/c1-2-4-6-5-3-1/h1-5H */
     @Test
     void borinine() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("B", 0, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));
@@ -484,7 +485,7 @@ class KekulizationTest {
     // e.g. CHEMBL422679
     @Test
     void sulfurCation() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 5, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("S", 1, true));
         m.addAtom(atom("C", 1, true));
         m.addAtom(atom("C", 1, true));

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/KekulizationTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/KekulizationTest.java
@@ -27,7 +27,6 @@ package org.openscience.cdk.aromaticity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-standard/src/test/java/org/openscience/cdk/atomtype/EStateAtomTypeMatcherTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/atomtype/EStateAtomTypeMatcherTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.test.CDKTestCase;

--- a/base/test-standard/src/test/java/org/openscience/cdk/atomtype/EStateAtomTypeMatcherTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/atomtype/EStateAtomTypeMatcherTest.java
@@ -76,7 +76,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
 
     @Test
     void testFindMatchingAtomType_IAtomContainer() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         final IAtomType.Hybridization thisHybridization = IAtomType.Hybridization.SP3;
         atom.setHybridization(thisHybridization);
@@ -93,7 +93,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
     @Test
     void testSP3Atoms() {
         //Testing with CC(C)(C)CC
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "C");
@@ -187,7 +187,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
     @Test
     void testSP2Atoms() {
         //Test with C=CC=N
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "C");
@@ -234,7 +234,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
     @Test
     void testSPAtoms() {
         //Testing with  C#CCC#N
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "C");
@@ -277,7 +277,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
     @Test
     void testAromaticAtoms() {
         //Testing with C1=CN=CC=C1C
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setFlag(CDKConstants.ISAROMATIC, true);
         mol.addAtom(a1);
@@ -370,7 +370,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
     @Test
     void testNaphthalene() {
         //Testing with C1=CC2C=CC=CC=2C=C1
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setFlag(CDKConstants.ISAROMATIC, true);
         mol.addAtom(a1);
@@ -472,7 +472,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
     @Test
     void testChargedAtoms() {
         //Testing with C[N+]
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         mol.addAtom(a1);
         IAtom a2 = mol.getBuilder().newInstance(IAtom.class, "N");
@@ -513,7 +513,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
     @Test
     void testNaCl() {
         //Testing with [Na+].[Cl-]
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "Na");
         a1.setFormalCharge(+1);
         mol.addAtom(a1);
@@ -526,7 +526,7 @@ class EStateAtomTypeMatcherTest extends CDKTestCase {
         Assertions.assertTrue(testAtom("SClm", a2));
 
         //Testing with different presentation - [Na]Cl
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         a1 = mol.getBuilder().newInstance(IAtom.class, "Na");
         mol.addAtom(a1);
         a2 = mol.getBuilder().newInstance(IAtom.class, "Cl");

--- a/base/test-standard/src/test/java/org/openscience/cdk/geometry/GeometryUtilTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/geometry/GeometryUtilTest.java
@@ -27,7 +27,6 @@ import org.hamcrest.number.IsCloseTo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-standard/src/test/java/org/openscience/cdk/geometry/GeometryUtilTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/geometry/GeometryUtilTest.java
@@ -79,7 +79,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 1));
         Atom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertTrue(GeometryUtil.has2DCoordinates(container));
@@ -88,7 +88,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint3d(new Point3d(1, 1, 1));
         atom2 = new Atom("C");
         atom2.setPoint3d(new Point3d(1, 0, 5));
-        container = new AtomContainer();
+        container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertFalse(GeometryUtil.has2DCoordinates(container));
@@ -96,14 +96,14 @@ class GeometryUtilTest extends CDKTestCase {
 
     @Test
     void testHas2DCoordinates_EmptyAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(GeometryUtil.has2DCoordinates(container));
         Assertions.assertFalse(GeometryUtil.has2DCoordinates((IAtomContainer) null));
     }
 
     @Test
     void testHas2DCoordinates_Partial() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         Atom atom2 = new Atom("C");
         atom1.setPoint2d(new Point2d(1, 1));
@@ -122,13 +122,13 @@ class GeometryUtilTest extends CDKTestCase {
         InputStream ins = this.getClass().getResourceAsStream(filenameMol);
         IAtomContainer molOne;
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molOne = reader.read(new AtomContainer());
+        molOne = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertTrue(GeometryUtil.has2DCoordinates(molOne));
     }
 
     @Test
     void get2DCoordinateCoverage_EmptyAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertEquals(GeometryUtil.CoordinateCoverage.NONE, GeometryUtil.get2DCoordinateCoverage(container));
         Assertions.assertEquals(GeometryUtil.CoordinateCoverage.NONE, GeometryUtil.get2DCoordinateCoverage(null));
     }
@@ -136,7 +136,7 @@ class GeometryUtilTest extends CDKTestCase {
     @Test
     void get2DCoordinateCoverage_Partial() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -156,7 +156,7 @@ class GeometryUtilTest extends CDKTestCase {
     @Test
     void get2DCoordinateCoverage_Full() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -177,7 +177,7 @@ class GeometryUtilTest extends CDKTestCase {
     @Test
     void get2DCoordinateCoverage_None_3D() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -197,7 +197,7 @@ class GeometryUtilTest extends CDKTestCase {
 
     @Test
     void testTranslateAllPositive_IAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom(Elements.CARBON);
         atom.setPoint2d(new Point2d(-3, -2));
         container.addAtom(atom);
@@ -224,11 +224,11 @@ class GeometryUtilTest extends CDKTestCase {
         IAtomContainer molTwo;
         Map<Integer, Integer> mappedAtoms = new HashMap<>();
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molOne = reader.read(new AtomContainer());
+        molOne = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         ins = this.getClass().getResourceAsStream(filenameMolTwo);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molTwo = reader.read(new AtomContainer());
+        molTwo = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         mappedAtoms = AtomMappingTools.mapAtomsOfAlignedStructures(molOne, molTwo, mappedAtoms);
         //logger.debug("mappedAtoms:"+mappedAtoms.toString());
@@ -352,7 +352,7 @@ class GeometryUtilTest extends CDKTestCase {
 
     @Test
     void testGet2DCenter_arrayIAtom() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         atom1.setPoint2d(new Point2d(1, 1));
         Atom atom2 = new Atom("C");
@@ -428,7 +428,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 1));
         Atom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertEquals(2, GeometryUtil.has2DCoordinatesNew(container));
@@ -437,7 +437,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 1));
         atom2 = new Atom("C");
         atom2.setPoint3d(new Point3d(1, 0, 1));
-        container = new AtomContainer();
+        container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertEquals(1, GeometryUtil.has2DCoordinatesNew(container));
@@ -446,7 +446,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint3d(new Point3d(1, 1, 1));
         atom2 = new Atom("C");
         atom2.setPoint3d(new Point3d(1, 0, 5));
-        container = new AtomContainer();
+        container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertEquals(0, GeometryUtil.has2DCoordinatesNew(container));
@@ -458,7 +458,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 1));
         Atom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertFalse(GeometryUtil.has3DCoordinates(container));
@@ -467,7 +467,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint3d(new Point3d(1, 1, 1));
         atom2 = new Atom("C");
         atom2.setPoint3d(new Point3d(1, 0, 5));
-        container = new AtomContainer();
+        container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertTrue(GeometryUtil.has3DCoordinates(container));
@@ -475,14 +475,14 @@ class GeometryUtilTest extends CDKTestCase {
 
     @Test
     void testHas3DCoordinates_EmptyAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(GeometryUtil.has3DCoordinates(container));
         Assertions.assertFalse(GeometryUtil.has3DCoordinates((IAtomContainer) null));
     }
 
     @Test
     void get3DCoordinateCoverage_EmptyAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertEquals(GeometryUtil.CoordinateCoverage.NONE, GeometryUtil.get3DCoordinateCoverage(container));
         Assertions.assertEquals(GeometryUtil.CoordinateCoverage.NONE, GeometryUtil.get3DCoordinateCoverage(null));
     }
@@ -490,7 +490,7 @@ class GeometryUtilTest extends CDKTestCase {
     @Test
     void get3DCoordinateCoverage_Partial() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -510,7 +510,7 @@ class GeometryUtilTest extends CDKTestCase {
     @Test
     void get3DCoordinateCoverage_Full() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -531,7 +531,7 @@ class GeometryUtilTest extends CDKTestCase {
     @Test
     void get3DCoordinateCoverage_None_2D() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -586,7 +586,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom2.setPoint2d(new Point2d(1, 0));
         IAtom atom3 = new Atom("C");
         atom3.setPoint2d(new Point2d(5, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         acont.addAtom(atom1);
         acont.addAtom(atom2);
         acont.addAtom(atom3);
@@ -601,7 +601,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(5, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         acont.addAtom(atom1);
         acont.addAtom(atom2);
         Assertions.assertEquals(atom2, GeometryUtil.getClosestAtom(1.0, 0.0, acont, atom1));
@@ -617,7 +617,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(-1, -1));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         acont.addAtom(atom1);
         acont.addAtom(atom2);
         Assertions.assertEquals(atom2, GeometryUtil.getClosestAtom(acont, atom1));
@@ -630,7 +630,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 1));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer react1 = new AtomContainer();
+        IAtomContainer react1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         react1.addAtom(atom1);
         react1.addAtom(atom2);
         IAtomContainer react2 = react1.clone();
@@ -661,7 +661,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(0, 1));
-        IAtomContainer react1 = new AtomContainer();
+        IAtomContainer react1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         react1.addAtom(atom1);
         react1.addAtom(atom2);
         IAtomContainer react2 = react1.clone();
@@ -686,7 +686,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IReaction reaction = new Reaction();
         reaction.addReactant(acont);
         acont.addAtom(atom1);
@@ -708,7 +708,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reaction.addReactant(acont);
         acont.addAtom(atom1);
         acont.addAtom(atom2);
@@ -719,7 +719,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(3, 0));
-        acont = new AtomContainer();
+        acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reaction.addProduct(acont);
         acont.addAtom(atom1);
         acont.addAtom(atom2);
@@ -734,7 +734,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 1));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer react1 = new AtomContainer();
+        IAtomContainer react1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IReaction reaction = new Reaction();
         reaction.addReactant(react1);
         react1.addAtom(atom1);
@@ -770,7 +770,7 @@ class GeometryUtilTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer react1 = new AtomContainer();
+        IAtomContainer react1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IReaction reaction = new Reaction();
         reaction.addReactant(react1);
         react1.addAtom(atom1);
@@ -818,7 +818,7 @@ class GeometryUtilTest extends CDKTestCase {
 
     @Test
     void medianBondLength() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atomAt(new Point2d(0, 0)));
         container.addAtom(atomAt(new Point2d(0, 1.5)));
         container.addAtom(atomAt(new Point2d(0, -1.5)));
@@ -832,7 +832,7 @@ class GeometryUtilTest extends CDKTestCase {
     @Test
     void medianBondLengthNoBonds() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(atomAt(new Point2d(0, 0)));
             container.addAtom(atomAt(new Point2d(0, 1.5)));
             container.addAtom(atomAt(new Point2d(0, -1.5)));
@@ -844,7 +844,7 @@ class GeometryUtilTest extends CDKTestCase {
     @Test
     void medianBondLengthNoPoints() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(atomAt(new Point2d(0, 0)));
             container.addAtom(atomAt(new Point2d(0, 1.5)));
             container.addAtom(atomAt(null));
@@ -858,7 +858,7 @@ class GeometryUtilTest extends CDKTestCase {
 
     @Test
     void medianBondLengthOneBond() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atomAt(new Point2d(0, 0)));
         container.addAtom(atomAt(new Point2d(0, 1.5)));
         container.addBond(0, 1, IBond.Order.SINGLE);
@@ -867,7 +867,7 @@ class GeometryUtilTest extends CDKTestCase {
 
     @Test
     void medianBondLengthWithZeroLengthBonds() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atomAt(new Point2d(0, 0)));
         container.addAtom(atomAt(new Point2d(0, 0)));
         container.addAtom(atomAt(new Point2d(0, 0)));
@@ -955,7 +955,7 @@ class GeometryUtilTest extends CDKTestCase {
     }
 
     private int alignmentTestHelper(IAtom zero, IAtom... pos) {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(zero);
         for (IAtom atom : pos) {
             mol.addAtom(atom);

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerAtomPermutorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerAtomPermutorTest.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.graph;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerAtomPermutorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerAtomPermutorTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -37,7 +38,7 @@ class AtomContainerAtomPermutorTest extends CDKTestCase {
 
     @Test
     void constructorTest() {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomContainer.addAtom(new Atom("C"));
         atomContainer.addAtom(new Atom("O"));
         atomContainer.addAtom(new Atom("S"));
@@ -49,7 +50,7 @@ class AtomContainerAtomPermutorTest extends CDKTestCase {
 
     @Test
     void testCountAtomPermutation() {
-        AtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("N"));
         ac.addAtom(new Atom("P"));
@@ -72,7 +73,7 @@ class AtomContainerAtomPermutorTest extends CDKTestCase {
 
     @Test
     void containerFromPermutationTest() {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomContainer.addAtom(new Atom("C"));
         atomContainer.addAtom(new Atom("O"));
         atomContainer.addAtom(new Atom("S"));

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerBondPermutorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerBondPermutorTest.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.graph;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerBondPermutorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerBondPermutorTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -37,7 +38,7 @@ class AtomContainerBondPermutorTest extends CDKTestCase {
 
     @Test
     void constructorTest() {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomContainer.addAtom(new Atom("C"));
         atomContainer.addAtom(new Atom("O"));
         atomContainer.addAtom(new Atom("S"));
@@ -49,7 +50,7 @@ class AtomContainerBondPermutorTest extends CDKTestCase {
 
     @Test
     void containerFromPermutationTest() {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomContainer.addAtom(new Atom("C"));
         atomContainer.addAtom(new Atom("O"));
         atomContainer.addAtom(new Atom("S"));
@@ -64,7 +65,7 @@ class AtomContainerBondPermutorTest extends CDKTestCase {
 
     @Test
     void testBondPermutation() {
-        AtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("N"));
         ac.addAtom(new Atom("P"));

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerPermutorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerPermutorTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IBond;
 
@@ -32,8 +34,8 @@ class AtomContainerPermutorTest extends CDKTestCase {
 
     @Test
     void testAtomPermutation() {
-        AtomContainer ac = new org.openscience.cdk.AtomContainer();
-        AtomContainer result;
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer result;
         String atoms;
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("N"));
@@ -51,7 +53,7 @@ class AtomContainerPermutorTest extends CDKTestCase {
         while (acap.hasNext()) {
             counter++;
             atoms = "";
-            result = (AtomContainer) acap.next();
+            result = acap.next();
             for (int f = 0; f < result.getAtomCount(); f++) {
                 atoms += result.getAtom(f).getSymbol();
             }
@@ -61,8 +63,8 @@ class AtomContainerPermutorTest extends CDKTestCase {
 
     @Test
     void testBondPermutation() {
-        AtomContainer ac = new org.openscience.cdk.AtomContainer();
-        AtomContainer result;
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer result;
         String bonds;
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("N"));
@@ -80,7 +82,7 @@ class AtomContainerPermutorTest extends CDKTestCase {
         while (acap.hasNext()) {
             counter++;
             bonds = "";
-            result = (AtomContainer) acap.next();
+            result = acap.next();
             for (int f = 0; f < result.getBondCount(); f++) {
                 bonds += result.getBond(f).getOrder();
             }

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerPermutorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/AtomContainerPermutorTest.java
@@ -21,11 +21,10 @@ package org.openscience.cdk.graph;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.test.CDKTestCase;
 
 /**
  * @cdk.module test-standard

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/ConnectivityCheckerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/ConnectivityCheckerTest.java
@@ -68,7 +68,7 @@ class ConnectivityCheckerTest extends CDKTestCase {
     @Test
     void testPartitionIntoMolecules_IAtomContainer() {
         //logger.debug(atomCon);
-        AtomContainer atomCon = new org.openscience.cdk.AtomContainer();
+        IAtomContainer atomCon = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomCon.add(TestMoleculeFactory.make4x3CondensedRings());
         atomCon.add(TestMoleculeFactory.makeAlphaPinene());
         atomCon.add(TestMoleculeFactory.makeSpiroRings());
@@ -82,7 +82,7 @@ class ConnectivityCheckerTest extends CDKTestCase {
      */
     @Test
     void testPartitionIntoMoleculesKeepsAtomIDs() {
-        AtomContainer atomCon = new org.openscience.cdk.AtomContainer();
+        IAtomContainer atomCon = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         atom1.setID("atom1");
         Atom atom2 = new Atom("C");
@@ -106,7 +106,7 @@ class ConnectivityCheckerTest extends CDKTestCase {
     @Test
     void testPartitionIntoMolecules_IsConnected_Consistency() {
         //logger.debug(atomCon);
-        AtomContainer atomCon = new org.openscience.cdk.AtomContainer();
+        IAtomContainer atomCon = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomCon.add(TestMoleculeFactory.make4x3CondensedRings());
         atomCon.add(TestMoleculeFactory.makeAlphaPinene());
         atomCon.add(TestMoleculeFactory.makeSpiroRings());
@@ -125,15 +125,15 @@ class ConnectivityCheckerTest extends CDKTestCase {
      */
     @Test
     void testDontDeleteSingleElectrons() {
-        AtomContainer atomCon = new org.openscience.cdk.AtomContainer();
+        IAtomContainer atomCon = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         // make two molecules; one with an LonePair, the other with a SingleElectron
-        IAtomContainer mol1 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         mol1.addAtom(atom1);
         LonePair lp1 = new LonePair(atom1);
         mol1.addLonePair(lp1);
         // mol2
-        IAtomContainer mol2 = new AtomContainer();
+        IAtomContainer mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom2 = new Atom("C");
         mol2.addAtom(atom2);
         SingleElectron se2 = new SingleElectron(atom2);
@@ -226,7 +226,7 @@ class ConnectivityCheckerTest extends CDKTestCase {
      */
     @Test
     void testNoAtomsIsConnected() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(ConnectivityChecker.isConnected(container), "Molecule appears not to be connected");
     }
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/CanonicalLabelerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/CanonicalLabelerTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/CanonicalLabelerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/invariant/CanonicalLabelerTest.java
@@ -120,7 +120,7 @@ class CanonicalLabelerTest extends CDKTestCase {
         String filename = "bug1014344-1.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLReader reader = new MDLReader(ins, Mode.STRICT);
-        IAtomContainer mol1 = reader.read(new AtomContainer());
+        IAtomContainer mol1 = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         addImplicitHydrogens(mol1);
         StringWriter output = new StringWriter();
         CMLWriter cmlWriter = new CMLWriter(output);

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/matrix/ConnectionMatrixTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/matrix/ConnectionMatrixTest.java
@@ -25,7 +25,6 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.ILonePair;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/matrix/ConnectionMatrixTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/matrix/ConnectionMatrixTest.java
@@ -50,7 +50,7 @@ class ConnectionMatrixTest extends CDKTestCase {
 
     @Test
     void testLonePairs() throws Exception {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(container.getBuilder().newInstance(IAtom.class, "I"));
         container.addLonePair(container.getBuilder().newInstance(ILonePair.class, container.getAtom(0)));
         container.addAtom(container.getBuilder().newInstance(IAtom.class, "H"));

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/rebond/RebondToolTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/rebond/RebondToolTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.config.AtomTypeFactory;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -49,7 +50,7 @@ class RebondToolTest extends CDKTestCase {
     @Test
     void testRebond_IAtomContainer() throws Exception {
         RebondTool rebonder = new RebondTool(2.0, 0.5, 0.5);
-        IAtomContainer methane = new AtomContainer();
+        IAtomContainer methane = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         methane.addAtom(new Atom("C", new Point3d(0.0, 0.0, 0.0)));
         methane.addAtom(new Atom("H", new Point3d(0.6, 0.6, 0.6)));
         methane.addAtom(new Atom("H", new Point3d(-0.6, -0.6, 0.6)));

--- a/base/test-standard/src/test/java/org/openscience/cdk/graph/rebond/RebondToolTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/graph/rebond/RebondToolTest.java
@@ -24,7 +24,6 @@ import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.config.AtomTypeFactory;

--- a/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/IsomorphismTesterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/IsomorphismTesterTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -50,7 +51,7 @@ class IsomorphismTesterTest extends CDKTestCase {
 
     @BeforeEach
     void setUp() {
-        pinene_1 = new AtomContainer();
+        pinene_1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         pinene_1.addAtom(new Atom("C")); // 1
         pinene_1.addAtom(new Atom("C")); // 2
         pinene_1.addAtom(new Atom("C")); // 3
@@ -74,7 +75,7 @@ class IsomorphismTesterTest extends CDKTestCase {
         pinene_1.addBond(7, 8, IBond.Order.SINGLE); // 10
         pinene_1.addBond(7, 9, IBond.Order.SINGLE); // 11
 
-        pinene_2 = new AtomContainer();
+        pinene_2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         pinene_2.addAtom(new Atom("C")); // 1
         pinene_2.addAtom(new Atom("C")); // 2
         pinene_2.addAtom(new Atom("C")); // 3
@@ -98,7 +99,7 @@ class IsomorphismTesterTest extends CDKTestCase {
         pinene_2.addBond(7, 9, IBond.Order.DOUBLE); // 10
         pinene_2.addBond(7, 6, IBond.Order.SINGLE); // 11
 
-        pinene_non = new AtomContainer();
+        pinene_non = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         pinene_non.addAtom(new Atom("C")); // 1
         pinene_non.addAtom(new Atom("C")); // 2
         pinene_non.addAtom(new Atom("C")); // 3

--- a/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/IsomorphismTesterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/IsomorphismTesterTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.aromaticity.Aromaticity;

--- a/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTesterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTesterTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.smarts.SmartsResult;
 import org.openscience.cdk.test.CDKTestCase;

--- a/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTesterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/isomorphism/UniversalIsomorphismTesterTest.java
@@ -181,8 +181,8 @@ class UniversalIsomorphismTesterTest extends CDKTestCase {
     void testGetSubgraphMap_IAtomContainer_IAtomContainer() throws Exception {
         String molfile = "decalin.mol";
         String queryfile = "decalin.mol";
-        IAtomContainer mol = new AtomContainer();
-        IAtomContainer temp = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer temp = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         QueryAtomContainer query1;
         QueryAtomContainer query2;
 
@@ -213,8 +213,8 @@ class UniversalIsomorphismTesterTest extends CDKTestCase {
     void testGetOverlaps_IAtomContainer_IAtomContainer() throws Exception {
         String file1 = "5SD.mol";
         String file2 = "ADN.mol";
-        IAtomContainer mol1 = new AtomContainer();
-        IAtomContainer mol2 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins1 = this.getClass().getResourceAsStream(file1);
         new MDLV2000Reader(ins1, Mode.STRICT).read(mol1);
@@ -371,15 +371,15 @@ class UniversalIsomorphismTesterTest extends CDKTestCase {
     void testSFBug999330() throws Exception {
         String file1 = "5SD.mol";
         String file2 = "ADN.mol";
-        IAtomContainer mol1 = new AtomContainer();
-        IAtomContainer mol2 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins1 = this.getClass().getResourceAsStream(file1);
         new MDLV2000Reader(ins1, Mode.STRICT).read(mol1);
         InputStream ins2 = this.getClass().getResourceAsStream(file2);
         new MDLV2000Reader(ins2, Mode.STRICT).read(mol2);
         AtomContainerAtomPermutor permutor = new AtomContainerAtomPermutor(mol2);
-        mol2 = new AtomContainer(permutor.next());
+        mol2 = DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, permutor.next());
 
         List<IAtomContainer> list1 = uiTester.getOverlaps(mol1, mol2);
         List<IAtomContainer> list2 = uiTester.getOverlaps(mol2, mol1);
@@ -407,9 +407,9 @@ class UniversalIsomorphismTesterTest extends CDKTestCase {
 
     @Test
     void testIsIsomorph_IAtomContainer_IAtomContainer() throws Exception {
-        AtomContainer ac1 = new AtomContainer();
+        IAtomContainer ac1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac1.addAtom(new Atom("C"));
-        AtomContainer ac2 = new AtomContainer();
+        IAtomContainer ac2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac2.addAtom(new Atom("C"));
         Assertions.assertTrue(uiTester.isIsomorph(ac1, ac2));
         Assertions.assertTrue(uiTester.isSubgraph(ac1, ac2));
@@ -589,7 +589,7 @@ class UniversalIsomorphismTesterTest extends CDKTestCase {
             Assertions.fail(result.getMessage());
 
         //Creating 'SCCS' target molecule
-        AtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         //atoms
         IAtom ta0 = new Atom("S");
         target.addAtom(ta0);

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_BenzylBenzene.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_BenzylBenzene.java
@@ -24,7 +24,6 @@ package org.openscience.cdk.ringsearch;
 
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_BenzylBenzene.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_BenzylBenzene.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -112,7 +113,7 @@ final class RingSearchTest_BenzylBenzene {
      * @cdk.inchi InChI=1S/C13H12/c1-3-7-12(8-4-1)11-13-9-5-2-6-10-13/h1-10H,11H2
      */
     static IAtomContainer benzylbenzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         mol.addAtom(a1);
         IAtom a2 = new Atom("C");

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Empty.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Empty.java
@@ -24,7 +24,6 @@ package org.openscience.cdk.ringsearch;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Empty.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Empty.java
@@ -25,6 +25,7 @@ package org.openscience.cdk.ringsearch;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -38,7 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 final class RingSearchTest_Empty {
 
-    private final IAtomContainer empty = new AtomContainer(0, 0, 0, 0);
+    private final IAtomContainer empty = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
     @Test
     void testCyclic() {

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Hexaphenylene.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Hexaphenylene.java
@@ -25,7 +25,6 @@ package org.openscience.cdk.ringsearch;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Hexaphenylene.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/ringsearch/RingSearchTest_Hexaphenylene.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -101,7 +102,7 @@ final class RingSearchTest_Hexaphenylene {
      * @cdk.inchi InChI=1S/C36H24/c1-2-14-26-25(13-1)27-15-3-4-17-29(27)31-19-7-8-21-33(31)35-23-11-12-24-36(35)34-22-10-9-20-32(34)30-18-6-5-16-28(26)30/h1-24H/b27-25-,28-26-,31-29-,32-30-,35-33-,36-34-
      */
     static IAtomContainer hexaphenylene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         mol.addAtom(a1);
         IAtom a2 = new Atom("C");

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/CyclicCarbohydrateRecognitionTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/CyclicCarbohydrateRecognitionTest.java
@@ -34,7 +34,6 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import javax.vecmath.Point2d;

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/CyclicCarbohydrateRecognitionTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/CyclicCarbohydrateRecognitionTest.java
@@ -35,6 +35,7 @@ import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import javax.vecmath.Point2d;
 
@@ -130,7 +131,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void betaDGlucose_Haworth() throws Exception {
-        IAtomContainer m = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, 4.16d, 1.66d));
         m.addAtom(atom("C", 1, 3.75d, 0.94d));
         m.addAtom(atom("C", 1, 4.16d, 0.23d));
@@ -191,7 +192,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void betaDGlucose_Chair() throws Exception {
-        IAtomContainer m = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -0.77d, 10.34d));
         m.addAtom(atom("C", 1, 0.03d, 10.13d));
         m.addAtom(atom("O", 0, 0.83d, 10.34d));
@@ -254,7 +255,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void betaDGlucoseWithExplicitHydrogens_Haworth() throws Exception {
-        IAtomContainer m = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 4.16d, 1.66d));
         m.addAtom(atom("C", 0, 3.75d, 0.94d));
         m.addAtom(atom("C", 0, 4.16d, 0.23d));
@@ -328,7 +329,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void oxpene() throws Exception {
-        IAtomContainer m = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, 1.39d, 3.65d));
         m.addAtom(atom("C", 2, 2.22d, 3.65d));
         m.addAtom(atom("C", 1, 2.93d, 4.07d));
@@ -401,7 +402,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void atp_Haworth() throws Exception {
-        IAtomContainer m = new AtomContainer(31, 33, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 0, 2.56d, -6.46d));
         m.addAtom(atom("C", 1, 1.90d, -6.83d));
         m.addAtom(atom("C", 1, 2.15d, -7.46d));
@@ -500,7 +501,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void hexopyranose() {
-        IAtomContainer m = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, 0.00d, 2.48d));
         m.addAtom(atom("C", 2, 0.71d, 2.06d));
         m.addAtom(atom("C", 1, 0.71d, 1.24d));
@@ -545,7 +546,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void betaDGlucose_Chair_Rotated() throws Exception {
-        IAtomContainer m = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -0.77d, 10.34d));
         m.addAtom(atom("C", 1, 0.03d, 10.13d));
         m.addAtom(atom("O", 0, 0.83d, 10.34d));
@@ -617,7 +618,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void haworthFalsePositive() {
-        IAtomContainer m = new AtomContainer(10, 10, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 2, -0.71d, 0.41d));
         m.addAtom(atom("C", 2, 0.71d, -0.41d));
         m.addAtom(atom("C", 2, 0.71d, 0.41d));
@@ -657,7 +658,7 @@ class CyclicCarbohydrateRecognitionTest {
      */
     @Test
     void requireAtLeastTwoProjectedSubstituents() {
-        IAtomContainer m = new AtomContainer(8, 8, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 0, -0.71d, 1.24d));
         m.addAtom(atom("C", 0, 0.00d, 0.83d));
         m.addAtom(atom("O", 0, 0.71d, 1.24d));

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/FischerRecognitionTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/FischerRecognitionTest.java
@@ -34,7 +34,6 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/FischerRecognitionTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/FischerRecognitionTest.java
@@ -36,6 +36,7 @@ import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import javax.vecmath.Point2d;
 
@@ -56,7 +57,7 @@ class FischerRecognitionTest {
      */
     @Test
     void recogniseRightHandedGlyceraldehyde() throws Exception {
-        IAtomContainer m = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 0.80d, 1.24d));
         m.addAtom(atom("C", 0, 0.80d, 0.42d));
         m.addAtom(atom("O", 1, 0.09d, 1.66d));
@@ -92,7 +93,7 @@ class FischerRecognitionTest {
      */
     @Test
     void recogniseLeftHandedGlyceraldehyde() throws Exception {
-        IAtomContainer m = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 0.80d, 1.24d));
         m.addAtom(atom("C", 0, 0.80d, 0.42d));
         m.addAtom(atom("O", 1, 0.09d, 1.66d));
@@ -128,7 +129,7 @@ class FischerRecognitionTest {
      */
     @Test
     void recogniseRightHandedGlyceraldehydeWithImplicitHydrogen() throws Exception {
-        IAtomContainer m = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 0.80d, 1.24d));
         m.addAtom(atom("C", 1, 0.80d, 0.42d));
         m.addAtom(atom("O", 1, 0.09d, 1.66d));
@@ -162,7 +163,7 @@ class FischerRecognitionTest {
      */
     @Test
     void mannitol() throws CDKException {
-        IAtomContainer m = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 2, -0.53d, 6.25d));
         m.addAtom(atom("C", 1, -0.53d, 5.42d));
         m.addAtom(atom("O", 1, 0.18d, 6.66d));
@@ -526,7 +527,7 @@ class FischerRecognitionTest {
      */
     @Test
     void ignoreCyclicStereocenters() {
-        IAtomContainer m = new AtomContainer(22, 25, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 6.87d, -5.59d));
         m.addAtom(atom("C", 0, 6.87d, -6.61d));
         m.addAtom(atom("C", 0, 7.82d, -5.62d));
@@ -590,7 +591,7 @@ class FischerRecognitionTest {
      */
     @Test
     void horizontalBondsMustBeTerminal() {
-        IAtomContainer m = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 12.71d, -16.51d));
         m.addAtom(atom("C", 1, 12.30d, -17.22d));
         m.addAtom(atom("C", 1, 11.47d, -17.22d));

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -63,7 +63,7 @@ class StereoElementFactoryTest {
     // don't create double bond configs in benzene
     @Test
     void benzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 1, 1.30, -0.75));
         mol.addAtom(atom("C", 1, -0.00, -1.50));
         mol.addAtom(atom("C", 1, -1.30, -0.75));
@@ -83,7 +83,7 @@ class StereoElementFactoryTest {
     // >=8 is okay for db stereo (ala inchi)
     @Test
     void cyclooctatetraene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 1, -10.46, 6.36));
         mol.addAtom(atom("C", 1, -11.34, 5.15));
         mol.addAtom(atom("C", 1, -10.46, 3.93));
@@ -107,7 +107,7 @@ class StereoElementFactoryTest {
     // not okay... but technically the trans form exists
     @Test
     void doubleBondInSevenMemberedRing() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 1, -10.46, 6.36));
         mol.addAtom(atom("C", 1, -11.34, 5.15));
         mol.addAtom(atom("C", 1, -10.46, 3.93));
@@ -128,7 +128,7 @@ class StereoElementFactoryTest {
 
     @Test
     void hydrogenIsotope() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 3, 0.00, 0.00));
         mol.addAtom(atom("C", 1, 1.30, -0.75));
         mol.addAtom(atom("C", 1, 2.60, -0.00));
@@ -143,7 +143,7 @@ class StereoElementFactoryTest {
 
     @Test
     void bridgeHeadNitrogen() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 2, 1.23, 0.75));
         mol.addAtom(atom("C", 2, 1.23, -0.75));
         mol.addAtom(atom("N", 0, -0.07, -1.50));
@@ -165,7 +165,7 @@ class StereoElementFactoryTest {
 
     @Test
     void e_but2ene() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -2.19d, 1.64d));
         m.addAtom(atom("C", 1, -1.36d, 1.64d));
         m.addAtom(atom("C", 3, -2.60d, 0.92d));
@@ -183,7 +183,7 @@ class StereoElementFactoryTest {
 
     @Test
     void z_but2ene() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -2.46d, 1.99d));
         m.addAtom(atom("C", 1, -1.74d, 0.68d));
         m.addAtom(atom("C", 1, -0.24d, 0.65d));
@@ -205,7 +205,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void e_hexa234triene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 1, 2.48d, 0.00d));
         mol.addAtom(atom("C", 0, 1.65d, 0.00d));
         mol.addAtom(atom("C", 0, 0.83d, 0.00d));
@@ -233,7 +233,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void z_hexa234triene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 1, 2.48d, 0.00d));
         mol.addAtom(atom("C", 0, 1.65d, 0.00d));
         mol.addAtom(atom("C", 0, 0.83d, 0.00d));
@@ -261,7 +261,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void e_hexa234triene_3D() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 1, 0.29d, 0.01d, 0.02d));
         mol.addAtom(atom("C", 0, -0.56d, -0.90d, 0.25d));
         mol.addAtom(atom("C", 0, -1.37d, -1.75d, 0.46d));
@@ -289,7 +289,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void z_hexa234triene_3D() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(atom("C", 1, -0.09d, -0.45d, -1.07d));
         mol.addAtom(atom("C", 0, -0.67d, -1.04d, -0.11d));
         mol.addAtom(atom("C", 0, -1.23d, -1.59d, 0.79d));
@@ -313,7 +313,7 @@ class StereoElementFactoryTest {
 
     @Test
     void unspec_but2ene_byCoordinates() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -1.37d, 1.64d));
         m.addAtom(atom("C", 1, -2.19d, 1.63d));
         m.addAtom(atom("C", 3, -2.59d, 0.90d));
@@ -330,7 +330,7 @@ class StereoElementFactoryTest {
 
     @Test
     void unspec_but2ene_wavyBond() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -1.27d, 1.48d));
         m.addAtom(atom("C", 1, -2.10d, 1.46d));
         m.addAtom(atom("C", 3, -2.50d, 0.74d));
@@ -347,7 +347,7 @@ class StereoElementFactoryTest {
 
     @Test
     void unspec_but2ene_crossBond() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -1.27d, 1.48d));
         m.addAtom(atom("C", 1, -2.10d, 1.46d));
         m.addAtom(atom("C", 3, -2.50d, 0.74d));
@@ -364,7 +364,7 @@ class StereoElementFactoryTest {
 
     @Test
     void r_butan2ol() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, -0.46d, 1.98d));
         m.addAtom(atom("C", 1, -1.28d, 1.96d));
         m.addAtom(atom("C", 2, -1.71d, 2.67d));
@@ -382,7 +382,7 @@ class StereoElementFactoryTest {
 
     @Test
     void s_butan2ol() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, -0.46d, 1.98d));
         m.addAtom(atom("C", 1, -1.28d, 1.96d));
         m.addAtom(atom("C", 2, -1.71d, 2.67d));
@@ -400,7 +400,7 @@ class StereoElementFactoryTest {
 
     @Test
     void r_butan2ol_3d() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, 0.56d, 0.05d, 0.71d));
         m.addAtom(atom("C", 2, -0.53d, 0.51d, -0.30d));
         m.addAtom(atom("C", 3, 1.81d, -0.53d, 0.02d));
@@ -418,7 +418,7 @@ class StereoElementFactoryTest {
 
     @Test
     void s_butan2ol_3d() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -0.17d, -0.12d, -0.89d));
         m.addAtom(atom("C", 2, 1.12d, -0.91d, -0.51d));
         m.addAtom(atom("C", 3, -0.10d, 0.46d, -2.32d));
@@ -436,7 +436,7 @@ class StereoElementFactoryTest {
 
     @Test
     void r_butan2ol_3d_expH() {
-        IAtomContainer m = new AtomContainer(6, 5, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -0.07d, -0.14d, 0.50d));
         m.addAtom(atom("C", 2, -0.05d, -1.20d, -0.65d));
         m.addAtom(atom("C", 3, 0.98d, -0.46d, 1.60d));
@@ -456,7 +456,7 @@ class StereoElementFactoryTest {
 
     @Test
     void s_butan2ol_3d_expH() {
-        IAtomContainer m = new AtomContainer(6, 5, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -0.17d, -0.12d, -0.89d));
         m.addAtom(atom("C", 2, 1.12d, -0.91d, -0.51d));
         m.addAtom(atom("C", 3, -0.10d, 0.46d, -2.32d));
@@ -476,7 +476,7 @@ class StereoElementFactoryTest {
 
     @Test
     void unspec_butan2ol() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, -0.46d, 1.98d));
         m.addAtom(atom("C", 1, -1.28d, 1.96d));
         m.addAtom(atom("C", 2, -1.71d, 2.67d));
@@ -497,7 +497,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void r_methanesulfinylethane() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("S", 0, 0.01d, 1.50d));
         m.addAtom(atom("C", 3, 0.03d, 0.00d));
         m.addAtom(atom("C", 2, -1.30d, 2.23d));
@@ -518,7 +518,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void s_methanesulfinylethane() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("S", 0, 0.01d, 1.50d));
         m.addAtom(atom("C", 3, 0.03d, 0.00d));
         m.addAtom(atom("C", 2, -1.30d, 2.23d));
@@ -536,7 +536,7 @@ class StereoElementFactoryTest {
 
     @Test
     void e_but2ene_3d() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -0.19d, 0.09d, -0.27d));
         m.addAtom(atom("C", 1, 0.22d, -1.15d, 0.05d));
         m.addAtom(atom("C", 3, 0.21d, 0.75d, -1.49d));
@@ -554,7 +554,7 @@ class StereoElementFactoryTest {
 
     @Test
     void z_but2ene_3d() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, 0.05d, -1.28d, 0.13d));
         m.addAtom(atom("C", 1, -0.72d, -0.58d, -0.72d));
         m.addAtom(atom("C", 3, 1.11d, -0.74d, 0.95d));
@@ -572,7 +572,7 @@ class StereoElementFactoryTest {
 
     @Test
     void inverse_style_downbond() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, -0.46d, 1.98d));
         m.addAtom(atom("C", 1, -1.28d, 1.96d));
         m.addAtom(atom("C", 2, -1.71d, 2.67d));
@@ -593,7 +593,7 @@ class StereoElementFactoryTest {
     // this bond is used to specify atom '2'
     @Test
     void inverse_style_downbond_ambiguous() throws CDKException {
-        IAtomContainer m = new AtomContainer(6, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, -0.46d, 1.98d));
         m.addAtom(atom("C", 1, -1.28d, 1.96d));
         m.addAtom(atom("C", 1, -1.71d, 2.67d));
@@ -613,7 +613,7 @@ class StereoElementFactoryTest {
 
     @Test
     void badWedgePatternWithThreeNeighbors() throws CDKException {
-        IAtomContainer m = new AtomContainer(6, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, -0.46d, 1.98d));
         m.addAtom(atom("C", 1, -1.28d, 1.96d));
         m.addAtom(atom("Cl", 0, -1.71d, 2.67d));
@@ -629,7 +629,7 @@ class StereoElementFactoryTest {
 
     @Test
     void okWedgePatternWithThreeNeighbors() throws CDKException {
-        IAtomContainer m = new AtomContainer(6, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, -0.46d, 1.98d));
         m.addAtom(atom("C", 1, -1.28d, 1.96d));
         m.addAtom(atom("Cl", 0, -1.71d, 2.67d));
@@ -745,7 +745,7 @@ class StereoElementFactoryTest {
         MDLV2000Reader mdl = null;
         try {
             mdl = new MDLV2000Reader(getClass().getResourceAsStream("CPD-7272.mol"));
-            IAtomContainer ac = mdl.read(new AtomContainer());
+            IAtomContainer ac = mdl.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
 
             // MDL reader currently adds stereo automatically
             List<IStereoElement> ses = new ArrayList<>();
@@ -760,7 +760,7 @@ class StereoElementFactoryTest {
 
     @Test
     void createExtendedTetrahedralFrom2DCoordinates_cw() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 0, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -784,7 +784,7 @@ class StereoElementFactoryTest {
 
     @Test
     void createExtendedTetrahedralFrom2DCoordinates_ccw() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 0, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -808,7 +808,7 @@ class StereoElementFactoryTest {
 
     @Test
     void createExtendedTetrahedralFrom2DCoordinatesImplicitHydrogens_cw() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 1, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -828,7 +828,7 @@ class StereoElementFactoryTest {
 
     @Test
     void createExtendedTetrahedralFrom2DCoordinatesImplicitHydrogens_ccw() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 1, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -848,7 +848,7 @@ class StereoElementFactoryTest {
 
     @Test
     void createExtendedTetrahedralFrom2DCoordinatesNoNonplanarBonds() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 0, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -870,7 +870,7 @@ class StereoElementFactoryTest {
 
     @Test
     void createExtendedTetrahedralFrom3DCoordinates_cw() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, 0.1925, -2.7911, 1.8739));
         m.addAtom(atom("C", 0, -0.4383, -2.0366, 0.8166));
         m.addAtom(atom("C", 0, 0.2349, -1.2464, 0.0943));
@@ -896,7 +896,7 @@ class StereoElementFactoryTest {
 
     @Test
     void createExtendedTetrahedralFrom3DCoordinates_ccw() throws Exception {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.4096, -2.1383, 0.6392));
         m.addAtom(atom("C", 0, -0.4383, -2.0366, 0.8166));
         m.addAtom(atom("C", 0, 0.2349, -1.2464, 0.0943));
@@ -922,7 +922,7 @@ class StereoElementFactoryTest {
 
     @Test
     void createExtendedTetrahedral() throws CDKException {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 1, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -939,7 +939,7 @@ class StereoElementFactoryTest {
 
     @Test
     void doNotCreateNonStereogenicExtendedTetrahedral() throws CDKException {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 1, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -962,7 +962,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void differentBondLengthsDoNotAffectWinding() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("O", 1, 14.50d, -8.72d));
         m.addAtom(atom("N", 2, 14.50d, -11.15d));
         m.addAtom(atom("C", 0, 15.28d, -7.81d));
@@ -989,7 +989,7 @@ class StereoElementFactoryTest {
 
     @Test
     void always2DTetrahedralElements() {
-        IAtomContainer m = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, 0.34d, 2.28d));
         m.addAtom(atom("O", 1, 1.17d, 2.28d));
         m.addAtom(atom("C", 1, -0.07d, 2.99d));
@@ -1019,7 +1019,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void badlyOptimizedAllene() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -4.02, 3.96, -1.09));
         m.addAtom(atom("C", 0, -4.96, 3.82, 0.13));
         m.addAtom(atom("C", 3, -3.70, 5.35, -1.67));
@@ -1035,7 +1035,7 @@ class StereoElementFactoryTest {
 
     @Test
     void onlyCreateStereoForConsitionalDifferencesIn3D() {
-        IAtomContainer m = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -1.00d, -0.25d, 1.22d));
         m.addAtom(atom("O", 1, -1.82d, 0.20d, 2.30d));
         m.addAtom(atom("C", 1, -0.04d, -1.38d, 1.71d));
@@ -1060,7 +1060,7 @@ class StereoElementFactoryTest {
 
     @Test
     void dontCreateStereoForNonStereogenicIn3D() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 0.00d, 0.00d, 0.00d));
         m.addAtom(atom("H", 0, -0.36d, -0.51d, 0.89d));
         m.addAtom(atom("H", 0, 1.09d, 0.00d, 0.00d));
@@ -1083,7 +1083,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void onlyInterpretFischerProjectionsWhenAsked() throws Exception {
-        IAtomContainer m = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 0.80d, 1.24d));
         m.addAtom(atom("C", 0, 0.80d, 0.42d));
         m.addAtom(atom("O", 1, 0.09d, 1.66d));
@@ -1123,7 +1123,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void onlyInterpretHaworthProjectionsWhenAsked() throws Exception {
-        IAtomContainer m = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, 4.16d, 1.66d));
         m.addAtom(atom("C", 1, 3.75d, 0.94d));
         m.addAtom(atom("C", 1, 4.16d, 0.23d));
@@ -1172,7 +1172,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void onlyInterpretChairProjectionsWhenAsked() throws Exception {
-        IAtomContainer m = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -0.77d, 10.34d));
         m.addAtom(atom("C", 1, 0.03d, 10.13d));
         m.addAtom(atom("O", 0, 0.83d, 10.34d));
@@ -1220,7 +1220,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void keepNonStereoConfiguration() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 0.07, 1.19));
         m.addAtom(atom("H", 0, 0.56, 2.02));
         m.addAtom(atom("C", 3, -0.29, 2.04));
@@ -1241,7 +1241,7 @@ class StereoElementFactoryTest {
 
     @Test
     void keepNonStereoConfigurationPhosphorusTautomer() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("P", 0, 0.07, 1.19));
         m.addAtom(atom("O", 0, 0.56, 2.02));
         m.addAtom(atom("O", 1, -0.29, 2.04));
@@ -1262,7 +1262,7 @@ class StereoElementFactoryTest {
 
     @Test
     void doNotkeepNonStereoConfigurationPhosphorusTautomer() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("P", 0, 0.07, 1.19));
         m.addAtom(atom("O", 0, 0.56, 2.02));
         m.addAtom(atom("O", 1, -0.29, 2.04));
@@ -1288,7 +1288,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void doNotKeepNonStereoConfiguration() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 0.07, 1.19));
         m.addAtom(atom("H", 0, 0.56, 2.02));
         m.addAtom(atom("C", 3, -0.29, 2.04));
@@ -1314,7 +1314,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void keepNonStereoConfigurationH2() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 0.07, 1.19));
         m.addAtom(atom("H", 0, 0.56, 2.02));
         m.addAtom(atom("H", 0, -0.29, 2.04));
@@ -1344,7 +1344,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void binol2D() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -0.83, -0.01));
         m.addAtom(atom("C", 0, -1.55, -0.42));
         m.addAtom(atom("C", 1, -1.55, -1.25));
@@ -1441,7 +1441,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void atropisomer1() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -7.53, -2.12));
         m.addAtom(atom("C", 1, -8.24, -2.53));
         m.addAtom(atom("C", 1, -8.24, -3.36));
@@ -1484,7 +1484,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void nonAtropisomer2() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -7.53, -2.12));
         m.addAtom(atom("C", 1, -8.24, -2.53));
         m.addAtom(atom("C", 1, -8.24, -3.36));
@@ -1525,7 +1525,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void nonAtropisomer3() throws CDKException {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -7.53, -2.12));
         m.addAtom(atom("C", 1, -8.24, -2.53));
         m.addAtom(atom("C", 1, -8.24, -3.36));
@@ -1567,7 +1567,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void nonAtropisomerExplHydrogens() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("H", 0, -1.43, 0.83));
         m.addAtom(atom("C", 0, -0.71, 1.24));
         m.addAtom(atom("C", 1, -0.71, 2.06));
@@ -1626,7 +1626,7 @@ class StereoElementFactoryTest {
      */
     @Test
     void atropisomer3D() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -4.95, 1.27));
         m.addAtom(atom("C", 1, -4.26, 1.73));
         m.addAtom(atom("C", 0, -2.85, 1.74));
@@ -1666,7 +1666,7 @@ class StereoElementFactoryTest {
     
     @Test
     void samePositionWithStereocenter() throws Exception {
-    	IAtomContainer m = new AtomContainer();
+    	IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("F", 0, -1, -1));
         m.addAtom(atom("Cl", 0, 1, -1));
         m.addAtom(atom("C", 0, 0, 0));

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -36,7 +36,6 @@ import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmiFlavor;
 import org.openscience.cdk.smiles.SmilesGenerator;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/HOSECodeGeneratorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/HOSECodeGeneratorTest.java
@@ -126,7 +126,7 @@ class HOSECodeGeneratorTest extends CDKTestCase {
                 "C-3;*C*C(//)", "C-3;*C*CO(//)", "O-2;CC(//)", "C-3;*C*CO(//)", "C-3;*C*CO(//)", "O-2;CC(//)",
                 "C-4;O(//)", "C-3;*C*C(//)", "C-3;*C*CC(//)", "C-3;*C*C*C(//)", "C-3;*C*C*C(//)"};
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "O");
         a1.setPoint2d(new Point2d(502.88457268119913, 730.4999999999999));
         mol.addAtom(a1);
@@ -317,7 +317,7 @@ class HOSECodeGeneratorTest extends CDKTestCase {
                 "C-3;*C*C*C(*C*C,*CC,*CC/*CO,*CC,*&,=OC,*&,=&/*&O,C,*&,*&*C,,=&)",
                 "C-3;*C*C*C(*C*C,*CO,*CC/*CC,*CC,*&O,C,*&,*&*C/*&,=OC,*&,=&,C,*&*C,*C)"};
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "O");
         a1.setPoint2d(new Point2d(502.88457268119913, 730.4999999999999));
         mol.addAtom(a1);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/HOSECodeGeneratorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/HOSECodeGeneratorTest.java
@@ -30,7 +30,6 @@ import javax.vecmath.Point2d;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/IDCreatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/IDCreatorTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/IDCreatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/IDCreatorTest.java
@@ -26,6 +26,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -43,7 +44,7 @@ class IDCreatorTest extends CDKTestCase {
 
     @Test
     void testCreateIDs_IChemObject() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         Atom atom2 = new Atom("C");
         mol.addAtom(atom1);
@@ -60,7 +61,7 @@ class IDCreatorTest extends CDKTestCase {
 
     @Test
     void testKeepingIDs() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setID("atom1");
         mol.addAtom(atom);
@@ -75,7 +76,7 @@ class IDCreatorTest extends CDKTestCase {
 
     @Test
     void testNoDuplicateCreation() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         Atom atom2 = new Atom("C");
         atom1.setID("a1");
@@ -94,7 +95,7 @@ class IDCreatorTest extends CDKTestCase {
     @Test
     void testCallingTwice() {
         IAtomContainerSet molSet = new AtomContainerSet();
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom0 = new Atom("C");
         Atom atom2 = new Atom("C");
         atom0.setID("a1");
@@ -106,7 +107,7 @@ class IDCreatorTest extends CDKTestCase {
         List<String> ids = MoleculeSetManipulator.getAllIDs(molSet);
         Assertions.assertEquals(4, ids.size());
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         atom2 = new Atom("C");
         atom1.setID("a2");
@@ -118,7 +119,7 @@ class IDCreatorTest extends CDKTestCase {
         ids = MoleculeSetManipulator.getAllIDs(molSet);
         Assertions.assertEquals(7, ids.size());
 
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atom1 = new Atom("C");
         atom2 = new Atom("C");
         mol.addAtom(atom2);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/LonePairElectronCheckerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/LonePairElectronCheckerTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/LonePairElectronCheckerTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/LonePairElectronCheckerTest.java
@@ -60,7 +60,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
     @Test
     void testAllSaturated_Formaldehyde() throws Exception {
         // test Formaldehyde, CH2=O with explicit hydrogen
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom c = new Atom("C");
         Atom h1 = new Atom("H");
         Atom h2 = new Atom("H");
@@ -94,7 +94,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
 
         Bond b1 = new Bond(c, s, IBond.Order.SINGLE);
 
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(c);
         m.addAtom(s);
         m.addBond(b1);
@@ -118,7 +118,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
         Atom cl = new Atom("Cl");
         Bond b1 = new Bond(c1, cl, IBond.Order.SINGLE);
 
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(c1);
         m.addAtom(cl);
         m.addBond(b1);
@@ -141,7 +141,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
         o.setImplicitHydrogenCount(1);
         Bond b1 = new Bond(c1, o, IBond.Order.SINGLE);
 
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(c1);
         m.addAtom(o);
         m.addBond(b1);
@@ -158,7 +158,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
     @Test
     void testNewSaturate_Methyl_alcohol_AddH() throws Exception {
         // test Methyl alcohol, CH3OH
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("O"));
         for (int i = 0; i < 4; i++)
@@ -189,7 +189,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
         o.setImplicitHydrogenCount(2);
         Bond b1 = new Bond(c1, o, IBond.Order.SINGLE);
 
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(c1);
         m.addAtom(o);
         m.addBond(b1);
@@ -212,7 +212,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
         o.setFormalCharge(-1);
         Bond b1 = new Bond(c1, o, IBond.Order.SINGLE);
 
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(c1);
         m.addAtom(o);
         m.addBond(b1);
@@ -232,7 +232,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
         Atom n = new Atom("N");
         n.setImplicitHydrogenCount(3);
 
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(n);
 
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(m);
@@ -254,7 +254,7 @@ class LonePairElectronCheckerTest extends CDKTestCase {
         n.setFormalCharge(+1);
         Bond b1 = new Bond(c, n, IBond.Order.SINGLE);
 
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(c);
         m.addAtom(n);
         m.addBond(b1);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerComparatorBy2DCenterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerComparatorBy2DCenterTest.java
@@ -27,7 +27,6 @@ import javax.vecmath.Point2d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtom;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerComparatorBy2DCenterTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerComparatorBy2DCenterTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -50,7 +51,7 @@ class AtomContainerComparatorBy2DCenterTest extends CDKTestCase {
 
     @Test
     void testCompare_Null_2DCoordinates() {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomContainer.addAtom(new Atom("N"));
         Comparator<IAtomContainer> comparator = new AtomContainerComparatorBy2DCenter();
         Assertions.assertEquals(0, comparator.compare(atomContainer, atomContainer), "null 2d Coords<-> null 2d coords");
@@ -58,7 +59,7 @@ class AtomContainerComparatorBy2DCenterTest extends CDKTestCase {
 
     @Test
     void testCompare_self_valid_2DCoordinates() {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         atom.setPoint2d(new Point2d(10, 10));
         atomContainer.addAtom(atom);
@@ -69,12 +70,12 @@ class AtomContainerComparatorBy2DCenterTest extends CDKTestCase {
 
     @Test
     void testCompare_minusOne() {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         atom.setPoint2d(new Point2d(10, 10));
         atomContainer.addAtom(atom);
 
-        IAtomContainer atomContainer2 = new AtomContainer();
+        IAtomContainer atomContainer2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom2 = new Atom("P");
         atom2.setPoint2d(new Point2d(20, 10));
         atomContainer2.addAtom(atom2);
@@ -85,12 +86,12 @@ class AtomContainerComparatorBy2DCenterTest extends CDKTestCase {
 
     @Test
     void testCompare_plusOne() {
-        IAtomContainer atomContainer = new AtomContainer();
+        IAtomContainer atomContainer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("N");
         atom.setPoint2d(new Point2d(20, 10));
         atomContainer.addAtom(atom);
 
-        IAtomContainer atomContainer2 = new AtomContainer();
+        IAtomContainer atomContainer2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom2 = new Atom("P");
         atom2.setPoint2d(new Point2d(20, 5));
         atomContainer2.addAtom(atom2);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerComparatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerComparatorTest.java
@@ -67,11 +67,11 @@ class AtomContainerComparatorTest extends CDKTestCase {
         // Instantiate the comparator
         Comparator<IAtomContainer> comparator = new AtomContainerComparator();
 
-        IAtomContainer atomContainer1 = new AtomContainer();
+        IAtomContainer atomContainer1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         atomContainer1.addAtom(new Atom("C"));
 
-        IAtomContainer atomContainer2 = new AtomContainer();
+        IAtomContainer atomContainer2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         atomContainer2.addAtom(new PseudoAtom("*"));
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerComparatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerComparatorTest.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.PseudoAtom;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -99,7 +99,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
         atomContainerSource.addBond(4, 6, Order.SINGLE);
         assertThat(atomContainerSource.getAtomCount(), is(7));
         assertThat(atomContainerSource.getBondCount(), is(6));
-        IAtomContainer atomContainerDestination = new AtomContainer();
+        IAtomContainer atomContainerDestination = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         // act
         AtomContainerManipulator.copy(atomContainerDestination, atomContainerSource, x -> true, x -> true);
@@ -168,7 +168,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     @Test
     void testCopy_completeCopy_sourceAtomContainer_destinationAtomContainer2() {
         // arrange
-        IAtomContainer atomContainerSource = new AtomContainer();
+        IAtomContainer atomContainerSource = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         // CC(=O)CC(=O)O
         atomContainerSource.addAtom(new Atom("C"));
         atomContainerSource.addAtom(new Atom("C"));
@@ -211,7 +211,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     @Test
     void testCopy_completeCopy_sourceAtomContainer_destinationAtomContainer() {
         // arrange
-        IAtomContainer atomContainerSource = new AtomContainer();
+        IAtomContainer atomContainerSource = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         // CC(=O)CC(=O)O
         atomContainerSource.addAtom(new Atom("C"));
         atomContainerSource.addAtom(new Atom("C"));
@@ -228,7 +228,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
         atomContainerSource.addBond(4, 6, Order.SINGLE);
         assertThat(atomContainerSource.getAtomCount(), is(7));
         assertThat(atomContainerSource.getBondCount(), is(6));
-        IAtomContainer atomContainerDestination = new AtomContainer();
+        IAtomContainer atomContainerDestination = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         // act
         AtomContainerManipulator.copy(atomContainerDestination, atomContainerSource, x -> true, x -> true);
@@ -466,7 +466,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
      */
     @Test
     void testGetTotalHydrogenCount_IAtomContainer() throws IOException, ClassNotFoundException, CDKException {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("H"));
@@ -486,7 +486,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testConvertImplicitToExplicitHydrogens_IAtomContainer() throws Exception {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setImplicitHydrogenCount(2);
         mol.addAtom(new Atom("C"));
@@ -502,7 +502,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testConvertImplicitToExplicitHydrogens_IAtomContainer2() throws Exception {
-        IAtomContainer mol = new AtomContainer(); // ethane
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethane
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setImplicitHydrogenCount(3);
@@ -519,7 +519,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     @Test
     void testGetTotalHydrogenCount_IAtomContainer_zeroImplicit() throws IOException, ClassNotFoundException,
             CDKException {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setImplicitHydrogenCount(0);
         mol.addAtom(new Atom("C"));
@@ -544,7 +544,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     @Test
     void testGetTotalHydrogenCount_IAtomContainer_nullImplicit() throws IOException, ClassNotFoundException,
             CDKException {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setImplicitHydrogenCount(null);
         mol.addAtom(new Atom("C"));
@@ -568,7 +568,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testGetTotalHydrogenCount_ImplicitHydrogens() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom carbon = new Atom("C");
         carbon.setImplicitHydrogenCount(4);
         mol.addAtom(carbon);
@@ -577,7 +577,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testRemoveHydrogens_IAtomContainer() throws IOException, ClassNotFoundException, CDKException {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("H"));
@@ -601,7 +601,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void dontSuppressHydrogensOnPseudoAtoms() throws Exception {
-        IAtomContainer mol = new AtomContainer(); // *[H]
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // *[H]
         mol.addAtom(new PseudoAtom("*"));
         mol.addAtom(new Atom("H"));
         mol.getAtom(0).setImplicitHydrogenCount(0);
@@ -614,7 +614,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void suppressHydrogensKeepsRadicals() throws Exception {
-        IAtomContainer mol = new AtomContainer(); // *[H]
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // *[H]
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("H"));
         mol.addAtom(new Atom("H"));
@@ -635,7 +635,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     }
 
     private IAtomContainer getChiralMolTemplate() {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("Cl"));
         molecule.addAtom(new Atom("C"));
         molecule.addAtom(new Atom("Br"));
@@ -716,7 +716,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testRemoveHydrogensZeroHydrogenCounts() throws IOException, ClassNotFoundException, CDKException {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("Br"));
@@ -751,7 +751,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testGetAllIDs_IAtomContainer() {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setID("a1");
         mol.addAtom(new Atom("C"));
@@ -777,7 +777,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testGetAtomArray_IAtomContainer() {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("H"));
@@ -797,7 +797,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testGetAtomArray_List() {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("H"));
@@ -820,7 +820,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testGetBondArray_List() {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("H"));
@@ -843,7 +843,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testGetBondArray_IAtomContainer() {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("H"));
@@ -868,7 +868,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testGetAtomById_IAtomContainer_String() throws Exception {
-        IAtomContainer mol = new AtomContainer(); // ethene
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // ethene
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setID("a1");
         mol.addAtom(new Atom("C"));
@@ -903,7 +903,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
      */
     @Test
     void testRemoveHydrogensBorane() throws Exception {
-        IAtomContainer borane = new AtomContainer();
+        IAtomContainer borane = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         borane.addAtom(borane.getBuilder().newInstance(IAtom.class, "H"));
         borane.addAtom(borane.getBuilder().newInstance(IAtom.class, "H"));
         borane.addAtom(borane.getBuilder().newInstance(IAtom.class, "B"));
@@ -965,7 +965,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     @Test
     void getNaturalExactMassNeedsHydrogens() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer mol = new AtomContainer();
+            IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             IAtom atom = new Atom("C");
             atom.setImplicitHydrogenCount(null);
             mol.addAtom(atom);
@@ -976,7 +976,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     @Test
     void getNaturalExactMassNeedsAtomicNumber() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer mol = new AtomContainer();
+            IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             mol.addAtom(new Atom("C"));
             mol.getAtom(0).setAtomicNumber(null);
             AtomContainerManipulator.getNaturalExactMass(mol);
@@ -1057,13 +1057,13 @@ class AtomContainerManipulatorTest extends CDKTestCase {
         IBond b2 = builder.newInstance(IBond.class, o, c2);
         IBond b3 = builder.newInstance(IBond.class, c2, c3);
 
-        IAtomContainer container1 = new org.openscience.cdk.AtomContainer();
+        IAtomContainer container1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container1.addAtom(c1);
         container1.addAtom(o);
         container1.addAtom(c2);
         container1.addBond(b1);
         container1.addBond(b2);
-        IAtomContainer container2 = new org.openscience.cdk.AtomContainer();
+        IAtomContainer container2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container2.addAtom(o);
         container2.addAtom(c3);
         container2.addAtom(c2);
@@ -1080,7 +1080,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testPerceiveAtomTypesAndConfigureAtoms() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("R"));
 
         // the next should not throw an exception
@@ -1093,7 +1093,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
 
     @Test
     void testPerceiveAtomTypesAndConfigureUnsetProperties() throws Exception {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         atom.setExactMass(13.0);
         container.addAtom(atom);
@@ -1365,7 +1365,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
      */
     @Test
     void testRemoveHydrogensPreserveMultiplyBonded() throws Exception {
-        IAtomContainer borane = new AtomContainer();
+        IAtomContainer borane = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         borane.addAtom(borane.getBuilder().newInstance(IAtom.class, "H"));
         borane.addAtom(borane.getBuilder().newInstance(IAtom.class, "H"));
         borane.addAtom(borane.getBuilder().newInstance(IAtom.class, "B"));
@@ -1530,7 +1530,7 @@ class AtomContainerManipulatorTest extends CDKTestCase {
      */
     @Test
     void testRemoveHydrogensFromMolecularHydrogen() {
-        IAtomContainer mol = new AtomContainer(); // molecular hydrogen
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // molecular hydrogen
         mol.addAtom(new Atom("H"));
         mol.addAtom(new Atom("H"));
         mol.addBond(0, 1, IBond.Order.SINGLE);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomType;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerSetManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerSetManipulatorTest.java
@@ -59,7 +59,7 @@ class AtomContainerSetManipulatorTest extends CDKTestCase {
 
     @BeforeEach
     void setUp() {
-        mol1 = new AtomContainer();
+        mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol1 = new Atom("Cl");
         atomInMol1.setCharge(-1.0);
         atomInMol1.setFormalCharge(-1);
@@ -68,7 +68,7 @@ class AtomContainerSetManipulatorTest extends CDKTestCase {
         mol1.addAtom(new Atom("Cl"));
         bondInMol1 = new Bond(atomInMol1, mol1.getAtom(1));
         mol1.addBond(bondInMol1);
-        mol2 = new AtomContainer();
+        mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol2 = new Atom("O");
         atomInMol2.setImplicitHydrogenCount(2);
         mol2.addAtom(atomInMol2);
@@ -91,7 +91,7 @@ class AtomContainerSetManipulatorTest extends CDKTestCase {
     @Test
     void testRemoveElectronContainer_IAtomContainerSet_IElectronContainer() {
         IAtomContainerSet ms = new AtomContainerSet();
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("O"));
         mol.addBond(0, 1, IBond.Order.DOUBLE);
@@ -107,7 +107,7 @@ class AtomContainerSetManipulatorTest extends CDKTestCase {
     @Test
     void testRemoveAtomAndConnectedElectronContainers_IAtomContainerSet_IAtom() {
         IAtomContainerSet ms = new AtomContainerSet();
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("O"));
         mol.addBond(0, 1, IBond.Order.DOUBLE);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerSetManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerSetManipulatorTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.test.CDKTestCase;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemFileManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemFileManipulatorTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemFileManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemFileManipulatorTest.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
@@ -80,13 +81,13 @@ class ChemFileManipulatorTest extends CDKTestCase {
 
     @BeforeEach
     void setUp() {
-        molecule1 = new AtomContainer();
+        molecule1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol1 = new Atom("Cl");
         molecule1.addAtom(atomInMol1);
         molecule1.addAtom(new Atom("Cl"));
         bondInMol1 = new Bond(atomInMol1, molecule1.getAtom(1));
         molecule1.addBond(bondInMol1);
-        molecule2 = new AtomContainer();
+        molecule2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol2 = new Atom("O");
         atomInMol2.setImplicitHydrogenCount(2);
         molecule2.addAtom(atomInMol2);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemModelManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemModelManipulatorTest.java
@@ -74,7 +74,7 @@ class ChemModelManipulatorTest extends CDKTestCase {
 
     @BeforeEach
     void setUp() {
-        molecule1 = new AtomContainer();
+        molecule1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol1 = new Atom("Cl");
         atomInMol1.setCharge(-1.0);
         atomInMol1.setFormalCharge(-1);
@@ -83,7 +83,7 @@ class ChemModelManipulatorTest extends CDKTestCase {
         molecule1.addAtom(new Atom("Cl"));
         bondInMol1 = new Bond(atomInMol1, molecule1.getAtom(1));
         molecule1.addBond(bondInMol1);
-        molecule2 = new AtomContainer();
+        molecule2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol2 = new Atom("O");
         atomInMol2.setImplicitHydrogenCount(2);
         molecule2.addAtom(atomInMol2);
@@ -129,7 +129,7 @@ class ChemModelManipulatorTest extends CDKTestCase {
 
     @Test
     void testNewChemModel_IAtomContainer() {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         IChemModel model = ChemModelManipulator.newChemModel(ac);
         IAtomContainer mol = model.getMoleculeSet().getAtomContainer(0);
@@ -151,12 +151,12 @@ class ChemModelManipulatorTest extends CDKTestCase {
 
     @Test
     void testRemoveElectronContainer_IChemModel_IElectronContainer() {
-        IAtomContainer mol1 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol1.addAtom(new Atom("Cl"));
         mol1.addAtom(new Atom("Cl"));
         IBond bond1 = new Bond(mol1.getAtom(0), mol1.getAtom(1));
         mol1.addBond(bond1);
-        IAtomContainer mol2 = new AtomContainer();
+        IAtomContainer mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol2.addAtom(new Atom("I"));
         mol2.addAtom(new Atom("I"));
         IBond bond2 = new Bond(mol2.getAtom(0), mol2.getAtom(1));
@@ -182,13 +182,13 @@ class ChemModelManipulatorTest extends CDKTestCase {
 
     @Test
     void testRemoveAtomAndConnectedElectronContainers_IChemModel_IAtom() {
-        IAtomContainer mol1 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom1 = new Atom("Cl");
         mol1.addAtom(atom1);
         mol1.addAtom(new Atom("Cl"));
         IBond bond1 = new Bond(mol1.getAtom(0), mol1.getAtom(1));
         mol1.addBond(bond1);
-        IAtomContainer mol2 = new AtomContainer();
+        IAtomContainer mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom2 = new Atom("I");
         mol2.addAtom(atom2);
         mol2.addAtom(new Atom("I"));

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemModelManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemModelManipulatorTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemModel;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemSequenceManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemSequenceManipulatorTest.java
@@ -68,13 +68,13 @@ class ChemSequenceManipulatorTest extends CDKTestCase {
 
     @BeforeEach
     void setUp() {
-        molecule1 = new AtomContainer();
+        molecule1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol1 = new Atom("Cl");
         molecule1.addAtom(atomInMol1);
         molecule1.addAtom(new Atom("Cl"));
         bondInMol1 = new Bond(atomInMol1, molecule1.getAtom(1));
         molecule1.addBond(bondInMol1);
-        molecule2 = new AtomContainer();
+        molecule2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol2 = new Atom("O");
         atomInMol2.setImplicitHydrogenCount(2);
         molecule2.addAtom(atomInMol2);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemSequenceManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ChemSequenceManipulatorTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemModel;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/MoleculeSetManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/MoleculeSetManipulatorTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/MoleculeSetManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/MoleculeSetManipulatorTest.java
@@ -27,6 +27,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -55,7 +56,7 @@ class MoleculeSetManipulatorTest extends CDKTestCase {
 
     @BeforeEach
     void setUp() {
-        mol1 = new AtomContainer();
+        mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol1 = new Atom("Cl");
         atomInMol1.setCharge(-1.0);
         atomInMol1.setFormalCharge(-1);
@@ -64,7 +65,7 @@ class MoleculeSetManipulatorTest extends CDKTestCase {
         mol1.addAtom(new Atom("Cl"));
         bondInMol1 = new Bond(atomInMol1, mol1.getAtom(1));
         mol1.addBond(bondInMol1);
-        mol2 = new AtomContainer();
+        mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         atomInMol2 = new Atom("O");
         atomInMol2.setImplicitHydrogenCount(2);
         mol2.addAtom(atomInMol2);
@@ -87,7 +88,7 @@ class MoleculeSetManipulatorTest extends CDKTestCase {
     @Test
     void testRemoveElectronContainer_IAtomContainerSet_IElectronContainer() {
         IAtomContainerSet ms = new AtomContainerSet();
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("O"));
         mol.addBond(0, 1, IBond.Order.DOUBLE);
@@ -103,7 +104,7 @@ class MoleculeSetManipulatorTest extends CDKTestCase {
     @Test
     void testRemoveAtomAndConnectedElectronContainers_IAtomContainerSet_IAtom() {
         IAtomContainerSet ms = new AtomContainerSet();
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("O"));
         mol.addBond(0, 1, IBond.Order.DOUBLE);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ReactionManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ReactionManipulatorTest.java
@@ -67,10 +67,10 @@ class ReactionManipulatorTest extends CDKTestCase {
     void testReverse_IReaction() {
         Reaction reaction = new Reaction();
         reaction.setDirection(IReaction.Direction.BACKWARD);
-        IAtomContainer water = new AtomContainer();
+        IAtomContainer water = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reaction.addReactant(water, 3.0);
-        reaction.addReactant(new AtomContainer());
-        reaction.addProduct(new AtomContainer());
+        reaction.addReactant(DefaultChemObjectBuilder.getInstance().newAtomContainer());
+        reaction.addProduct(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         Reaction reversedReaction = (Reaction) ReactionManipulator.reverse(reaction);
         Assertions.assertEquals(IReaction.Direction.FORWARD, reversedReaction.getDirection());
@@ -83,7 +83,7 @@ class ReactionManipulatorTest extends CDKTestCase {
     void testGetAllIDs_IReaction() {
         Reaction reaction = new Reaction();
         reaction.setID("r1");
-        IAtomContainer water = new AtomContainer();
+        IAtomContainer water = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         water.setID("m1");
         Atom oxygen = new Atom("O");
         oxygen.setID("a1");
@@ -310,9 +310,9 @@ class ReactionManipulatorTest extends CDKTestCase {
     @Test
     void perceiveAtomTypesAndConfigureAtomsUnknownAtomTypeTest() throws CDKException {
         // arrange
-        IAtomContainer reactant = new AtomContainer();
+        IAtomContainer reactant = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reactant.addAtom(new Atom("R"));
-        IAtomContainer product = new AtomContainer();
+        IAtomContainer product = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reactant.addAtom(new Atom("C"));
         IReaction reaction = new Reaction();
         reaction.addReactant(reactant);
@@ -334,7 +334,7 @@ class ReactionManipulatorTest extends CDKTestCase {
         IAtom reactantOneAtomThree = new Atom("C");
         IBond reactantOneBondOne = new Bond(reactantOneAtomOne, reactantOneAtomTwo, Order.SINGLE);
         IBond reactantOneBondTwo = new Bond(reactantOneAtomTwo, reactantOneAtomThree, Order.DOUBLE);
-        IAtomContainer reactantOne = new AtomContainer();
+        IAtomContainer reactantOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reactantOne.addAtom(reactantOneAtomOne);
         reactantOne.addAtom(reactantOneAtomTwo);
         reactantOne.addAtom(reactantOneAtomThree);
@@ -343,12 +343,12 @@ class ReactionManipulatorTest extends CDKTestCase {
 
         // reactant two: Br
         IAtom reactantTwoAtom1 = new Atom("Br");
-        IAtomContainer reactantTwo = new AtomContainer();
+        IAtomContainer reactantTwo = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reactantTwo.addAtom(reactantTwoAtom1);
 
         // agent one: O
         IAtom agentOneAtomOne = new Atom("O");
-        IAtomContainer agentOne = new AtomContainer();
+        IAtomContainer agentOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         agentOne.addAtom(agentOneAtomOne);
 
         // product one: CC(Br)C
@@ -359,7 +359,7 @@ class ReactionManipulatorTest extends CDKTestCase {
         IBond productOneBondOne = new Bond(productOneAtomOne, productOneAtomTwo, Order.SINGLE);
         IBond productOneBondTwo = new Bond(productOneAtomTwo, productOneAtomThree, Order.SINGLE);
         IBond productOneBondThree = new Bond(productOneAtomTwo, productOneAtomFour, Order.SINGLE);
-        IAtomContainer productOne = new AtomContainer();
+        IAtomContainer productOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         productOne.addAtom(productOneAtomOne);
         productOne.addAtom(productOneAtomTwo);
         productOne.addAtom(productOneAtomThree);
@@ -431,7 +431,7 @@ class ReactionManipulatorTest extends CDKTestCase {
         reactantOneAtomThree.setFormalNeighbourCount(2);
         IBond reactantOneBondOne = new Bond(reactantOneAtomOne, reactantOneAtomTwo, Order.SINGLE);
         IBond reactantOneBondTwo = new Bond(reactantOneAtomTwo, reactantOneAtomThree, Order.DOUBLE);
-        IAtomContainer reactantOne = new AtomContainer();
+        IAtomContainer reactantOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reactantOne.addAtom(reactantOneAtomOne);
         reactantOne.addAtom(reactantOneAtomTwo);
         reactantOne.addAtom(reactantOneAtomThree);
@@ -440,12 +440,12 @@ class ReactionManipulatorTest extends CDKTestCase {
 
         // reactant two: Br
         IAtom reactantTwoAtom1 = new Atom("Br");
-        IAtomContainer reactantTwo = new AtomContainer();
+        IAtomContainer reactantTwo = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reactantTwo.addAtom(reactantTwoAtom1);
 
         // agent one: O
         IAtom agentOneAtomOne = new Atom("O");
-        IAtomContainer agentOne = new AtomContainer();
+        IAtomContainer agentOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         agentOne.addAtom(agentOneAtomOne);
 
         // product one: CC(Br)C
@@ -458,7 +458,7 @@ class ReactionManipulatorTest extends CDKTestCase {
         IBond productOneBondOne = new Bond(productOneAtomOne, productOneAtomTwo, Order.SINGLE);
         IBond productOneBondTwo = new Bond(productOneAtomTwo, productOneAtomThree, Order.SINGLE);
         IBond productOneBondThree = new Bond(productOneAtomTwo, productOneAtomFour, Order.SINGLE);
-        IAtomContainer productOne = new AtomContainer();
+        IAtomContainer productOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         productOne.addAtom(productOneAtomOne);
         productOne.addAtom(productOneAtomTwo);
         productOne.addAtom(productOneAtomThree);
@@ -547,7 +547,7 @@ class ReactionManipulatorTest extends CDKTestCase {
         IAtom reactantOneAtomThree = new Atom("C");
         IBond reactantOneBondOne = new Bond(reactantOneAtomOne, reactantOneAtomTwo, Order.SINGLE);
         IBond reactantOneBondTwo = new Bond(reactantOneAtomTwo, reactantOneAtomThree, Order.DOUBLE);
-        IAtomContainer reactantOne = new AtomContainer();
+        IAtomContainer reactantOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reactantOne.addAtom(reactantOneAtomOne);
         reactantOne.addAtom(reactantOneAtomTwo);
         reactantOne.addAtom(reactantOneAtomThree);
@@ -556,12 +556,12 @@ class ReactionManipulatorTest extends CDKTestCase {
 
         // reactant two: Br
         IAtom reactantTwoAtom1 = new Atom("Br");
-        IAtomContainer reactantTwo = new AtomContainer();
+        IAtomContainer reactantTwo = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reactantTwo.addAtom(reactantTwoAtom1);
 
         // agent one: O
         IAtom agentOneAtomOne = new Atom("O");
-        IAtomContainer agentOne = new AtomContainer();
+        IAtomContainer agentOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         agentOne.addAtom(agentOneAtomOne);
 
         // product one: CC(Br)C
@@ -572,7 +572,7 @@ class ReactionManipulatorTest extends CDKTestCase {
         IBond productOneBondOne = new Bond(productOneAtomOne, productOneAtomTwo, Order.SINGLE);
         IBond productOneBondTwo = new Bond(productOneAtomTwo, productOneAtomThree, Order.SINGLE);
         IBond productOneBondThree = new Bond(productOneAtomTwo, productOneAtomFour, Order.SINGLE);
-        IAtomContainer productOne = new AtomContainer();
+        IAtomContainer productOne = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         productOne.addAtom(productOneAtomOne);
         productOne.addAtom(productOneAtomTwo);
         productOne.addAtom(productOneAtomThree);

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ReactionSetManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ReactionSetManipulatorTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.ReactionSet;

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ReactionSetManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ReactionSetManipulatorTest.java
@@ -207,7 +207,7 @@ class ReactionSetManipulatorTest extends CDKTestCase {
         IReaction reaction1 = builder.newInstance(IReaction.class);
         set.addReaction(reaction1);
         reaction1.setID("r1");
-        IAtomContainer water = new AtomContainer();
+        IAtomContainer water = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         water.setID("m1");
         Atom oxygen = new Atom("O");
         oxygen.setID("a1");

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/ATASaturationCheckerTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/ATASaturationCheckerTest.java
@@ -34,7 +34,6 @@ import org.openscience.cdk.interfaces.IAtomType;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IElement;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.test.CDKTestCase;

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/ATASaturationCheckerTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/ATASaturationCheckerTest.java
@@ -68,7 +68,7 @@ class ATASaturationCheckerTest extends CDKTestCase {
     @Test
     void testASimpleCarbonRing() throws Exception {
         // First we create a simple carbon ring to play with...
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtomType carbon = new AtomType(Elements.CARBON);
 
         IAtom a0 = new Atom("C");
@@ -596,7 +596,7 @@ class ATASaturationCheckerTest extends CDKTestCase {
 
     @Test
     void testButadiene() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtomType carbon = new AtomType(Elements.CARBON);
 
         IAtom a0 = new Atom("C");

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKHydrogenAdderTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKHydrogenAdderTest.java
@@ -44,7 +44,6 @@ import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.AtomTypeManipulator;

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKHydrogenAdderTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKHydrogenAdderTest.java
@@ -77,7 +77,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testMethane() throws Exception {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom newAtom = new Atom(Elements.CARBON);
         molecule.addAtom(newAtom);
         IAtomType type = matcher.findMatchingAtomType(molecule, newAtom);
@@ -92,7 +92,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testFormaldehyde() throws Exception {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom newAtom = new Atom(Elements.CARBON);
         IAtom newAtom2 = new Atom(Elements.OXYGEN);
         molecule.addAtom(newAtom);
@@ -115,7 +115,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testMethanol() throws Exception {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom newAtom = new Atom(Elements.CARBON);
         IAtom newAtom2 = new Atom(Elements.OXYGEN);
         molecule.addAtom(newAtom);
@@ -138,7 +138,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testHCN() throws Exception {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom newAtom = new Atom(Elements.CARBON);
         IAtom newAtom2 = new Atom(Elements.NITROGEN);
         molecule.addAtom(newAtom);
@@ -161,7 +161,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testMethylAmine() throws Exception {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom newAtom = new Atom(Elements.CARBON);
         IAtom newAtom2 = new Atom(Elements.NITROGEN);
         molecule.addAtom(newAtom);
@@ -184,7 +184,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testMethyleneImine() throws Exception {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom newAtom = new Atom(Elements.CARBON);
         IAtom newAtom2 = new Atom(Elements.NITROGEN);
         molecule.addAtom(newAtom);
@@ -207,7 +207,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testSulphur() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("S");
         mol.addAtom(atom);
         IAtomType type = matcher.findMatchingAtomType(mol, atom);
@@ -223,7 +223,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testProton() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom proton = new Atom("H");
         proton.setFormalCharge(+1);
         mol.addAtom(proton);
@@ -243,7 +243,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testHydrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom proton = new Atom("H");
         mol.addAtom(proton);
         IAtomType type = matcher.findMatchingAtomType(mol, proton);
@@ -262,7 +262,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testAmmonia() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom nitrogen = new Atom("N");
         mol.addAtom(nitrogen);
         IAtomType type = matcher.findMatchingAtomType(mol, nitrogen);
@@ -276,7 +276,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testAmmonium() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom nitrogen = new Atom("N");
         nitrogen.setFormalCharge(+1);
         mol.addAtom(nitrogen);
@@ -291,7 +291,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testWater() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom oxygen = new Atom("O");
         mol.addAtom(oxygen);
         IAtomType type = matcher.findMatchingAtomType(mol, oxygen);
@@ -305,7 +305,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testHydroxonium() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom oxygen = new Atom("O");
         oxygen.setFormalCharge(+1);
         mol.addAtom(oxygen);
@@ -320,7 +320,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testHydroxyl() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom oxygen = new Atom("O");
         oxygen.setFormalCharge(-1);
         mol.addAtom(oxygen);
@@ -350,7 +350,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
     }
 
     private void halogenTest(String halogen) throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom(halogen);
         mol.addAtom(atom);
         IAtomType type = matcher.findMatchingAtomType(mol, atom);
@@ -364,7 +364,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
     }
 
     private void negativeHalogenTest(String halogen) throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom(halogen);
         atom.setFormalCharge(-1);
         mol.addAtom(atom);
@@ -380,7 +380,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testSulfite() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom s = new Atom("S");
         Atom o1 = new Atom("O");
         Atom o2 = new Atom("O");
@@ -425,7 +425,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testAceticAcid() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom carbonylOxygen = new Atom("O");
         Atom hydroxylOxygen = new Atom("O");
         Atom methylCarbon = new Atom("C");
@@ -453,7 +453,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testEthane() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom carbon1 = new Atom("C");
         Atom carbon2 = new Atom("C");
         Bond b = new Bond(carbon1, carbon2, IBond.Order.SINGLE);
@@ -471,7 +471,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testEthaneWithPresetImplicitHCount() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom carbon1 = new Atom("C");
         Atom carbon2 = new Atom("C");
         Bond b = new Bond(carbon1, carbon2, IBond.Order.SINGLE);
@@ -492,7 +492,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testEthene() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom carbon1 = new Atom("C");
         Atom carbon2 = new Atom("C");
         Bond b = new Bond(carbon1, carbon2, IBond.Order.DOUBLE);
@@ -510,7 +510,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testEthyne() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom carbon1 = new Atom("C");
         Atom carbon2 = new Atom("C");
         Bond b = new Bond(carbon1, carbon2, IBond.Order.TRIPLE);
@@ -528,7 +528,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testAromaticSaturation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -559,7 +559,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testaddImplicitHydrogensToSatisfyValency_OldValue() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         Atom oxygen = new Atom("O");
         mol.addAtom(oxygen);
@@ -577,7 +577,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testAdenine() throws Exception {
-        IAtomContainer mol = new AtomContainer(); // Adenine
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer(); // Adenine
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(21.0223, -17.2946));
         mol.addAtom(a1);
@@ -646,7 +646,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
         String filename = "carbocations.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        molecule = reader.read(new AtomContainer());
+        molecule = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         findAndConfigureAtomTypesForAllAtoms(molecule);
         adder.addImplicitHydrogens(molecule);
         Assertions.assertEquals(2, molecule.getAtom(0).getImplicitHydrogenCount().intValue());
@@ -663,7 +663,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
         String filename = "furan.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         findAndConfigureAtomTypesForAllAtoms(molecule);
         adder.addImplicitHydrogens(molecule);
         Assertions.assertEquals(1, molecule.getAtom(0).getImplicitHydrogenCount().intValue());
@@ -677,7 +677,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
         String filename = "furan.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         findAndConfigureAtomTypesForAllAtoms(molecule);
         for (IAtom atom : molecule.atoms()) {
             adder.addImplicitHydrogens(molecule, atom);
@@ -690,7 +690,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testPseudoAtom() throws Exception {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new PseudoAtom("Waterium"));
         findAndConfigureAtomTypesForAllAtoms(molecule);
         Assertions.assertNull(molecule.getAtom(0).getImplicitHydrogenCount());
@@ -698,7 +698,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testNaCl() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom cl = new Atom("Cl");
         cl.setFormalCharge(-1);
         mol.addAtom(cl);
@@ -750,7 +750,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
      */
     @Test
     void testBug1627763() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "O"));
         mol.addBond(mol.getBuilder().newInstance(IBond.class, mol.getAtom(0), mol.getAtom(1),
@@ -772,7 +772,7 @@ class CDKHydrogenAdderTest extends CDKTestCase {
 
     @Test
     void testMercaptan() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));
         mol.addAtom(mol.getBuilder().newInstance(IAtom.class, "C"));

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKValencyCheckerTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKValencyCheckerTest.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.tools;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKValencyCheckerTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/CDKValencyCheckerTest.java
@@ -52,7 +52,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_IAtomContainer() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKValencyChecker checker = CDKValencyChecker.getInstance(mol.getBuilder());
         Atom c = new Atom("C");
         Atom h1 = new Atom("H");
@@ -72,7 +72,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
         Assertions.assertTrue(checker.isSaturated(mol));
 
         // test methane with implicit hydrogen
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         c = new Atom("C");
         c.setImplicitHydrogenCount(4);
         mol.addAtom(c);
@@ -83,7 +83,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturatedPerAtom() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKValencyChecker checker = CDKValencyChecker.getInstance(mol.getBuilder());
         Atom c = new Atom("C");
         Atom h1 = new Atom("H");
@@ -103,7 +103,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
         Assertions.assertTrue(checker.isSaturated(mol));
 
         // test methane with implicit hydrogen
-        mol = new AtomContainer();
+        mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         c = new Atom("C");
         c.setImplicitHydrogenCount(4);
         mol.addAtom(c);
@@ -116,7 +116,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_MissingHydrogens_Methane() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKValencyChecker checker = CDKValencyChecker.getInstance(mol.getBuilder());
         Atom c = new Atom("C");
         mol.addAtom(c);
@@ -131,7 +131,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_NegativelyChargedOxygen() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKValencyChecker checker = CDKValencyChecker.getInstance(mol.getBuilder());
         Atom c = new Atom("C");
         Atom h1 = new Atom("H");
@@ -159,7 +159,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_PositivelyChargedNitrogen() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKValencyChecker checker = CDKValencyChecker.getInstance(mol.getBuilder());
         Atom n = new Atom("N");
         Atom h1 = new Atom("H");
@@ -186,7 +186,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
     @Test
     void testBug772316() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKValencyChecker checker = CDKValencyChecker.getInstance(mol.getBuilder());
         Atom sulphur = new Atom("S");
         Atom o1 = new Atom("O");
@@ -218,7 +218,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_Proton() throws Exception {
         // test H+
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKValencyChecker checker = CDKValencyChecker.getInstance(mol.getBuilder());
         Atom hydrogen = new Atom("H");
         hydrogen.setFormalCharge(+1);
@@ -232,7 +232,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
      */
     @Test
     void test1() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom f1 = new Atom("F");
         Atom c2 = new Atom("C");
         Atom c3 = new Atom("C");
@@ -251,7 +251,7 @@ class CDKValencyCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_MissingBondOrders_Ethane() throws Exception {
         // test ethane with explicit hydrogen
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         CDKValencyChecker checker = CDKValencyChecker.getInstance(mol.getBuilder());
         Atom c1 = new Atom("C");
         c1.setImplicitHydrogenCount(2);

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/DeduceBondOrderTestFromExplicitHydrogens.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/DeduceBondOrderTestFromExplicitHydrogens.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.interfaces.IAtom;
@@ -56,7 +57,7 @@ class DeduceBondOrderTestFromExplicitHydrogens extends CDKTestCase {
      */
     @Test
     void testAcetylene() throws Exception {
-        IAtomContainer keto = new AtomContainer();
+        IAtomContainer keto = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -83,7 +84,7 @@ class DeduceBondOrderTestFromExplicitHydrogens extends CDKTestCase {
      */
     @Test
     void testKeto() throws Exception {
-        IAtomContainer keto = new AtomContainer();
+        IAtomContainer keto = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -115,7 +116,7 @@ class DeduceBondOrderTestFromExplicitHydrogens extends CDKTestCase {
      */
     @Test
     void testEnol() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -148,7 +149,7 @@ class DeduceBondOrderTestFromExplicitHydrogens extends CDKTestCase {
      */
     @Test
     void xtestButadiene() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -187,7 +188,7 @@ class DeduceBondOrderTestFromExplicitHydrogens extends CDKTestCase {
      */
     @Test
     void testQuinone() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -249,7 +250,7 @@ class DeduceBondOrderTestFromExplicitHydrogens extends CDKTestCase {
      */
     @Test
     void testBenzene() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -309,7 +310,7 @@ class DeduceBondOrderTestFromExplicitHydrogens extends CDKTestCase {
      */
     @Test
     void testPyrrole() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -357,7 +358,7 @@ class DeduceBondOrderTestFromExplicitHydrogens extends CDKTestCase {
      */
     @Disabled("previously disabled 'xtest'")
     void xtestPyridine() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/DeduceBondOrderTestFromExplicitHydrogens.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/DeduceBondOrderTestFromExplicitHydrogens.java
@@ -30,7 +30,6 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 
 /**

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/SaturationCheckerTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/SaturationCheckerTest.java
@@ -56,7 +56,7 @@ class SaturationCheckerTest extends CDKTestCase {
     @Test
     void testAllSaturated() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom c = new Atom("C");
         Atom h1 = new Atom("H");
         Atom h2 = new Atom("H");
@@ -74,7 +74,7 @@ class SaturationCheckerTest extends CDKTestCase {
         Assertions.assertTrue(satcheck.allSaturated(m));
 
         // test methane with implicit hydrogen
-        m = new AtomContainer();
+        m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         c = new Atom("C");
         c.setImplicitHydrogenCount(4);
         m.addAtom(c);
@@ -87,7 +87,7 @@ class SaturationCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom c = new Atom("C");
         Atom h1 = new Atom("H");
         Atom h2 = new Atom("H");
@@ -116,7 +116,7 @@ class SaturationCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_NegativelyChargedOxygen() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom c = new Atom("C");
         Atom h1 = new Atom("H");
         Atom h2 = new Atom("H");
@@ -146,7 +146,7 @@ class SaturationCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_PositivelyChargedNitrogen() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom n = new Atom("N");
         Atom h1 = new Atom("H");
         Atom h2 = new Atom("H");
@@ -181,7 +181,7 @@ class SaturationCheckerTest extends CDKTestCase {
         c2.setImplicitHydrogenCount(2);
         Bond b = new Bond(c1, c2, IBond.Order.SINGLE);
         // force single bond, saturate() must fix that
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(c1);
         m.addAtom(c2);
         m.addBond(b);
@@ -207,7 +207,7 @@ class SaturationCheckerTest extends CDKTestCase {
         Bond b2 = new Bond(c3, c2, IBond.Order.SINGLE);
         Bond b3 = new Bond(c3, c4, IBond.Order.SINGLE);
         // force single bond, saturate() must fix that
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(c1);
         m.addAtom(c2);
         m.addAtom(c3);
@@ -223,7 +223,7 @@ class SaturationCheckerTest extends CDKTestCase {
 
     @Test
     void testSaturate_ParaDiOxygenBenzene() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom a1 = new Atom("C");
         mol.addAtom(a1);
         Atom a2 = new Atom("O");
@@ -289,7 +289,7 @@ class SaturationCheckerTest extends CDKTestCase {
     @Test
     void testBug772316() throws Exception {
         // test methane with explicit hydrogen
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom sulphur = new Atom("S");
         Atom o1 = new Atom("O");
         Atom o2 = new Atom("O");
@@ -321,7 +321,7 @@ class SaturationCheckerTest extends CDKTestCase {
 
     @Test
     void testBug777529() throws Exception {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));

--- a/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/SaturationCheckerTest.java
+++ b/base/test-valencycheck/src/test/java/org/openscience/cdk/tools/SaturationCheckerTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.test.CDKTestCase;

--- a/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/CIPToolTest.java
+++ b/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/CIPToolTest.java
@@ -277,7 +277,7 @@ class CIPToolTest extends CDKTestCase {
     //(timeout=5000)
     void testTermination() {
         int ringSize = 7;
-        IAtomContainer ring = new AtomContainer();
+        IAtomContainer ring = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         for (int i = 0; i < ringSize; i++) {
             ring.addAtom(new Atom("C"));
         }

--- a/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/CIPToolTest.java
+++ b/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/CIPToolTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/LigancyFourChiralityTest.java
+++ b/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/LigancyFourChiralityTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -48,7 +49,7 @@ class LigancyFourChiralityTest extends CDKTestCase {
 
     @BeforeAll
     static void setup() throws Exception {
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("Cl"));
         molecule.addAtom(new Atom("C"));
         molecule.addAtom(new Atom("Br"));

--- a/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/LigancyFourChiralityTest.java
+++ b/descriptor/cip/src/test/java/org/openscience/cdk/geometry/cip/LigancyFourChiralityTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtom;

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/CircularFingerprinterTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/CircularFingerprinterTest.java
@@ -47,6 +47,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDK;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
@@ -213,7 +214,7 @@ class CircularFingerprinterTest extends CDKTestCase {
             byte[] molBytes = content.get(basefn + ".mol");
             if (molBytes == null) break;
 
-            AtomContainer mol = new AtomContainer();
+            IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             MDLV2000Reader mdl = new MDLV2000Reader(new ByteArrayInputStream(molBytes));
             mdl.read(mol);
             mdl.close();
@@ -250,7 +251,7 @@ class CircularFingerprinterTest extends CDKTestCase {
         return list.toArray(new CircularFingerprinter.FP[list.size()]);
     }
 
-    private void validateFingerprints(String label, AtomContainer mol, int classType,
+    private void validateFingerprints(String label, IAtomContainer mol, int classType,
             CircularFingerprinter.FP[] validate) throws Exception {
         CircularFingerprinter circ = new CircularFingerprinter(classType);
         try {
@@ -320,7 +321,7 @@ class CircularFingerprinterTest extends CDKTestCase {
 
     @Test
     void protonsDontCauseNPE() throws Exception {
-        IAtomContainer proton = new AtomContainer(1, 0, 0, 0);
+        IAtomContainer proton = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         proton.addAtom(atom("H", +1, 0));
         CircularFingerprinter circ = new CircularFingerprinter(CircularFingerprinter.CLASS_FCFP2);
         assertThat(circ.getBitFingerprint(proton).cardinality(), is(0));
@@ -328,7 +329,7 @@ class CircularFingerprinterTest extends CDKTestCase {
 
     @Test
     void iminesDetectionDoesntCauseNPE() throws Exception {
-        IAtomContainer pyrazole = new AtomContainer(6, 6, 0, 0);
+        IAtomContainer pyrazole = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         pyrazole.addAtom(atom("H", 0, 0));
         pyrazole.addAtom(atom("N", 0, 0));
         pyrazole.addAtom(atom("C", 0, 1));
@@ -350,7 +351,7 @@ class CircularFingerprinterTest extends CDKTestCase {
      */
     @Test
     void partialCoordinatesDontCauseNPE() throws Exception {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, 0.000, 0.000));
         m.addAtom(atom("C", 0, 1.299, -0.750));
         m.addAtom(atom("H", 0, 0));
@@ -368,7 +369,7 @@ class CircularFingerprinterTest extends CDKTestCase {
 
 	@Test
     void testNonZZeroPlaner() throws Exception {
-	    IAtomContainer mol = new AtomContainer();
+	    IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 	    Atom[] atoms = new Atom[] {
 	        new Atom("C"),
 	        new Atom("F"),

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/CircularFingerprinterTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/CircularFingerprinterTest.java
@@ -45,7 +45,6 @@ import java.util.zip.ZipInputStream;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDK;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ExtendedFingerprinterTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ExtendedFingerprinterTest.java
@@ -33,7 +33,6 @@ import javax.vecmath.Point2d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ExtendedFingerprinterTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/ExtendedFingerprinterTest.java
@@ -36,6 +36,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
@@ -134,7 +135,7 @@ class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterTest {
     @Test
     void testDifferentRingFinders() throws Exception {
         IFingerprinter fingerprinter = new ExtendedFingerprinter();
-        IAtomContainer ac1 = new AtomContainer();
+        IAtomContainer ac1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         Atom atom2 = new Atom("C");
         Atom atom3 = new Atom("C");
@@ -159,7 +160,7 @@ class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         ac1.addBond(bond4);
         ac1.addBond(bond5);
         ac1.addBond(bond6);
-        IAtomContainer ac2 = new AtomContainer();
+        IAtomContainer ac2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac2.addAtom(atom1);
         ac2.addAtom(atom2);
         ac2.addAtom(atom3);
@@ -187,7 +188,7 @@ class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterTest {
      */
     @Test
     void testCondensedSingle() throws Exception {
-        IAtomContainer molcondensed = new AtomContainer();
+        IAtomContainer molcondensed = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = molcondensed.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(421.99999999999994, 860.0));
         molcondensed.addAtom(a1);
@@ -273,7 +274,7 @@ class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         IBond b18 = molcondensed.getBuilder().newInstance(IBond.class, a13, a16, IBond.Order.SINGLE);
         molcondensed.addBond(b18);
 
-        IAtomContainer molsingle = new AtomContainer();
+        IAtomContainer molsingle = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1s = molsingle.getBuilder().newInstance(IAtom.class, "C");
         a1s.setPoint2d(new Point2d(421.99999999999994, 860.0));
         molsingle.addAtom(a1s);
@@ -399,12 +400,12 @@ class ExtendedFingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         String filename = "chebisearch.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        searchmol = reader.read(new AtomContainer());
+        searchmol = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         filename = "chebifind.mol";
         ins = this.getClass().getResourceAsStream(filename);
         reader = new MDLV2000Reader(ins);
-        findmol = reader.read(new AtomContainer());
+        findmol = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         IFingerprinter fingerprinter = new ExtendedFingerprinter();
         BitSet superBS = fingerprinter.getBitFingerprint(findmol).asBitSet();

--- a/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/GraphOnlyFingerprinterTest.java
+++ b/descriptor/fingerprint/src/test/java/org/openscience/cdk/fingerprint/GraphOnlyFingerprinterTest.java
@@ -108,7 +108,7 @@ class GraphOnlyFingerprinterTest extends AbstractFixedLengthFingerprinterTest {
         if (molecule != null) {
             ISimpleChemObjectReader reader = new MDLV2000Reader(new StringReader(molecule));
             Assertions.assertNotNull(reader, "Could not create reader");
-            if (reader.accepts(AtomContainer.class)) {
+            if (reader.accepts(IAtomContainer.class)) {
                 structure = reader.read(DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class));
             }
         }

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/AtomHybridizationVSEPRDescriptorTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/AtomHybridizationVSEPRDescriptorTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/AtomHybridizationVSEPRDescriptorTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/AtomHybridizationVSEPRDescriptorTest.java
@@ -56,7 +56,7 @@ class AtomHybridizationVSEPRDescriptorTest extends AtomicDescriptorTest {
         AtomHybridizationVSEPRDescriptor descriptor = new AtomHybridizationVSEPRDescriptor();
 
         //O=CC
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom O1 = new Atom("O");
         Atom c2 = new Atom("C");
         c2.setImplicitHydrogenCount(1);
@@ -85,7 +85,7 @@ class AtomHybridizationVSEPRDescriptorTest extends AtomicDescriptorTest {
         AtomHybridizationVSEPRDescriptor descriptor = new AtomHybridizationVSEPRDescriptor();
 
         //[O+]#CC
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom O1 = new Atom("O");
         O1.setFormalCharge(1);
         Atom c2 = new Atom("C");
@@ -114,7 +114,7 @@ class AtomHybridizationVSEPRDescriptorTest extends AtomicDescriptorTest {
         AtomHybridizationVSEPRDescriptor descriptor = new AtomHybridizationVSEPRDescriptor();
 
         //[C+]CC
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom c1 = new Atom("C");
         c1.setFormalCharge(1);
         c1.setImplicitHydrogenCount(2);
@@ -145,7 +145,7 @@ class AtomHybridizationVSEPRDescriptorTest extends AtomicDescriptorTest {
         AtomHybridizationVSEPRDescriptor descriptor = new AtomHybridizationVSEPRDescriptor();
 
         //SO3
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom S1 = new Atom("S");
         Atom O2 = new Atom("O");
         Atom O3 = new Atom("O");
@@ -177,7 +177,7 @@ class AtomHybridizationVSEPRDescriptorTest extends AtomicDescriptorTest {
         AtomHybridizationVSEPRDescriptor descriptor = new AtomHybridizationVSEPRDescriptor();
 
         //XeF4
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom Xe1 = new Atom("Xe");
         Atom F2 = new Atom("F");
         Atom F3 = new Atom("F");
@@ -213,7 +213,7 @@ class AtomHybridizationVSEPRDescriptorTest extends AtomicDescriptorTest {
         AtomHybridizationVSEPRDescriptor descriptor = new AtomHybridizationVSEPRDescriptor();
 
         //IF2-
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom I1 = new Atom("I");
         I1.setFormalCharge(-1);
         Atom F2 = new Atom("F");

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/DistanceToAtomDescriptorTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/DistanceToAtomDescriptorTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/DistanceToAtomDescriptorTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/DistanceToAtomDescriptorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.qsar.IAtomicDescriptor;
@@ -50,7 +51,7 @@ class DistanceToAtomDescriptorTest extends AtomicDescriptorTest {
         Object[] params = {2};
         descriptor.setParameters(params);
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom a0 = new Atom("C");
         mol.addAtom(a0);
         a0.setPoint3d(new Point3d(1.2492, -0.2810, 0.0000));

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/InductiveAtomicHardnessDescriptorTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/InductiveAtomicHardnessDescriptorTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/InductiveAtomicHardnessDescriptorTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/InductiveAtomicHardnessDescriptorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.qsar.IAtomicDescriptor;
@@ -53,7 +54,7 @@ class InductiveAtomicHardnessDescriptorTest extends AtomicDescriptorTest {
         Point3d h2_coord = new Point3d(1.7439615035767404, -0.5279422553651107, 0.914422809754875);
         Point3d h3_coord = new Point3d(1.7439615035767402, -0.5279422553651113, -0.9144228097548747);
 
-        IAtomContainer mol = new AtomContainer(); // molecule is CF
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // molecule is CF
 
         Atom c = new Atom("C");
         mol.addAtom(c);

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/InductiveAtomicSoftnessDescriptorTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/InductiveAtomicSoftnessDescriptorTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/InductiveAtomicSoftnessDescriptorTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/InductiveAtomicSoftnessDescriptorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.qsar.IAtomicDescriptor;
@@ -53,7 +54,7 @@ class InductiveAtomicSoftnessDescriptorTest extends AtomicDescriptorTest {
         Point3d h2_coord = new Point3d(1.7439615035767404, -0.5279422553651107, 0.914422809754875);
         Point3d h3_coord = new Point3d(1.7439615035767402, -0.5279422553651113, -0.9144228097548747);
 
-        IAtomContainer mol = new AtomContainer(); // molecule is CF
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // molecule is CF
 
         Atom c = new Atom("C");
         mol.addAtom(c);

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3RTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3RTest.java
@@ -9,6 +9,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -62,7 +63,7 @@ class RDFProtonDescriptor_G3RTest extends AtomicDescriptorTest {
 
     @Test
     void testReturnsNaNForNonHydrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         mol.addAtom(atom);
         DescriptorValue dv = descriptor.calculate(atom, mol);

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3RTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_G3RTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDRTest.java
@@ -9,6 +9,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -62,7 +63,7 @@ class RDFProtonDescriptor_GDRTest extends AtomicDescriptorTest {
 
     @Test
     void testReturnsNaNForNonHydrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         mol.addAtom(atom);
         DescriptorValue dv = descriptor.calculate(atom, mol);

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GDRTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHRTest.java
@@ -9,6 +9,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -67,7 +68,7 @@ class RDFProtonDescriptor_GHRTest extends AtomicDescriptorTest {
 
     @Test
     void testReturnsNaNForNonHydrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         mol.addAtom(atom);
         DescriptorValue dv = descriptor.calculate(atom, mol);

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHRTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topolTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topolTest.java
@@ -9,6 +9,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -62,7 +63,7 @@ class RDFProtonDescriptor_GHR_topolTest extends AtomicDescriptorTest {
 
     @Test
     void testReturnsNaNForNonHydrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         mol.addAtom(atom);
         DescriptorValue dv = descriptor.calculate(atom, mol);

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topolTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GHR_topolTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSRTest.java
@@ -9,6 +9,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -62,7 +63,7 @@ class RDFProtonDescriptor_GSRTest extends AtomicDescriptorTest {
 
     @Test
     void testReturnsNaNForNonHydrogen() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("O");
         mol.addAtom(atom);
         DescriptorValue dv = descriptor.calculate(atom, mol);

--- a/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSRTest.java
+++ b/descriptor/qsaratomic/src/test/java/org/openscience/cdk/qsar/descriptors/atomic/RDFProtonDescriptor_GSRTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/graph/matrix/TopologicalMatrixTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/graph/matrix/TopologicalMatrixTest.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
@@ -20,7 +21,7 @@ class TopologicalMatrixTest extends CDKTestCase {
         String filename = "data/mdl/chlorobenzene.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer container = reader.read(new AtomContainer());
+        IAtomContainer container = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         int[][] matrix = TopologicalMatrix.getMatrix(container);
         Assertions.assertEquals(12, matrix.length);
         for (int[] ints : matrix) {

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/graph/matrix/TopologicalMatrixTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/graph/matrix/TopologicalMatrixTest.java
@@ -4,7 +4,6 @@ import java.io.InputStream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptorTest.java
@@ -23,7 +23,6 @@ import javax.vecmath.Point2d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AcidicGroupCountDescriptorTest.java
@@ -52,7 +52,7 @@ class AcidicGroupCountDescriptorTest extends MolecularDescriptorTest {
     @Test
     void uninitalisedError() {
         Assertions.assertThrows(IllegalStateException.class,
-                                () -> {new BasicGroupCountDescriptor().calculate(new AtomContainer());});
+                                () -> {new BasicGroupCountDescriptor().calculate(DefaultChemObjectBuilder.getInstance().newAtomContainer());});
     }
 
     @Test

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorChargeTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorChargeTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.qsar.DescriptorValue;
@@ -30,7 +31,7 @@ class AutocorrelationDescriptorChargeTest extends MolecularDescriptorTest {
         String filename = "chlorobenzene.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer container = reader.read(new AtomContainer());
+        IAtomContainer container = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         DescriptorValue count = descriptor.calculate(container);
         Assertions.assertEquals(5, count.getValue().length());
         Assertions.assertTrue(count.getValue() instanceof DoubleArrayResult);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorChargeTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorChargeTest.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.MDLV2000Reader;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorMassTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorMassTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.qsar.DescriptorValue;
@@ -48,7 +49,7 @@ class AutocorrelationDescriptorMassTest extends MolecularDescriptorTest {
         String filename = "chlorobenzene.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer container = reader.read(new AtomContainer());
+        IAtomContainer container = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         DescriptorValue count = new AutocorrelationDescriptorMass().calculate(container);
         Assertions.assertEquals(5, count.getValue().length());
         Assertions.assertTrue(count.getValue() instanceof DoubleArrayResult);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorMassTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorMassTest.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.MDLV2000Reader;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorPolarizabilityTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorPolarizabilityTest.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.qsar.DescriptorValue;
@@ -28,7 +29,7 @@ class AutocorrelationDescriptorPolarizabilityTest extends MolecularDescriptorTes
         String filename = "data/mdl/chlorobenzene.mol";
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer container = reader.read(new AtomContainer());
+        IAtomContainer container = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         DescriptorValue count = descriptor.calculate(container);
         System.out.println(count.getValue());
 

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorPolarizabilityTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/AutocorrelationDescriptorPolarizabilityTest.java
@@ -4,7 +4,6 @@ import java.io.InputStream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.MDLV2000Reader;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/BasicGroupCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/BasicGroupCountDescriptorTest.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.qsar.descriptors.molecular;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/BasicGroupCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/BasicGroupCountDescriptorTest.java
@@ -59,7 +59,7 @@ class BasicGroupCountDescriptorTest extends MolecularDescriptorTest {
     @Test
     void uninitalisedError() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
-            new BasicGroupCountDescriptor().calculate(new AtomContainer());
+            new BasicGroupCountDescriptor().calculate(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         });
     }
 

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiChainDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiChainDescriptorTest.java
@@ -5,7 +5,6 @@ import javax.vecmath.Point2d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiChainDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiChainDescriptorTest.java
@@ -30,7 +30,7 @@ class ChiChainDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     void testDan64() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.7500000000000004, 2.799038105676658));
         mol.addAtom(a1);
@@ -66,7 +66,7 @@ class ChiChainDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     void testDan80() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);
@@ -108,7 +108,7 @@ class ChiChainDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     void testDan81() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);
@@ -150,7 +150,7 @@ class ChiChainDescriptorTest extends MolecularDescriptorTest {
     @Test
     void testDan82() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);
@@ -192,7 +192,7 @@ class ChiChainDescriptorTest extends MolecularDescriptorTest {
     @Test
     void testDan154() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiClusterDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiClusterDescriptorTest.java
@@ -30,7 +30,7 @@ class ChiClusterDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     void testDan64() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.7500000000000004, 2.799038105676658));
         mol.addAtom(a1);
@@ -67,7 +67,7 @@ class ChiClusterDescriptorTest extends MolecularDescriptorTest {
     @Test
     void testDan154() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);
@@ -124,7 +124,7 @@ class ChiClusterDescriptorTest extends MolecularDescriptorTest {
     @Test
     void testDan248() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiClusterDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiClusterDescriptorTest.java
@@ -5,7 +5,6 @@ import javax.vecmath.Point2d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathClusterDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathClusterDescriptorTest.java
@@ -30,7 +30,7 @@ class ChiPathClusterDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     void testDan64() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.7500000000000004, 2.799038105676658));
         mol.addAtom(a1);
@@ -65,7 +65,7 @@ class ChiPathClusterDescriptorTest extends MolecularDescriptorTest {
     @Test
     void testDan154() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);
@@ -120,7 +120,7 @@ class ChiPathClusterDescriptorTest extends MolecularDescriptorTest {
     @Test
     void testDan248() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathClusterDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathClusterDescriptorTest.java
@@ -5,7 +5,6 @@ import javax.vecmath.Point2d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathDescriptorTest.java
@@ -30,7 +30,7 @@ class ChiPathDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     void testDan64() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.7500000000000004, 2.799038105676658));
         mol.addAtom(a1);
@@ -69,7 +69,7 @@ class ChiPathDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     void testDan80() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);
@@ -112,7 +112,7 @@ class ChiPathDescriptorTest extends MolecularDescriptorTest {
 
     @Test
     void testDan81() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);
@@ -155,7 +155,7 @@ class ChiPathDescriptorTest extends MolecularDescriptorTest {
     @Test
     void testDan82() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);
@@ -198,7 +198,7 @@ class ChiPathDescriptorTest extends MolecularDescriptorTest {
     @Test
     void testDan154() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(0.0, 1.5));
         mol.addAtom(a1);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/ChiPathDescriptorTest.java
@@ -5,7 +5,6 @@ import javax.vecmath.Point2d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FractionalPSADescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FractionalPSADescriptorTest.java
@@ -28,7 +28,6 @@
 
 package org.openscience.cdk.qsar.descriptors.molecular;
 
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FractionalPSADescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FractionalPSADescriptorTest.java
@@ -29,7 +29,9 @@
 package org.openscience.cdk.qsar.descriptors.molecular;
 
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.qsar.DescriptorValue;
 import org.openscience.cdk.qsar.result.DoubleResult;
@@ -60,7 +62,7 @@ class FractionalPSADescriptorTest extends MolecularDescriptorTest {
     void testDescriptors() throws Exception {
         String fnmol = "data/cdd/pyridineacid.mol";
         MDLV2000Reader mdl = new MDLV2000Reader(this.getClass().getClassLoader().getResourceAsStream(fnmol));
-        AtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mdl.read(mol);
         mdl.close();
 

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FragmentComplexityDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FragmentComplexityDescriptorTest.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.fragment.MurckoFragmenter;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FragmentComplexityDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/FragmentComplexityDescriptorTest.java
@@ -36,7 +36,7 @@ class FragmentComplexityDescriptorTest extends MolecularDescriptorTest {
         MurckoFragmenter gf = new MurckoFragmenter();
         double Complexity = 0;
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         gf.generateFragments(mol);
         IAtomContainer[] setOfFragments = gf.getFrameworksAsContainers();
         for (IAtomContainer setOfFragment : setOfFragments) {

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptorTest.java
@@ -29,7 +29,6 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.qsar.DescriptorValue;
 import org.openscience.cdk.qsar.IMolecularDescriptor;
 import org.openscience.cdk.qsar.result.IntegerResult;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.CDKHydrogenAdder;

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/RotatableBondsCountDescriptorTest.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.qsar.DescriptorValue;
 import org.openscience.cdk.qsar.IMolecularDescriptor;
 import org.openscience.cdk.qsar.result.IntegerResult;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
@@ -61,7 +62,7 @@ class RotatableBondsCountDescriptorTest extends MolecularDescriptorTest {
     }
 
     private IAtomContainer makeEthane() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(container.getBuilder().newInstance(IAtom.class, Elements.CARBON));
         container.addAtom(container.getBuilder().newInstance(IAtom.class, Elements.CARBON));
         container.addBond(0, 1, IBond.Order.SINGLE);

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/SmallRingDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/SmallRingDescriptorTest.java
@@ -40,7 +40,9 @@ import java.util.zip.ZipInputStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.io.MDLV2000Writer;
 import org.openscience.cdk.qsar.DescriptorValue;
@@ -112,7 +114,7 @@ class SmallRingDescriptorTest extends MolecularDescriptorTest {
             byte[] molBytes = content.get(basefn + ".mol");
             if (molBytes == null) break;
 
-            AtomContainer mol = new AtomContainer();
+            IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             MDLV2000Reader mdl = new MDLV2000Reader(new ByteArrayInputStream(molBytes));
             mdl.read(mol);
             mdl.close();

--- a/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/SmallRingDescriptorTest.java
+++ b/descriptor/qsarmolecular/src/test/java/org/openscience/cdk/qsar/descriptors/molecular/SmallRingDescriptorTest.java
@@ -39,7 +39,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/display/render/src/test/java/org/openscience/cdk/renderer/RendererModelTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/RendererModelTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.event.ICDKChangeListener;

--- a/display/render/src/test/java/org/openscience/cdk/renderer/RendererModelTest.java
+++ b/display/render/src/test/java/org/openscience/cdk/renderer/RendererModelTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.event.ICDKChangeListener;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -266,7 +267,7 @@ class RendererModelTest {
         RendererModel model = new RendererModel();
         // test default
         Assertions.assertNull(model.getClipboardContent());
-        IAtomContainer content = new AtomContainer();
+        IAtomContainer content = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         model.setClipboardContent(content);
         Assertions.assertEquals(content, model.getClipboardContent());
         model.setClipboardContent(null);
@@ -278,7 +279,7 @@ class RendererModelTest {
         RendererModel model = new RendererModel();
         // test default
         Assertions.assertNull(model.getExternalSelectedPart());
-        IAtomContainer content = new AtomContainer();
+        IAtomContainer content = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         model.setExternalSelectedPart(content);
         Assertions.assertEquals(content, model.getExternalSelectedPart());
         model.setExternalSelectedPart(null);

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/BoundsCalculatorTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/BoundsCalculatorTest.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.interfaces.IChemModel;
 import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.interfaces.IReactionSet;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 /**
  * @cdk.module test-renderbasic
@@ -43,7 +44,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IAtomContainer_SingleAtom() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             BoundsCalculator.calculateBounds(container);
         });
@@ -56,7 +57,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IAtomContainer() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             BoundsCalculator.calculateBounds(container);
@@ -70,7 +71,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IAtomContainerSet_SingleAtom() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             IAtomContainerSet set = container.getBuilder().newInstance(IAtomContainerSet.class);
             set.addAtomContainer(container);
@@ -85,7 +86,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IAtomContainerSet() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             IAtomContainerSet set = container.getBuilder().newInstance(IAtomContainerSet.class);
@@ -101,7 +102,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IReactionSet_SingleAtom() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             IReaction reaction = container.getBuilder().newInstance(IReaction.class);
             reaction.addReactant(container.getBuilder().newInstance(IAtomContainer.class, container));
@@ -118,7 +119,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IReactionSet() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             IReaction reaction = container.getBuilder().newInstance(IReaction.class);
@@ -136,7 +137,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IChemModel_SingleAtom() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             IAtomContainerSet set = container.getBuilder().newInstance(IAtomContainerSet.class);
             set.addAtomContainer(container);
@@ -153,7 +154,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IChemModel() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             IAtomContainerSet set = container.getBuilder().newInstance(IAtomContainerSet.class);
@@ -172,7 +173,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IReaction_SingleAtom() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             IReaction reaction = container.getBuilder().newInstance(IReaction.class);
             reaction.addReactant(container.getBuilder().newInstance(IAtomContainer.class, container));
@@ -187,7 +188,7 @@ class BoundsCalculatorTest {
     @Test
     void testCalculateBounds_IReaction() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer container = new AtomContainer();
+            IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             container.addAtom(container.getBuilder().newInstance(IAtom.class, "C"));
             IReaction reaction = container.getBuilder().newInstance(IReaction.class);

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/BoundsCalculatorTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/BoundsCalculatorTest.java
@@ -29,7 +29,6 @@ import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IChemModel;
 import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.interfaces.IReactionSet;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 /**

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/SelectionVisibilityTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/SelectionVisibilityTest.java
@@ -2,7 +2,6 @@ package org.openscience.cdk.renderer.generators.standard;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/SelectionVisibilityTest.java
+++ b/display/renderbasic/src/test/java/org/openscience/cdk/renderer/generators/standard/SelectionVisibilityTest.java
@@ -3,6 +3,7 @@ package org.openscience.cdk.renderer.generators.standard;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -22,7 +23,7 @@ class SelectionVisibilityTest {
 
     @Test
     void noHighlightOrGlow() {
-        IAtomContainer methyl = new AtomContainer();
+        IAtomContainer methyl = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         methyl.addAtom(atomAt("C", new Point2d(0, 0)));
         methyl.addAtom(atomAt("H", new Point2d(0, 1)));
         methyl.addAtom(atomAt("H", new Point2d(0, -1)));
@@ -39,7 +40,7 @@ class SelectionVisibilityTest {
 
     @Test
     void withHighlight() {
-        IAtomContainer methyl = new AtomContainer();
+        IAtomContainer methyl = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         methyl.addAtom(atomAt("C", new Point2d(0, 0)));
         methyl.addAtom(atomAt("H", new Point2d(0, 1)));
         methyl.addAtom(atomAt("H", new Point2d(0, -1)));
@@ -57,7 +58,7 @@ class SelectionVisibilityTest {
 
     @Test
     void isolated() {
-        IAtomContainer methyl = new AtomContainer();
+        IAtomContainer methyl = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         methyl.addAtom(atomAt("C", new Point2d(0, 0)));
         methyl.addAtom(atomAt("H", new Point2d(0, 1)));
         methyl.addAtom(atomAt("H", new Point2d(0, -1)));
@@ -75,7 +76,7 @@ class SelectionVisibilityTest {
 
     @Test
     void unIsolated() {
-        IAtomContainer methyl = new AtomContainer();
+        IAtomContainer methyl = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         methyl.addAtom(atomAt("C", new Point2d(0, 0)));
         methyl.addAtom(atomAt("H", new Point2d(0, 1)));
         methyl.addAtom(atomAt("H", new Point2d(0, -1)));

--- a/legacy/src/main/java/org/openscience/cdk/io/inchi/INChIHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/io/inchi/INChIHandler.java
@@ -23,6 +23,7 @@ import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
 import org.openscience.cdk.ChemSequence;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.tools.ILoggingTool;
@@ -102,8 +103,8 @@ public class INChIHandler extends DefaultHandler {
         } else if ("formula".equals(local)) {
             if (tautomer != null) {
                 logger.info("Parsing <formula> chars: ", currentChars);
-                tautomer = new AtomContainer(inchiTool.processFormula(
-                        setOfMolecules.getBuilder().newInstance(IAtomContainer.class), currentChars));
+                tautomer = DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, (inchiTool.processFormula(
+                        setOfMolecules.getBuilder().newInstance(IAtomContainer.class), currentChars)));
             } else {
                 logger.warn("Cannot set atom info for empty tautomer");
             }
@@ -141,7 +142,7 @@ public class INChIHandler extends DefaultHandler {
                 if (atts.getQName(i).equals("version")) logger.info("INChI version: ", atts.getValue(i));
             }
         } else if ("structure".equals(local)) {
-            tautomer = new AtomContainer();
+            tautomer = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         } else {
             // skip all other elements
         }

--- a/legacy/src/main/java/org/openscience/cdk/io/inchi/INChIHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/io/inchi/INChIHandler.java
@@ -18,7 +18,6 @@
  */
 package org.openscience.cdk.io.inchi;
 
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;

--- a/legacy/src/main/java/org/openscience/cdk/iupac/parser/MoleculeBuilder.java
+++ b/legacy/src/main/java/org/openscience/cdk/iupac/parser/MoleculeBuilder.java
@@ -449,7 +449,7 @@ public class MoleculeBuilder {
     }
 
     private static IAtomContainer makeBenzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -477,7 +477,7 @@ public class MoleculeBuilder {
      * @cdk.created 2003-08-15
      */
     private static IAtomContainer makeAlkane(int chainLength) {
-        IAtomContainer currentChain = new AtomContainer();
+        IAtomContainer currentChain = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         //Add the initial atom
         currentChain.addAtom(new Atom("C"));

--- a/legacy/src/main/java/org/openscience/cdk/iupac/parser/MoleculeBuilder.java
+++ b/legacy/src/main/java/org/openscience/cdk/iupac/parser/MoleculeBuilder.java
@@ -22,7 +22,6 @@
 package org.openscience.cdk.iupac.parser;
 
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.atomtype.CDKAtomTypeMatcher;

--- a/legacy/src/main/java/org/openscience/cdk/smsd/tools/MolHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/tools/MolHandler.java
@@ -29,7 +29,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;

--- a/legacy/src/main/java/org/openscience/cdk/smsd/tools/MolHandler.java
+++ b/legacy/src/main/java/org/openscience/cdk/smsd/tools/MolHandler.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.BondTools;
@@ -75,7 +76,7 @@ public class MolHandler {
 
             readMolecule = new FileInputStream(molFile);
             molRead = new MDLReader(new InputStreamReader(readMolecule));
-            this.atomContainer = molRead.read(new AtomContainer());
+            this.atomContainer = molRead.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
             molRead.close();
             readMolecule.close();
             /* Remove Hydrogen by Asad */

--- a/legacy/src/main/java/org/openscience/cdk/templates/MoleculeFactory.java
+++ b/legacy/src/main/java/org/openscience/cdk/templates/MoleculeFactory.java
@@ -22,6 +22,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.config.Isotopes;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
@@ -51,7 +52,7 @@ public class MoleculeFactory {
     private static final ILoggingTool logger = LoggingToolFactory.createLoggingTool(MoleculeFactory.class);
 
     public static IAtomContainer makeAlphaPinene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -89,7 +90,7 @@ public class MoleculeFactory {
      * @cdk.created 2003-08-15
      */
     public static IAtomContainer makeAlkane(int chainLength) {
-        IAtomContainer currentChain = new AtomContainer();
+        IAtomContainer currentChain = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         //Add the initial atom
         currentChain.addAtom(new Atom("C"));
@@ -104,7 +105,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeEthylCyclohexane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -131,7 +132,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C6H10/c1-2-4-6-5-3-1/h1-2H,3-6H2
      */
     public static IAtomContainer makeCyclohexene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -154,7 +155,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C6H12/c1-2-4-6-5-3-1/h1-6H2
      */
     public static IAtomContainer makeCyclohexane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -177,7 +178,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C5H10/c1-2-4-5-3-1/h1-5H2
      */
     public static IAtomContainer makeCyclopentane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -198,7 +199,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C4H8/c1-2-4-3-1/h1-4H2
      */
     public static IAtomContainer makeCyclobutane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -217,7 +218,7 @@ public class MoleculeFactory {
          * @cdk.inchi InChI=1/C4H4/c1-2-4-3-1/h1-4H
      */
     public static IAtomContainer makeCyclobutadiene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -231,7 +232,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makePropylCycloPropane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -254,7 +255,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C12H10/c1-3-7-11(8-4-1)12-9-5-2-6-10-12/h1-10H
      */
     public static IAtomContainer makeBiphenyl() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -286,7 +287,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makePhenylEthylBenzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -322,7 +323,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makePhenylAmine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -344,7 +345,7 @@ public class MoleculeFactory {
 
     /* build a molecule from 4 condensed triangles */
     public static IAtomContainer make4x3CondensedRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
         mol.addAtom(new Atom("C")); // 3
@@ -366,7 +367,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeSpiroRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -393,7 +394,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeBicycloRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -416,7 +417,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeFusedRings() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -444,7 +445,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeMethylDecaline() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -474,7 +475,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeEthylPropylPhenantren() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -521,7 +522,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeSteran() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -571,7 +572,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C10H8/c1-2-5-9-7-4-8-10(9)6-3-1/h1-8H
      */
     public static IAtomContainer makeAzulene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -604,7 +605,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C8H7N/c1-2-4-8-7(3-1)5-6-9-8/h1-6,9H
      */
     public static IAtomContainer makeIndole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -635,7 +636,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C4H5N/c1-2-4-5-3-1/h1-5H
      */
     public static IAtomContainer makePyrrole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -657,7 +658,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N/c1-2-4-5-3-1/h1-4H/q-1
      */
     public static IAtomContainer makePyrroleAnion() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom nitrogenAnion = new Atom("N");
         nitrogenAnion.setFormalCharge(-1);
         mol.addAtom(new Atom("C")); // 0
@@ -681,7 +682,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-5-3-4-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer makeImidazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -703,7 +704,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-4-5-3-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer makePyrazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -725,7 +726,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C3H4N2/c1-2-4-5-3-1/h1-3H,(H,4,5)/f/h4H
      */
     public static IAtomContainer make124Triazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -747,7 +748,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C2H3N3/c1-2-4-5-3-1/h1-2H,(H,3,4,5)/f/h5H
      */
     public static IAtomContainer make123Triazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -769,7 +770,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/CH2N4/c1-2-4-5-3-1/h1H,(H,2,3,4,5)/f/h4H
      */
     public static IAtomContainer makeTetrazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("N")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -791,7 +792,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-5-3-4-1/h1-3H
      */
     public static IAtomContainer makeOxazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -813,7 +814,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makeIsoxazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -835,7 +836,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NS/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makeIsothiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("S")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -857,7 +858,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C2H2N2S/c1-3-4-2-5-1/h1-2H
      */
     public static IAtomContainer makeThiadiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("S")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -879,7 +880,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C2H2N2O/c1-3-4-2-5-1/h1-2H
      */
     public static IAtomContainer makeOxadiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("O")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -901,7 +902,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NO/c1-2-4-5-3-1/h1-3H
      */
     public static IAtomContainer makePyridine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -925,7 +926,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C5H5NO/c7-6-4-2-1-3-5-6/h1-5H
      */
     public static IAtomContainer makePyridineOxide() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.getAtom(1).setFormalCharge(1);
@@ -953,7 +954,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-5-4-6-3-1/h1-4H
      */
     public static IAtomContainer makePyrimidine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -977,7 +978,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-4-6-5-3-1/h1-4H
      */
     public static IAtomContainer makePyridazine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("N")); // 2
@@ -1001,7 +1002,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C4H4N2/c1-2-4-6-5-3-1/h1-4H
      */
     public static IAtomContainer makeTriazine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1025,7 +1026,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C3H3NS/c1-2-5-3-4-1/h1-3H
      */
     public static IAtomContainer makeThiazole() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("N")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1042,7 +1043,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeSingleRing() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1070,7 +1071,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeDiamantane() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1109,7 +1110,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeBranchedAliphatic() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1153,7 +1154,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeBenzene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1171,7 +1172,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeQuinone() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O")); // 0
         mol.addAtom(new Atom("C")); // 1
         mol.addAtom(new Atom("C")); // 2
@@ -1193,7 +1194,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makePiperidine() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("N"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -1216,7 +1217,7 @@ public class MoleculeFactory {
     }
 
     public static IAtomContainer makeTetrahydropyran() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -1265,7 +1266,7 @@ public class MoleculeFactory {
      * @cdk.inchi InChI=1/C5H5N5/c6-4-3-5(9-1-7-3)10-2-8-4/h1-2H,(H3,6,7,8,9,10)/f/h7H,6H2
      */
     public static IAtomContainer makeAdenine() {
-        IAtomContainer mol = new AtomContainer(); // Adenine
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // Adenine
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "C");
         a1.setPoint2d(new Point2d(21.0223, -17.2946));
         mol.addAtom(a1);

--- a/legacy/src/main/java/org/openscience/cdk/templates/MoleculeFactory.java
+++ b/legacy/src/main/java/org/openscience/cdk/templates/MoleculeFactory.java
@@ -19,7 +19,6 @@
 package org.openscience.cdk.templates;
 
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/legacy/src/test/java/org/openscience/cdk/aromaticity/CDKHueckelAromaticityDetectorTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/aromaticity/CDKHueckelAromaticityDetectorTest.java
@@ -27,7 +27,6 @@ import javax.vecmath.Point2d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.test.CDKTestCase;

--- a/legacy/src/test/java/org/openscience/cdk/aromaticity/CDKHueckelAromaticityDetectorTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/aromaticity/CDKHueckelAromaticityDetectorTest.java
@@ -112,7 +112,7 @@ class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
 
     @Test
     void testPyridine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("N"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -143,7 +143,7 @@ class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
 
     @Test
     void testCyclopentadienyl() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setFormalCharge(-1);
         for (int i = 1; i < 5; i++) {
@@ -562,7 +562,7 @@ class CDKHueckelAromaticityDetectorTest extends CDKTestCase {
     @Test
     void test3Amino2MethylPyridine() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "N");
         a1.setPoint2d(new Point2d(3.7321, 1.345));
         mol.addAtom(a1);

--- a/legacy/src/test/java/org/openscience/cdk/aromaticity/DoubleBondAcceptingAromaticityDetectorTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/aromaticity/DoubleBondAcceptingAromaticityDetectorTest.java
@@ -46,7 +46,6 @@ import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.ringsearch.AllRingsFinder;
 import org.openscience.cdk.ringsearch.SSSRFinder;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.CDKHydrogenAdder;

--- a/legacy/src/test/java/org/openscience/cdk/aromaticity/DoubleBondAcceptingAromaticityDetectorTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/aromaticity/DoubleBondAcceptingAromaticityDetectorTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IElement;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
@@ -111,7 +112,7 @@ class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
 
     @Test
     void testPyridine() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("N"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -142,7 +143,7 @@ class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
 
     @Test
     void testCyclopentadienyl() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setFormalCharge(-1);
         for (int i = 1; i < 5; i++) {
@@ -505,7 +506,7 @@ class DoubleBondAcceptingAromaticityDetectorTest extends CDKTestCase {
     @Test
     void test3Amino2MethylPyridine() throws Exception {
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = mol.getBuilder().newInstance(IAtom.class, "N");
         a1.setPoint2d(new Point2d(3.7321, 1.345));
         mol.addAtom(a1);

--- a/legacy/src/test/java/org/openscience/cdk/atomtype/MM2AtomTypeMatcherTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/atomtype/MM2AtomTypeMatcherTest.java
@@ -69,7 +69,7 @@ class MM2AtomTypeMatcherTest extends AbstractAtomTypeTest {
             InputStream ins = MM2AtomTypeMatcher.class.getResourceAsStream(
                     "mmff94AtomTypeTest_molecule.mol");
             ISimpleChemObjectReader mdl = new MDLV2000Reader(ins);
-            testMolecule = mdl.read(new AtomContainer());
+            testMolecule = mdl.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             logger.debug("Molecule load:" + testMolecule.getAtomCount());
             att.assignAtomTypePropertiesToAtom(testMolecule);
             for (int i = 0; i < testMolecule.getAtomCount(); i++) {
@@ -90,7 +90,7 @@ class MM2AtomTypeMatcherTest extends AbstractAtomTypeTest {
 
     @Test
     void testFindMatchingAtomType_IAtomContainer() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         final IAtomType.Hybridization thisHybridization = IAtomType.Hybridization.SP3;
         atom.setHybridization(thisHybridization);

--- a/legacy/src/test/java/org/openscience/cdk/atomtype/MM2AtomTypeMatcherTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/atomtype/MM2AtomTypeMatcherTest.java
@@ -35,7 +35,6 @@ import org.openscience.cdk.interfaces.IAtomType;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.io.ISimpleChemObjectReader;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.atomtype.AbstractAtomTypeTest;
 import org.openscience.cdk.tools.AtomTypeTools;

--- a/legacy/src/test/java/org/openscience/cdk/atomtype/MMFF94AtomTypeMatcherTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/atomtype/MMFF94AtomTypeMatcherTest.java
@@ -39,7 +39,6 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.atomtype.AbstractAtomTypeTest;
 import org.openscience.cdk.tools.AtomTypeTools;

--- a/legacy/src/test/java/org/openscience/cdk/atomtype/MMFF94AtomTypeMatcherTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/atomtype/MMFF94AtomTypeMatcherTest.java
@@ -73,7 +73,7 @@ class MMFF94AtomTypeMatcherTest extends AbstractAtomTypeTest {
             InputStream ins = MMFF94AtomTypeMatcherTest.class.getResourceAsStream(
                     "mmff94AtomTypeTest_molecule.mol");
             MDLV2000Reader mdl = new MDLV2000Reader(new InputStreamReader(ins));
-            testMolecule = mdl.read(new AtomContainer());
+            testMolecule = mdl.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
 
             att.assignAtomTypePropertiesToAtom(testMolecule);
             for (int i = 0; i < testMolecule.getAtomCount(); i++) {
@@ -96,7 +96,7 @@ class MMFF94AtomTypeMatcherTest extends AbstractAtomTypeTest {
     @Test
     @Disabled("Old atom typing method - see new Mmff class")
     void testFindMatchingAtomType_IAtomContainer() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         final IAtomType.Hybridization thisHybridization = IAtomType.Hybridization.SP3;
         atom.setHybridization(thisHybridization);

--- a/legacy/src/test/java/org/openscience/cdk/geometry/GeometryToolsTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/geometry/GeometryToolsTest.java
@@ -70,7 +70,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 1));
         Atom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertTrue(GeometryTools.has2DCoordinates(container));
@@ -79,7 +79,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint3d(new Point3d(1, 1, 1));
         atom2 = new Atom("C");
         atom2.setPoint3d(new Point3d(1, 0, 5));
-        container = new AtomContainer();
+        container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertFalse(GeometryTools.has2DCoordinates(container));
@@ -87,14 +87,14 @@ class GeometryToolsTest extends CDKTestCase {
 
     @Test
     void testHas2DCoordinates_EmptyAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(GeometryTools.has2DCoordinates(container));
         Assertions.assertFalse(GeometryTools.has2DCoordinates((IAtomContainer) null));
     }
 
     @Test
     void testHas2DCoordinates_Partial() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         Atom atom2 = new Atom("C");
         atom1.setPoint2d(new Point2d(1, 1));
@@ -113,13 +113,13 @@ class GeometryToolsTest extends CDKTestCase {
         InputStream ins = this.getClass().getResourceAsStream(filenameMol);
         IAtomContainer molOne;
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molOne = reader.read(new AtomContainer());
+        molOne = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertTrue(GeometryTools.has2DCoordinates(molOne));
     }
 
     @Test
     void get2DCoordinateCoverage_EmptyAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertEquals(GeometryTools.CoordinateCoverage.NONE, GeometryTools.get2DCoordinateCoverage(container));
         Assertions.assertEquals(GeometryTools.CoordinateCoverage.NONE, GeometryTools.get2DCoordinateCoverage(null));
     }
@@ -127,7 +127,7 @@ class GeometryToolsTest extends CDKTestCase {
     @Test
     void get2DCoordinateCoverage_Partial() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -147,7 +147,7 @@ class GeometryToolsTest extends CDKTestCase {
     @Test
     void get2DCoordinateCoverage_Full() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -168,7 +168,7 @@ class GeometryToolsTest extends CDKTestCase {
     @Test
     void get2DCoordinateCoverage_None_3D() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -188,7 +188,7 @@ class GeometryToolsTest extends CDKTestCase {
 
     @Test
     void testTranslateAllPositive_IAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom(Elements.CARBON);
         atom.setPoint2d(new Point2d(-3, -2));
         container.addAtom(atom);
@@ -216,11 +216,11 @@ class GeometryToolsTest extends CDKTestCase {
         IAtomContainer molTwo;
         Map<Integer, Integer> mappedAtoms = new HashMap<>();
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molOne = reader.read(new AtomContainer());
+        molOne = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         ins = this.getClass().getResourceAsStream(filenameMolTwo);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molTwo = reader.read(new AtomContainer());
+        molTwo = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         mappedAtoms = AtomMappingTools.mapAtomsOfAlignedStructures(molOne, molTwo, mappedAtoms);
         //logger.debug("mappedAtoms:"+mappedAtoms.toString());
@@ -300,7 +300,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(2, 2));
         Atom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(5, 1));
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Rectangle2D rectangle = GeometryTools.getRectangle2D(container);
@@ -360,7 +360,7 @@ class GeometryToolsTest extends CDKTestCase {
 
     @Test
     void testGet2DCenter_arrayIAtom() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom1 = new Atom("C");
         atom1.setPoint2d(new Point2d(1, 1));
         Atom atom2 = new Atom("C");
@@ -436,7 +436,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 1));
         Atom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertEquals(2, GeometryTools.has2DCoordinatesNew(container));
@@ -445,7 +445,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 1));
         atom2 = new Atom("C");
         atom2.setPoint3d(new Point3d(1, 0, 1));
-        container = new AtomContainer();
+        container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertEquals(1, GeometryTools.has2DCoordinatesNew(container));
@@ -454,7 +454,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint3d(new Point3d(1, 1, 1));
         atom2 = new Atom("C");
         atom2.setPoint3d(new Point3d(1, 0, 5));
-        container = new AtomContainer();
+        container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertEquals(0, GeometryTools.has2DCoordinatesNew(container));
@@ -466,7 +466,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 1));
         Atom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertFalse(GeometryTools.has3DCoordinates(container));
@@ -475,7 +475,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint3d(new Point3d(1, 1, 1));
         atom2 = new Atom("C");
         atom2.setPoint3d(new Point3d(1, 0, 5));
-        container = new AtomContainer();
+        container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom1);
         container.addAtom(atom2);
         Assertions.assertTrue(GeometryTools.has3DCoordinates(container));
@@ -483,14 +483,14 @@ class GeometryToolsTest extends CDKTestCase {
 
     @Test
     void testHas3DCoordinates_EmptyAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(GeometryTools.has3DCoordinates(container));
         Assertions.assertFalse(GeometryTools.has3DCoordinates((IAtomContainer) null));
     }
 
     @Test
     void get3DCoordinateCoverage_EmptyAtomContainer() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertEquals(GeometryTools.CoordinateCoverage.NONE, GeometryTools.get3DCoordinateCoverage(container));
         Assertions.assertEquals(GeometryTools.CoordinateCoverage.NONE, GeometryTools.get3DCoordinateCoverage(null));
     }
@@ -498,7 +498,7 @@ class GeometryToolsTest extends CDKTestCase {
     @Test
     void get3DCoordinateCoverage_Partial() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -518,7 +518,7 @@ class GeometryToolsTest extends CDKTestCase {
     @Test
     void get3DCoordinateCoverage_Full() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -539,7 +539,7 @@ class GeometryToolsTest extends CDKTestCase {
     @Test
     void get3DCoordinateCoverage_None_2D() {
 
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         IAtom atom1 = new Atom("C");
         IAtom atom2 = new Atom("C");
@@ -594,7 +594,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom2.setPoint2d(new Point2d(1, 0));
         IAtom atom3 = new Atom("C");
         atom3.setPoint2d(new Point2d(5, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         acont.addAtom(atom1);
         acont.addAtom(atom2);
         acont.addAtom(atom3);
@@ -609,7 +609,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(1, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(5, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         acont.addAtom(atom1);
         acont.addAtom(atom2);
         Assertions.assertEquals(atom2, GeometryTools.getClosestAtom(1.0, 0.0, acont, atom1));
@@ -625,7 +625,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(-1, -1));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         acont.addAtom(atom1);
         acont.addAtom(atom2);
         Assertions.assertEquals(atom2, GeometryTools.getClosestAtom(acont, atom1));
@@ -638,7 +638,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 1));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer react1 = new AtomContainer();
+        IAtomContainer react1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         react1.addAtom(atom1);
         react1.addAtom(atom2);
         IAtomContainer react2 = react1.clone();
@@ -670,7 +670,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(0, 1));
-        IAtomContainer react1 = new AtomContainer();
+        IAtomContainer react1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         react1.addAtom(atom1);
         react1.addAtom(atom2);
         IAtomContainer react2 = react1.clone();
@@ -696,7 +696,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IReaction reaction = new Reaction();
         reaction.addReactant(acont);
         acont.addAtom(atom1);
@@ -718,7 +718,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer acont = new AtomContainer();
+        IAtomContainer acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reaction.addReactant(acont);
         acont.addAtom(atom1);
         acont.addAtom(atom2);
@@ -729,7 +729,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(3, 0));
-        acont = new AtomContainer();
+        acont = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         reaction.addProduct(acont);
         acont.addAtom(atom1);
         acont.addAtom(atom2);
@@ -744,7 +744,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 1));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer react1 = new AtomContainer();
+        IAtomContainer react1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IReaction reaction = new Reaction();
         reaction.addReactant(react1);
         react1.addAtom(atom1);
@@ -782,7 +782,7 @@ class GeometryToolsTest extends CDKTestCase {
         atom1.setPoint2d(new Point2d(0, 0));
         IAtom atom2 = new Atom("C");
         atom2.setPoint2d(new Point2d(1, 0));
-        IAtomContainer react1 = new AtomContainer();
+        IAtomContainer react1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IReaction reaction = new Reaction();
         reaction.addReactant(react1);
         react1.addAtom(atom1);
@@ -832,7 +832,7 @@ class GeometryToolsTest extends CDKTestCase {
 
     @Test
     void medianBondLength() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atomAt(new Point2d(0, 0)));
         container.addAtom(atomAt(new Point2d(0, 1.5)));
         container.addAtom(atomAt(new Point2d(0, -1.5)));
@@ -845,7 +845,7 @@ class GeometryToolsTest extends CDKTestCase {
 
     @Test
     void medianBondLengthNoBonds() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atomAt(new Point2d(0, 0)));
         container.addAtom(atomAt(new Point2d(0, 1.5)));
         container.addAtom(atomAt(new Point2d(0, -1.5)));
@@ -857,7 +857,7 @@ class GeometryToolsTest extends CDKTestCase {
 
     @Test
     void medianBondLengthNoPoints() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atomAt(new Point2d(0, 0)));
         container.addAtom(atomAt(new Point2d(0, 1.5)));
         container.addAtom(atomAt(null));
@@ -872,7 +872,7 @@ class GeometryToolsTest extends CDKTestCase {
 
     @Test
     void medianBondLengthOneBond() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atomAt(new Point2d(0, 0)));
         container.addAtom(atomAt(new Point2d(0, 1.5)));
         container.addBond(0, 1, IBond.Order.SINGLE);
@@ -886,7 +886,7 @@ class GeometryToolsTest extends CDKTestCase {
     }
 
     private int alignmentTestHelper(IAtom zero, IAtom... pos) {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(zero);
         for (IAtom atom : pos) {
             mol.addAtom(atom);

--- a/legacy/src/test/java/org/openscience/cdk/geometry/GeometryToolsTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/geometry/GeometryToolsTest.java
@@ -29,7 +29,6 @@ import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/legacy/src/test/java/org/openscience/cdk/normalize/NormalizerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/normalize/NormalizerTest.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.normalize;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;

--- a/legacy/src/test/java/org/openscience/cdk/normalize/NormalizerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/normalize/NormalizerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -36,7 +37,7 @@ class NormalizerTest extends CDKTestCase {
 
     @Test
     void testNormalize() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("N"));
         ac.addAtom(new Atom("O"));

--- a/legacy/src/test/java/org/openscience/cdk/ringsearch/SSSRFinderTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/ringsearch/SSSRFinderTest.java
@@ -135,7 +135,7 @@ class SSSRFinderTest extends CDKTestCase {
         String filename = "figueras-test-sep3D.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molecule = (IAtomContainer) reader.read((IChemObject) new AtomContainer());
+        molecule = (IAtomContainer) reader.read((IChemObject) DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         logger.debug("Testing " + filename);
 
@@ -153,7 +153,7 @@ class SSSRFinderTest extends CDKTestCase {
         String filename = "ring_03419.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer molecule = (IAtomContainer) reader.read((IChemObject) new AtomContainer());
+        IAtomContainer molecule = (IAtomContainer) reader.read((IChemObject) DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         logger.debug("Testing " + filename);
 
@@ -173,7 +173,7 @@ class SSSRFinderTest extends CDKTestCase {
         String filename = "figueras-test-buried.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molecule = (IAtomContainer) reader.read((IChemObject) new AtomContainer());
+        molecule = (IAtomContainer) reader.read((IChemObject) DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         logger.debug("Testing " + filename);
 
@@ -193,7 +193,7 @@ class SSSRFinderTest extends CDKTestCase {
         String filename = "figueras-test-inring.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molecule = (IAtomContainer) reader.read((IChemObject) new AtomContainer());
+        molecule = (IAtomContainer) reader.read((IChemObject) DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         logger.debug("Testing " + filename);
 
@@ -215,7 +215,7 @@ class SSSRFinderTest extends CDKTestCase {
         String filename = "too.many.rings.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molecule = (IAtomContainer) reader.read((IChemObject) new AtomContainer());
+        molecule = (IAtomContainer) reader.read((IChemObject) DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         logger.debug("Testing " + filename);
 
@@ -293,7 +293,7 @@ class SSSRFinderTest extends CDKTestCase {
         String filename = "buckyball.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molecule = reader.read(new AtomContainer());
+        molecule = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertTrue(molecule.getAtomCount() == 60, "Atom count is 60 ");
         Assertions.assertTrue(molecule.getBondCount() == 90, "Bond count is 90 ");

--- a/legacy/src/test/java/org/openscience/cdk/ringsearch/SSSRFinderTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/ringsearch/SSSRFinderTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/legacy/src/test/java/org/openscience/cdk/smiles/DeduceBondSystemToolTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smiles/DeduceBondSystemToolTest.java
@@ -197,7 +197,7 @@ class DeduceBondSystemToolTest extends CDKTestCase {
      */
     @Disabled("previouls disabled 'xtest'")
     void xtestQuinone() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -268,7 +268,7 @@ class DeduceBondSystemToolTest extends CDKTestCase {
      */
     @Test
     void xtestPyrrole() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -319,7 +319,7 @@ class DeduceBondSystemToolTest extends CDKTestCase {
 
     @Test
     void xtestPyridine() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -391,7 +391,7 @@ class DeduceBondSystemToolTest extends CDKTestCase {
      */
     @Test
     void xtestBenzene() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);

--- a/legacy/src/test/java/org/openscience/cdk/smiles/DeduceBondSystemToolTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smiles/DeduceBondSystemToolTest.java
@@ -33,7 +33,6 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.ringsearch.AllRingsFinder;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;

--- a/legacy/src/test/java/org/openscience/cdk/smiles/FixBondOrdersToolTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smiles/FixBondOrdersToolTest.java
@@ -33,7 +33,6 @@ import org.openscience.cdk.interfaces.IAtomType.Hybridization;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;

--- a/legacy/src/test/java/org/openscience/cdk/smiles/FixBondOrdersToolTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smiles/FixBondOrdersToolTest.java
@@ -167,7 +167,7 @@ class FixBondOrdersToolTest extends CDKTestCase {
      */
     @Test
     void xtestPyrrole() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -218,7 +218,7 @@ class FixBondOrdersToolTest extends CDKTestCase {
 
     @Test
     void xtestPyridine() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);
@@ -290,7 +290,7 @@ class FixBondOrdersToolTest extends CDKTestCase {
      */
     @Test
     void xtestBenzene() throws Exception {
-        IAtomContainer enol = new AtomContainer();
+        IAtomContainer enol = SilentChemObjectBuilder.getInstance().newAtomContainer();
 
         // atom block
         IAtom atom1 = new Atom(Elements.CARBON);

--- a/legacy/src/test/java/org/openscience/cdk/smiles/smarts/SMARTSTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smiles/smarts/SMARTSTest.java
@@ -99,7 +99,7 @@ class SMARTSTest extends CDKTestCase {
     }
 
     private IAtomContainer createEthane() {
-        IAtomContainer container = new org.openscience.cdk.AtomContainer(); // SMILES "CC"
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // SMILES "CC"
         IAtom carbon = new org.openscience.cdk.Atom("C");
         IAtom carbon2 = carbon.getBuilder().newInstance(IAtom.class, "C");
         carbon.setImplicitHydrogenCount(3);

--- a/legacy/src/test/java/org/openscience/cdk/smsd/SMSDTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/SMSDTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/SMSDTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/SMSDTest.java
@@ -159,8 +159,8 @@ class SMSDTest {
     void testSet_String_String() throws CDKException, IOException {
         String molfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
         String queryfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
-        IAtomContainer query = new AtomContainer();
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer query = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(molfile);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/GenerateCompatibilityGraphTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/GenerateCompatibilityGraphTest.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.openscience.cdk.AtomContainer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/GenerateCompatibilityGraphTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/GenerateCompatibilityGraphTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 
 /**
  * @cdk.module test-smsd
@@ -56,6 +57,6 @@ class GenerateCompatibilityGraphTest {
     @Test
     void testSomeMethod() throws IOException {
         // TODO review the generated test code and remove the default call to fail.
-        Assertions.assertNotNull(new GenerateCompatibilityGraph(new AtomContainer(), new AtomContainer(), true));
+        Assertions.assertNotNull(new GenerateCompatibilityGraph(DefaultChemObjectBuilder.getInstance().newAtomContainer(), DefaultChemObjectBuilder.getInstance().newAtomContainer(), true));
     }
 }

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/MCSPlusHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/MCSPlusHandlerTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/MCSPlusHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/MCSPlusHandlerTest.java
@@ -107,8 +107,8 @@ public class MCSPlusHandlerTest extends AbstractMCSAlgorithmTest {
     void testSet_String_String() throws CDKException, IOException {
         String molfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
         String queryfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
-        IAtomContainer query = new AtomContainer();
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer query = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(molfile);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/MCSPlusTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/MCSPlusTest.java
@@ -24,7 +24,6 @@ package org.openscience.cdk.smsd.algorithm.mcsplus;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/MCSPlusTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/mcsplus/MCSPlusTest.java
@@ -25,6 +25,7 @@ package org.openscience.cdk.smsd.algorithm.mcsplus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -56,7 +57,7 @@ class MCSPlusTest {
     void testSomeMethod() throws CDKException {
 
         // TODO review the generated test code and remove the default call to fail.
-        Assertions.assertNotNull(new MCSPlus().getOverlaps(new AtomContainer(), new AtomContainer(), true));
+        Assertions.assertNotNull(new MCSPlus().getOverlaps(DefaultChemObjectBuilder.getInstance().newAtomContainer(), DefaultChemObjectBuilder.getInstance().newAtomContainer(), true));
 
     }
 }

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSHandlerTest.java
@@ -29,7 +29,6 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSHandlerTest.java
@@ -106,8 +106,8 @@ public class CDKMCSHandlerTest extends AbstractMCSAlgorithmTest {
     void testSet_String_String() throws CDKException, IOException {
         String molfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
         String queryfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
-        IAtomContainer query = new AtomContainer();
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer query = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(molfile);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/rgraph/CDKMCSTest.java
@@ -197,8 +197,8 @@ class CDKMCSTest extends CDKTestCase {
     void testGetSubgraphMap_IAtomContainer_IAtomContainer() throws Exception {
         String molfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
         String queryfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
-        IAtomContainer mol = new AtomContainer();
-        IAtomContainer temp = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer temp = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         QueryAtomContainer query1;
         QueryAtomContainer query2;
 
@@ -230,8 +230,8 @@ class CDKMCSTest extends CDKTestCase {
     void testGetOverlaps_IAtomContainer_IAtomContainer() throws Exception {
         String file1 = "org/openscience/cdk/smsd/algorithm/5SD.mol";
         String file2 = "org/openscience/cdk/smsd/algorithm/ADN.mol";
-        IAtomContainer mol1 = new AtomContainer();
-        IAtomContainer mol2 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins1 = this.getClass().getClassLoader().getResourceAsStream(file1);
         new MDLV2000Reader(ins1, Mode.STRICT).read(mol1);
@@ -265,15 +265,15 @@ class CDKMCSTest extends CDKTestCase {
     void testSFBug999330() throws Exception {
         String file1 = "org/openscience/cdk/smsd/algorithm/5SD.mol";
         String file2 = "org/openscience/cdk/smsd/algorithm/ADN.mol";
-        IAtomContainer mol1 = new AtomContainer();
-        IAtomContainer mol2 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer mol2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins1 = this.getClass().getClassLoader().getResourceAsStream(file1);
         new MDLV2000Reader(ins1, Mode.STRICT).read(mol1);
         InputStream ins2 = this.getClass().getClassLoader().getResourceAsStream(file2);
         new MDLV2000Reader(ins2, Mode.STRICT).read(mol2);
         AtomContainerAtomPermutor permutor = new AtomContainerAtomPermutor(mol2);
-        mol2 = new AtomContainer(permutor.next());
+        mol2 = DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, permutor.next());
 
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol1);
         CDKHydrogenAdder adder = CDKHydrogenAdder.getInstance(mol1.getBuilder());
@@ -315,9 +315,9 @@ class CDKMCSTest extends CDKTestCase {
 
     @Test
     void testIsIsomorph_IAtomContainer_IAtomContainer() throws Exception {
-        AtomContainer ac1 = new AtomContainer();
+        IAtomContainer ac1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac1.addAtom(new Atom("C"));
-        AtomContainer ac2 = new AtomContainer();
+        IAtomContainer ac2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac2.addAtom(new Atom("C"));
         Assertions.assertTrue(CDKMCS.isIsomorph(ac1, ac2, true));
         Assertions.assertTrue(CDKMCS.isSubgraph(ac1, ac2, true));

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/single/SingleMappingHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/single/SingleMappingHandlerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -62,9 +63,9 @@ public class SingleMappingHandlerTest extends AbstractMCSAlgorithmTest {
     void testSet_IAtomContainer_IAtomContainer() throws Exception {
         IAtom atomSource = new Atom("R");
         IAtom atomTarget = new Atom("R");
-        IAtomContainer source = new AtomContainer();
+        IAtomContainer source = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         source.addAtom(atomSource);
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         target.addAtom(atomTarget);
         boolean removeHydrogen = false;
         SingleMappingHandler instance = new SingleMappingHandler(removeHydrogen);
@@ -83,8 +84,8 @@ public class SingleMappingHandlerTest extends AbstractMCSAlgorithmTest {
     void testSet_String_String() throws CDKException, IOException {
         String molfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
         String queryfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
-        IAtomContainer query = new AtomContainer();
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer query = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(molfile);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
@@ -107,9 +108,9 @@ public class SingleMappingHandlerTest extends AbstractMCSAlgorithmTest {
     void testSet_MolHandler_MolHandler() {
         IAtom atomSource = new Atom("R");
         IAtom atomTarget = new Atom("R");
-        IAtomContainer source = new AtomContainer();
+        IAtomContainer source = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         source.addAtom(atomSource);
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         target.addAtom(atomTarget);
         MolHandler source1 = new MolHandler(source, true, true);
         MolHandler target1 = new MolHandler(target, true, true);
@@ -129,9 +130,9 @@ public class SingleMappingHandlerTest extends AbstractMCSAlgorithmTest {
     public void testSearchMCS() {
         IAtom atomSource = new Atom("R");
         IAtom atomTarget = new Atom("R");
-        IAtomContainer source = new AtomContainer();
+        IAtomContainer source = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         source.addAtom(atomSource);
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         target.addAtom(atomTarget);
         boolean removeHydrogen = false;
         SingleMappingHandler instance = new SingleMappingHandler(removeHydrogen);
@@ -150,9 +151,9 @@ public class SingleMappingHandlerTest extends AbstractMCSAlgorithmTest {
     void testGetAllMapping() {
         IAtom atomSource = new Atom("R");
         IAtom atomTarget = new Atom("R");
-        IAtomContainer source = new AtomContainer();
+        IAtomContainer source = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         source.addAtom(atomSource);
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         target.addAtom(atomTarget);
         boolean removeHydrogen = false;
         SingleMappingHandler instance = new SingleMappingHandler(removeHydrogen);
@@ -170,9 +171,9 @@ public class SingleMappingHandlerTest extends AbstractMCSAlgorithmTest {
     void testGetFirstMapping() {
         IAtom atomSource = new Atom("R");
         IAtom atomTarget = new Atom("R");
-        IAtomContainer source = new AtomContainer();
+        IAtomContainer source = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         source.addAtom(atomSource);
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         target.addAtom(atomTarget);
         boolean removeHydrogen = false;
         SingleMappingHandler instance = new SingleMappingHandler(removeHydrogen);
@@ -190,9 +191,9 @@ public class SingleMappingHandlerTest extends AbstractMCSAlgorithmTest {
     void testGetAllAtomMapping() {
         IAtom atomSource = new Atom("R");
         IAtom atomTarget = new Atom("R");
-        IAtomContainer source = new AtomContainer();
+        IAtomContainer source = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         source.addAtom(atomSource);
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         target.addAtom(atomTarget);
         boolean removeHydrogen = false;
         SingleMappingHandler instance = new SingleMappingHandler(removeHydrogen);
@@ -210,9 +211,9 @@ public class SingleMappingHandlerTest extends AbstractMCSAlgorithmTest {
     void testGetFirstAtomMapping() {
         IAtom atomSource = new Atom("R");
         IAtom atomTarget = new Atom("R");
-        IAtomContainer source = new AtomContainer();
+        IAtomContainer source = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         source.addAtom(atomSource);
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         target.addAtom(atomTarget);
         boolean removeHydrogen = false;
         SingleMappingHandler instance = new SingleMappingHandler(removeHydrogen);

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/single/SingleMappingHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/single/SingleMappingHandlerTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/single/SingleMappingTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/single/SingleMappingTest.java
@@ -24,7 +24,6 @@ package org.openscience.cdk.smsd.algorithm.single;
 
 import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/single/SingleMappingTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/single/SingleMappingTest.java
@@ -25,6 +25,7 @@ package org.openscience.cdk.smsd.algorithm.single;
 import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -64,9 +65,9 @@ class SingleMappingTest {
     void testGetOverLaps() throws CDKException {
         IAtom atomSource = new Atom("R");
         IAtom atomTarget = new Atom("R");
-        IAtomContainer source = new AtomContainer();
+        IAtomContainer source = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         source.addAtom(atomSource);
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         target.addAtom(atomTarget);
         boolean removeHydrogen = false;
         SingleMapping instance = new SingleMapping();

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibMCSHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibMCSHandlerTest.java
@@ -124,8 +124,8 @@ public class VFlibMCSHandlerTest extends AbstractMCSAlgorithmTest {
     void testSet_String_String() throws CDKException {
         String molfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
         String queryfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
-        IAtomContainer query = new AtomContainer();
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer query = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(molfile);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibMCSHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibMCSHandlerTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibTurboHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibTurboHandlerTest.java
@@ -100,8 +100,8 @@ public class VFlibTurboHandlerTest extends AbstractSubGraphTest {
     void testSet_String_String() throws CDKException {
         String molfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
         String queryfile = "org/openscience/cdk/smsd/algorithm/decalin.mol";
-        IAtomContainer query = new AtomContainer();
-        IAtomContainer target = new AtomContainer();
+        IAtomContainer query = DefaultChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer target = DefaultChemObjectBuilder.getInstance().newAtomContainer();
 
         InputStream ins = this.getClass().getClassLoader().getResourceAsStream(molfile);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);

--- a/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibTurboHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/algorithm/vflib/VFlibTurboHandlerTest.java
@@ -25,12 +25,9 @@ package org.openscience.cdk.smsd.algorithm.vflib;
 import java.io.InputStream;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;

--- a/legacy/src/test/java/org/openscience/cdk/smsd/helper/MolHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/helper/MolHandlerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.smsd.tools.MolHandler;
 
@@ -59,7 +60,7 @@ class MolHandlerTest {
      */
     @Test
     void testGetMolecule() {
-        MolHandler instance = new MolHandler(new AtomContainer(), true, true);
+        MolHandler instance = new MolHandler(DefaultChemObjectBuilder.getInstance().newAtomContainer(), true, true);
         IAtomContainer result = instance.getMolecule();
         Assertions.assertNotNull(result);
     }
@@ -69,7 +70,7 @@ class MolHandlerTest {
      */
     @Test
     void testGetRemoveHydrogenFlag() {
-        MolHandler instance = new MolHandler(new AtomContainer(), true, true);
+        MolHandler instance = new MolHandler(DefaultChemObjectBuilder.getInstance().newAtomContainer(), true, true);
         boolean expResult = true;
         boolean result = instance.getRemoveHydrogenFlag();
         Assertions.assertEquals(expResult, result);

--- a/legacy/src/test/java/org/openscience/cdk/smsd/helper/MolHandlerTest.java
+++ b/legacy/src/test/java/org/openscience/cdk/smsd/helper/MolHandlerTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.smsd.tools.MolHandler;

--- a/misc/test-extra/src/test/java/org/openscience/cdk/config/XMLIsotopeFactoryTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/config/XMLIsotopeFactoryTest.java
@@ -22,7 +22,6 @@ package org.openscience.cdk.config;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemObject;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.Element;

--- a/misc/test-extra/src/test/java/org/openscience/cdk/config/XMLIsotopeFactoryTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/config/XMLIsotopeFactoryTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.Element;
 import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.interfaces.IIsotope;
 import org.openscience.cdk.test.CDKTestCase;
@@ -171,7 +173,7 @@ class XMLIsotopeFactoryTest extends CDKTestCase {
 
     @Test
     void testConfigureAtoms_IAtomContainer() throws Exception {
-        AtomContainer container = new org.openscience.cdk.AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("C"));
         container.addAtom(new Atom("H"));
         container.addAtom(new Atom("N"));

--- a/misc/test-extra/src/test/java/org/openscience/cdk/geometry/RDFCalculatorTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/geometry/RDFCalculatorTest.java
@@ -23,7 +23,6 @@ import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.test.CDKTestCase;

--- a/misc/test-extra/src/test/java/org/openscience/cdk/geometry/RDFCalculatorTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/geometry/RDFCalculatorTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 
 /**
@@ -63,7 +65,7 @@ class RDFCalculatorTest extends CDKTestCase {
     @Test
     void testCalculate() {
         RDFCalculator calculator = new RDFCalculator(0.0, 5.0, 0.1, 0.0);
-        AtomContainer h2mol = new org.openscience.cdk.AtomContainer();
+        IAtomContainer h2mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom h1 = new Atom("H");
         h1.setPoint3d(new Point3d(-0.5, 0.0, 0.0));
         Atom h2 = new Atom("H");
@@ -95,7 +97,7 @@ class RDFCalculatorTest extends CDKTestCase {
                 return 1.0;
             }
         });
-        AtomContainer h2mol = new org.openscience.cdk.AtomContainer();
+        IAtomContainer h2mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom h1 = new Atom("H");
         h1.setPoint3d(new Point3d(-0.5, 0.0, 0.0));
         Atom h2 = new Atom("H");
@@ -127,7 +129,7 @@ class RDFCalculatorTest extends CDKTestCase {
                 return atom.getCharge() * atom2.getCharge();
             }
         });
-        AtomContainer h2mol = new org.openscience.cdk.AtomContainer();
+        IAtomContainer h2mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom h1 = new Atom("H");
         h1.setPoint3d(new Point3d(-0.5, 0.0, 0.0));
         h1.setCharge(+1.0);
@@ -161,7 +163,7 @@ class RDFCalculatorTest extends CDKTestCase {
                 return atom.getCharge() * atom2.getCharge();
             }
         });
-        AtomContainer h2mol = new org.openscience.cdk.AtomContainer();
+        IAtomContainer h2mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom h1 = new Atom("H");
         h1.setPoint3d(new Point3d(-0.5, 0.0, 0.0));
         h1.setCharge(+1.0);

--- a/misc/test-extra/src/test/java/org/openscience/cdk/graph/invariant/EquivalentClassPartitionerTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/graph/invariant/EquivalentClassPartitionerTest.java
@@ -53,7 +53,7 @@ class EquivalentClassPartitionerTest extends CDKTestCase {
 
     @Test
     void testEquivalent() throws Exception {
-        AtomContainer C40C3V = new org.openscience.cdk.AtomContainer();
+        IAtomContainer C40C3V = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         C40C3V.addAtom(new Atom("C")); // 1
         C40C3V.addAtom(new Atom("C")); // 2
         C40C3V.addAtom(new Atom("C")); // 3
@@ -169,7 +169,7 @@ class EquivalentClassPartitionerTest extends CDKTestCase {
 
     @Test
     void testFullereneC24D6D() throws Exception {
-        AtomContainer C24D6D = new org.openscience.cdk.AtomContainer();
+        IAtomContainer C24D6D = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         C24D6D.addAtom(new Atom("C")); // 1
         C24D6D.addAtom(new Atom("C")); // 2
         C24D6D.addAtom(new Atom("C")); // 3

--- a/misc/test-extra/src/test/java/org/openscience/cdk/graph/invariant/EquivalentClassPartitionerTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/graph/invariant/EquivalentClassPartitionerTest.java
@@ -47,10 +47,6 @@ import java.io.InputStream;
  */
 class EquivalentClassPartitionerTest extends CDKTestCase {
 
-    AtomContainer C40C3V = null;
-    AtomContainer C24D6D = null;
-    AtomContainer C28TD  = null;
-
     @Test
     void testEquivalent() throws Exception {
         IAtomContainer C40C3V = DefaultChemObjectBuilder.getInstance().newAtomContainer();

--- a/misc/test-extra/src/test/java/org/openscience/cdk/io/CrystClustReaderTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/io/CrystClustReaderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.test.io.SimpleChemObjectReaderTest;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
@@ -55,7 +56,7 @@ class CrystClustReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void testAccepts() {
         Assertions.assertTrue(chemObjectIO.accepts(ChemFile.class));
-        Assertions.assertFalse(chemObjectIO.accepts(AtomContainer.class));
+        Assertions.assertFalse(chemObjectIO.accepts(IAtomContainer.class));
     }
 
     @Test

--- a/misc/test-extra/src/test/java/org/openscience/cdk/io/ExtraReaderFactoryTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/io/ExtraReaderFactoryTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.Reaction;
 import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.io.formats.GamessFormat;
@@ -61,7 +62,7 @@ class ExtraReaderFactoryTest {
         Assertions.assertNotNull(reader);
         Assertions.assertEquals(((IChemFormat) expectedFormat).getReaderClassName(), reader.getClass().getName());
         // now try reading something from it
-        IChemObject[] objects = {new ChemFile(), new ChemModel(), new AtomContainer(), new Reaction()};
+        IChemObject[] objects = {new ChemFile(), new ChemModel(), DefaultChemObjectBuilder.getInstance().newAtomContainer(), new Reaction()};
         boolean read = false;
         for (int i = 0; (i < objects.length && !read); i++) {
             if (reader.accepts(objects[i].getClass())) {

--- a/misc/test-extra/src/test/java/org/openscience/cdk/io/ExtraReaderFactoryTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/io/ExtraReaderFactoryTest.java
@@ -24,7 +24,6 @@ package org.openscience.cdk.io;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/misc/test-extra/src/test/java/org/openscience/cdk/limitations/tools/SaturationCheckerTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/limitations/tools/SaturationCheckerTest.java
@@ -26,6 +26,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
@@ -62,7 +63,7 @@ public class SaturationCheckerTest extends CDKTestCase {
      */
     @Test
     void testSaturate_WithNitrate() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom a1 = new Atom("O");
         mol.addAtom(a1);
         Atom a2 = new Atom("N");
@@ -137,7 +138,7 @@ public class SaturationCheckerTest extends CDKTestCase {
      */
     @Test
     void testSaturation_S4AtomType() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom a1 = new Atom("N");
         mol.addAtom(a1);
         Atom a2 = new Atom("H");
@@ -244,7 +245,7 @@ public class SaturationCheckerTest extends CDKTestCase {
      */
     @Test
     void testSaturate_NumberingProblem() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom a1 = new Atom("C");
         mol.addAtom(a1);
         Atom a2 = new Atom("C");
@@ -295,7 +296,7 @@ public class SaturationCheckerTest extends CDKTestCase {
     @Test
     void testIsSaturated_Proton() throws Exception {
         // test H+
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom h = new Atom("H");
         h.setFormalCharge(+1);
         m.addAtom(h);

--- a/misc/test-extra/src/test/java/org/openscience/cdk/limitations/tools/SaturationCheckerTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/limitations/tools/SaturationCheckerTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/misc/test-extra/src/test/java/org/openscience/cdk/tools/BremserPredictorTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/tools/BremserPredictorTest.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.test.CDKTestCase;

--- a/misc/test-extra/src/test/java/org/openscience/cdk/tools/BremserPredictorTest.java
+++ b/misc/test-extra/src/test/java/org/openscience/cdk/tools/BremserPredictorTest.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -95,7 +96,7 @@ class BremserPredictorTest extends CDKTestCase {
         String filename = "BremserPredictionTest.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molecule = reader.read(new AtomContainer());
+        molecule = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         double prediction;
         BremserOneSphereHOSECodePredictor bp = new BremserOneSphereHOSECodePredictor();
         HOSECodeGenerator hcg = new HOSECodeGenerator(HOSECodeGenerator.LEGACY_MODE);

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLRXNReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLRXNReaderTest.java
@@ -32,6 +32,7 @@ import org.openscience.cdk.ChemModel;
 import org.openscience.cdk.Reaction;
 import org.openscience.cdk.ReactionSet;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IChemFile;
 import org.openscience.cdk.interfaces.IChemModel;
@@ -39,7 +40,6 @@ import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IMapping;
 import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.interfaces.IReactionSet;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.test.io.SimpleChemObjectReaderTest;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
@@ -71,7 +71,7 @@ class MDLRXNReaderTest extends SimpleChemObjectReaderTest {
         Assertions.assertTrue(reader.accepts(Reaction.class));
         Assertions.assertTrue(reader.accepts(ReactionSet.class));
         Assertions.assertFalse(reader.accepts(AtomContainerSet.class));
-        Assertions.assertFalse(reader.accepts(AtomContainer.class));
+        Assertions.assertFalse(reader.accepts(IAtomContainer.class));
     }
 
     @Test

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLReaderTest.java
@@ -41,7 +41,6 @@ import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemFile;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.io.SimpleChemObjectReaderTest;
 import org.openscience.cdk.tools.ILoggingTool;
@@ -74,7 +73,7 @@ class MDLReaderTest extends SimpleChemObjectReaderTest {
         reader.setReaderMode(Mode.STRICT);
         Assertions.assertTrue(reader.accepts(ChemFile.class));
         Assertions.assertTrue(reader.accepts(ChemModel.class));
-        Assertions.assertTrue(reader.accepts(AtomContainer.class));
+        Assertions.assertTrue(reader.accepts(IAtomContainer.class));
     }
 
     @Test

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLReaderTest.java
@@ -42,6 +42,7 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemFile;
 import org.openscience.cdk.io.IChemObjectReader.Mode;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.io.SimpleChemObjectReaderTest;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
@@ -115,7 +116,7 @@ class MDLReaderTest extends SimpleChemObjectReaderTest {
         String mdl = "deuterium.mol\n" + "\n" + "\n" + "  1  0  0  0  0                 1\n"
                 + "    0.0000    0.0000    0.0000 H  +1  0  0  0  0\n";
         try (MDLReader reader = new MDLReader(new StringReader(mdl), Mode.STRICT)) {
-            IAtomContainer mol = reader.read(new AtomContainer());
+            IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             IAtom atom = mol.getAtom(0);
             Assertions.assertEquals(1, atom.getAtomicNumber().intValue());
             Assertions.assertEquals(2, atom.getMassNumber().intValue());
@@ -145,7 +146,7 @@ class MDLReaderTest extends SimpleChemObjectReaderTest {
         String mdl = "proton.mol\n" + "\n" + "\n" + "  1  0  0  0  0                 1\n"
                 + "   -0.0073   -0.5272    0.9655 H   0  3  0  0  0\n";
         MDLReader reader = new MDLReader(new StringReader(mdl), Mode.STRICT);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(mol);
         Assertions.assertEquals(1, mol.getAtomCount());
@@ -197,7 +198,7 @@ class MDLReaderTest extends SimpleChemObjectReaderTest {
     void testEmptyString() throws Exception {
         String emptyString = "";
         MDLReader reader = new MDLReader(new StringReader(emptyString), Mode.STRICT);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         assertNull(mol);
     }
@@ -208,7 +209,7 @@ class MDLReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLReader reader = new MDLReader(ins, Mode.RELAXED);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertEquals(IBond.Stereo.E_OR_Z, mol.getBond(1).getStereo());
         Assertions.assertEquals(IBond.Stereo.E_OR_Z, mol.getBond(6).getStereo());
@@ -223,7 +224,7 @@ class MDLReaderTest extends SimpleChemObjectReaderTest {
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
 
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(mol);
         Assertions.assertEquals(1, ((Integer) mol.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING)).intValue());
@@ -237,7 +238,7 @@ class MDLReaderTest extends SimpleChemObjectReaderTest {
         InputStream ins = this.getClass().getResourceAsStream(filenameMol);
         IAtomContainer molOne;
         MDLReader reader = new MDLReader(ins, Mode.RELAXED);
-        molOne = reader.read(new AtomContainer());
+        molOne = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         // 0,0 or null no Coords, MDLV2000 will get this OK if there is 2D/3D
         // in the headerO

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000PropertiesBlockTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000PropertiesBlockTest.java
@@ -27,14 +27,11 @@ package org.openscience.cdk.io;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
-import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import java.io.BufferedReader;
@@ -44,7 +41,6 @@ import java.io.StringReader;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author John May

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000PropertiesBlockTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000PropertiesBlockTest.java
@@ -25,6 +25,7 @@
 
 package org.openscience.cdk.io;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openscience.cdk.CDKConstants;
@@ -104,51 +105,51 @@ class MDLV2000PropertiesBlockTest {
     void anion() throws Exception {
         IAtomContainer mock = mock(3);
         read("M  CHG  1   1  -1", mock);
-        verify(mock.getAtom(0)).setFormalCharge(-1);
+        Assertions.assertEquals(mock.getAtom(0).getFormalCharge(), -1);
     }
 
     @Test
     void cation() throws Exception {
         IAtomContainer mock = mock(3);
         read("M  CHG  1   1   1", mock);
-        verify(mock.getAtom(0)).setFormalCharge(+1);
+        Assertions.assertEquals(mock.getAtom(0).getFormalCharge(), +1);
     }
 
     @Test
     void multipleCharges() throws Exception {
         IAtomContainer mock = mock(6);
         read("M  CHG  2   2   1   5  -2", mock);
-        verify(mock.getAtom(1)).setFormalCharge(+1);
-        verify(mock.getAtom(4)).setFormalCharge(-2);
+        Assertions.assertEquals(mock.getAtom(1).getFormalCharge(), +1);
+        Assertions.assertEquals(mock.getAtom(4).getFormalCharge(), -2);
     }
 
     @Test
     void multipleChargesTruncated() throws Exception {
         IAtomContainer mock = mock(6);
         read("M  CHG  2   2  -3", mock);
-        verify(mock.getAtom(1)).setFormalCharge(-3);
+        Assertions.assertEquals(mock.getAtom(1).getFormalCharge(), -3);
     }
 
     @Test
     void c13() throws Exception {
         IAtomContainer mock = mock(3);
         read("M  ISO  1   1  13", mock);
-        verify(mock.getAtom(0)).setMassNumber(13);
+        Assertions.assertEquals(mock.getAtom(0).getMassNumber(), 13);
     }
 
     @Test
     void c13n14() throws Exception {
         IAtomContainer mock = mock(4);
         read("M  ISO  2   1  13   3  14", mock);
-        verify(mock.getAtom(0)).setMassNumber(13);
-        verify(mock.getAtom(2)).setMassNumber(14);
+        Assertions.assertEquals(mock.getAtom(0).getMassNumber(), 13);
+        Assertions.assertEquals(mock.getAtom(2).getMassNumber(), 14);
     }
 
     @Test
     void atomValue() throws Exception {
         IAtomContainer mock = mock(3);
         read("V    1 A Comment", mock);
-        verify(mock.getAtom(0)).setProperty(CDKConstants.COMMENT, "A Comment");
+        Assertions.assertEquals(mock.getAtom(0).getProperty(CDKConstants.COMMENT), "A Comment");
     }
 
     @Test
@@ -163,13 +164,13 @@ class MDLV2000PropertiesBlockTest {
     void acdAtomLabel() throws Exception {
         IAtomContainer mock = mock(3);
         read("M  ZZC   1 6", mock);
-        verify(mock.getAtom(0)).setProperty(CDKConstants.ACDLABS_LABEL, "6");
+        Assertions.assertEquals(mock.getAtom(0).getProperty(CDKConstants.ACDLABS_LABEL), "6");
     }
     
     static IAtomContainer mock(int n) {
-        IAtomContainer mock = new AtomContainer(n, 0, 0, 0);
+        IAtomContainer mock = SilentChemObjectBuilder.getInstance().newAtomContainer();
         for (int i = 0; i < n; i++)
-            mock.addAtom(Mockito.mock(IAtom.class));
+            mock.newAtom();
         return mock;
     }
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -113,7 +113,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         MDLV2000Reader reader = new MDLV2000Reader();
         Assertions.assertTrue(reader.accepts(ChemFile.class));
         Assertions.assertTrue(reader.accepts(ChemModel.class));
-        Assertions.assertTrue(reader.accepts(AtomContainer.class));
+        Assertions.assertTrue(reader.accepts(IAtomContainer.class));
     }
 
     /**

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000ReaderTest.java
@@ -267,7 +267,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertEquals("a-pinen.mol", mol.getTitle());
     }
@@ -397,7 +397,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "superspiro.mol"; // just a random file
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer superspiro = new AtomContainer();
+        IAtomContainer superspiro = SilentChemObjectBuilder.getInstance().newAtomContainer();
         superspiro.setID("superspiro");
         IAtomContainer result = reader.read(superspiro);
         reader.close();
@@ -448,7 +448,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertEquals("R2", ((IPseudoAtom) mol.getAtom(19)).getLabel());
     }
@@ -459,7 +459,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         IAtom atom = mol.getAtom(0);
         Assertions.assertTrue(atom instanceof IPseudoAtom);
@@ -489,7 +489,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String mdl = "proton.mol\n" + "\n" + "\n" + "  1  0  0  0  0                 1 V2000\n"
                 + "   -0.0073   -0.5272    0.9655 H   0  0  0  0  0\n" + "M  CHG  1   1   1\n" + "M  END\n";
         MDLV2000Reader reader = new MDLV2000Reader(new StringReader(mdl));
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(mol);
         Assertions.assertEquals(1, mol.getAtomCount());
@@ -516,7 +516,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     void testEmptyString() throws Exception {
         String emptyString = "";
         MDLV2000Reader reader = new MDLV2000Reader(new StringReader(emptyString));
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNull(mol);
     }
@@ -662,7 +662,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
                 + "  2  6  1  0  0  0\n" + "  2  7  1  6  0  0\n" + "  3  8  1  6  0  0\n" + "  3  9  1  0  0  0\n"
                 + "M  END\n";
         MDLV2000Reader reader = new MDLV2000Reader(new StringReader(mdl));
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(molecule);
         Assertions.assertEquals(9, molecule.getAtomCount());
@@ -679,7 +679,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertEquals(IBond.Stereo.E_OR_Z, mol.getBond(1).getStereo());
         Assertions.assertEquals(IBond.Stereo.E_OR_Z, mol.getBond(6).getStereo());
@@ -692,7 +692,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "a-pinene-with-undefined-stereo.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertEquals(IBond.Stereo.UP_OR_DOWN, mol.getBond(1).getStereo());
     }
@@ -732,7 +732,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
                 + "  2  6  1  0  0  0\n" + "  2  7  1  6  0  0\n" + "  3  8  1  6  0  0\n" + "  3  9  1  0  0  0\n"
                 + "M  END\n";
         MDLV2000Reader reader = new MDLV2000Reader(new StringReader(mdl));
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(mol);
         Assertions.assertEquals(9, mol.getAtomCount());
@@ -767,7 +767,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         for (IBond bond : mol.bonds()) {
             IPseudoAtom rGroup;
@@ -830,7 +830,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
 
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(mol);
         Assertions.assertEquals(2, mol.getAtom(0).getValency().intValue());
@@ -852,7 +852,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "glycine-short-lines.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, mode);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(mol);
         Assertions.assertEquals(mol.getAtomCount(), 5);
@@ -865,7 +865,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(mol);
         Assertions.assertEquals(1, ((Integer) mol.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING)).intValue());
@@ -882,7 +882,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         InputStream ins = this.getClass().getResourceAsStream(filenameMol);
         IAtomContainer molOne;
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        molOne = reader.read(new AtomContainer());
+        molOne = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(molOne.getAtom(0).getPoint2d());
         Assertions.assertNotNull(molOne.getAtom(0).getPoint3d());
@@ -913,7 +913,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         reader.addChemObjectIOListener(listener);
         reader.customizeJob();
 
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         molecule = reader.read(molecule);
         reader.close();
         int deuteriumCount = 0;
@@ -928,7 +928,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemblMolregno5369.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.RELAXED);
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         molecule = reader.read(molecule);
         reader.close();
         IAtom deuterium = molecule.getAtom(molecule.getAtomCount() - 1);
@@ -941,7 +941,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemblMolregno7039.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         molecule = reader.read(molecule);
         reader.close();
         int tritiumCount = 0;
@@ -956,7 +956,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemblMolregno7039.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         molecule = reader.read(molecule);
         reader.close();
         IAtom tritium = molecule.getAtom(molecule.getAtomCount() - 1);
@@ -972,7 +972,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "iridiumCoordination.chebi52748.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer atc = reader.read(new AtomContainer());
+        IAtomContainer atc = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
 
         int queryBondCount = 0;
@@ -998,7 +998,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chebi.querybond.51736.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer atc = reader.read(new AtomContainer());
+        IAtomContainer atc = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         int queryBondCount = 0;
 
@@ -1374,7 +1374,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     void testAliasAfterRgroup() throws Exception {
         InputStream in = getClass().getResourceAsStream("r-group-with-alias.mol");
         MDLV2000Reader reader = new MDLV2000Reader(in);
-        IAtomContainer container = reader.read(new AtomContainer());
+        IAtomContainer container = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         assertThat(container.getAtom(6), is(instanceOf(IPseudoAtom.class)));
         assertThat(((IPseudoAtom) container.getAtom(6)).getLabel(), is("R6"));
@@ -1386,7 +1386,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     void keepAtomicNumberOfAlias() throws Exception {
         InputStream in = getClass().getResourceAsStream("element-with-alias.mol");
         MDLV2000Reader reader = new MDLV2000Reader(in);
-        IAtomContainer container = reader.read(new AtomContainer());
+        IAtomContainer container = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         assertThat(container.getAtom(6), is(instanceOf(IPseudoAtom.class)));
         assertThat(((IPseudoAtom) container.getAtom(6)).getLabel(), is("N1"));
@@ -1420,7 +1420,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void radicalsReflectedInHydrogenCount() throws Exception {
         MDLV2000Reader r = new MDLV2000Reader(getClass().getResourceAsStream("structure-with-radical.mol"));
-        IAtomContainer m = r.read(new AtomContainer());
+        IAtomContainer m = r.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         r.close();
         assertThat(m.getAtom(0).getAtomicNumber(), is(8));
         assertThat(m.getAtom(0).getImplicitHydrogenCount(), is(0));
@@ -1433,7 +1433,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     void nonNegativeHydrogenCount() throws Exception {
         InputStream in = getClass().getResourceAsStream("ChEBI_30668.mol");
         MDLV2000Reader reader = new MDLV2000Reader(in);
-        IAtomContainer container = reader.read(new AtomContainer());
+        IAtomContainer container = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         for (IAtom atom : container.atoms()) {
             assertThat(atom.getImplicitHydrogenCount(), is(greaterThanOrEqualTo(0)));
@@ -1448,7 +1448,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     void nonNegativeHydrogenCountOnHydrogenRadical() throws Exception {
         InputStream in = getClass().getResourceAsStream("ChEBI_29293.mol");
         MDLV2000Reader reader = new MDLV2000Reader(in);
-        IAtomContainer container = reader.read(new AtomContainer());
+        IAtomContainer container = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         assertThat(container.getAtom(0).getImplicitHydrogenCount(), is(0));
         assertThat(container.getAtom(1).getImplicitHydrogenCount(), is(0));
@@ -1465,7 +1465,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
         Assertions.assertThrows(CDKException.class,
                                 () -> {
-                                    reader.read(new AtomContainer());
+                                    reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
                                 });
     }
 
@@ -1478,7 +1478,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemsketch-one-label.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
 
         assertThat(mol.getAtom(1).getProperty(CDKConstants.ACDLABS_LABEL), is("6"));
@@ -1493,7 +1493,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemsketch-printable-ascii.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
 
         // Printable ASCII characters, excluding whitespace. Note each string contains an atom number
@@ -1517,7 +1517,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemsketch-all-labelled.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
 
         Iterable<IAtom> atoms = mol.atoms();
@@ -1535,7 +1535,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemsketch-leading-trailing-space.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
 
         // Leading and trailing whitespace in both prefix and suffix
@@ -1552,7 +1552,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemsketch-embedded-space.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
 
         // Embedded whitespace in both prefix and suffix
@@ -1569,7 +1569,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "chemsketch-longest-label.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
 
         // Longest allowed atom label is 103 characters
@@ -1584,7 +1584,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void testSgroupAbbreviation() throws Exception {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-abbrv.mol"))) {
-            final IAtomContainer container = mdlr.read(new AtomContainer());
+            final IAtomContainer container = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             List<Sgroup> sgroups = container.getProperty(CDKConstants.CTAB_SGROUPS);
             Assertions.assertNotNull(sgroups);
             assertThat(sgroups.size(), is(1));
@@ -1598,7 +1598,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void testSgroupRepeatUnit() throws Exception {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-sru.mol"))) {
-            IAtomContainer container = mdlr.read(new AtomContainer());
+            IAtomContainer container = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             List<Sgroup> sgroups = container.getProperty(CDKConstants.CTAB_SGROUPS);
             Assertions.assertNotNull(sgroups);
             assertThat(sgroups.size(), is(1));
@@ -1627,7 +1627,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void testSgroupUnorderedMixture() throws Exception {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-unord-mixture.mol"))) {
-            IAtomContainer container = mdlr.read(new AtomContainer());
+            IAtomContainer container = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             List<Sgroup> sgroups = container.getProperty(CDKConstants.CTAB_SGROUPS);
             Assertions.assertNotNull(sgroups);
             assertThat(sgroups.size(), is(3));
@@ -1651,7 +1651,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void testSgroupExpandedAbbreviation() throws Exception {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("triphenyl-phosphate-expanded.mol"))) {
-            IAtomContainer container = mdlr.read(new AtomContainer());
+            IAtomContainer container = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             List<Sgroup> sgroups = container.getProperty(CDKConstants.CTAB_SGROUPS);
             Assertions.assertNotNull(sgroups);
             assertThat(sgroups.size(), is(3));
@@ -1679,7 +1679,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
                                 () -> {
                                     try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-sru-bad-scn.mol"))) {
                                         mdlr.setReaderMode(Mode.STRICT);
-                                        mdlr.read(new AtomContainer());
+                                        mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
                                     }
                                 });
     }
@@ -1690,7 +1690,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
                                 () -> {
                                     try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-sru-bad-def.mol"))) {
                                         mdlr.setReaderMode(Mode.STRICT);
-                                        mdlr.read(new AtomContainer());
+                                        mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
                                     }
                                 });
     }
@@ -1698,7 +1698,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void testSgroupBracketStyle() throws Exception {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-sru-bracketstyles.mol"))) {
-            IAtomContainer container = mdlr.read(new AtomContainer());
+            IAtomContainer container = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             List<Sgroup> sgroups = container.getProperty(CDKConstants.CTAB_SGROUPS);
             Assertions.assertNotNull(sgroups);
             assertThat(sgroups.size(), is(2));
@@ -1714,7 +1714,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void testReading0DStereochemistry() throws Exception {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("tetrahedral-parity-withImplH.mol"))) {
-            IAtomContainer container = mdlr.read(new AtomContainer());
+            IAtomContainer container = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             Iterable<IStereoElement> selements = container.stereoElements();
             Iterator<IStereoElement> siter = selements.iterator();
             Assertions.assertTrue(siter.hasNext());
@@ -1730,7 +1730,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void testReading0DStereochemistryWithHydrogen() throws Exception {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("tetrahedral-parity-withExpH.mol"))) {
-            IAtomContainer container = mdlr.read(new AtomContainer());
+            IAtomContainer container = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             Iterable<IStereoElement> selements = container.stereoElements();
             Iterator<IStereoElement> siter = selements.iterator();
             Assertions.assertTrue(siter.hasNext());
@@ -1752,7 +1752,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
                                 () -> {
                                     try (InputStream in = getClass().getResourceAsStream("seaborgium.mol");
                                          MDLV2000Reader mdlr = new MDLV2000Reader(in, Mode.STRICT)) {
-                                        mdlr.read(new AtomContainer());
+                                        mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
                                     }
                                 });
     }
@@ -1761,7 +1761,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
     void seaborgiumAbsMass() throws Exception {
         try (InputStream in = getClass().getResourceAsStream("seaborgium_abs.mol");
              MDLV2000Reader mdlr = new MDLV2000Reader(in, Mode.STRICT)) {
-            IAtomContainer mol = mdlr.read(new AtomContainer());
+            IAtomContainer mol = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             assertThat(mol.getAtom(0).getMassNumber(), is(261));
         }
     }
@@ -1772,7 +1772,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
                 + "    0.0000    0.0000    0.0000 H  +1  0  0  0  0\n"
                 + "M  END\n";
         try (MDLV2000Reader reader = new MDLV2000Reader(new StringReader(mdl), Mode.STRICT)) {
-            IAtomContainer mol = reader.read(new AtomContainer());
+            IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             IAtom atom = mol.getAtom(0);
             Assertions.assertEquals(1, atom.getAtomicNumber().intValue());
             Assertions.assertEquals(2, atom.getMassNumber().intValue());
@@ -1825,7 +1825,7 @@ class MDLV2000ReaderTest extends SimpleChemObjectReaderTest {
                 "\n";
         final MDLV2000Reader mdlv2000Reader = new MDLV2000Reader(new ByteArrayInputStream(mol.getBytes(StandardCharsets.UTF_8)));
         mdlv2000Reader.setReaderMode(IChemObjectReader.Mode.RELAXED);
-        final org.openscience.cdk.silent.AtomContainer atomContainer = mdlv2000Reader.read(new org.openscience.cdk.silent.AtomContainer());
+        final IAtomContainer atomContainer = mdlv2000Reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertEquals(17, atomContainer.getAtomCount());
     }
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
@@ -87,7 +87,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         MDLV2000Writer reader = new MDLV2000Writer();
         Assertions.assertTrue(reader.accepts(ChemFile.class));
         Assertions.assertTrue(reader.accepts(ChemModel.class));
-        Assertions.assertTrue(reader.accepts(AtomContainer.class));
+        Assertions.assertTrue(reader.accepts(IAtomContainer.class));
     }
 
     /**

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV2000WriterTest.java
@@ -97,7 +97,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
     @Test
     void testBug890456() throws Exception {
         StringWriter   writer   = new StringWriter();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new PseudoAtom("*"));
         molecule.addAtom(new Atom("C"));
         molecule.addAtom(new Atom("C"));
@@ -114,7 +114,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
     @Test
     void testBug1212219() throws Exception {
         StringWriter   writer   = new StringWriter();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom           atom     = new Atom("C");
         atom.setMassNumber(14);
         molecule.addAtom(atom);
@@ -146,7 +146,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
 
     @Test
     void nonDefaultValence_fe_iii() throws Exception {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom          fe1       = new Atom("Fe");
         fe1.setImplicitHydrogenCount(3);
         container.addAtom(fe1);
@@ -317,7 +317,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
 
     @Test
     void testUnsupportedBondOrder() throws Exception {
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molecule.addAtom(new Atom("C"));
         molecule.addBond(new Bond(molecule.getAtom(0), molecule.getAtom(1), Order.QUADRUPLE));
@@ -392,7 +392,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         oxygen.setProperty(CDKConstants.COMMENT, "Oxygen comment");
         IBond bond = builder.newInstance(IBond.class, carbon, oxygen, Order.DOUBLE);
 
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(oxygen);
         molecule.addAtom(carbon);
         molecule.addBond(bond);
@@ -690,7 +690,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-sru.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("M  STY  1   1 SRU"));
             assertThat(output, containsString("M  SMT   1 n"));
@@ -703,7 +703,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-sru-bracketstyles.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("M  STY  2   1 SRU   2 SRU"));
             assertThat(output, containsString("M  SBT  1   1   1"));
@@ -715,7 +715,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-unord-mixture.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("M  STY  3   1 COM   2 COM   3 MIX"));
             assertThat(output, containsString("M  SPL  2   1   3   2   3"));
@@ -727,7 +727,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-ran-copolymer.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("M  SST  1   1 RAN"));
             assertThat(output, containsString("M  STY  3   1 COP   2 SRU   3 SRU"));
@@ -739,7 +739,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("triphenyl-phosphate-expanded.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("M  STY  3   1 SUP   2 SUP   3 SUP\n"));
             assertThat(output, containsString("M  SDS EXP  1   1"));
@@ -751,7 +751,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("ChEBI_81539.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("M  STY  5   1 MUL   2 SRU"));
             assertThat(output, containsString("M  SPA   1 12"));
@@ -763,7 +763,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-ord-mixture.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("M  STY  3   1 COM   2 COM   3 FOR"));
             assertThat(output, containsString("M  SNC  1   1   1"));
@@ -776,7 +776,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("tetrahedral-parity-withExpH.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("    0.0000    0.0000    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0\n"));
         }
@@ -787,7 +787,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("tetrahedral-parity-withImplH.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("    0.0000    0.0000    0.0000 C   0  0  1  0  0  0  0  0  0  0  0  0\n"));
         }
@@ -798,7 +798,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
         StringWriter sw = new StringWriter();
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("tetrahedral-parity-withImplH.mol"));
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
-            AtomContainer         mol = mdlr.read(new AtomContainer());
+            IAtomContainer mol = mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
             ITetrahedralChirality tc  = (ITetrahedralChirality) mol.stereoElements().iterator().next();
             tc.setStereo(tc.getStereo().invert());
             mdlw.write(mol);
@@ -956,7 +956,7 @@ class MDLV2000WriterTest extends ChemObjectIOTest {
              MDLV2000Writer mdlw = new MDLV2000Writer(sw)) {
             mdlw.getSetting(MDLV2000Writer.OptWriteDefaultProperties)
                 .setSetting("false");
-            mdlw.write(mdlr.read(new AtomContainer()));
+            mdlw.write(mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer()));
             String output = sw.toString();
             assertThat(output, containsString("\n"
                                               + "  5  4  0  0  0  0  0  0  0  0999 V2000\n"

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000ReaderTest.java
@@ -84,7 +84,7 @@ class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         try (InputStream ins = this.getClass().getResourceAsStream(filename);
              MDLV3000Reader reader = new MDLV3000Reader(ins)) {
-            IAtomContainer m = reader.read(new AtomContainer());
+            IAtomContainer m = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             reader.close();
             Assertions.assertNotNull(m);
             Assertions.assertEquals(31, m.getAtomCount());
@@ -102,7 +102,7 @@ class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
     void testEmptyString() throws Exception {
         String emptyString = "";
         try (MDLV3000Reader reader = new MDLV3000Reader(new StringReader(emptyString))) {
-            reader.read(new AtomContainer());
+            reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             reader.close();
             Assertions.fail("Should have received a CDK Exception");
         } catch (CDKException cdkEx) {

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000ReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000ReaderTest.java
@@ -127,7 +127,7 @@ class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void pseudoAtomReplacement() throws Exception {
         try (MDLV3000Reader reader = new MDLV3000Reader(getClass().getResourceAsStream("pseudoAtomReplacement.mol"))) {
-            IAtomContainer container = reader.read(new org.openscience.cdk.AtomContainer(0, 0, 0, 0));
+            IAtomContainer container = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
             for (IAtom atom : container.getBond(9).atoms()) {
                 Assertions.assertTrue(container.contains(atom));
             }
@@ -137,7 +137,7 @@ class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void positionalVariation() throws Exception {
         try (MDLV3000Reader reader = new MDLV3000Reader(getClass().getResourceAsStream("multicenterBond.mol"))) {
-            IAtomContainer container = reader.read(new org.openscience.cdk.AtomContainer(0, 0, 0, 0));
+            IAtomContainer container = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
             assertThat(container.getBondCount(), is(8));
             List<Sgroup> sgroups = container.getProperty(CDKConstants.CTAB_SGROUPS);
             Assertions.assertNotNull(sgroups);
@@ -149,7 +149,7 @@ class MDLV3000ReaderTest extends SimpleChemObjectReaderTest {
     @Test
     void radicalsInCH3() throws Exception {
         try (MDLV3000Reader reader = new MDLV3000Reader(getClass().getResourceAsStream("CH3.mol"))) {
-            IAtomContainer container = reader.read(new org.openscience.cdk.AtomContainer(0, 0, 0, 0));
+            IAtomContainer container = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
             assertThat(container.getSingleElectronCount(), is(1));
             assertThat(container.getAtom(0).getImplicitHydrogenCount(), is(3));
         }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -61,7 +61,7 @@ class MDLV3000WriterTest {
 
     @Test
     void outputValencyWhenNeeded() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Na"));
         mol.addAtom(new Atom("Na"));
         mol.getAtom(0).setImplicitHydrogenCount(0); // Na metal
@@ -73,7 +73,7 @@ class MDLV3000WriterTest {
 
     @Test
     void outputFormalCharge() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -87,7 +87,7 @@ class MDLV3000WriterTest {
 
     @Test
     void outputMassNumber() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("H"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -102,7 +102,7 @@ class MDLV3000WriterTest {
 
     @Test
     void outputRadical() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setImplicitHydrogenCount(3);
         mol.addSingleElectron(0);
@@ -112,7 +112,7 @@ class MDLV3000WriterTest {
 
     @Test
     void nullBondOrder() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("H"));
         mol.addAtom(new Atom("C"));
         mol.addBond(new Bond(mol.getAtom(0), mol.getAtom(1), null));
@@ -127,7 +127,7 @@ class MDLV3000WriterTest {
 
     @Test
     void unsetBondOrder() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("H"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, IBond.Order.UNSET);
@@ -142,7 +142,7 @@ class MDLV3000WriterTest {
 
     @Test
     void solidWedgeBonds() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("O"));
         mol.addBond(0, 1, IBond.Order.SINGLE, IBond.Stereo.UP);
@@ -154,7 +154,7 @@ class MDLV3000WriterTest {
 
     @Test
     void hashedWedgeBonds() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("O"));
         mol.addBond(0, 1, IBond.Order.SINGLE, IBond.Stereo.DOWN);
@@ -166,7 +166,7 @@ class MDLV3000WriterTest {
 
     @Test
     void solidWedgeInvBonds() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("O"));
         mol.addBond(0, 1, IBond.Order.SINGLE, IBond.Stereo.UP_INVERTED);
@@ -178,7 +178,7 @@ class MDLV3000WriterTest {
 
     @Test
     void hashedWedgeInvBonds() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("O"));
         mol.addBond(0, 1, IBond.Order.SINGLE, IBond.Stereo.DOWN_INVERTED);
@@ -190,7 +190,7 @@ class MDLV3000WriterTest {
 
     @Test
     void writeLeadingZero() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom           atom   = new Atom("C");
         atom.setPoint2d(new Point2d(0.5, 1.2));
         mol.addAtom(atom);
@@ -199,7 +199,7 @@ class MDLV3000WriterTest {
 
     @Test
     void writeParity() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -229,7 +229,7 @@ class MDLV3000WriterTest {
 
     @Test
     void writeParityHNotLast() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -261,7 +261,7 @@ class MDLV3000WriterTest {
 
     @Test
     void writeParityImplH() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -288,7 +288,7 @@ class MDLV3000WriterTest {
 
     @Test
     void writeParityImplHInverted() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -315,7 +315,7 @@ class MDLV3000WriterTest {
 
     @Test
     void writeSRUs() throws IOException, CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("O"));
@@ -345,7 +345,7 @@ class MDLV3000WriterTest {
     @Test
     void writeMultipleGroup() throws IOException, CDKException {
         final int repeatAtoms = 50;
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         for (int i = 0; i < repeatAtoms; i++)
             mol.addAtom(new Atom("C"));
@@ -378,7 +378,7 @@ class MDLV3000WriterTest {
     @Test
     void roundTripSRU() throws IOException, CDKException {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-sru-bracketstyles.mol"))) {
-            IAtomContainer mol = mdlr.read(new AtomContainer(0, 0, 0, 0));
+            IAtomContainer mol = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             String res = writeToStr(mol);
             assertThat(res, CoreMatchers.containsString("M  V30 1 SRU 0 ATOMS=(1 2) XBONDS=(2 1 2) LABEL=n CONNECT=HT BRKXYZ=(9 -2.5742-\n"
                                                         + "M  V30  4.207 0 -3.0692 3.3497 0 0 0 0) BRKXYZ=(9 -3.1626 3.3497 0 -3.6576 4.2-\n"
@@ -392,7 +392,7 @@ class MDLV3000WriterTest {
     @Test
     void roundTripExpandedAbbrv() throws IOException, CDKException {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("triphenyl-phosphate-expanded.mol"))) {
-            IAtomContainer mol = mdlr.read(new AtomContainer(0, 0, 0, 0));
+            IAtomContainer mol = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             String res = writeToStr(mol);
             assertThat(res, CoreMatchers.containsString("M  V30 1 SUP 0 ATOMS=(6 6 19 20 21 22 23) XBONDS=(1 5) ESTATE=E LABEL=Ph\n"
                                                         + "M  V30 2 SUP 0 ATOMS=(6 8 14 15 16 17 18) XBONDS=(1 7) ESTATE=E LABEL=Ph\n"
@@ -403,7 +403,7 @@ class MDLV3000WriterTest {
     @Test
     void roundTripOrderMixtures() throws IOException, CDKException {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("sgroup-ord-mixture.mol"))) {
-            IAtomContainer mol = mdlr.read(new AtomContainer(0, 0, 0, 0));
+            IAtomContainer mol = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             String res = writeToStr(mol);
             assertThat(res, CoreMatchers.containsString("M  V30 1 FOR 0 ATOMS=(24 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21-\n"
                                                         + "M  V30  22 23 24) BRKXYZ=(9 -6.9786 -1.9329 0 -6.9786 4.5847 0 0 0 0) BRKXYZ=(-\n"
@@ -420,7 +420,7 @@ class MDLV3000WriterTest {
     @Test
     void positionalVariationRoundTrip() throws Exception {
         try (MDLV3000Reader mdlr = new MDLV3000Reader(getClass().getResourceAsStream("multicenterBond.mol"))) {
-            IAtomContainer mol = mdlr.read(new AtomContainer(0, 0, 0, 0));
+            IAtomContainer mol = mdlr.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             String res = writeToStr(mol);
             assertThat(res, CoreMatchers.containsString("M  V30 8 1 8 9 ATTACH=ANY ENDPTS=(5 2 3 4 5 6)\n"));
         }

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLV3000WriterTest.java
@@ -38,7 +38,6 @@ import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.sgroup.SgroupType;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.stereo.TetrahedralChirality;

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLValenceTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLValenceTest.java
@@ -26,7 +26,6 @@ package org.openscience.cdk.io;
 
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/MDLValenceTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/MDLValenceTest.java
@@ -27,6 +27,7 @@ package org.openscience.cdk.io;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -42,7 +43,7 @@ class MDLValenceTest {
 
     @Test
     void sodium_metal() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("Na");
         atom.setValency(0);
         container.addAtom(atom);
@@ -53,7 +54,7 @@ class MDLValenceTest {
 
     @Test
     void sodium_hydride() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("Na");
         atom.setValency(1);
         container.addAtom(atom);
@@ -64,7 +65,7 @@ class MDLValenceTest {
 
     @Test
     void sodium_implicit() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("Na");
         container.addAtom(atom);
         MDLValence.apply(container);
@@ -74,7 +75,7 @@ class MDLValenceTest {
 
     @Test
     void bismuth() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom bi1 = new Atom("Bi");
         IAtom h2 = new Atom("H");
         bi1.setFormalCharge(+2);
@@ -90,7 +91,7 @@ class MDLValenceTest {
 
     @Test
     void tin_ii() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("Sn");
         atom.setValency(2);
         container.addAtom(atom);
@@ -101,7 +102,7 @@ class MDLValenceTest {
 
     @Test
     void tin_iv() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("Sn");
         atom.setValency(4);
         IAtom hydrogen = new Atom("H");
@@ -115,7 +116,7 @@ class MDLValenceTest {
 
     @Test
     void carbon_neutral() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         container.addAtom(atom);
         MDLValence.apply(container);
@@ -125,7 +126,7 @@ class MDLValenceTest {
 
     @Test
     void carbon_cation() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         atom.setFormalCharge(-1);
         container.addAtom(atom);
@@ -136,7 +137,7 @@ class MDLValenceTest {
 
     @Test
     void carbon_cation_doubleBonded() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom c1 = new Atom("C");
         IAtom c2 = new Atom("C");
         c1.setFormalCharge(-1);
@@ -152,7 +153,7 @@ class MDLValenceTest {
 
     @Test
     void carbon_anion() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C");
         atom.setFormalCharge(+1);
         container.addAtom(atom);
@@ -163,7 +164,7 @@ class MDLValenceTest {
 
     @Test
     void bismuth_isImplicit() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom bi1 = new Atom("Bi");
         IAtom h2 = new Atom("H");
         bi1.setFormalCharge(+2);

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
@@ -86,7 +86,7 @@ class SDFWriterTest extends ChemObjectWriterTest {
     void testWrite_IAtomContainerSet_Properties_Off() throws Exception {
         StringWriter writer = new StringWriter();
         IAtomContainerSet molSet = new AtomContainerSet();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molecule.setProperty("foo", "bar");
         molSet.addAtomContainer(molecule);
@@ -123,7 +123,7 @@ class SDFWriterTest extends ChemObjectWriterTest {
     void testWrite_IAtomContainerSet_Properties() throws Exception {
         StringWriter writer = new StringWriter();
         IAtomContainerSet molSet = new AtomContainerSet();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molecule.setProperty("foo", "bar");
         molSet.addAtomContainer(molecule);
@@ -139,7 +139,7 @@ class SDFWriterTest extends ChemObjectWriterTest {
     void testWrite_IAtomContainerSet_CDKProperties() throws Exception {
         StringWriter writer = new StringWriter();
         IAtomContainerSet molSet = new AtomContainerSet();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molecule.setProperty(InvPair.CANONICAL_LABEL, "bar");
         molSet.addAtomContainer(molecule);
@@ -154,7 +154,7 @@ class SDFWriterTest extends ChemObjectWriterTest {
     void testWrite_IAtomContainerSet_SingleMolecule() throws Exception {
         StringWriter writer = new StringWriter();
         IAtomContainerSet molSet = new AtomContainerSet();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molSet.addAtomContainer(molecule);
 
@@ -168,10 +168,10 @@ class SDFWriterTest extends ChemObjectWriterTest {
     void testWrite_IAtomContainerSet_MultIAtomContainer() throws Exception {
         StringWriter writer = new StringWriter();
         IAtomContainerSet molSet = new AtomContainerSet();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molSet.addAtomContainer(molecule);
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molSet.addAtomContainer(molecule);
 
@@ -186,12 +186,12 @@ class SDFWriterTest extends ChemObjectWriterTest {
         StringWriter writer = new StringWriter();
         SDFWriter sdfWriter = new SDFWriter(writer);
 
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molecule.setProperty("foo", "bar");
         sdfWriter.write(molecule);
 
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molecule.setProperty("toys", "r-us");
         sdfWriter.write(molecule);
@@ -209,7 +209,7 @@ class SDFWriterTest extends ChemObjectWriterTest {
         StringWriter writer = new StringWriter();
         SDFWriter sdfWriter = new SDFWriter(writer);
 
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("C"));
         molecule.setProperty("http://not-valid.com", "URL");
         sdfWriter.write(molecule);
@@ -223,16 +223,16 @@ class SDFWriterTest extends ChemObjectWriterTest {
         StringWriter writer = new StringWriter();
         SDFWriter sdfWriter = new SDFWriter(writer);
 
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("CH4"));
         sdfWriter.write(molecule);
 
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         for (int i = 0; i < 1000; i++)
             molecule.addAtom(new Atom("CH4"));
         sdfWriter.write(molecule);
 
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("CH4"));
         sdfWriter.write(molecule);
 
@@ -248,16 +248,16 @@ class SDFWriterTest extends ChemObjectWriterTest {
         SDFWriter sdfWriter = new SDFWriter(writer);
         sdfWriter.setAlwaysV3000(true);
 
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("CH4"));
         sdfWriter.write(molecule);
 
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         for (int i = 0; i < 1000; i++)
             molecule.addAtom(new Atom("CH4"));
         sdfWriter.write(molecule);
 
-        molecule = new AtomContainer();
+        molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(new Atom("CH4"));
         sdfWriter.write(molecule);
 

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/SDFWriterTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;

--- a/storage/ctab/src/test/java/org/openscience/cdk/io/iterator/IteratingSDFReaderTest.java
+++ b/storage/ctab/src/test/java/org/openscience/cdk/io/iterator/IteratingSDFReaderTest.java
@@ -25,11 +25,8 @@ package org.openscience.cdk.io.iterator;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.test.CDKTestCase;

--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
@@ -32,7 +32,6 @@ import io.github.dan2097.jnainchi.InchiStereoParity;
 import io.github.dan2097.jnainchi.InchiStereoType;
 import io.github.dan2097.jnainchi.JnaInchi;
 import net.sf.jniinchi.INCHI_RET;
-import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;

--- a/storage/inchi/src/test/java/org/openscience/cdk/graph/invariant/InChINumbersToolsTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/graph/invariant/InChINumbersToolsTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;

--- a/storage/inchi/src/test/java/org/openscience/cdk/graph/invariant/InChINumbersToolsTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/graph/invariant/InChINumbersToolsTest.java
@@ -42,7 +42,7 @@ class InChINumbersToolsTest extends CDKTestCase {
 
     @Test
     void testSimpleNumbering() throws CDKException {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("O"));
         container.addAtom(new Atom("C"));
         container.addBond(0, 1, IBond.Order.SINGLE);
@@ -54,7 +54,7 @@ class InChINumbersToolsTest extends CDKTestCase {
 
     @Test
     void testHydrogens() throws CDKException {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("H"));
         container.addAtom(new Atom("C"));
         container.addBond(0, 1, IBond.Order.SINGLE);

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorFactoryTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorFactoryTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorFactoryTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorFactoryTest.java
@@ -62,7 +62,7 @@ class InChIGeneratorFactoryTest {
      */
     @Test
     void testGetInChIGenerator_IAtomContainer() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("Cl");
         a.setImplicitHydrogenCount(1);
         ac.addAtom(a);
@@ -76,7 +76,7 @@ class InChIGeneratorFactoryTest {
      */
     @Test
     void testGetInChIGenerator_IAtomContainer_String() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("Cl");
         a.setImplicitHydrogenCount(1);
         ac.addAtom(a);
@@ -90,7 +90,7 @@ class InChIGeneratorFactoryTest {
      */
     @Test
     void testGetInChIGenerator_IAtomContainer_NullString() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("Cl");
         a.setImplicitHydrogenCount(1);
         ac.addAtom(a);
@@ -133,7 +133,7 @@ class InChIGeneratorFactoryTest {
      */
     @Test
     void testGetInChIGenerator_IAtomContainer_List() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("Cl");
         a.setImplicitHydrogenCount(1);
         ac.addAtom(a);
@@ -150,7 +150,7 @@ class InChIGeneratorFactoryTest {
     @Test
     void testGetInChIGenerator_IAtomContainer_NullList() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            IAtomContainer ac = new AtomContainer();
+            IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             IAtom a = new Atom("Cl");
             a.setImplicitHydrogenCount(1);
             ac.addAtom(a);

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
@@ -33,11 +33,9 @@ import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 
 import net.sf.jniinchi.INCHI_OPTION;
-import org.apache.logging.log4j.core.util.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIGeneratorTest.java
@@ -86,7 +86,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetInchiFromChlorineAtom() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("ClH"));
         InChIGenerator gen = getFactory().getInChIGenerator(ac, "FixedH");
         Assertions.assertEquals(gen.getReturnStatus(), INCHI_RET.OKAY);
@@ -95,7 +95,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void testGetLog() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("Cl"));
         InChIGenerator gen = getFactory().getInChIGenerator(ac, "FixedH");
         Assertions.assertNotNull(gen.getLog());
@@ -103,7 +103,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void testGetAuxInfo() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
         a1.setImplicitHydrogenCount(3);
@@ -118,7 +118,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void testGetMessage() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("Cl"));
         InChIGenerator gen = getFactory().getInChIGenerator(ac, "FixedH");
         Assertions.assertEquals("", gen.getMessage(), "Because this generation should work, I expected an empty message String.");
@@ -126,7 +126,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void testGetWarningMessage() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("Cl"));
         ac.addAtom(new Atom("H"));
         ac.addBond(0, 1, Order.TRIPLE);
@@ -142,7 +142,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetInchiFromLithiumIon() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("Li");
         a.setFormalCharge(+1);
         ac.addAtom(a);
@@ -158,7 +158,7 @@ class InChIGeneratorTest extends CDKTestCase {
     */
     @Test
     void testGetInchiFromChlorine37Atom() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("ClH");
         a.setMassNumber(37);
         ac.addAtom(a);
@@ -174,7 +174,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetInchiFromHydrogenChlorideImplicitH() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("Cl");
         a.setImplicitHydrogenCount(1);
         ac.addAtom(a);
@@ -190,7 +190,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetInchiFromMethylRadical() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("C");
         a.setImplicitHydrogenCount(3);
         ac.addAtom(a);
@@ -207,7 +207,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetInchiFromEthane() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
         a1.setImplicitHydrogenCount(3);
@@ -230,7 +230,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void nonStandardInChIWithEnumOptions() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
         a1.setImplicitHydrogenCount(3);
@@ -258,7 +258,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetInchiFromEthene() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
         a1.setImplicitHydrogenCount(2);
@@ -278,7 +278,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetInchiFromEthyne() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
         a1.setImplicitHydrogenCount(1);
@@ -300,7 +300,7 @@ class InChIGeneratorTest extends CDKTestCase {
     void testGetInchiEandZ12Dichloroethene2D() throws Exception {
 
         // (E)-1,2-dichloroethene
-        IAtomContainer acE = new AtomContainer();
+        IAtomContainer acE = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1E = new Atom("C", new Point2d(2.866, -0.250));
         IAtom a2E = new Atom("C", new Point2d(3.732, 0.250));
         IAtom a3E = new Atom("Cl", new Point2d(2.000, 2.500));
@@ -321,7 +321,7 @@ class InChIGeneratorTest extends CDKTestCase {
         Assertions.assertEquals("InChI=1/C2H2Cl2/c3-1-2-4/h1-2H/b2-1+", genE.getInchi());
 
         // (Z)-1,2-dichloroethene
-        IAtomContainer acZ = new AtomContainer();
+        IAtomContainer acZ = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1Z = new Atom("C", new Point2d(2.866, -0.440));
         IAtom a2Z = new Atom("C", new Point2d(3.732, 0.060));
         IAtom a3Z = new Atom("Cl", new Point2d(2.000, 0.060));
@@ -351,7 +351,7 @@ class InChIGeneratorTest extends CDKTestCase {
     void testGetInchiFromLandDAlanine3D() throws Exception {
 
         // L-Alanine
-        IAtomContainer acL = new AtomContainer();
+        IAtomContainer acL = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1L = new Atom("C", new Point3d(-0.358, 0.819, 20.655));
         IAtom a2L = new Atom("C", new Point3d(-1.598, -0.032, 20.905));
         IAtom a3L = new Atom("N", new Point3d(-0.275, 2.014, 21.574));
@@ -380,7 +380,7 @@ class InChIGeneratorTest extends CDKTestCase {
         Assertions.assertEquals("InChI=1/C3H7NO2/c1-2(4)3(5)6/h2H,4H2,1H3,(H,5,6)/t2-/m0/s1/f/h5H", genL.getInchi());
 
         // D-Alanine
-        IAtomContainer acD = new AtomContainer();
+        IAtomContainer acD = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1D = new Atom("C", new Point3d(0.358, 0.819, 20.655));
         IAtom a2D = new Atom("C", new Point3d(1.598, -0.032, 20.905));
         IAtom a3D = new Atom("N", new Point3d(0.275, 2.014, 21.574));
@@ -412,7 +412,7 @@ class InChIGeneratorTest extends CDKTestCase {
     // ensure only
     @Test
     void zeroHydrogenCount() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("O"));
         ac.getAtom(0).setImplicitHydrogenCount(0);
         InChIGenerator gen = getFactory().getInChIGenerator(ac);
@@ -427,7 +427,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetStandardInchiFromChlorineAtom() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("ClH"));
         InChIGenerator gen = getFactory().getInChIGenerator(ac);
         Assertions.assertEquals(INCHI_RET.OKAY, gen.getReturnStatus());
@@ -441,7 +441,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetStandardInchiFromLithiumIon() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("Li");
         a.setFormalCharge(+1);
         ac.addAtom(a);
@@ -457,7 +457,7 @@ class InChIGeneratorTest extends CDKTestCase {
     */
     @Test
     void testGetStandardInchiFromChlorine37Atom() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("ClH");
         a.setMassNumber(37);
         ac.addAtom(a);
@@ -473,7 +473,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetStandardInchiFromHydrogenChlorideImplicitH() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("Cl");
         a.setImplicitHydrogenCount(1);
         ac.addAtom(a);
@@ -489,7 +489,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetStandardInchiFromMethylRadical() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("C");
         a.setImplicitHydrogenCount(3);
         ac.addAtom(a);
@@ -506,7 +506,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetStandardInchiFromEthane() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
         a1.setImplicitHydrogenCount(3);
@@ -527,7 +527,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetStandardInchiFromEthene() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
         a1.setImplicitHydrogenCount(2);
@@ -547,7 +547,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testGetStandardInchiFromEthyne() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1 = new Atom("C");
         IAtom a2 = new Atom("C");
         a1.setImplicitHydrogenCount(1);
@@ -569,7 +569,7 @@ class InChIGeneratorTest extends CDKTestCase {
     void testGetStandardInchiEandZ12Dichloroethene2D() throws Exception {
 
         // (E)-1,2-dichloroethene
-        IAtomContainer acE = new AtomContainer();
+        IAtomContainer acE = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1E = new Atom("C", new Point2d(2.866, -0.250));
         IAtom a2E = new Atom("C", new Point2d(3.732, 0.250));
         IAtom a3E = new Atom("Cl", new Point2d(2.000, 2.500));
@@ -590,7 +590,7 @@ class InChIGeneratorTest extends CDKTestCase {
         Assertions.assertEquals("InChI=1S/C2H2Cl2/c3-1-2-4/h1-2H/b2-1+", genE.getInchi());
 
         // (Z)-1,2-dichloroethene
-        IAtomContainer acZ = new AtomContainer();
+        IAtomContainer acZ = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1Z = new Atom("C", new Point2d(2.866, -0.440));
         IAtom a2Z = new Atom("C", new Point2d(3.732, 0.060));
         IAtom a3Z = new Atom("Cl", new Point2d(2.000, 0.060));
@@ -620,7 +620,7 @@ class InChIGeneratorTest extends CDKTestCase {
     void testGetStandardInchiFromLandDAlanine3D() throws Exception {
 
         // L-Alanine
-        IAtomContainer acL = new AtomContainer();
+        IAtomContainer acL = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1L = new Atom("C", new Point3d(-0.358, 0.819, 20.655));
         IAtom a2L = new Atom("C", new Point3d(-1.598, -0.032, 20.905));
         IAtom a3L = new Atom("N", new Point3d(-0.275, 2.014, 21.574));
@@ -649,7 +649,7 @@ class InChIGeneratorTest extends CDKTestCase {
         Assertions.assertEquals("InChI=1S/C3H7NO2/c1-2(4)3(5)6/h2H,4H2,1H3,(H,5,6)/t2-/m0/s1", genL.getInchi());
 
         // D-Alanine
-        IAtomContainer acD = new AtomContainer();
+        IAtomContainer acD = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1D = new Atom("C", new Point3d(0.358, 0.819, 20.655));
         IAtom a2D = new Atom("C", new Point3d(1.598, -0.032, 20.905));
         IAtom a3D = new Atom("N", new Point3d(0.275, 2.014, 21.574));
@@ -681,7 +681,7 @@ class InChIGeneratorTest extends CDKTestCase {
     @Test
     void testTetrahedralStereo() throws Exception {
         // L-Alanine
-        IAtomContainer acL = new AtomContainer();
+        IAtomContainer acL = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom[] ligandAtoms = new IAtom[4];
         IAtom a1 = new Atom("C");
         IAtom a1H = new Atom("H");
@@ -724,7 +724,7 @@ class InChIGeneratorTest extends CDKTestCase {
     @Test
     void testDoubleBondStereochemistry() throws Exception {
         // (E)-1,2-dichloroethene
-        IAtomContainer acE = new AtomContainer();
+        IAtomContainer acE = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a1E = new Atom("C");
         IAtom a2E = new Atom("C");
         IAtom a3E = new Atom("Cl");
@@ -759,7 +759,7 @@ class InChIGeneratorTest extends CDKTestCase {
     void bug1295() throws Exception {
         MDLV2000Reader reader = new MDLV2000Reader(getClass().getResourceAsStream("bug1295.mol"));
         try {
-            IAtomContainer container = reader.read(new AtomContainer());
+            IAtomContainer container = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
             InChIGenerator generator = getFactory().getInChIGenerator(container);
             Assertions.assertEquals("InChI=1S/C7H15NO/c1-4-7(3)6-8-9-5-2/h6-7H,4-5H2,1-3H3", generator.getInchi());
         } finally {
@@ -769,7 +769,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void r_penta_2_3_diene_impl_h() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("CH3"));
         m.addAtom(new Atom("CH"));
         m.addAtom(new Atom("C"));
@@ -798,7 +798,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void s_penta_2_3_diene_impl_h() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("CH3"));
         m.addAtom(new Atom("CH"));
         m.addAtom(new Atom("C"));
@@ -828,7 +828,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void r_penta_2_3_diene_expl_h() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("CH3"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
@@ -862,7 +862,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void s_penta_2_3_diene_expl_h() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("CH3"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
@@ -987,7 +987,7 @@ class InChIGeneratorTest extends CDKTestCase {
      */
     @Test
     void testFiveSecondTimeoutFlag() throws Exception {
-    	IAtomContainer ac = new AtomContainer();
+    	IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
     	InChIGeneratorFactory factory = InChIGeneratorFactory.getInstance();
     	InChIGenerator generator = factory.getInChIGenerator(ac);
@@ -996,7 +996,7 @@ class InChIGeneratorTest extends CDKTestCase {
 
     @Test
     void testTc99() throws CDKException {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("99Tc"));
         InChIGeneratorFactory factory = InChIGeneratorFactory.getInstance();
         InChIGenerator generator = factory.getInChIGenerator(ac);

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIToStructureTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIToStructureTest.java
@@ -20,7 +20,6 @@ package org.openscience.cdk.inchi;
 
 import net.sf.jniinchi.INCHI_RET;
 
-import org.apache.logging.log4j.core.util.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IBond;

--- a/storage/io/src/test/java/org/openscience/cdk/io/AbstractReaderFactoryTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/AbstractReaderFactoryTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.Reaction;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemFile;
@@ -62,7 +63,7 @@ class AbstractReaderFactoryTest {
         Assertions.assertNotNull(reader);
         Assertions.assertEquals(((IChemFormat) expectedFormat).getReaderClassName(), reader.getClass().getName());
         // now try reading something from it
-        IChemObject[] objects = {new ChemFile(), new ChemModel(), new AtomContainer(), new Reaction()};
+        IChemObject[] objects = {new ChemFile(), new ChemModel(), DefaultChemObjectBuilder.getInstance().newAtomContainer(), new Reaction()};
         boolean read = false;
         for (int i = 0; (i < objects.length && !read); i++) {
             if (reader.accepts(objects[i].getClass())) {

--- a/storage/io/src/test/java/org/openscience/cdk/io/AbstractReaderFactoryTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/AbstractReaderFactoryTest.java
@@ -24,7 +24,6 @@
 package org.openscience.cdk.io;
 
 import org.junit.jupiter.api.Assertions;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/storage/io/src/test/java/org/openscience/cdk/io/CDKSourceCodeWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/CDKSourceCodeWriterTest.java
@@ -52,7 +52,7 @@ class CDKSourceCodeWriterTest extends ChemObjectIOTest {
 
     @Test
     void testAccepts() throws Exception {
-        Assertions.assertTrue(chemObjectIO.accepts(AtomContainer.class));
+        Assertions.assertTrue(chemObjectIO.accepts(IAtomContainer.class));
     }
 
     @Test

--- a/storage/io/src/test/java/org/openscience/cdk/io/CDKSourceCodeWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/CDKSourceCodeWriterTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.test.io.ChemObjectIOTest;
 
@@ -57,7 +58,7 @@ class CDKSourceCodeWriterTest extends ChemObjectIOTest {
     @Test
     void testOutput() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setMassNumber(14);
         molecule.addAtom(atom);

--- a/storage/io/src/test/java/org/openscience/cdk/io/ChemObjectIOTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/ChemObjectIOTest.java
@@ -24,6 +24,7 @@ package org.openscience.cdk.io;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
@@ -69,7 +70,7 @@ public abstract class ChemObjectIOTest extends CDKTestCase {
         Assertions.assertNotNull(format, "The IChemObjectIO.getFormat method returned null.");
     }
 
-    private static final IChemObject[] acceptableNNChemObjects = {new ChemFile(), new ChemModel(), new AtomContainer(),
+    private static final IChemObject[] acceptableNNChemObjects = {new ChemFile(), new ChemModel(), SilentChemObjectBuilder.getInstance().newAtomContainer(),
             new Reaction()                               };
 
     @Test
@@ -99,11 +100,11 @@ public abstract class ChemObjectIOTest extends CDKTestCase {
 
     /** static objects, shared between tests - difficult to locate bugs. */
     @Deprecated
-    protected static final IChemObject[] acceptableChemObjects = {new ChemFile(), new ChemModel(), new AtomContainer(),
+    protected static final IChemObject[] acceptableChemObjects = {new ChemFile(), new ChemModel(), SilentChemObjectBuilder.getInstance().newAtomContainer(),
             new Reaction(), new RGroupQuery(DefaultChemObjectBuilder.getInstance())};
 
     static IChemObject[] acceptableChemObjects() {
-        return new IChemObject[]{new ChemFile(), new ChemModel(), new AtomContainer(), new Reaction(),
+        return new IChemObject[]{new ChemFile(), new ChemModel(), SilentChemObjectBuilder.getInstance().newAtomContainer(), new Reaction(),
                 new RGroupQuery(DefaultChemObjectBuilder.getInstance())};
     }
 

--- a/storage/io/src/test/java/org/openscience/cdk/io/ChemObjectIOTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/ChemObjectIOTest.java
@@ -44,7 +44,6 @@ import org.openscience.cdk.io.listener.IChemObjectIOListener;
 import org.openscience.cdk.io.setting.IOSetting;
 import org.openscience.cdk.isomorphism.matchers.IRGroupQuery;
 import org.openscience.cdk.isomorphism.matchers.RGroupQuery;
-import org.openscience.cdk.silent.AtomContainer;
 
 /**
  * TestCase for CDK IO classes.

--- a/storage/io/src/test/java/org/openscience/cdk/io/ChemObjectWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/ChemObjectWriterTest.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.silent.AtomContainerSet;
 import org.openscience.cdk.silent.ChemFile;
 import org.openscience.cdk.silent.ChemModel;
 import org.openscience.cdk.silent.Reaction;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.io.ChemObjectIOTest;
 
 import java.io.ByteArrayOutputStream;
@@ -50,7 +51,7 @@ abstract class ChemObjectWriterTest extends org.openscience.cdk.test.io.ChemObje
     }
 
     private static final IChemObject[] allChemObjectsTypes = {new ChemFile(), new ChemModel(), new Reaction(),
-            new AtomContainerSet(), new AtomContainer()};
+            new AtomContainerSet(), SilentChemObjectBuilder.getInstance().newAtomContainer()};
 
     /**
      * Unit tests that iterates over all common objects that can be

--- a/storage/io/src/test/java/org/openscience/cdk/io/ChemObjectWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/ChemObjectWriterTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IChemObject;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.AtomContainerSet;
 import org.openscience.cdk.silent.ChemFile;
 import org.openscience.cdk.silent.ChemModel;

--- a/storage/io/src/test/java/org/openscience/cdk/io/Mol2ReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/Mol2ReaderTest.java
@@ -114,7 +114,7 @@ class Mol2ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "fromWebsite.mol2";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         Mol2Reader reader = new Mol2Reader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(molecule);
         IAtomContainer reference = molecule.clone();
@@ -183,7 +183,7 @@ class Mol2ReaderTest extends SimpleChemObjectReaderTest {
         String filename = "fromWebsite.mol2";
         InputStream in = Mol2ReaderTest.class.getResourceAsStream(filename);
         Mol2Reader reader = new Mol2Reader(in);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(mol);
         Assertions.assertEquals(12, mol.getAtomCount());
@@ -400,7 +400,7 @@ class Mol2ReaderTest extends SimpleChemObjectReaderTest {
         Mol2Reader mol2Reader = null;
         try {
             mol2Reader = new Mol2Reader(getClass().getResourceAsStream("CLMW1.mol2"));
-            IAtomContainer container = mol2Reader.read(new AtomContainer());
+            IAtomContainer container = mol2Reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
             for (IAtom atom : container.atoms())
                 Assertions.assertNotNull(atom.getAtomicNumber());
         } finally {

--- a/storage/io/src/test/java/org/openscience/cdk/io/PCCompoundXMLReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/PCCompoundXMLReaderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.io.SimpleChemObjectReaderTest;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
@@ -60,7 +61,7 @@ class PCCompoundXMLReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         PCCompoundXMLReader reader = new PCCompoundXMLReader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(molecule);
 
@@ -89,7 +90,7 @@ class PCCompoundXMLReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         PCCompoundXMLReader reader = new PCCompoundXMLReader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         Assertions.assertNotNull(molecule);
 

--- a/storage/io/src/test/java/org/openscience/cdk/io/PCSubstanceXMLReaderTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/PCSubstanceXMLReaderTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.io.SimpleChemObjectReaderTest;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
@@ -58,7 +59,7 @@ class PCSubstanceXMLReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         PCSubstanceXMLReader reader = new PCSubstanceXMLReader(ins);
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertNotNull(molecule);
 
         // check atom stuff

--- a/storage/io/src/test/java/org/openscience/cdk/io/ReaderFactoryTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/ReaderFactoryTest.java
@@ -29,7 +29,6 @@ import java.util.zip.GZIPInputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/storage/io/src/test/java/org/openscience/cdk/io/ReaderFactoryTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/ReaderFactoryTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemFile;
 import org.openscience.cdk.io.formats.CMLFormat;
@@ -179,7 +180,7 @@ class ReaderFactoryTest extends AbstractReaderFactoryTest {
         Assertions.assertEquals(((IChemFormat) PubChemCompoundXMLFormat.getInstance()).getReaderClassName(), reader
                 .getClass().getName());
         // now try reading something from it
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         Assertions.assertNotNull(molecule);
         Assertions.assertNotSame(0, molecule.getAtomCount());
         Assertions.assertNotSame(0, molecule.getBondCount());
@@ -196,7 +197,7 @@ class ReaderFactoryTest extends AbstractReaderFactoryTest {
         Assertions.assertEquals(((IChemFormat) XYZFormat.getInstance()).getReaderClassName(), reader.getClass().getName());
         // now try reading something from it
         IChemFile chemFile = reader.read(new ChemFile());
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         for (IAtomContainer container : ChemFileManipulator.getAllAtomContainers(chemFile)) {
             molecule.add(container);
         }
@@ -214,7 +215,7 @@ class ReaderFactoryTest extends AbstractReaderFactoryTest {
         Assertions.assertEquals(((IChemFormat) XYZFormat.getInstance()).getReaderClassName(), reader.getClass().getName());
         // now try reading something from it
         IChemFile chemFile = reader.read(new ChemFile());
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         for (IAtomContainer container : ChemFileManipulator.getAllAtomContainers(chemFile)) {
             molecule.add(container);
         }

--- a/storage/io/src/test/java/org/openscience/cdk/io/XYZWriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/XYZWriterTest.java
@@ -36,6 +36,7 @@ import org.openscience.cdk.Atom;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.io.ChemObjectIOTest;
 
 /**
@@ -61,7 +62,7 @@ class XYZWriterTest extends ChemObjectIOTest {
     @Test
     void testWriting() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom1 = new Atom("C");
         atom1.setPoint3d(new Point3d(1.0, 2.0, 3.0));
         IAtom atom2 = new Atom("C");
@@ -90,7 +91,7 @@ class XYZWriterTest extends ChemObjectIOTest {
     @Test
     void testWriting_Point2d() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom1 = new Atom("C");
         atom1.setPoint2d(new Point2d(1.0, 2.0));
         molecule.addAtom(atom1);
@@ -110,7 +111,7 @@ class XYZWriterTest extends ChemObjectIOTest {
     @Test
     void testSixDecimalOuput() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom1 = new Atom("C");
         atom1.setPoint3d(new Point3d(1.0, 2.0, 3.0));
         molecule.addAtom(atom1);

--- a/storage/io/src/test/java/org/openscience/cdk/io/program/Mopac7WriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/program/Mopac7WriterTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.test.io.ChemObjectWriterTest;
@@ -56,7 +57,7 @@ class Mopac7WriterTest extends ChemObjectWriterTest {
         StringWriter strWriter = new StringWriter();
         Mopac7Writer writer = new Mopac7Writer(strWriter);
 
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Cr"));
         writer.write(mol);
         writer.close();
@@ -68,7 +69,7 @@ class Mopac7WriterTest extends ChemObjectWriterTest {
 
     @Test
     void testWriteWithOptimizationTrue() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Cr"));
 
         StringWriter strWriter = new StringWriter();
@@ -83,7 +84,7 @@ class Mopac7WriterTest extends ChemObjectWriterTest {
 
     @Test
     void testWriteWithOptimizationFalse() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Cr"));
 
         StringWriter strWriter = new StringWriter();
@@ -98,7 +99,7 @@ class Mopac7WriterTest extends ChemObjectWriterTest {
 
     @Test
     void testWriteWithCustomCommands() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("Cr"));
 
         StringWriter strWriter = new StringWriter();
@@ -113,7 +114,7 @@ class Mopac7WriterTest extends ChemObjectWriterTest {
 
     @Test
     void testChargedCompounds() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom aluminum = new Atom("Al");
         aluminum.setFormalCharge(+3);
         mol.addAtom(aluminum);

--- a/storage/io/src/test/java/org/openscience/cdk/io/program/Mopac7WriterTest.java
+++ b/storage/io/src/test/java/org/openscience/cdk/io/program/Mopac7WriterTest.java
@@ -49,7 +49,7 @@ class Mopac7WriterTest extends ChemObjectWriterTest {
     @Test
     void testAccepts() throws Exception {
         Mopac7Writer reader = new Mopac7Writer();
-        Assertions.assertTrue(reader.accepts(AtomContainer.class));
+        Assertions.assertTrue(reader.accepts(IAtomContainer.class));
     }
 
     @Test

--- a/storage/iordf/src/test/java/org/openscience/cdk/io/rdf/CDKOWLReaderTest.java
+++ b/storage/iordf/src/test/java/org/openscience/cdk/io/rdf/CDKOWLReaderTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.io.SimpleChemObjectReaderTest;
 import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.tools.ILoggingTool;
@@ -57,7 +58,7 @@ class CDKOWLReaderTest extends SimpleChemObjectReaderTest {
         logger.info("Testing: " + filename);
         InputStream ins = this.getClass().getResourceAsStream(filename);
         CDKOWLReader reader = new CDKOWLReader(new InputStreamReader(ins));
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
 
         Assertions.assertNotNull(mol);

--- a/storage/iordf/src/test/java/org/openscience/cdk/libio/jena/ConvertorTest.java
+++ b/storage/iordf/src/test/java/org/openscience/cdk/libio/jena/ConvertorTest.java
@@ -35,7 +35,6 @@ import org.openscience.cdk.interfaces.IBond.Order;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.diff.AtomContainerDiff;
 

--- a/storage/iordf/src/test/java/org/openscience/cdk/libio/jena/ConvertorTest.java
+++ b/storage/iordf/src/test/java/org/openscience/cdk/libio/jena/ConvertorTest.java
@@ -48,7 +48,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripMolecule() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Model model = Convertor.molecule2Model(mol);
         IAtomContainer rtMol = Convertor.model2Molecule(model, builder);
         String diff = AtomContainerDiff.diff(mol, rtMol);
@@ -57,7 +57,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripAtom() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         Model model = Convertor.molecule2Model(mol);
         IAtomContainer rtMol = Convertor.model2Molecule(model, builder);
@@ -86,7 +86,7 @@ class ConvertorTest extends CDKTestCase {
     }
 
     private void roundtripBond_Order(IBond.Order order) {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, order);
@@ -98,7 +98,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripElectronContainer_ElectronCount() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addBond(0, 1, IBond.Order.SINGLE);
@@ -111,7 +111,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripChemObject() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom object = new Atom("C");
         object.setID("atom1");
         mol.addAtom(object);
@@ -123,7 +123,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripElement() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom object = new Atom("C");
         object.setAtomicNumber(6);
         mol.addAtom(object);
@@ -135,7 +135,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripPseudoAtom() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IPseudoAtom object = new PseudoAtom("FunnyAtom");
         mol.addAtom(object);
         Model model = Convertor.molecule2Model(mol);
@@ -146,7 +146,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripAtomType() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom object = new Atom("C");
         object.setAtomTypeName("C.sp3");
         object.setFormalCharge(+1);
@@ -159,7 +159,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripIsotope_ExactMass() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom object = new Atom("C");
         object.setExactMass(0.3);
         mol.addAtom(object);
@@ -171,7 +171,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripIsotope_MassNumber() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom object = new Atom("C");
         object.setMassNumber(13);
         mol.addAtom(object);
@@ -183,7 +183,7 @@ class ConvertorTest extends CDKTestCase {
 
     @Test
     void roundtripIsotope_NaturalAbundance() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom object = new Atom("C");
         object.setNaturalAbundance(0.95);
         mol.addAtom(object);
@@ -244,7 +244,7 @@ class ConvertorTest extends CDKTestCase {
     }
 
     private void roundtripAtomType_Hybridization(Hybridization hybrid) {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom object = new Atom("C");
         object.setHybridization(hybrid);
         mol.addAtom(object);
@@ -275,7 +275,7 @@ class ConvertorTest extends CDKTestCase {
     }
 
     private void roundtripAtomType_MaxBondOrder(Order order) {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom object = new Atom("C");
         object.setMaxBondOrder(order);
         mol.addAtom(object);

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/MDLCMLRoundtripTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/MDLCMLRoundtripTest.java
@@ -28,7 +28,6 @@ import java.io.StringWriter;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemFile;

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/MDLCMLRoundtripTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/MDLCMLRoundtripTest.java
@@ -29,6 +29,7 @@ import java.io.StringWriter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemFile;
 
@@ -53,7 +54,7 @@ class MDLCMLRoundtripTest {
         String filename = "bug-1649526.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLReader reader = new MDLReader(ins);
-        IAtomContainer mol = reader.read(new AtomContainer());
+        IAtomContainer mol = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         reader.close();
         //Write it as cml
         StringWriter writer = new StringWriter();

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CML2WriterTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CML2WriterTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.ReactionScheme;
@@ -96,7 +97,7 @@ class CML2WriterTest extends CDKTestCase {
     @Test
     void testHydrogenCount() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer molecule = new AtomContainer(); // methane
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer(); // methane
         molecule.addAtom(molecule.getBuilder().newInstance(IAtom.class, Elements.CARBON));
         molecule.getAtom(0).setImplicitHydrogenCount(4);
         CMLWriter cmlWriter = new CMLWriter(writer);
@@ -112,7 +113,7 @@ class CML2WriterTest extends CDKTestCase {
     @Test
     void testNullFormalCharge() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer molecule = new AtomContainer(); // methane
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer(); // methane
         molecule.addAtom(molecule.getBuilder().newInstance(IAtom.class, Elements.CARBON));
         molecule.getAtom(0).setFormalCharge(null);
         CMLWriter cmlWriter = new CMLWriter(writer);
@@ -132,7 +133,7 @@ class CML2WriterTest extends CDKTestCase {
     @Test
     void testMassNumber() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setMassNumber(12);
         mol.addAtom(atom);
@@ -154,7 +155,7 @@ class CML2WriterTest extends CDKTestCase {
     @Test
     void testHydrogenCount_2() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer molecule = new AtomContainer(); // methane
+        IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newAtomContainer(); // methane
         molecule.addAtom(molecule.getBuilder().newInstance(IAtom.class, Elements.CARBON));
         molecule.addAtom(molecule.getBuilder().newInstance(IAtom.class, Elements.HYDROGEN));
         molecule.getAtom(0).setImplicitHydrogenCount(3);

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CML2WriterTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CML2WriterTest.java
@@ -52,7 +52,6 @@ import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.interfaces.IReactionScheme;
 import org.openscience.cdk.io.CMLWriter;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.AtomContainerSet;
 import org.openscience.cdk.silent.ChemModel;
 import org.openscience.cdk.silent.Crystal;

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;

--- a/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
+++ b/storage/libiocml/src/test/java/org/openscience/cdk/io/cml/CMLRoundTripTest.java
@@ -37,6 +37,7 @@ import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.AtomContainerSet;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
@@ -78,7 +79,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testAtom() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         mol.addAtom(atom);
 
@@ -91,7 +92,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testAtomId() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         atom.setID("N1");
         mol.addAtom(atom);
@@ -105,7 +106,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testAtom2D() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         Point2d p2d = new Point2d(1.3, 1.4);
         atom.setPoint2d(p2d);
@@ -120,7 +121,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testAtom3D() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         Point3d p3d = new Point3d(1.3, 1.4, 0.9);
         atom.setPoint3d(p3d);
@@ -135,7 +136,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testAtom2DAnd3D() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         Point2d p2d = new Point2d(1.3, 1.4);
         atom.setPoint2d(p2d);
@@ -153,7 +154,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testAtomFract3D() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         Point3d p3d = new Point3d(0.3, 0.4, 0.9);
         atom.setFractionalPoint3d(p3d);
@@ -168,7 +169,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testPseudoAtom() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         PseudoAtom atom = new PseudoAtom("N");
         atom.setLabel("Glu55");
         mol.addAtom(atom);
@@ -189,7 +190,7 @@ class CMLRoundTripTest extends CDKTestCase {
     void testChemModel() throws Exception {
         ChemModel model = new ChemModel();
         IAtomContainerSet moleculeSet = new AtomContainerSet();
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         PseudoAtom atom = new PseudoAtom("N");
         mol.addAtom(atom);
         moleculeSet.addAtomContainer(mol);
@@ -207,7 +208,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testAtomFormalCharge() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         int formalCharge = +1;
         atom.setFormalCharge(formalCharge);
@@ -225,7 +226,7 @@ class CMLRoundTripTest extends CDKTestCase {
      */
     @Test
     void testHydrogenCount() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         atom.setImplicitHydrogenCount(3);
         mol.addAtom(atom);
@@ -242,7 +243,7 @@ class CMLRoundTripTest extends CDKTestCase {
      */
     @Test
     void testHydrogenCount_UNSET() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         atom.setImplicitHydrogenCount((Integer) CDKConstants.UNSET);
         mol.addAtom(atom);
@@ -256,7 +257,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Disabled("Have to figure out how to store partial charges in CML2")
     void testAtomPartialCharge() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         double partialCharge = 0.5;
         atom.setCharge(partialCharge);
@@ -271,7 +272,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Disabled("Have to figure out how to store atom parity in CML2")
     void testAtomStereoParity() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         int stereo = CDKConstants.STEREO_ATOM_PARITY_PLUS;
         atom.setStereoParity(stereo);
@@ -286,7 +287,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testIsotope() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setMassNumber(13);
         mol.addAtom(atom);
@@ -302,7 +303,7 @@ class CMLRoundTripTest extends CDKTestCase {
      */
     @Disabled("Functionality not yet implemented - exact mass can not be written/read")
     void testIsotope_ExactMass() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setExactMass(13.0);
         mol.addAtom(atom);
@@ -320,7 +321,7 @@ class CMLRoundTripTest extends CDKTestCase {
      */
     @Disabled("Functionality not yet implemented - natural abundance can not be written/read")
     void testIsotope_Abundance() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setNaturalAbundance(1.0);
         mol.addAtom(atom);
@@ -339,7 +340,7 @@ class CMLRoundTripTest extends CDKTestCase {
      */
     @Test
     void testMassNumber() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setMassNumber(12);
         mol.addAtom(atom);
@@ -354,7 +355,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testBond() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         Atom atom2 = new Atom("O");
         mol.addAtom(atom);
@@ -375,7 +376,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testBondID() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         Atom atom2 = new Atom("O");
         mol.addAtom(atom);
@@ -391,7 +392,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testBondStereo() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         Atom atom2 = new Atom("O");
         mol.addAtom(atom);
@@ -411,7 +412,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testBondAromatic() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         // surely, this bond is not aromatic... but fortunately, file formats do not care about chemistry
         Atom atom = new Atom("C");
         Atom atom2 = new Atom("C");
@@ -435,7 +436,7 @@ class CMLRoundTripTest extends CDKTestCase {
      */
     @Test
     void testBondAromatic_Double() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         // surely, this bond is not aromatic... but fortunately, file formats do not care about chemistry
         Atom atom = new Atom("C");
         Atom atom2 = new Atom("C");
@@ -456,7 +457,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testPartialCharge() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         mol.addAtom(atom);
         double charge = -0.267;
@@ -471,7 +472,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testInChI() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         String inchi = "InChI=1/CH2O2/c2-1-3/h1H,(H,2,3)";
         mol.setProperty(CDKConstants.INCHI, inchi);
 
@@ -483,7 +484,7 @@ class CMLRoundTripTest extends CDKTestCase {
 
     @Test
     void testSpinMultiplicity() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         mol.addAtom(atom);
         mol.addSingleElectron(new SingleElectron(atom));
@@ -684,8 +685,8 @@ class CMLRoundTripTest extends CDKTestCase {
     @Test
     void testMoleculeSet() throws Exception {
         IAtomContainerSet list = new AtomContainerSet();
-        list.addAtomContainer(new AtomContainer());
-        list.addAtomContainer(new AtomContainer());
+        list.addAtomContainer(DefaultChemObjectBuilder.getInstance().newAtomContainer());
+        list.addAtomContainer(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         IChemModel model = new ChemModel();
         model.setMoleculeSet(list);
 
@@ -720,7 +721,7 @@ class CMLRoundTripTest extends CDKTestCase {
      */
     @Test
     void testUnsetHydrogenCount() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setImplicitHydrogenCount(null);
         Assertions.assertNull(atom.getImplicitHydrogenCount());

--- a/storage/libiomd/src/test/java/org/openscience/cdk/libio/md/MDMoleculeTest.java
+++ b/storage/libiomd/src/test/java/org/openscience/cdk/libio/md/MDMoleculeTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.exception.CDKException;
@@ -104,7 +105,7 @@ class MDMoleculeTest extends CDKTestCase {
         mol.addBond(5, 0, IBond.Order.DOUBLE); // 6
 
         //Create 2 residues
-        AtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(mol.getAtom(0));
         ac.addAtom(mol.getAtom(1));
         ac.addAtom(mol.getAtom(2));
@@ -112,7 +113,7 @@ class MDMoleculeTest extends CDKTestCase {
         res1.setName("myResidue1");
         mol.addResidue(res1);
 
-        AtomContainer ac2 = new AtomContainer();
+        IAtomContainer ac2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac2.addAtom(mol.getAtom(3));
         ac2.addAtom(mol.getAtom(4));
         ac2.addAtom(mol.getAtom(5));
@@ -133,13 +134,13 @@ class MDMoleculeTest extends CDKTestCase {
         Assertions.assertEquals(mol.getResidues().get(1), res2);
 
         //Create 2 chargegroups
-        AtomContainer ac3 = new AtomContainer();
+        IAtomContainer ac3 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac3.addAtom(mol.getAtom(0));
         ac3.addAtom(mol.getAtom(1));
         ChargeGroup chg1 = new ChargeGroup(ac3, 0, mol);
         mol.addChargeGroup(chg1);
 
-        AtomContainer ac4 = new AtomContainer();
+        IAtomContainer ac4 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac4.addAtom(mol.getAtom(2));
         ac4.addAtom(mol.getAtom(3));
         ac4.addAtom(mol.getAtom(4));
@@ -285,7 +286,7 @@ class MDMoleculeTest extends CDKTestCase {
         mol.addBond(5, 0, IBond.Order.DOUBLE); // 6
 
         //Create 2 residues
-        AtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(mol.getAtom(0));
         ac.addAtom(mol.getAtom(1));
         ac.addAtom(mol.getAtom(2));
@@ -293,7 +294,7 @@ class MDMoleculeTest extends CDKTestCase {
         res1.setName("myResidue1");
         mol.addResidue(res1);
 
-        AtomContainer ac2 = new AtomContainer();
+        IAtomContainer ac2 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac2.addAtom(mol.getAtom(3));
         ac2.addAtom(mol.getAtom(4));
         ac2.addAtom(mol.getAtom(5));
@@ -302,14 +303,14 @@ class MDMoleculeTest extends CDKTestCase {
         mol.addResidue(res2);
 
         //Create 2 chargegroups
-        AtomContainer ac3 = new AtomContainer();
+        IAtomContainer ac3 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac3.addAtom(mol.getAtom(0));
         ac3.addAtom(mol.getAtom(1));
         ChargeGroup chg1 = new ChargeGroup(ac3, 2, mol);
         chg1.setSwitchingAtom(mol.getAtom(1));
         mol.addChargeGroup(chg1);
 
-        AtomContainer ac4 = new AtomContainer();
+        IAtomContainer ac4 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac4.addAtom(mol.getAtom(2));
         ac4.addAtom(mol.getAtom(3));
         ac4.addAtom(mol.getAtom(4));

--- a/storage/libiomd/src/test/java/org/openscience/cdk/libio/md/MDMoleculeTest.java
+++ b/storage/libiomd/src/test/java/org/openscience/cdk/libio/md/MDMoleculeTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;

--- a/storage/pdb/src/test/java/org/openscience/cdk/io/PDBReaderFactoryTest.java
+++ b/storage/pdb/src/test/java/org/openscience/cdk/io/PDBReaderFactoryTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.Reaction;
 import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.io.formats.IChemFormat;
@@ -57,7 +58,7 @@ class PDBReaderFactoryTest {
         Assertions.assertNotNull(reader);
         Assertions.assertEquals(((IChemFormat) expectedFormat).getReaderClassName(), reader.getClass().getName());
         // now try reading something from it
-        IChemObject[] objects = {new ChemFile(), new ChemModel(), new AtomContainer(), new Reaction()};
+        IChemObject[] objects = {new ChemFile(), new ChemModel(), DefaultChemObjectBuilder.getInstance().newAtomContainer(), new Reaction()};
         boolean read = false;
         for (int i = 0; (i < objects.length && !read); i++) {
             if (reader.accepts(objects[i].getClass())) {

--- a/storage/pdb/src/test/java/org/openscience/cdk/io/PDBReaderFactoryTest.java
+++ b/storage/pdb/src/test/java/org/openscience/cdk/io/PDBReaderFactoryTest.java
@@ -24,7 +24,6 @@ package org.openscience.cdk.io;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemModel;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/storage/pdb/src/test/java/org/openscience/cdk/io/PDBWriterTest.java
+++ b/storage/pdb/src/test/java/org/openscience/cdk/io/PDBWriterTest.java
@@ -148,7 +148,7 @@ class PDBWriterTest extends ChemObjectIOTest {
     }
 
     private IAtomContainer singleAtomMolecule(String id, Integer formalCharge) {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom atom = new Atom("C", new Point3d(0.0, 0.0, 0.0));
         mol.addAtom(atom);
         mol.setID(id);
@@ -159,7 +159,7 @@ class PDBWriterTest extends ChemObjectIOTest {
     }
 
     private IAtomContainer singleBondMolecule() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C", new Point3d(0.0, 0.0, 0.0)));
         mol.addAtom(new Atom("O", new Point3d(1.0, 1.0, 1.0)));
         mol.addBond(0, 1, IBond.Order.SINGLE);

--- a/storage/pdb/src/test/java/org/openscience/cdk/io/PDBWriterTest.java
+++ b/storage/pdb/src/test/java/org/openscience/cdk/io/PDBWriterTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.Crystal;
 import org.openscience.cdk.DefaultChemObjectBuilder;

--- a/storage/pdbcml/src/test/java/org/openscience/cdk/libio/cml/PDBAtomCustomizerTest.java
+++ b/storage/pdbcml/src/test/java/org/openscience/cdk/libio/cml/PDBAtomCustomizerTest.java
@@ -3,6 +3,7 @@ package org.openscience.cdk.libio.cml;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IPDBAtom;
 import org.openscience.cdk.io.CMLWriter;
@@ -23,7 +24,7 @@ class PDBAtomCustomizerTest {
     @Test
     void testPDBAtomCustomization() throws Exception {
         StringWriter writer = new StringWriter();
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IPDBAtom atom = new PDBAtom("C");
         atom.setName("CA");
         atom.setResName("PHE");

--- a/storage/pdbcml/src/test/java/org/openscience/cdk/libio/cml/PDBAtomCustomizerTest.java
+++ b/storage/pdbcml/src/test/java/org/openscience/cdk/libio/cml/PDBAtomCustomizerTest.java
@@ -2,7 +2,6 @@ package org.openscience.cdk.libio.cml;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IPDBAtom;

--- a/storage/smiles/src/test/java/org/openscience/cdk/io/SMILESWriterTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/io/SMILESWriterTest.java
@@ -61,7 +61,7 @@ class SMILESWriterTest extends ChemObjectIOTest {
     @Test
     void testAccepts() throws Exception {
         SMILESWriter reader = new SMILESWriter();
-        Assertions.assertTrue(reader.accepts(AtomContainer.class));
+        Assertions.assertTrue(reader.accepts(IAtomContainer.class));
         Assertions.assertTrue(reader.accepts(AtomContainerSet.class));
     }
 

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CDKToBeamTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CDKToBeamTest.java
@@ -34,7 +34,6 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.Bond;
 import org.openscience.cdk.silent.PseudoAtom;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CDKToBeamTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CDKToBeamTest.java
@@ -332,7 +332,7 @@ class CDKToBeamTest {
 
     @Test
     void C13_isomeric() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("C");
         a.setMassNumber(13);
         ac.addAtom(a);
@@ -343,7 +343,7 @@ class CDKToBeamTest {
 
     @Test
     void C13_nonIsomeric() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("C");
         a.setMassNumber(13);
         ac.addAtom(a);
@@ -354,7 +354,7 @@ class CDKToBeamTest {
 
     @Test
     void azanium() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("N");
         a.setFormalCharge(+1);
         ac.addAtom(a);
@@ -365,7 +365,7 @@ class CDKToBeamTest {
 
     @Test
     void oxidanide() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("O");
         a.setFormalCharge(-1);
         ac.addAtom(a);
@@ -376,7 +376,7 @@ class CDKToBeamTest {
 
     @Test
     void oxidandiide() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IAtom a = new Atom("O");
         a.setFormalCharge(-2);
         ac.addAtom(a);
@@ -393,7 +393,7 @@ class CDKToBeamTest {
     @Test
     void e_1_2_difluoroethene() throws Exception {
 
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("F"));
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
@@ -416,7 +416,7 @@ class CDKToBeamTest {
     @Test
     void z_1_2_difluoroethene() throws Exception {
 
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("F"));
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
@@ -439,7 +439,7 @@ class CDKToBeamTest {
     @Test
     void _2R_butan_2_ol() throws Exception {
 
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
@@ -470,7 +470,7 @@ class CDKToBeamTest {
     @Test
     void _2S_butan_2_ol() throws Exception {
 
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
@@ -503,7 +503,7 @@ class CDKToBeamTest {
     @Test
     void z_1_2_difluoroethene_aromatic() throws Exception {
 
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("F"));
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
@@ -529,7 +529,7 @@ class CDKToBeamTest {
 
     @Test
     void writeAtomClass() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("C"));
         ac.addAtom(new Atom("O"));
@@ -543,7 +543,7 @@ class CDKToBeamTest {
 
     @Test
     void r_penta_2_3_diene_impl_h() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
@@ -563,7 +563,7 @@ class CDKToBeamTest {
 
     @Test
     void s_penta_2_3_diene_impl_h() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
@@ -583,7 +583,7 @@ class CDKToBeamTest {
 
     @Test
     void r_penta_2_3_diene_expl_h() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
@@ -616,7 +616,7 @@ class CDKToBeamTest {
 
     @Test
     void s_penta_2_3_diene_expl_h() throws Exception {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));
         m.addAtom(new Atom("C"));

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesGeneratorTest.java
@@ -24,7 +24,6 @@
 package org.openscience.cdk.smiles;
 
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesGeneratorTest.java
@@ -26,6 +26,7 @@ package org.openscience.cdk.smiles;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -115,7 +116,7 @@ class CxSmilesGeneratorTest {
     @Test
     void chembl367774() throws Exception {
         try (MDLV2000Reader mdlr = new MDLV2000Reader(getClass().getResourceAsStream("CHEMBL367774.mol"))) {
-            IAtomContainer container = mdlr.read(new AtomContainer());
+            IAtomContainer container = mdlr.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
             SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.CxSmiles);
             assertThat(smigen.create(container), is("OC(=O)C1=CC(F)=CC=2NC(=NC12)C3=CC=C(C=C3F)C4=CC=CC=C4"));
         }

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
@@ -38,7 +38,6 @@ import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.sgroup.SgroupType;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.PseudoAtom;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
@@ -226,7 +226,7 @@ class CxSmilesTest {
 
     @Test
     void generateLabelledSmiles() throws CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setImplicitHydrogenCount(3);
         mol.addAtom(new Atom("C"));
@@ -242,7 +242,7 @@ class CxSmilesTest {
 
     @Test
     void generateCanonLabelledSmiles() throws CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.getAtom(0).setImplicitHydrogenCount(3);
         mol.addAtom(new Atom("C"));

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
@@ -130,7 +130,7 @@ class SmilesGeneratorTest extends CDKTestCase {
      */
     @Test
     void testAlanin() throws Exception {
-        IAtomContainer mol1 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         SmilesGenerator sg = SmilesGenerator.isomeric();
         mol1.addAtom(new Atom("N", new Point2d(1, 0)));
         // 1
@@ -283,7 +283,7 @@ class SmilesGeneratorTest extends CDKTestCase {
      */
     @Test
     void testCisTransDecalin() throws Exception {
-        IAtomContainer mol1 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         SmilesGenerator sg = SmilesGenerator.isomeric();
 
         mol1.addAtom(new Atom("H", new Point2d(0, 3))); // 0
@@ -369,7 +369,7 @@ class SmilesGeneratorTest extends CDKTestCase {
      */
     @Test
     void testDoubleBondConfiguration() throws Exception {
-        IAtomContainer mol1 = new AtomContainer();
+        IAtomContainer mol1 = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         SmilesGenerator sg = SmilesGenerator.isomeric();
         mol1.addAtom(new Atom("S", new Point2d(0, 0)));
         // 1
@@ -446,7 +446,7 @@ class SmilesGeneratorTest extends CDKTestCase {
     @Test
     void testPartitioning() throws Exception {
         String smiles;
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         SmilesGenerator sg = new SmilesGenerator();
         Atom sodium = new Atom("Na");
         sodium.setFormalCharge(+1);
@@ -466,7 +466,7 @@ class SmilesGeneratorTest extends CDKTestCase {
     @Test
     void testBug791091() throws Exception {
         String smiles;
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         SmilesGenerator sg = new SmilesGenerator();
         molecule.addAtom(new Atom("C"));
         molecule.addAtom(new Atom("C"));
@@ -489,7 +489,7 @@ class SmilesGeneratorTest extends CDKTestCase {
     @Test
     void testBug590236() throws Exception {
         String smiles;
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         SmilesGenerator sg = SmilesGenerator.isomeric();
         molecule.addAtom(new Atom("C"));
         Atom carbon2 = new Atom("C");
@@ -509,7 +509,7 @@ class SmilesGeneratorTest extends CDKTestCase {
     @Test
     void testSFBug956923_aromatic() throws Exception {
         String smiles;
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         SmilesGenerator sg = new SmilesGenerator().aromatic();
         Atom sp2CarbonWithOneHydrogen = new Atom("C");
         sp2CarbonWithOneHydrogen.setHybridization(IAtomType.Hybridization.SP2);
@@ -535,7 +535,7 @@ class SmilesGeneratorTest extends CDKTestCase {
     @Test
     void testSFBug956923_nonAromatic() throws Exception {
         String smiles;
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         SmilesGenerator sg = new SmilesGenerator();
         Atom sp2CarbonWithOneHydrogen = new Atom("C");
         sp2CarbonWithOneHydrogen.setHybridization(IAtomType.Hybridization.SP2);
@@ -561,7 +561,7 @@ class SmilesGeneratorTest extends CDKTestCase {
      */
     @Test
     void testAtomPermutation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("S"));
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("O"));
@@ -579,7 +579,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         String smiles;
         String oldSmiles = sg.create(mol);
         while (acap.hasNext()) {
-            smiles = sg.create(new AtomContainer(acap.next()));
+            smiles = sg.create(DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, acap.next()));
             //logger.debug(smiles);
             Assertions.assertEquals(oldSmiles, smiles);
         }
@@ -591,7 +591,7 @@ class SmilesGeneratorTest extends CDKTestCase {
      */
     @Test
     void testBondPermutation() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("S"));
         mol.addAtom(new Atom("O"));
         mol.addAtom(new Atom("O"));
@@ -609,7 +609,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         String smiles;
         String oldSmiles = sg.create(mol);
         while (acbp.hasNext()) {
-            smiles = sg.create(new AtomContainer(acbp.next()));
+            smiles = sg.create(DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, acbp.next()));
             //logger.debug(smiles);
             Assertions.assertEquals(oldSmiles, smiles);
         }
@@ -644,7 +644,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         IAtom atom = new PseudoAtom("Star");
         SmilesGenerator sg = new SmilesGenerator(SmiFlavor.Generic);
         String smiles;
-        IAtomContainer molecule = new AtomContainer();
+        IAtomContainer molecule = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         molecule.addAtom(atom);
         addImplicitHydrogens(molecule);
         smiles = sg.create(molecule);
@@ -658,13 +658,13 @@ class SmilesGeneratorTest extends CDKTestCase {
     @Test
     void testReactionSMILES() throws Exception {
         Reaction reaction = new Reaction();
-        AtomContainer methane = new AtomContainer();
+        IAtomContainer methane = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         methane.addAtom(new Atom("C"));
         reaction.addReactant(methane);
-        IAtomContainer magic = new AtomContainer();
+        IAtomContainer magic = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         magic.addAtom(new PseudoAtom("magic"));
         reaction.addAgent(magic);
-        IAtomContainer gold = new AtomContainer();
+        IAtomContainer gold = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         gold.addAtom(new Atom("Au"));
         reaction.addProduct(gold);
 
@@ -708,11 +708,11 @@ class SmilesGeneratorTest extends CDKTestCase {
         String filename = "D-mannose.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol1 = reader.read(new AtomContainer());
+        IAtomContainer mol1 = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         filename = "D+-glucose.mol";
         ins = this.getClass().getResourceAsStream(filename);
         reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol2 = reader.read(new AtomContainer());
+        IAtomContainer mol2 = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         SmilesGenerator sg = SmilesGenerator.isomeric();
 
         define(mol1, anticlockwise(mol1, 0, 0, 1, 5, 9), anticlockwise(mol1, 1, 1, 0, 2, 8),
@@ -733,7 +733,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         String filename = "cyclooctan.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol1 = reader.read(new AtomContainer());
+        IAtomContainer mol1 = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         SmilesGenerator sg = new SmilesGenerator();
         String moleculeSmile = sg.create(mol1);
         Assertions.assertEquals("C\\1=C\\CCCCCC1", moleculeSmile);
@@ -747,7 +747,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         String filename = "cycloocten.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol1 = reader.read(new AtomContainer());
+        IAtomContainer mol1 = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         SmilesGenerator sg = new SmilesGenerator();
         String moleculeSmile = sg.create(mol1);
         Assertions.assertEquals("C1/C=C\\CCCCC1", moleculeSmile);
@@ -775,7 +775,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         String filename = "bug1089770-1.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol1 = reader.read(new AtomContainer());
+        IAtomContainer mol1 = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         SmilesGenerator sg = new SmilesGenerator();
         String moleculeSmile = sg.create(mol1);
         //logger.debug(filename + " -> " + moleculeSmile);
@@ -791,7 +791,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         String filename = "bug1089770-2.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLV2000Reader reader = new MDLV2000Reader(ins, Mode.STRICT);
-        IAtomContainer mol1 = reader.read(new AtomContainer());
+        IAtomContainer mol1 = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         SmilesGenerator sg = new SmilesGenerator();
         String moleculeSmile = sg.create(mol1);
         //logger.debug(filename + " -> " + moleculeSmile);
@@ -808,7 +808,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         String filename = "bug1014344-1.mol";
         InputStream ins = this.getClass().getResourceAsStream(filename);
         MDLReader reader = new MDLReader(ins, Mode.STRICT);
-        IAtomContainer mol1 = reader.read(new AtomContainer());
+        IAtomContainer mol1 = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         addImplicitHydrogens(mol1);
         SmilesGenerator sg = new SmilesGenerator();
         String molSmiles = sg.create(mol1);
@@ -819,7 +819,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         IAtomContainer mol2 = ((IChemFile) cmlreader.read(new ChemFile())).getChemSequence(0).getChemModel(0)
                 .getMoleculeSet().getAtomContainer(0);
         addImplicitHydrogens(mol2);
-        String cmlSmiles = sg.create(new AtomContainer(mol2));
+        String cmlSmiles = sg.create(DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, mol2));
         Assertions.assertEquals(molSmiles, cmlSmiles);
     }
 
@@ -833,10 +833,10 @@ class SmilesGeneratorTest extends CDKTestCase {
         InputStream ins1 = this.getClass().getResourceAsStream(filename_cml);
         InputStream ins2 = this.getClass().getResourceAsStream(filename_mol);
         MDLV2000Reader reader1 = new MDLV2000Reader(ins1, Mode.STRICT);
-        IAtomContainer mol1 = reader1.read(new AtomContainer());
+        IAtomContainer mol1 = reader1.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         MDLV2000Reader reader2 = new MDLV2000Reader(ins2, Mode.STRICT);
-        IAtomContainer mol2 = reader2.read(new AtomContainer());
+        IAtomContainer mol2 = reader2.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         SmilesGenerator sg = SmilesGenerator.isomeric();
 
@@ -893,7 +893,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         IAtomContainer mol1 = model.getMoleculeSet().getAtomContainer(0);
 
         MDLReader reader2 = new MDLReader(ins2);
-        IAtomContainer mol2 = reader2.read(new AtomContainer());
+        IAtomContainer mol2 = reader2.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
 
         addImplicitHydrogens(mol1);
         addImplicitHydrogens(mol2);
@@ -912,14 +912,14 @@ class SmilesGeneratorTest extends CDKTestCase {
      */
     @Test
     void testPreservingFormalCharge() throws Exception {
-        AtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom(Elements.OXYGEN));
         mol.getAtom(0).setFormalCharge(-1);
         mol.addAtom(new Atom(Elements.CARBON));
         mol.addBond(0, 1, IBond.Order.SINGLE);
         addImplicitHydrogens(mol);
         SmilesGenerator generator = new SmilesGenerator();
-        generator.create(new AtomContainer(mol));
+        generator.create(DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, mol));
         Assertions.assertEquals(-1, mol.getAtom(0).getFormalCharge().intValue());
         // mmm, that does not reproduce the bug findings yet :(
     }

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
@@ -26,7 +26,6 @@ import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 import javax.vecmath.Vector3d;
 
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;

--- a/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
+++ b/tool/builder3d/src/main/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3D.java
@@ -28,6 +28,7 @@ import javax.vecmath.Vector3d;
 
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.GeometryUtil;
 import org.openscience.cdk.interfaces.IAtom;
@@ -585,7 +586,7 @@ public class AtomPlacer3D {
      * @return    The allPlacedAtoms value
      */
     private IAtomContainer getAllPlacedAtoms(IAtomContainer molecule) {
-        IAtomContainer placedAtoms = new AtomContainer();
+        IAtomContainer placedAtoms = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         for (int i = 0; i < molecule.getAtomCount(); i++) {
             if (molecule.getAtom(i).getFlag(CDKConstants.ISPLACED)) {
                 placedAtoms.addAtom(molecule.getAtom(i));

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3DTest.java
@@ -44,7 +44,6 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.tools.manipulator.ChemFileManipulator;
 
 import org.junit.jupiter.api.BeforeAll;

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/AtomPlacer3DTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
@@ -86,7 +87,7 @@ class AtomPlacer3DTest extends CDKTestCase {
      * @return the created test molecule
      */
     private IAtomContainer makeAlphaPinene() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("C"));
@@ -118,7 +119,7 @@ class AtomPlacer3DTest extends CDKTestCase {
     }
 
     private IAtomContainer makeMethaneWithExplicitHydrogens() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
         mol.addAtom(new Atom("H"));
         mol.addAtom(new Atom("H"));
@@ -152,7 +153,7 @@ class AtomPlacer3DTest extends CDKTestCase {
         ChemFile chemFile = (ChemFile) reader.read((ChemObject) new ChemFile());
         reader.close();
         List<IAtomContainer> containersList = ChemFileManipulator.getAllAtomContainers(chemFile);
-        IAtomContainer ac = new AtomContainer(containersList.get(0));
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, containersList.get(0));
         addExplicitHydrogens(ac);
         IAtomContainer chain = ac.getBuilder().newInstance(IAtomContainer.class);
         for (int i = 16; i < 25; i++) {

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
@@ -31,7 +31,6 @@ import javax.vecmath.Point3d;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 import org.openscience.cdk.test.CDKTestCase;
@@ -46,7 +45,6 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.layout.StructureDiagramGenerator;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/ModelBuilder3DTest.java
@@ -215,7 +215,7 @@ class ModelBuilder3DTest extends CDKTestCase {
         ChemFile chemFile = (ChemFile) reader.read((ChemObject) new ChemFile());
         reader.close();
         List<IAtomContainer> containersList = ChemFileManipulator.getAllAtomContainers(chemFile);
-        IAtomContainer ac = new AtomContainer(containersList.get(0));
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, containersList.get(0));
         addExplicitHydrogens(ac);
         ac = mb3d.generate3DCoordinates(ac, false);
         Assertions.assertNotNull(ac.getAtom(0).getPoint3d());
@@ -242,7 +242,7 @@ class ModelBuilder3DTest extends CDKTestCase {
         ChemFile chemFile = (ChemFile) reader.read((ChemObject) new ChemFile());
         reader.close();
         List<IAtomContainer> containersList = ChemFileManipulator.getAllAtomContainers(chemFile);
-        IAtomContainer ac = new AtomContainer(containersList.get(0));
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, containersList.get(0));
         addExplicitHydrogens(ac);
         ac = mb3d.generate3DCoordinates(ac, false);
         for (int i = 0; i < ac.getAtomCount(); i++) {
@@ -259,7 +259,7 @@ class ModelBuilder3DTest extends CDKTestCase {
     void testModelBuilder3D_keepChemObjectIDs() throws Exception {
         ModelBuilder3D mb3d = ModelBuilder3D.getInstance(DefaultChemObjectBuilder.getInstance());
 
-        IAtomContainer methanol = new AtomContainer();
+        IAtomContainer methanol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         IChemObjectBuilder builder = methanol.getBuilder();
 
         IAtom carbon1 = builder.newInstance(IAtom.class, "C");
@@ -367,7 +367,7 @@ class ModelBuilder3DTest extends CDKTestCase {
         ChemFile chemFile = (ChemFile) reader.read((ChemObject) new ChemFile());
         reader.close();
         List<IAtomContainer> containersList = ChemFileManipulator.getAllAtomContainers(chemFile);
-        IAtomContainer ac = new AtomContainer(containersList.get(0));
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, containersList.get(0));
         ac = mb3d.generate3DCoordinates(ac, false);
         checkAverageBondLength(ac);
     }
@@ -382,7 +382,7 @@ class ModelBuilder3DTest extends CDKTestCase {
         ChemFile chemFile = (ChemFile) reader.read((ChemObject) new ChemFile());
         reader.close();
         List<IAtomContainer> containersList = ChemFileManipulator.getAllAtomContainers(chemFile);
-        IAtomContainer ac = new AtomContainer(containersList.get(0));
+        IAtomContainer ac = SilentChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, containersList.get(0));
         ac = mb3d.generate3DCoordinates(ac, false);
         for (int i = 0; i < ac.getAtomCount(); i++) {
             Assertions.assertNotNull(ac.getAtom(i).getPoint3d());

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/TemplateHandler3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/TemplateHandler3DTest.java
@@ -37,7 +37,6 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IRingSet;
 import org.openscience.cdk.isomorphism.matchers.QueryChemObject;
 import org.openscience.cdk.ringsearch.RingPartitioner;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.templates.TestMoleculeFactory;
 import org.openscience.cdk.tools.manipulator.RingSetManipulator;
 

--- a/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/TemplateHandler3DTest.java
+++ b/tool/builder3d/src/test/java/org/openscience/cdk/modeling/builder3d/TemplateHandler3DTest.java
@@ -29,6 +29,7 @@ import java.util.StringTokenizer;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.fingerprint.IBitFingerprint;
@@ -53,7 +54,7 @@ class TemplateHandler3DTest extends CDKTestCase {
     void testGetInstance() throws Exception {
         TemplateHandler3D th3d = TemplateHandler3D.getInstance();
         // need to trigger a load of the templates
-        th3d.mapTemplates(new AtomContainer(), 0);
+        th3d.mapTemplates(SilentChemObjectBuilder.getInstance().newAtomContainer(), 0);
         Assertions.assertEquals(10751, th3d.getTemplateCount());
     }
 

--- a/tool/charges/src/test/java/org/openscience/cdk/charges/InductivePartialChargesTest.java
+++ b/tool/charges/src/test/java/org/openscience/cdk/charges/InductivePartialChargesTest.java
@@ -91,7 +91,7 @@ class InductivePartialChargesTest extends CDKTestCase {
         Point3d h2_coord = new Point3d(1.7439615035767404, -0.5279422553651107, 0.914422809754875);
         Point3d h3_coord = new Point3d(1.7439615035767402, -0.5279422553651113, -0.9144228097548747);
 
-        IAtomContainer mol = new AtomContainer(); // molecule is CF
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // molecule is CF
 
         Atom c = new Atom("C");
         mol.addAtom(c);
@@ -138,7 +138,7 @@ class InductivePartialChargesTest extends CDKTestCase {
         Point3d h2_coord = new Point3d(1.7439615035767404, -0.5279422553651107, 0.914422809754875);
         Point3d h3_coord = new Point3d(1.7439615035767402, -0.5279422553651113, -0.9144228097548747);
 
-        IAtomContainer mol = new AtomContainer(); // molecule is CF
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer(); // molecule is CF
 
         Atom c = new Atom("C");
         mol.addAtom(c);

--- a/tool/charges/src/test/java/org/openscience/cdk/charges/InductivePartialChargesTest.java
+++ b/tool/charges/src/test/java/org/openscience/cdk/charges/InductivePartialChargesTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/AbstractMmffAtomTypeValidationSuiteTest.java
+++ b/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/AbstractMmffAtomTypeValidationSuiteTest.java
@@ -3,7 +3,6 @@ package org.openscience.cdk.forcefield.mmff;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import static org.openscience.cdk.interfaces.IBond.Order.DOUBLE;

--- a/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/AbstractMmffAtomTypeValidationSuiteTest.java
+++ b/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/AbstractMmffAtomTypeValidationSuiteTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import static org.openscience.cdk.interfaces.IBond.Order.DOUBLE;
 import static org.openscience.cdk.interfaces.IBond.Order.SINGLE;
@@ -22,7 +23,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAGLYSL01() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("H", 0));
@@ -54,7 +55,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAMHTAR01() {
-        IAtomContainer container = new AtomContainer(15, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -97,7 +98,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAMPTRB10() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -162,7 +163,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testARGIND11() {
-        IAtomContainer container = new AtomContainer(26, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -227,7 +228,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBAOXLM01() {
-        IAtomContainer container = new AtomContainer(6, 5, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("C", 0));
@@ -251,7 +252,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBBSPRT10() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -314,7 +315,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBEVJER10() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -376,7 +377,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBEWCUB() {
-        IAtomContainer container = new AtomContainer(59, 61, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -512,7 +513,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBEWKUJ04() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -583,7 +584,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBIHKEI01() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -640,7 +641,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBIPDEJ02() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -701,7 +702,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBIPJUF10() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -753,7 +754,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBIPYCL01() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -812,7 +813,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBITNAT10() {
-        IAtomContainer container = new AtomContainer(27, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -882,7 +883,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBIYBIU10() {
-        IAtomContainer container = new AtomContainer(23, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -944,7 +945,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBODKOU() {
-        IAtomContainer container = new AtomContainer(37, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -1033,7 +1034,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBSALAP01() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -1098,7 +1099,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBUPSLB10() {
-        IAtomContainer container = new AtomContainer(38, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -1188,7 +1189,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBUPSLD10() {
-        IAtomContainer container = new AtomContainer(39, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("S", 0));
@@ -1280,7 +1281,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBUYTIY10() {
-        IAtomContainer container = new AtomContainer(31, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -1359,7 +1360,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBUYTOE10() {
-        IAtomContainer container = new AtomContainer(31, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -1438,7 +1439,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBUYXEY10() {
-        IAtomContainer container = new AtomContainer(38, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -1528,7 +1529,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBYITOT02() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -1599,7 +1600,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCABWEH10() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -1660,7 +1661,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCAFORM07() {
-        IAtomContainer container = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -1680,7 +1681,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCAGREH10() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -1737,7 +1738,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCALXES20() {
-        IAtomContainer container = new AtomContainer(27, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -1804,7 +1805,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCAMALD03() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -1834,7 +1835,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCEFMEN() {
-        IAtomContainer container = new AtomContainer(50, 53, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -1953,7 +1954,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCETROI01() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -2032,7 +2033,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCEWCUC10() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -2119,7 +2120,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCEWVIJ10() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -2195,7 +2196,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCEWYIM30() {
-        IAtomContainer container = new AtomContainer(22, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -2255,7 +2256,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIHWUL10() {
-        IAtomContainer container = new AtomContainer(17, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -2305,7 +2306,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIJXOI10() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -2370,7 +2371,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIKSEU10() {
-        IAtomContainer container = new AtomContainer(20, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -2426,7 +2427,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCILBII() {
-        IAtomContainer container = new AtomContainer(35, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -2511,7 +2512,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCILDOQ() {
-        IAtomContainer container = new AtomContainer(23, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -2570,7 +2571,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCILWUP11() {
-        IAtomContainer container = new AtomContainer(9, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -2601,7 +2602,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIMRUL10() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -2674,7 +2675,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCINVIE() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -2754,7 +2755,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIPVOM() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -2821,7 +2822,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIPYAB10() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -2871,7 +2872,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCISMOG() {
-        IAtomContainer container = new AtomContainer(14, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -2915,7 +2916,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCISPOJ() {
-        IAtomContainer container = new AtomContainer(24, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -2979,7 +2980,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCITDIS() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -3029,7 +3030,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCITNOI10() {
-        IAtomContainer container = new AtomContainer(28, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -3099,7 +3100,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCITPEA10() {
-        IAtomContainer container = new AtomContainer(31, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -3175,7 +3176,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCITSED10() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -3205,7 +3206,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIVCEP02() {
-        IAtomContainer container = new AtomContainer(36, 39, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -3295,7 +3296,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIVLAU02() {
-        IAtomContainer container = new AtomContainer(31, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -3374,7 +3375,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIXWAH() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -3431,7 +3432,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIYNUT() {
-        IAtomContainer container = new AtomContainer(14, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -3475,7 +3476,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIZFIA() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -3544,7 +3545,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIZJAW() {
-        IAtomContainer container = new AtomContainer(48, 48, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("Si", 0));
@@ -3655,7 +3656,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIZWUD() {
-        IAtomContainer container = new AtomContainer(15, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -3699,7 +3700,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIZYEP() {
-        IAtomContainer container = new AtomContainer(29, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -3771,7 +3772,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCIZZUG() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -3826,7 +3827,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOBKIN01() {
-        IAtomContainer container = new AtomContainer(25, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -3890,7 +3891,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOCXUN() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -3949,7 +3950,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOGDEH() {
-        IAtomContainer container = new AtomContainer(23, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -4012,7 +4013,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOGYAY() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -4063,7 +4064,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOHKOZ() {
-        IAtomContainer container = new AtomContainer(15, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -4107,7 +4108,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOJFIQ() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -4168,7 +4169,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOKDEL() {
-        IAtomContainer container = new AtomContainer(25, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -4231,7 +4232,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOKROJ() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -4300,7 +4301,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOLZUY() {
-        IAtomContainer container = new AtomContainer(44, 46, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -4405,7 +4406,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOMDIR() {
-        IAtomContainer container = new AtomContainer(23, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("O", 0));
@@ -4467,7 +4468,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOMKAQ() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -4516,7 +4517,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOMWOQ() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -4567,7 +4568,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOMWUW() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -4636,7 +4637,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCONBAI() {
-        IAtomContainer container = new AtomContainer(36, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -4725,7 +4726,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCONFAM() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -4757,7 +4758,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCONLIA() {
-        IAtomContainer container = new AtomContainer(27, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -4825,7 +4826,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCORDOC() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
@@ -4885,7 +4886,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCORWUB10() {
-        IAtomContainer container = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("C", 0));
@@ -4913,7 +4914,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOSFAR() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -4964,7 +4965,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOSSEI() {
-        IAtomContainer container = new AtomContainer(16, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("C", 0));
@@ -5009,7 +5010,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOSWIQ() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -5071,7 +5072,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOTMON() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -5125,7 +5126,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOTPEG() {
-        IAtomContainer container = new AtomContainer(15, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -5168,7 +5169,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOTRIM() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 1));
@@ -5233,7 +5234,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOVHUQ() {
-        IAtomContainer container = new AtomContainer(17, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -5280,7 +5281,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOVMAB() {
-        IAtomContainer container = new AtomContainer(32, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -5358,7 +5359,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOVXIU() {
-        IAtomContainer container = new AtomContainer(33, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -5440,7 +5441,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOWTIR() {
-        IAtomContainer container = new AtomContainer(32, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -5519,7 +5520,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOXBAS() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -5579,7 +5580,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOXZEU() {
-        IAtomContainer container = new AtomContainer(15, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
@@ -5622,7 +5623,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOYMOS() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -5689,7 +5690,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOYNAF() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
@@ -5740,7 +5741,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCOYVIV() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -5809,7 +5810,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUBTUO() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -5882,7 +5883,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUCDAF() {
-        IAtomContainer container = new AtomContainer(27, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -5952,7 +5953,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUCHOX() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -6025,7 +6026,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUCHUD() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -6090,7 +6091,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUDJAM() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -6150,7 +6151,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUDNEU() {
-        IAtomContainer container = new AtomContainer(35, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -6235,7 +6236,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUDPAS() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -6283,7 +6284,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUDPOG() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -6348,7 +6349,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUDREY() {
-        IAtomContainer container = new AtomContainer(11, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
@@ -6383,7 +6384,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUFFAK() {
-        IAtomContainer container = new AtomContainer(37, 41, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -6476,7 +6477,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUGBEL() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -6552,7 +6553,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUGGOA() {
-        IAtomContainer container = new AtomContainer(23, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -6611,7 +6612,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUGLOF() {
-        IAtomContainer container = new AtomContainer(28, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -6685,7 +6686,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUJYUB10() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -6745,7 +6746,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCULGEV10() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
@@ -6804,7 +6805,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCULHIA10() {
-        IAtomContainer container = new AtomContainer(39, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -6898,7 +6899,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCULVEK() {
-        IAtomContainer container = new AtomContainer(29, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
@@ -6970,7 +6971,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUNVAI() {
-        IAtomContainer container = new AtomContainer(29, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -7042,7 +7043,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUNVEM() {
-        IAtomContainer container = new AtomContainer(29, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -7114,7 +7115,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCURZIY() {
-        IAtomContainer container = new AtomContainer(24, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -7178,7 +7179,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUVFOO() {
-        IAtomContainer container = new AtomContainer(24, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("C", 0));
@@ -7239,7 +7240,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUVGAB() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -7301,7 +7302,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUVJOS() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -7333,7 +7334,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCUYRAP() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -7404,7 +7405,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCYANAM01() {
-        IAtomContainer container = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -7426,7 +7427,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCYGUAN01() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -7506,7 +7507,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDABHAP() {
-        IAtomContainer container = new AtomContainer(34, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -7590,7 +7591,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDABLIB() {
-        IAtomContainer container = new AtomContainer(20, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -7646,7 +7647,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDACSAB() {
-        IAtomContainer container = new AtomContainer(31, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -7723,7 +7724,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDACYIP() {
-        IAtomContainer container = new AtomContainer(35, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("N", 0));
@@ -7808,7 +7809,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDADDAN() {
-        IAtomContainer container = new AtomContainer(32, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -7889,7 +7890,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDADLAV() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -7941,7 +7942,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDADLEZ() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -7993,7 +7994,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAFKIE() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -8051,7 +8052,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAFPUV() {
-        IAtomContainer container = new AtomContainer(11, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -8086,7 +8087,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAGTUA() {
-        IAtomContainer container = new AtomContainer(26, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -8151,7 +8152,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAHBAP() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -8211,7 +8212,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAHNAB() {
-        IAtomContainer container = new AtomContainer(26, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
@@ -8276,7 +8277,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAJXER() {
-        IAtomContainer container = new AtomContainer(31, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -8356,7 +8357,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAKBAS() {
-        IAtomContainer container = new AtomContainer(34, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -8440,7 +8441,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAKCEX() {
-        IAtomContainer container = new AtomContainer(20, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -8496,7 +8497,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAKDOI() {
-        IAtomContainer container = new AtomContainer(36, 39, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -8586,7 +8587,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDANCUQ() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -8635,7 +8636,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAPSUO03() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -8708,7 +8709,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDARDEF() {
-        IAtomContainer container = new AtomContainer(30, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -8784,7 +8785,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDARPOB10() {
-        IAtomContainer container = new AtomContainer(39, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("N", 0));
@@ -8876,7 +8877,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDARXID() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -8943,7 +8944,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDARZEB() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -9006,7 +9007,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAVWEC() {
-        IAtomContainer container = new AtomContainer(30, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("C", 0));
@@ -9080,7 +9081,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAVXED() {
-        IAtomContainer container = new AtomContainer(35, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -9165,7 +9166,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAWXII() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -9221,7 +9222,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAWYUV() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -9270,7 +9271,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAYWEF() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
@@ -9339,7 +9340,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDAZVEF() {
-        IAtomContainer container = new AtomContainer(27, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -9410,7 +9411,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEBMOM01() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -9444,7 +9445,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDECJAW() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -9501,7 +9502,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDECKUR() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -9577,7 +9578,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDECRIM() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
@@ -9644,7 +9645,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEDCIY() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -9699,7 +9700,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEDSIO() {
-        IAtomContainer container = new AtomContainer(30, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("I", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
@@ -9774,7 +9775,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEFGIE() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -9836,7 +9837,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEFLEF() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
@@ -9912,7 +9913,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEFPUZ() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
@@ -9962,7 +9963,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEFTUD() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -10031,7 +10032,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEFVAL() {
-        IAtomContainer container = new AtomContainer(31, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -10109,7 +10110,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEFYUI() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
@@ -10159,7 +10160,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEGLUW() {
-        IAtomContainer container = new AtomContainer(14, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
@@ -10200,7 +10201,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEGRIQ() {
-        IAtomContainer container = new AtomContainer(37, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -10292,7 +10293,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEKRUG() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -10343,7 +10344,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEMBIG() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -10404,7 +10405,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEPKEO() {
-        IAtomContainer container = new AtomContainer(19, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -10458,7 +10459,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDERZUV() {
-        IAtomContainer container = new AtomContainer(31, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -10535,7 +10536,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDESWUT() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -10587,7 +10588,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDESYOP() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -10617,7 +10618,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEWHOC() {
-        IAtomContainer container = new AtomContainer(29, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
@@ -10691,7 +10692,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEWJEU() {
-        IAtomContainer container = new AtomContainer(36, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -10778,7 +10779,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEXCIS() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -10847,7 +10848,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEXGIW() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -10910,7 +10911,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEZDUH() {
-        IAtomContainer container = new AtomContainer(20, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("F", 0));
@@ -10966,7 +10967,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEZNIF() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -11037,7 +11038,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDEZXEL() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -11088,7 +11089,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDHOADS01() {
-        IAtomContainer container = new AtomContainer(28, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -11160,7 +11161,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDICKIJ() {
-        IAtomContainer container = new AtomContainer(32, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -11242,7 +11243,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDICPUA() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -11293,7 +11294,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDICRAI() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -11344,7 +11345,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDICYIX() {
-        IAtomContainer container = new AtomContainer(22, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -11401,7 +11402,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDICYOD() {
-        IAtomContainer container = new AtomContainer(26, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -11466,7 +11467,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIDYOE() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -11528,7 +11529,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIFSIU() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -11599,7 +11600,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIGCOL() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("N", 0));
@@ -11631,7 +11632,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIGCUR() {
-        IAtomContainer container = new AtomContainer(22, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -11688,7 +11689,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIGLEK() {
-        IAtomContainer container = new AtomContainer(40, 42, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -11785,7 +11786,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIHTET() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -11842,7 +11843,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIKGAF() {
-        IAtomContainer container = new AtomContainer(25, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -11906,7 +11907,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIKGEJ() {
-        IAtomContainer container = new AtomContainer(25, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -11970,7 +11971,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIKWID() {
-        IAtomContainer container = new AtomContainer(38, 41, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -12064,7 +12065,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIKYUR() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
@@ -12115,7 +12116,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDILCOQ() {
-        IAtomContainer container = new AtomContainer(32, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -12194,7 +12195,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIMYIH10() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -12261,7 +12262,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIPDAH10() {
-        IAtomContainer container = new AtomContainer(29, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -12335,7 +12336,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIPDIP10() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
@@ -12391,7 +12392,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIRMIA() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -12425,7 +12426,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDISHES() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -12494,7 +12495,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDISJOE() {
-        IAtomContainer container = new AtomContainer(15, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -12537,7 +12538,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDITRAZ() {
-        IAtomContainer container = new AtomContainer(14, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -12578,7 +12579,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDITYAG10() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -12647,7 +12648,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIVJUN() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -12701,7 +12702,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIVTUX() {
-        IAtomContainer container = new AtomContainer(25, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -12767,7 +12768,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIVVEJ() {
-        IAtomContainer container = new AtomContainer(14, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -12808,7 +12809,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIVWEK() {
-        IAtomContainer container = new AtomContainer(34, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -12893,7 +12894,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIWCOB() {
-        IAtomContainer container = new AtomContainer(16, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
@@ -12938,7 +12939,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIXJEZ() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -12997,7 +12998,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIYDIY() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -13053,7 +13054,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIYPOQ() {
-        IAtomContainer container = new AtomContainer(34, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -13137,7 +13138,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIYPUW() {
-        IAtomContainer container = new AtomContainer(16, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -13184,7 +13185,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDIZPUX() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -13255,7 +13256,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDMEOXA01() {
-        IAtomContainer container = new AtomContainer(14, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -13296,7 +13297,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOCCIH() {
-        IAtomContainer container = new AtomContainer(16, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("C", 0));
@@ -13342,7 +13343,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOCFIK() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -13399,7 +13400,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOCWUN() {
-        IAtomContainer container = new AtomContainer(26, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -13465,7 +13466,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDODNOZ() {
-        IAtomContainer container = new AtomContainer(31, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -13541,7 +13542,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDODNUF() {
-        IAtomContainer container = new AtomContainer(22, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -13598,7 +13599,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOJPAT() {
-        IAtomContainer container = new AtomContainer(21, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -13656,7 +13657,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDONFOB() {
-        IAtomContainer container = new AtomContainer(28, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -13725,7 +13726,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOSNOO() {
-        IAtomContainer container = new AtomContainer(15, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -13769,7 +13770,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOTNIJ() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -13819,7 +13820,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOTVEN() {
-        IAtomContainer container = new AtomContainer(15, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -13863,7 +13864,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOTWOY() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
@@ -13936,7 +13937,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOWDEY() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -13984,7 +13985,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOXXAP() {
-        IAtomContainer container = new AtomContainer(17, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -14031,7 +14032,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOXZOF() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -14080,7 +14081,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOZFON() {
-        IAtomContainer container = new AtomContainer(20, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("O", 0));
@@ -14133,7 +14134,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDOZNIP() {
-        IAtomContainer container = new AtomContainer(15, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -14177,7 +14178,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUBNET() {
-        IAtomContainer container = new AtomContainer(22, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -14237,7 +14238,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUDMUK() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -14291,7 +14292,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUGMUN() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -14339,7 +14340,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUGWIL01() {
-        IAtomContainer container = new AtomContainer(19, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -14390,7 +14391,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUJHEV() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -14440,7 +14441,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUJMEA() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -14527,7 +14528,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUKVAG() {
-        IAtomContainer container = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
@@ -14565,7 +14566,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUKWUB() {
-        IAtomContainer container = new AtomContainer(28, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -14635,7 +14636,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDULTIN() {
-        IAtomContainer container = new AtomContainer(24, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -14699,7 +14700,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUMHIC() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -14766,7 +14767,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUMPAC() {
-        IAtomContainer container = new AtomContainer(30, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -14840,7 +14841,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUPHEB() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
@@ -14902,7 +14903,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUPTAJ() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -14963,7 +14964,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDURDID() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -15017,7 +15018,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUTHIJ() {
-        IAtomContainer container = new AtomContainer(32, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -15098,7 +15099,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUVHUX10() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -15159,7 +15160,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUVXIB() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -15208,7 +15209,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUWGAD() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("N", 0));
@@ -15266,7 +15267,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUWKUB() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -15322,7 +15323,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUWRIW() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("O", -1));
@@ -15380,7 +15381,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUXTIZ() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
@@ -15416,7 +15417,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUXWUO() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -15489,7 +15490,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUXXAV() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -15565,7 +15566,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUYNOA() {
-        IAtomContainer container = new AtomContainer(38, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -15658,7 +15659,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUYPES() {
-        IAtomContainer container = new AtomContainer(47, 48, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
@@ -15769,7 +15770,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testDUYRAQ() {
-        IAtomContainer container = new AtomContainer(35, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("N", 0));
@@ -15854,7 +15855,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFACMIF() {
-        IAtomContainer container = new AtomContainer(27, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -15924,7 +15925,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFACREG() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("O", -1));
@@ -15980,7 +15981,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFACYAJ() {
-        IAtomContainer container = new AtomContainer(19, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -16034,7 +16035,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFADMIG() {
-        IAtomContainer container = new AtomContainer(16, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -16081,7 +16082,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFADVEL() {
-        IAtomContainer container = new AtomContainer(23, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -16140,7 +16141,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFADVUB() {
-        IAtomContainer container = new AtomContainer(23, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -16199,7 +16200,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAGBUK() {
-        IAtomContainer container = new AtomContainer(41, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 1));
@@ -16295,7 +16296,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAGCOF() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -16362,7 +16363,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAGLII() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
@@ -16404,7 +16405,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAGVEO() {
-        IAtomContainer container = new AtomContainer(8, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -16433,7 +16434,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAGZOC() {
-        IAtomContainer container = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -16470,7 +16471,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAHPUZ() {
-        IAtomContainer container = new AtomContainer(29, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -16545,7 +16546,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAHSUC() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -16612,7 +16613,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAHYUI() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 1));
@@ -16672,7 +16673,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAHZET() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -16737,7 +16738,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAJWIW() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -16787,7 +16788,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAMHAC() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
@@ -16858,7 +16859,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAMYUN() {
-        IAtomContainer container = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -16895,7 +16896,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAPLUD() {
-        IAtomContainer container = new AtomContainer(13, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -16935,7 +16936,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFARMAM() {
-        IAtomContainer container = new AtomContainer(24, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -17000,7 +17001,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFARSOG() {
-        IAtomContainer container = new AtomContainer(22, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -17060,7 +17061,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFARWEA() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("N", 0));
@@ -17096,7 +17097,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFASGUB() {
-        IAtomContainer container = new AtomContainer(15, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -17139,7 +17140,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFASJIS() {
-        IAtomContainer container = new AtomContainer(39, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 1));
         container.addAtom(newAtm("P", 1));
         container.addAtom(newAtm("S", -1));
@@ -17233,7 +17234,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFATLIV() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 1));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -17320,7 +17321,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAXFUF10() {
-        IAtomContainer container = new AtomContainer(15, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
@@ -17365,7 +17366,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAXVAB() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -17424,7 +17425,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAXVEF() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -17486,7 +17487,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAXVIJ() {
-        IAtomContainer container = new AtomContainer(26, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -17554,7 +17555,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAZBAJ() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("C", 0));
@@ -17590,7 +17591,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFAZKUM() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -17626,7 +17627,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFBATNB() {
-        IAtomContainer container = new AtomContainer(32, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -17705,7 +17706,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFECXEQ() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -17767,7 +17768,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEGSEP() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -17817,7 +17818,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEHDAX() {
-        IAtomContainer container = new AtomContainer(14, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -17859,7 +17860,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEJJEJ() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -17924,7 +17925,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEJKIO() {
-        IAtomContainer container = new AtomContainer(38, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -18017,7 +18018,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFELYIE() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -18071,7 +18072,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFELYUQ() {
-        IAtomContainer container = new AtomContainer(25, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -18135,7 +18136,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEMGEJ() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("C", 0));
@@ -18200,7 +18201,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFENCOQ() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -18250,7 +18251,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFENHAH() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -18298,7 +18299,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFENJIR() {
-        IAtomContainer container = new AtomContainer(31, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -18375,7 +18376,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFENJOX() {
-        IAtomContainer container = new AtomContainer(34, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -18458,7 +18459,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFENJUD() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", 0));
@@ -18529,7 +18530,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFENNUH() {
-        IAtomContainer container = new AtomContainer(21, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -18584,7 +18585,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFENYIG() {
-        IAtomContainer container = new AtomContainer(36, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -18672,7 +18673,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEPWAY() {
-        IAtomContainer container = new AtomContainer(13, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("N", 0));
@@ -18711,7 +18712,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEPWOM() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("F", 0));
@@ -18747,7 +18748,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFESCAH() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -18779,7 +18780,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFESMIZ() {
-        IAtomContainer container = new AtomContainer(25, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -18843,7 +18844,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFETRUR() {
-        IAtomContainer container = new AtomContainer(23, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -18905,7 +18906,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFETWOQ() {
-        IAtomContainer container = new AtomContainer(30, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -18982,7 +18983,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEVNUP() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -19034,7 +19035,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEYLUQ() {
-        IAtomContainer container = new AtomContainer(19, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -19087,7 +19088,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEZPOP() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 0));
@@ -19119,7 +19120,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFEZRUX() {
-        IAtomContainer container = new AtomContainer(29, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -19194,7 +19195,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIBLIL() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -19267,7 +19268,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFICDOK() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -19317,7 +19318,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIFGUW() {
-        IAtomContainer container = new AtomContainer(34, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -19401,7 +19402,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIGYID() {
-        IAtomContainer container = new AtomContainer(11, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -19436,7 +19437,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIHXID() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -19516,7 +19517,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIKJAK() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -19576,7 +19577,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIKZOO10() {
-        IAtomContainer container = new AtomContainer(19, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -19629,7 +19630,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFILGEM() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -19694,7 +19695,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFILNOD() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -19757,7 +19758,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFINBIN() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -19818,7 +19819,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFINPEX() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -19876,7 +19877,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFITGIY() {
-        IAtomContainer container = new AtomContainer(28, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -19946,7 +19947,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFITSEG() {
-        IAtomContainer container = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -19983,7 +19984,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFITTIL() {
-        IAtomContainer container = new AtomContainer(19, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -20036,7 +20037,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIVNUT() {
-        IAtomContainer container = new AtomContainer(32, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -20115,7 +20116,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIVRAD() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -20195,7 +20196,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIXPIL() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -20262,7 +20263,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIYBIY() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -20329,7 +20330,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIZGEA() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -20398,7 +20399,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIZGOK() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -20454,7 +20455,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFIZJED() {
-        IAtomContainer container = new AtomContainer(16, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -20500,7 +20501,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOBJUB01() {
-        IAtomContainer container = new AtomContainer(14, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 1));
@@ -20542,7 +20543,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFODTUN() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -20611,7 +20612,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOGBIM() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
@@ -20680,7 +20681,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOGVIG01() {
-        IAtomContainer container = new AtomContainer(35, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -20765,7 +20766,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOHXEF() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
@@ -20832,7 +20833,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOHYAC() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
@@ -20882,7 +20883,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOJBEL() {
-        IAtomContainer container = new AtomContainer(27, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -20950,7 +20951,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOJPAV() {
-        IAtomContainer container = new AtomContainer(26, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -21018,7 +21019,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFONCOA() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -21094,7 +21095,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFORGOI() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("I", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -21144,7 +21145,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFORHEZ() {
-        IAtomContainer container = new AtomContainer(16, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -21189,7 +21190,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFORJIF() {
-        IAtomContainer container = new AtomContainer(22, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -21251,7 +21252,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFORJUR() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -21326,7 +21327,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFORTAH() {
-        IAtomContainer container = new AtomContainer(23, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("C", 0));
@@ -21385,7 +21386,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOSDIA() {
-        IAtomContainer container = new AtomContainer(29, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -21459,7 +21460,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOVHUT() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -21509,7 +21510,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOVJIJ() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -21574,7 +21575,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOVRAJ() {
-        IAtomContainer container = new AtomContainer(34, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -21659,7 +21660,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOVRUD() {
-        IAtomContainer container = new AtomContainer(34, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -21744,7 +21745,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOWBEY() {
-        IAtomContainer container = new AtomContainer(23, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -21806,7 +21807,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOWPOW() {
-        IAtomContainer container = new AtomContainer(28, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -21878,7 +21879,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOWVES() {
-        IAtomContainer container = new AtomContainer(16, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -21926,7 +21927,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOWZAS() {
-        IAtomContainer container = new AtomContainer(29, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -22001,7 +22002,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOYMAH() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -22051,7 +22052,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFOYNUC() {
-        IAtomContainer container = new AtomContainer(27, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -22121,7 +22122,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUCMIZ() {
-        IAtomContainer container = new AtomContainer(13, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Si", 0));
@@ -22159,7 +22160,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUCMUL() {
-        IAtomContainer container = new AtomContainer(10, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -22193,7 +22194,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUCTIG01() {
-        IAtomContainer container = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", -1));
@@ -22213,7 +22214,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUCWIJ() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -22300,7 +22301,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUCWOP() {
-        IAtomContainer container = new AtomContainer(25, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -22366,7 +22367,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUDPOJ() {
-        IAtomContainer container = new AtomContainer(8, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -22395,7 +22396,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUDXUX() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -22431,7 +22432,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUFDIT() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -22485,7 +22486,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUGWIN() {
-        IAtomContainer container = new AtomContainer(32, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -22566,7 +22567,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUHFAP() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -22602,7 +22603,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUHSEG() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -22654,7 +22655,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFULRAF() {
-        IAtomContainer container = new AtomContainer(33, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -22736,7 +22737,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUNSIQ() {
-        IAtomContainer container = new AtomContainer(19, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -22787,7 +22788,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUNXOB() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -22852,7 +22853,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUPJUV() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 0));
@@ -22928,7 +22929,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUPKIK() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -22985,7 +22986,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUPKOQ() {
-        IAtomContainer container = new AtomContainer(32, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
@@ -23066,7 +23067,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUPTOZ() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -23118,7 +23119,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUPZEV() {
-        IAtomContainer container = new AtomContainer(33, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -23200,7 +23201,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUSPEO() {
-        IAtomContainer container = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -23228,7 +23229,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUTCEC() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -23293,7 +23294,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUTZEZ() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -23323,7 +23324,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUVDOP() {
-        IAtomContainer container = new AtomContainer(36, 39, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -23413,7 +23414,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUVMUE() {
-        IAtomContainer container = new AtomContainer(33, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -23493,7 +23494,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUVNEP() {
-        IAtomContainer container = new AtomContainer(40, 41, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -23589,7 +23590,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUVXOJ() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
@@ -23645,7 +23646,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUWMOZ() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -23712,7 +23713,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUWTUM() {
-        IAtomContainer container = new AtomContainer(20, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -23768,7 +23769,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUXXAX() {
-        IAtomContainer container = new AtomContainer(27, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
@@ -23835,7 +23836,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFUXZED() {
-        IAtomContainer container = new AtomContainer(23, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -23894,7 +23895,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGADHEY() {
-        IAtomContainer container = new AtomContainer(35, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -23980,7 +23981,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAFNUW() {
-        IAtomContainer container = new AtomContainer(31, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -24059,7 +24060,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAHPIO() {
-        IAtomContainer container = new AtomContainer(22, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -24116,7 +24117,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAJTEQ() {
-        IAtomContainer container = new AtomContainer(15, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -24160,7 +24161,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAKGOO() {
-        IAtomContainer container = new AtomContainer(28, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -24232,7 +24233,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAKNEL() {
-        IAtomContainer container = new AtomContainer(15, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -24277,7 +24278,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAKNIP() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -24331,7 +24332,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAKPEN() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -24386,7 +24387,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAKTAN() {
-        IAtomContainer container = new AtomContainer(15, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -24432,7 +24433,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGANHUY() {
-        IAtomContainer container = new AtomContainer(9, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -24463,7 +24464,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAPMEP() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -24512,7 +24513,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAVKOD() {
-        IAtomContainer container = new AtomContainer(13, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 0));
@@ -24551,7 +24552,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAVMEV() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -24610,7 +24611,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGAWWOQ() {
-        IAtomContainer container = new AtomContainer(31, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -24688,7 +24689,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEHBOK() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -24768,7 +24769,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEHPUE() {
-        IAtomContainer container = new AtomContainer(21, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -24823,7 +24824,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEHXEW() {
-        IAtomContainer container = new AtomContainer(38, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -24916,7 +24917,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEJYOJ() {
-        IAtomContainer container = new AtomContainer(16, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("F", 0));
@@ -24961,7 +24962,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEKXEZ() {
-        IAtomContainer container = new AtomContainer(18, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25010,7 +25011,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEMCEG() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25058,7 +25059,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEMCOQ() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25110,7 +25111,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEMDAD() {
-        IAtomContainer container = new AtomContainer(27, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25178,7 +25179,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGERCUB() {
-        IAtomContainer container = new AtomContainer(19, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25231,7 +25232,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGESCIQ() {
-        IAtomContainer container = new AtomContainer(35, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -25317,7 +25318,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGESNIB() {
-        IAtomContainer container = new AtomContainer(13, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25357,7 +25358,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGESSUS() {
-        IAtomContainer container = new AtomContainer(26, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -25423,7 +25424,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGETFIU() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25471,7 +25472,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGETFOA() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25519,7 +25520,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGETJOE() {
-        IAtomContainer container = new AtomContainer(30, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("P", 1));
         container.addAtom(newAtm("S", -1));
@@ -25595,7 +25596,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEWTAD() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25652,7 +25653,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEXGIZ() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -25710,7 +25711,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGEYWOW() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -25790,7 +25791,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGICTIV01() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -25845,7 +25846,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIDJUY() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -25912,7 +25913,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIDMEL() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -25973,7 +25974,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIDTIW() {
-        IAtomContainer container = new AtomContainer(37, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -26063,7 +26064,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIFRAO() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -26143,7 +26144,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIGCEE() {
-        IAtomContainer container = new AtomContainer(26, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -26212,7 +26213,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIGMUE() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -26283,7 +26284,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIHZEC() {
-        IAtomContainer container = new AtomContainer(22, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -26343,7 +26344,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIJMOB01() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", -1));
@@ -26392,7 +26393,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIKJIT() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -26435,7 +26436,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIKNOD() {
-        IAtomContainer container = new AtomContainer(27, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -26503,7 +26504,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIKTUP() {
-        IAtomContainer container = new AtomContainer(19, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -26556,7 +26557,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIMJIV() {
-        IAtomContainer container = new AtomContainer(27, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -26627,7 +26628,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGINMUL() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -26688,7 +26689,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIPHES() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -26748,7 +26749,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGIRDOA01() {
-        IAtomContainer container = new AtomContainer(34, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -26833,7 +26834,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGOHVUU() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -26876,7 +26877,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGOJCIR() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("H", 0));
@@ -26932,7 +26933,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGOJKIZ() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -26987,7 +26988,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testGUANCH01() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -27036,7 +27037,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testHYTPRD01() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -27111,7 +27112,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testISTZCN10() {
-        IAtomContainer container = new AtomContainer(12, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -27149,7 +27150,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJABGAU() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -27220,7 +27221,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJADLIJ() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -27262,7 +27263,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJADXER() {
-        IAtomContainer container = new AtomContainer(39, 41, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -27357,7 +27358,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAHKOS() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -27424,7 +27425,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAHTOB() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -27493,7 +27494,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAHYEW() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -27556,7 +27557,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAKGUX() {
-        IAtomContainer container = new AtomContainer(24, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("C", 0));
@@ -27620,7 +27621,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAKJOU() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -27676,7 +27677,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJALSOE() {
-        IAtomContainer container = new AtomContainer(28, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -27748,7 +27749,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAMREU() {
-        IAtomContainer container = new AtomContainer(52, 53, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -27869,7 +27870,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJANDOR() {
-        IAtomContainer container = new AtomContainer(53, 56, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -27994,7 +27995,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJANMAM() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -28054,7 +28055,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAPFAH() {
-        IAtomContainer container = new AtomContainer(28, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -28126,7 +28127,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJATBIP() {
-        IAtomContainer container = new AtomContainer(24, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -28187,7 +28188,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJATCOW() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -28230,7 +28231,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJATLOF() {
-        IAtomContainer container = new AtomContainer(36, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -28317,7 +28318,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJATMEW() {
-        IAtomContainer container = new AtomContainer(38, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -28408,7 +28409,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAVGAO() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -28468,7 +28469,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAWJIA() {
-        IAtomContainer container = new AtomContainer(37, 39, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -28559,7 +28560,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAWMAV() {
-        IAtomContainer container = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -28596,7 +28597,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAWVEI() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -28667,7 +28668,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAWZEM() {
-        IAtomContainer container = new AtomContainer(19, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -28720,7 +28721,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAZGOG() {
-        IAtomContainer container = new AtomContainer(30, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -28797,7 +28798,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAZVIP10() {
-        IAtomContainer container = new AtomContainer(34, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -28881,7 +28882,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJAZZOZ10() {
-        IAtomContainer container = new AtomContainer(37, 39, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -28972,7 +28973,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEBFEB01() {
-        IAtomContainer container = new AtomContainer(27, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -29042,7 +29043,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJECVES() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -29118,7 +29119,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJECVUI() {
-        IAtomContainer container = new AtomContainer(24, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -29179,7 +29180,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJECYIZ() {
-        IAtomContainer container = new AtomContainer(40, 41, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -29275,7 +29276,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEFRAN() {
-        IAtomContainer container = new AtomContainer(36, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
@@ -29362,7 +29363,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEHCUU01() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -29421,7 +29422,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEHXOJ() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -29475,7 +29476,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJELKUG() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("P", 1));
@@ -29533,7 +29534,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJELREX() {
-        IAtomContainer container = new AtomContainer(24, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -29597,7 +29598,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJELRIB() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("C", 0));
@@ -29656,7 +29657,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEMHIS() {
-        IAtomContainer container = new AtomContainer(15, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -29699,7 +29700,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEMWUT() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -29761,7 +29762,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJESFES() {
-        IAtomContainer container = new AtomContainer(25, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("H", 0));
@@ -29824,7 +29825,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJETJUN() {
-        IAtomContainer container = new AtomContainer(18, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("C", 0));
@@ -29873,7 +29874,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEVXIR() {
-        IAtomContainer container = new AtomContainer(26, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -29939,7 +29940,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEWFAS() {
-        IAtomContainer container = new AtomContainer(38, 39, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -30031,7 +30032,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEWPIK() {
-        IAtomContainer container = new AtomContainer(19, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -30085,7 +30086,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEXREJ() {
-        IAtomContainer container = new AtomContainer(34, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -30168,7 +30169,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJEYBUK() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -30229,7 +30230,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIDHIN() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -30309,7 +30310,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIFYUS() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -30372,7 +30373,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIGCIL() {
-        IAtomContainer container = new AtomContainer(15, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -30417,7 +30418,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIGRAS() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -30475,7 +30476,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIHVEB() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("O", 0));
@@ -30509,7 +30510,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIKHUG() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -30580,7 +30581,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJILWUW() {
-        IAtomContainer container = new AtomContainer(18, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", -1));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -30631,7 +30632,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJINDAL() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -30687,7 +30688,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJINDOZ() {
-        IAtomContainer container = new AtomContainer(33, 35, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -30770,7 +30771,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIRJID() {
-        IAtomContainer container = new AtomContainer(13, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -30808,7 +30809,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJISZAM() {
-        IAtomContainer container = new AtomContainer(33, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
@@ -30890,7 +30891,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJITMII() {
-        IAtomContainer container = new AtomContainer(32, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -30970,7 +30971,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIWKOP() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("C", 0));
@@ -31037,7 +31038,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIXBAT() {
-        IAtomContainer container = new AtomContainer(27, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -31105,7 +31106,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIYJAC() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -31162,7 +31163,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIYREO() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -31212,7 +31213,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIYTOA() {
-        IAtomContainer container = new AtomContainer(11, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", -1));
@@ -31247,7 +31248,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJIZWUK() {
-        IAtomContainer container = new AtomContainer(37, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -31335,7 +31336,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testJOFDUD() {
-        IAtomContainer container = new AtomContainer(16, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
@@ -31380,7 +31381,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKAFXIY() {
-        IAtomContainer container = new AtomContainer(25, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
@@ -31446,7 +31447,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKAGBOJ() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -31533,7 +31534,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKAKGOS() {
-        IAtomContainer container = new AtomContainer(28, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
@@ -31605,7 +31606,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKAMCUW() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("C", 0));
@@ -31692,7 +31693,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKAMJAJ() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -31763,7 +31764,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKANWEB() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -31820,7 +31821,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKANZOO() {
-        IAtomContainer container = new AtomContainer(40, 43, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -31918,7 +31919,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKAPCUZ() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("N", 0));
@@ -31968,7 +31969,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKARYAD() {
-        IAtomContainer container = new AtomContainer(30, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -32044,7 +32045,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKASBAH() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -32098,7 +32099,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKASBOV() {
-        IAtomContainer container = new AtomContainer(25, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -32162,7 +32163,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKATNAU() {
-        IAtomContainer container = new AtomContainer(31, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -32241,7 +32242,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKAVFUI() {
-        IAtomContainer container = new AtomContainer(13, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("O", -1));
@@ -32280,7 +32281,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKAVTEG() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -32351,7 +32352,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKECSIU() {
-        IAtomContainer container = new AtomContainer(30, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("F", 0));
@@ -32425,7 +32426,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKECSUG() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -32473,7 +32474,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKEDYAT() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -32536,7 +32537,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKEFJEK() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -32601,7 +32602,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKEJFOU() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -32657,7 +32658,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKEMFAJ() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -32730,7 +32731,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKENHOA() {
-        IAtomContainer container = new AtomContainer(22, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("N", 0));
@@ -32790,7 +32791,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKEPKIZ() {
-        IAtomContainer container = new AtomContainer(15, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -32836,7 +32837,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKESNEB() {
-        IAtomContainer container = new AtomContainer(32, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -32915,7 +32916,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKEWJIF() {
-        IAtomContainer container = new AtomContainer(11, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -32950,7 +32951,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKHDFRM11() {
-        IAtomContainer container = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -32972,7 +32973,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKIBDII() {
-        IAtomContainer container = new AtomContainer(28, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -33042,7 +33043,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKIBFAC() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
@@ -33103,7 +33104,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKICCUU() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("F", 0));
@@ -33139,7 +33140,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKICGAE() {
-        IAtomContainer container = new AtomContainer(22, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -33200,7 +33201,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKICLAJ() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -33263,7 +33264,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKIGKIU() {
-        IAtomContainer container = new AtomContainer(15, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -33307,7 +33308,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKIKVUV() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -33370,7 +33371,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKIMLEX01() {
-        IAtomContainer container = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("F", 0));
@@ -33392,7 +33393,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKINKUN() {
-        IAtomContainer container = new AtomContainer(31, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -33468,7 +33469,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKINTUW() {
-        IAtomContainer container = new AtomContainer(34, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -33550,7 +33551,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKINWEJ() {
-        IAtomContainer container = new AtomContainer(39, 43, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -33647,7 +33648,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKINWIN() {
-        IAtomContainer container = new AtomContainer(19, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -33698,7 +33699,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKIRCAP() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -33785,7 +33786,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKIRCOD() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -33841,7 +33842,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKITREK() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -33917,7 +33918,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKIYGAA() {
-        IAtomContainer container = new AtomContainer(20, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("F", 0));
@@ -33970,7 +33971,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOBXOO() {
-        IAtomContainer container = new AtomContainer(14, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -34012,7 +34013,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOBYOP() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -34055,7 +34056,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOBZEG() {
-        IAtomContainer container = new AtomContainer(39, 42, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
@@ -34151,7 +34152,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOCWUU() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -34206,7 +34207,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKODFUE() {
-        IAtomContainer container = new AtomContainer(31, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -34282,7 +34283,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOFKIZ() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -34342,7 +34343,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOFMEX() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -34415,7 +34416,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOFNIC() {
-        IAtomContainer container = new AtomContainer(32, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -34496,7 +34497,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOHVEI() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -34558,7 +34559,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOHVIM() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -34606,7 +34607,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOJGOF() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -34682,7 +34683,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOJKID() {
-        IAtomContainer container = new AtomContainer(26, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -34748,7 +34749,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOJZOY() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -34804,7 +34805,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOKMIG() {
-        IAtomContainer container = new AtomContainer(30, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -34878,7 +34879,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKOLCUJ() {
-        IAtomContainer container = new AtomContainer(29, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -34950,7 +34951,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testMAPMIP03() {
-        IAtomContainer container = new AtomContainer(28, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -35019,7 +35020,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testMENBZS01() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -35071,7 +35072,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testMETBZC10() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -35131,7 +35132,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNAESCB01() {
-        IAtomContainer container = new AtomContainer(18, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("C", 0));
@@ -35180,7 +35181,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNHOXAL06() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -35206,7 +35207,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPHOSLA10() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -35263,7 +35264,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPHOSLB10() {
-        IAtomContainer container = new AtomContainer(34, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -35346,7 +35347,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPIMTAZ01() {
-        IAtomContainer container = new AtomContainer(26, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -35414,7 +35415,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testQUICNA01() {
-        IAtomContainer container = new AtomContainer(16, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -35460,7 +35461,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSABNOY() {
-        IAtomContainer container = new AtomContainer(30, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -35535,7 +35536,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSACXAV() {
-        IAtomContainer container = new AtomContainer(35, 36, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -35621,7 +35622,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSADXAW() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -35682,7 +35683,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAFFOU() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -35725,7 +35726,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAFFUA() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
@@ -35768,7 +35769,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAFKAL() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -35800,7 +35801,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAHSOJ() {
-        IAtomContainer container = new AtomContainer(36, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -35888,7 +35889,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAHSUP() {
-        IAtomContainer container = new AtomContainer(27, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -35956,7 +35957,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAKGUG() {
-        IAtomContainer container = new AtomContainer(35, 39, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
@@ -36045,7 +36046,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSALVEG() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -36118,7 +36119,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAMFUH() {
-        IAtomContainer container = new AtomContainer(18, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("S", 0));
@@ -36168,7 +36169,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAMXUZ() {
-        IAtomContainer container = new AtomContainer(33, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -36249,7 +36250,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSANKEX10() {
-        IAtomContainer container = new AtomContainer(31, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -36328,7 +36329,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAVDOI() {
-        IAtomContainer container = new AtomContainer(40, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -36423,7 +36424,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSAWKEG10() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -36480,7 +36481,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEBPEU01() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -36545,7 +36546,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSECDAF() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -36632,7 +36633,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEFRAW() {
-        IAtomContainer container = new AtomContainer(24, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -36696,7 +36697,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEFYIL() {
-        IAtomContainer container = new AtomContainer(32, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("P", 0));
@@ -36774,7 +36775,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEGFIT() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -36834,7 +36835,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEGJAP() {
-        IAtomContainer container = new AtomContainer(30, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -36910,7 +36911,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEGLAR() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -36962,7 +36963,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEGNEX() {
-        IAtomContainer container = new AtomContainer(16, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
@@ -37007,7 +37008,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEGWEG() {
-        IAtomContainer container = new AtomContainer(16, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("I", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -37054,7 +37055,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEHBEM() {
-        IAtomContainer container = new AtomContainer(31, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("N", 1));
@@ -37130,7 +37131,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEJDAM() {
-        IAtomContainer container = new AtomContainer(27, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -37201,7 +37202,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEKKIC() {
-        IAtomContainer container = new AtomContainer(30, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -37275,7 +37276,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEKPED() {
-        IAtomContainer container = new AtomContainer(16, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -37322,7 +37323,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEKPIH() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -37371,7 +37372,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSELFIY() {
-        IAtomContainer container = new AtomContainer(36, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -37460,7 +37461,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEMDIX() {
-        IAtomContainer container = new AtomContainer(28, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("O", 0));
@@ -37529,7 +37530,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEMXOX() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -37598,7 +37599,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSETHAA() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -37665,7 +37666,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSETLIM() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -37732,7 +37733,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEYVUN() {
-        IAtomContainer container = new AtomContainer(15, 16, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -37777,7 +37778,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEYWUO() {
-        IAtomContainer container = new AtomContainer(32, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", -1));
         container.addAtom(newAtm("N", 1));
@@ -37856,7 +37857,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSEZMEP() {
-        IAtomContainer container = new AtomContainer(19, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -37909,7 +37910,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSICNUN() {
-        IAtomContainer container = new AtomContainer(26, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -37975,7 +37976,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSICPEZ() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
@@ -38042,7 +38043,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSICSEC() {
-        IAtomContainer container = new AtomContainer(22, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -38102,7 +38103,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSIDFIU() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("I", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -38156,7 +38157,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSIDRUS() {
-        IAtomContainer container = new AtomContainer(38, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
@@ -38247,7 +38248,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSINMIL() {
-        IAtomContainer container = new AtomContainer(40, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 1));
@@ -38342,7 +38343,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSIYLOB() {
-        IAtomContainer container = new AtomContainer(38, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
@@ -38433,7 +38434,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSIZJIU() {
-        IAtomContainer container = new AtomContainer(38, 40, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -38526,7 +38527,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSIZWUT() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -38591,7 +38592,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSLFNMB04() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -38662,7 +38663,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSOGVOZ() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -38731,7 +38732,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSOHXOC() {
-        IAtomContainer container = new AtomContainer(32, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -38810,7 +38811,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSOJNEK() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -38868,7 +38869,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSOMKIO() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("Br", 0));
@@ -38929,7 +38930,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSONZIE() {
-        IAtomContainer container = new AtomContainer(36, 38, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -39018,7 +39019,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSOPZEC() {
-        IAtomContainer container = new AtomContainer(17, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -39066,7 +39067,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSORBIK() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", -1));
@@ -39121,7 +39122,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSURDOX02() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -39153,7 +39154,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTACGIN() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -39214,7 +39215,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTACLEO() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -39283,7 +39284,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAFKIU() {
-        IAtomContainer container = new AtomContainer(17, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -39332,7 +39333,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAFXIH() {
-        IAtomContainer container = new AtomContainer(26, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -39400,7 +39401,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAFZIJ() {
-        IAtomContainer container = new AtomContainer(15, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", -1));
@@ -39443,7 +39444,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAGVIG() {
-        IAtomContainer container = new AtomContainer(14, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -39485,7 +39486,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAHMOE() {
-        IAtomContainer container = new AtomContainer(18, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -39534,7 +39535,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAJPUP() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -39601,7 +39602,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAJSUS() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -39676,7 +39677,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAJVUV() {
-        IAtomContainer container = new AtomContainer(6, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("N", 0));
@@ -39701,7 +39702,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAJWAC() {
-        IAtomContainer container = new AtomContainer(19, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -39754,7 +39755,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAKHES() {
-        IAtomContainer container = new AtomContainer(14, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -39796,7 +39797,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAMMAV() {
-        IAtomContainer container = new AtomContainer(16, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -39843,7 +39844,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTANHAR() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -39898,7 +39899,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAPJUP() {
-        IAtomContainer container = new AtomContainer(23, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -39960,7 +39961,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTAPSAE() {
-        IAtomContainer container = new AtomContainer(19, 19, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -40012,7 +40013,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTCYMPH02() {
-        IAtomContainer container = new AtomContainer(16, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -40057,7 +40058,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testTMTCHD01() {
-        IAtomContainer container = new AtomContainer(24, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -40121,7 +40122,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVABLIT() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -40180,7 +40181,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVABROF() {
-        IAtomContainer container = new AtomContainer(28, 29, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -40251,7 +40252,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVACRUM() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -40320,7 +40321,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVAJFAN() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -40387,7 +40388,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVALTEH() {
-        IAtomContainer container = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("C", 0));
@@ -40415,7 +40416,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVALWOU() {
-        IAtomContainer container = new AtomContainer(31, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -40492,7 +40493,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVAPZOB10() {
-        IAtomContainer container = new AtomContainer(32, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -40573,7 +40574,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVASDOI() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -40628,7 +40629,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVATKAC() {
-        IAtomContainer container = new AtomContainer(29, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -40703,7 +40704,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVAWDUS() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -40763,7 +40764,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVAWMOV() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -40839,7 +40840,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVAWWAR() {
-        IAtomContainer container = new AtomContainer(33, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", 0));
@@ -40919,7 +40920,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVAYKUB() {
-        IAtomContainer container = new AtomContainer(26, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -40985,7 +40986,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVAZHUZ() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -41052,7 +41053,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVECSAX() {
-        IAtomContainer container = new AtomContainer(26, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -41118,7 +41119,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEDTED() {
-        IAtomContainer container = new AtomContainer(23, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -41179,7 +41180,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEHCOA() {
-        IAtomContainer container = new AtomContainer(23, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -41239,7 +41240,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEHZOX() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -41308,7 +41309,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEJWOW() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -41370,7 +41371,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEKMON() {
-        IAtomContainer container = new AtomContainer(25, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -41434,7 +41435,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVENYUI() {
-        IAtomContainer container = new AtomContainer(24, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -41499,7 +41500,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVETWAS() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -41562,7 +41563,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEVDIJ() {
-        IAtomContainer container = new AtomContainer(29, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
@@ -41636,7 +41637,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEWZOM() {
-        IAtomContainer container = new AtomContainer(31, 33, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -41715,7 +41716,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEXKOY() {
-        IAtomContainer container = new AtomContainer(21, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -41773,7 +41774,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEXMOA() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -41838,7 +41839,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEYBIK() {
-        IAtomContainer container = new AtomContainer(24, 24, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("O", 0));
@@ -41900,7 +41901,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEYWAX() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -41932,7 +41933,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVEZBUX() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
@@ -41987,7 +41988,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVICGAP() {
-        IAtomContainer container = new AtomContainer(31, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -42065,7 +42066,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVICGET() {
-        IAtomContainer container = new AtomContainer(35, 37, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -42152,7 +42153,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVICKIB() {
-        IAtomContainer container = new AtomContainer(27, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -42221,7 +42222,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVICPOM() {
-        IAtomContainer container = new AtomContainer(26, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 1));
@@ -42289,7 +42290,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIDKUO() {
-        IAtomContainer container = new AtomContainer(21, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -42345,7 +42346,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIFFEV() {
-        IAtomContainer container = new AtomContainer(25, 28, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -42412,7 +42413,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIGPEG() {
-        IAtomContainer container = new AtomContainer(33, 34, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -42494,7 +42495,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIGTUA() {
-        IAtomContainer container = new AtomContainer(22, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -42556,7 +42557,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIHHID() {
-        IAtomContainer container = new AtomContainer(26, 27, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -42623,7 +42624,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIKVIU() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -42677,7 +42678,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIKYAP() {
-        IAtomContainer container = new AtomContainer(26, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -42747,7 +42748,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIMHII() {
-        IAtomContainer container = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("O", -1));
@@ -42769,7 +42770,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIPXAT() {
-        IAtomContainer container = new AtomContainer(24, 25, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -42832,7 +42833,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIRBON() {
-        IAtomContainer container = new AtomContainer(29, 30, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
@@ -42905,7 +42906,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIWCOT() {
-        IAtomContainer container = new AtomContainer(20, 21, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -42960,7 +42961,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIXRID() {
-        IAtomContainer container = new AtomContainer(16, 17, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -43007,7 +43008,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIXXOP() {
-        IAtomContainer container = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("F", 0));
@@ -43044,7 +43045,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVIYPAU() {
-        IAtomContainer container = new AtomContainer(30, 32, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -43121,7 +43122,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVOBLAZ() {
-        IAtomContainer container = new AtomContainer(29, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -43195,7 +43196,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVOBWOY() {
-        IAtomContainer container = new AtomContainer(21, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -43252,7 +43253,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVOFBOH() {
-        IAtomContainer container = new AtomContainer(25, 26, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("O", 0));
@@ -43317,7 +43318,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVOFCAU() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Br", 0));
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -43376,7 +43377,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVOJGEG() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 1));
         container.addAtom(newAtm("C", 0));
@@ -43406,7 +43407,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVOJJIN() {
-        IAtomContainer container = new AtomContainer(20, 20, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("N", 1));
@@ -43460,7 +43461,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVUWXUG() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -43492,7 +43493,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVUXGOK() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
@@ -43551,7 +43552,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVUXPUZ() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -43610,7 +43611,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testVUXREL() {
-        IAtomContainer container = new AtomContainer(22, 23, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -43669,7 +43670,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testZZZIZA01() {
-        IAtomContainer container = new AtomContainer(14, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -43710,7 +43711,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testZZZMVU10() {
-        IAtomContainer container = new AtomContainer(30, 31, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
@@ -43785,7 +43786,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testZZZVCQ01() {
-        IAtomContainer container = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("I", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -43822,7 +43823,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAR14A() {
-        IAtomContainer container = new AtomContainer(8, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -43851,7 +43852,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCA04A() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -43877,7 +43878,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCE05A() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -43907,7 +43908,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCO01A() {
-        IAtomContainer container = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
@@ -43927,7 +43928,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCO08A() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -43961,7 +43962,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testHL08A() {
-        IAtomContainer container = new AtomContainer(12, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -43998,7 +43999,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testIM02A() {
-        IAtomContainer container = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -44026,7 +44027,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNC10A() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -44056,7 +44057,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNC13A() {
-        IAtomContainer container = new AtomContainer(6, 5, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("H", 0));
@@ -44080,7 +44081,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNH10A() {
-        IAtomContainer container = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -44100,7 +44101,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNH20A() {
-        IAtomContainer container = new AtomContainer(14, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -44140,7 +44141,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNH22A() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("N", 1));
         container.addAtom(newAtm("C", 0));
@@ -44174,7 +44175,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNH23A() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -44208,7 +44209,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testOH10A() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -44234,7 +44235,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSR01A() {
-        IAtomContainer container = new AtomContainer(3, 2, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -44252,7 +44253,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSR05A() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("C", 0));
@@ -44278,7 +44279,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSR07A() {
-        IAtomContainer container = new AtomContainer(13, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -44317,7 +44318,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAN05A() {
-        IAtomContainer container = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", -1));
         container.addAtom(newAtm("H", 0));
@@ -44339,7 +44340,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAN06A() {
-        IAtomContainer container = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("H", 0));
@@ -44361,7 +44362,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAN08A() {
-        IAtomContainer container = new AtomContainer(6, 5, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", -1));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -44385,7 +44386,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAN11A() {
-        IAtomContainer container = new AtomContainer(6, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", -1));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -44410,7 +44411,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testAN12A() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", -1));
@@ -44436,7 +44437,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testHL11A() {
-        IAtomContainer container = new AtomContainer(9, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -44467,7 +44468,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testHL13A() {
-        IAtomContainer container = new AtomContainer(6, 5, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("F", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -44491,7 +44492,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNO03A() {
-        IAtomContainer container = new AtomContainer(6, 5, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("O", 0));
@@ -44515,7 +44516,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNX02A() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 1));
@@ -44549,7 +44550,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testOC02A() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 1));
@@ -44583,7 +44584,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPO02A() {
-        IAtomContainer container = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
@@ -44605,7 +44606,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPO05A() {
-        IAtomContainer container = new AtomContainer(13, 12, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("P", 0));
@@ -44643,7 +44644,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPR01A() {
-        IAtomContainer container = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -44663,7 +44664,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPR02A() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("H", 0));
@@ -44689,7 +44690,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPR03A() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("Cl", 0));
@@ -44715,7 +44716,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testPR04A() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("P", 0));
@@ -44749,7 +44750,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSI02A() {
-        IAtomContainer container = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("H", 0));
@@ -44777,7 +44778,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSI03A() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("O", 0));
@@ -44807,7 +44808,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSO07A() {
-        IAtomContainer container = new AtomContainer(22, 22, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
@@ -44865,7 +44866,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSO12A() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("O", 0));
@@ -44891,7 +44892,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSO15A() {
-        IAtomContainer container = new AtomContainer(12, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("O", 0));
@@ -44927,7 +44928,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSO16A() {
-        IAtomContainer container = new AtomContainer(11, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", 0));
@@ -44961,7 +44962,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testSO18A() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("S", 0));
@@ -44987,7 +44988,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testBRMW1() {
-        IAtomContainer container = new AtomContainer(4, 2, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45006,7 +45007,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCA2PW3() {
-        IAtomContainer container = new AtomContainer(10, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45035,7 +45036,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCLMW1() {
-        IAtomContainer container = new AtomContainer(4, 2, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45054,7 +45055,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCU1PW1() {
-        IAtomContainer container = new AtomContainer(4, 2, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45073,7 +45074,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testCU2PW3() {
-        IAtomContainer container = new AtomContainer(10, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45102,7 +45103,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFE2PW3() {
-        IAtomContainer container = new AtomContainer(10, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45131,7 +45132,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFE3PW3() {
-        IAtomContainer container = new AtomContainer(10, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45160,7 +45161,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testFMW1() {
-        IAtomContainer container = new AtomContainer(4, 2, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45179,7 +45180,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testH3OPW1() {
-        IAtomContainer container = new AtomContainer(7, 5, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45204,7 +45205,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testKPW1() {
-        IAtomContainer container = new AtomContainer(4, 2, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45223,7 +45224,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testLIPW1() {
-        IAtomContainer container = new AtomContainer(4, 2, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45242,7 +45243,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testMG2PW3() {
-        IAtomContainer container = new AtomContainer(10, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45271,7 +45272,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testNAPW() {
-        IAtomContainer container = new AtomContainer(4, 2, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45290,7 +45291,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testOHMW1() {
-        IAtomContainer container = new AtomContainer(5, 3, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45311,7 +45312,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testZN2PW3() {
-        IAtomContainer container = new AtomContainer(10, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("O", 0));
         container.addAtom(newAtm("H", 0));
         container.addAtom(newAtm("H", 0));
@@ -45340,7 +45341,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testERULE01() {
-        IAtomContainer container = new AtomContainer(14, 14, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("S", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
@@ -45381,7 +45382,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testERULE02() {
-        IAtomContainer container = new AtomContainer(11, 11, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -45416,7 +45417,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testERULE03() {
-        IAtomContainer container = new AtomContainer(19, 18, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("Si", 0));
         container.addAtom(newAtm("C", 0));
@@ -45467,7 +45468,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testERULE04() {
-        IAtomContainer container = new AtomContainer(10, 10, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("Cl", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("N", 0));
@@ -45500,7 +45501,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testERULE05() {
-        IAtomContainer container = new AtomContainer(6, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("P", 0));
         container.addAtom(newAtm("P", 0));
@@ -45525,7 +45526,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testERULE06() {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("C", 0));
         container.addAtom(newAtm("F", 0));
@@ -45557,7 +45558,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testERULE07() {
-        IAtomContainer container = new AtomContainer(14, 15, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));
@@ -45599,7 +45600,7 @@ abstract class AbstractMmffAtomTypeValidationSuiteTest {
      */
     @Test
     void testERULE08() {
-        IAtomContainer container = new AtomContainer(13, 13, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("N", 0));
         container.addAtom(newAtm("C", 0));

--- a/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/MmffAtomTypeMatcherTest.java
+++ b/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/MmffAtomTypeMatcherTest.java
@@ -31,7 +31,6 @@ import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import java.io.ByteArrayInputStream;

--- a/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/MmffAtomTypeMatcherTest.java
+++ b/tool/forcefield/src/test/java/org/openscience/cdk/forcefield/mmff/MmffAtomTypeMatcherTest.java
@@ -32,6 +32,7 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -49,7 +50,7 @@ class MmffAtomTypeMatcherTest {
 
     @Test
     void hydrogenCountMustBeDefined() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("C"));
         container.addAtom(new Atom("H"));
         container.addAtom(new Atom("H"));
@@ -67,7 +68,7 @@ class MmffAtomTypeMatcherTest {
 
     @Test
     void hydrogenCountMustBeExplicit() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("C"));
         container.getAtom(0).setImplicitHydrogenCount(4);
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
@@ -77,7 +78,7 @@ class MmffAtomTypeMatcherTest {
 
     @Test
     void aromaticCompoundsAreRejected() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("C"));
         container.getAtom(0).setImplicitHydrogenCount(4);
         container.getAtom(0).setFlag(CDKConstants.ISAROMATIC, true);
@@ -94,7 +95,7 @@ class MmffAtomTypeMatcherTest {
      */
     @Test
     void bug3523240IsResolved() throws Exception {
-        IAtomContainer container = new AtomContainer(50, 51, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("H", 0));
         container.addAtom(atom("O", 0));
         container.addAtom(atom("C", 0));
@@ -212,7 +213,7 @@ class MmffAtomTypeMatcherTest {
      */
     @Test
     void bug3524734IsResolved() throws Exception {
-        IAtomContainer container = new AtomContainer(10, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("H", 0));
         container.addAtom(atom("C", 0));
         container.addAtom(atom("H", 0));
@@ -245,7 +246,7 @@ class MmffAtomTypeMatcherTest {
      */
     @Test
     void hydroxyurea() {
-        IAtomContainer container = new AtomContainer(9, 8, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("H", 0));
         container.addAtom(atom("O", 0));
         container.addAtom(atom("N", 0));
@@ -275,7 +276,7 @@ class MmffAtomTypeMatcherTest {
      */
     @Test
     void molecularHydrogenDoesNotBreakAssignment() {
-        IAtomContainer container = new AtomContainer(2, 1, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("H", 0));
         container.addAtom(atom("H", 0));
         container.addBond(0, 1, SINGLE);
@@ -291,7 +292,7 @@ class MmffAtomTypeMatcherTest {
      */
     @Test
     void methylamine() {
-        IAtomContainer container = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("H", 0));
         container.addAtom(atom("N", 0));
         container.addAtom(atom("H", 0));
@@ -316,7 +317,7 @@ class MmffAtomTypeMatcherTest {
      */
     @Test
     void thiophene() {
-        IAtomContainer container = new AtomContainer(9, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("H", 0));
         container.addAtom(atom("C", 0));
         container.addAtom(atom("C", 0));
@@ -346,7 +347,7 @@ class MmffAtomTypeMatcherTest {
      */
     @Test
     void furane() {
-        IAtomContainer container = new AtomContainer(9, 9, 0, 0);
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("H", 0));
         container.addAtom(atom("C", 0));
         container.addAtom(atom("C", 0));
@@ -372,7 +373,7 @@ class MmffAtomTypeMatcherTest {
 
     @Test
     void methane() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("C", 0));
         container.addAtom(atom("H", 0));
         container.addAtom(atom("H", 0));

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -976,7 +976,7 @@ class MolecularFormulaManipulatorTest extends CDKTestCase {
      */
     @Test
     void testSingleAtomFromSmiles() throws CDKException {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new Atom("C"));
 
         // previously performed inside SmilesParser
@@ -1148,7 +1148,7 @@ class MolecularFormulaManipulatorTest extends CDKTestCase {
      */
     @Test
     void testHelium() {
-        IAtomContainer helium = new AtomContainer();
+        IAtomContainer helium = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         helium.addAtom(new Atom("He"));
 
         IMolecularFormula formula = MolecularFormulaManipulator.getMolecularFormula(helium);
@@ -1161,7 +1161,7 @@ class MolecularFormulaManipulatorTest extends CDKTestCase {
      */
     @Test
     void testAmericum() {
-        IAtomContainer helium = new AtomContainer();
+        IAtomContainer helium = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         helium.addAtom(new Atom("Am"));
 
         IMolecularFormula formula = MolecularFormulaManipulator.getMolecularFormula(helium);

--- a/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
+++ b/tool/formula/src/test/java/org/openscience/cdk/tools/manipulator/MolecularFormulaManipulatorTest.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.tools.manipulator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/AllEquivalentCyclicSetTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/AllEquivalentCyclicSetTest.java
@@ -27,7 +27,6 @@ package org.openscience.cdk.hash;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/AllEquivalentCyclicSetTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/AllEquivalentCyclicSetTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -113,7 +114,7 @@ class AllEquivalentCyclicSetTest {
      * @cdk.inchi InChI=1S/C10H16S4/c1-7-5-8(2)13-10(4,14-8)6-9(3,11-7)12-7/h5-6H2,1-4H3
      */
     private IAtomContainer cid241107() {
-        IAtomContainer m = new AtomContainer(14, 16, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom[] as = new IAtom[]{new Atom("C"), new Atom("C"), new Atom("C"), new Atom("C"), new Atom("S"),
                 new Atom("C"), new Atom("S"), new Atom("C"), new Atom("C"), new Atom("S"), new Atom("S"),
                 new Atom("C"), new Atom("C"), new Atom("C"),};
@@ -133,7 +134,7 @@ class AllEquivalentCyclicSetTest {
      * @cdk.inchi InChI=1S/C10H16S4/c1-7-5-8(2)13-9(3,11-7)6-10(4,12-7)14-8/h5-6H2,1-4H3
      */
     private IAtomContainer cid138898() {
-        IAtomContainer m = new AtomContainer(14, 16, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom[] as = new IAtom[]{new Atom("C"), new Atom("C"), new Atom("C"), new Atom("C"), new Atom("S"),
                 new Atom("C"), new Atom("S"), new Atom("C"), new Atom("C"), new Atom("S"), new Atom("S"),
                 new Atom("C"), new Atom("C"), new Atom("C"),};

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/HashCodeScenariosTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/HashCodeScenariosTest.java
@@ -808,7 +808,7 @@ class HashCodeScenariosTest {
     void butan2ol_UsingStereoElement() {
 
         // C[CH](O)CC
-        IAtomContainer butan2ol = new AtomContainer();
+        IAtomContainer butan2ol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         butan2ol.addAtom(new Atom("C"));
         butan2ol.addAtom(new Atom("C"));
         butan2ol.addAtom(new Atom("O"));
@@ -876,7 +876,7 @@ class HashCodeScenariosTest {
     void dichloroethenes_stereoElements() {
 
         // CLC=CCL
-        IAtomContainer dichloroethene = new AtomContainer();
+        IAtomContainer dichloroethene = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         dichloroethene.addAtom(new Atom("Cl"));
         dichloroethene.addAtom(new Atom("C"));
         dichloroethene.addAtom(new Atom("C"));
@@ -917,7 +917,7 @@ class HashCodeScenariosTest {
     void dichloroethenes_stereoElements_explicitH() {
 
         // CLC=CCL
-        IAtomContainer dichloroethene = new AtomContainer();
+        IAtomContainer dichloroethene = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         dichloroethene.addAtom(new Atom("Cl")); // Cl1
         dichloroethene.addAtom(new Atom("C")); // C2
         dichloroethene.addAtom(new Atom("C")); // C3
@@ -1015,7 +1015,7 @@ class HashCodeScenariosTest {
     void dichloroethenes_stereoElements_explicitH_suppressed() {
 
         // CLC=CCL
-        IAtomContainer dichloroethene = new AtomContainer();
+        IAtomContainer dichloroethene = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         dichloroethene.addAtom(new Atom("Cl")); // Cl1
         dichloroethene.addAtom(new Atom("C")); // C2
         dichloroethene.addAtom(new Atom("C")); // C3

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/HashCodeScenariosTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/HashCodeScenariosTest.java
@@ -28,7 +28,6 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.graph.AtomContainerAtomPermutor;

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/MinimumEquivalentCyclicSetUnionTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/MinimumEquivalentCyclicSetUnionTest.java
@@ -27,7 +27,6 @@ package org.openscience.cdk.hash;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/MinimumEquivalentCyclicSetUnionTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/MinimumEquivalentCyclicSetUnionTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -111,7 +112,7 @@ class MinimumEquivalentCyclicSetUnionTest {
      * @cdk.inchi InChI=1S/C13H17N/c1-10-2-4-11(5-3-10)14-12-6-7-13(14)9-8-12/h2-5,12-13H,6-9H2,1H3
      */
     private IAtomContainer cid44333798() {
-        IAtomContainer m = new AtomContainer(14, 16, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom[] as = new IAtom[]{new Atom("C"), new Atom("C"), new Atom("C"), new Atom("C"), new Atom("C"),
                 new Atom("C"), new Atom("C"), new Atom("N"), new Atom("C"), new Atom("C"), new Atom("C"),
                 new Atom("C"), new Atom("C"), new Atom("C"),};
@@ -131,7 +132,7 @@ class MinimumEquivalentCyclicSetUnionTest {
      * @cdk.inchi InChI=1S/C13H17N/c1-10-2-4-11(5-3-10)14(12-6-7-12)13-8-9-13/h2-5,12-13H,6-9H2,1H3
      */
     private IAtomContainer cid57170558() {
-        IAtomContainer m = new AtomContainer(14, 16, 0, 0);
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         IAtom[] as = new IAtom[]{new Atom("C"), new Atom("C"), new Atom("C"), new Atom("C"), new Atom("C"),
                 new Atom("C"), new Atom("C"), new Atom("N"), new Atom("C"), new Atom("C"), new Atom("C"),
                 new Atom("C"), new Atom("C"), new Atom("C"),};

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/PerturbedAtomHashGeneratorTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/PerturbedAtomHashGeneratorTest.java
@@ -27,7 +27,6 @@ package org.openscience.cdk.hash;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.hash.stereo.StereoEncoderFactory;

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/PerturbedAtomHashGeneratorTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/PerturbedAtomHashGeneratorTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.hash.stereo.StereoEncoderFactory;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -94,7 +95,7 @@ class PerturbedAtomHashGeneratorTest {
                 new Bond(atoms[5], atoms[9], SINGLE), new Bond(atoms[6], atoms[7], SINGLE),
                 new Bond(atoms[7], atoms[8], SINGLE), new Bond(atoms[8], atoms[9], SINGLE),
                 new Bond(atoms[8], atoms[0], SINGLE),};
-        IAtomContainer mol = new AtomContainer(0, 0, 0, 0);
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.setAtoms(atoms);
         mol.setBonds(bonds);
         return mol;
@@ -112,7 +113,7 @@ class PerturbedAtomHashGeneratorTest {
                 new Bond(atoms[5], atoms[4], SINGLE), new Bond(atoms[4], atoms[7], SINGLE),
                 new Bond(atoms[6], atoms[9], SINGLE), new Bond(atoms[7], atoms[8], SINGLE),
                 new Bond(atoms[8], atoms[9], SINGLE),};
-        IAtomContainer mol = new AtomContainer(0, 0, 0, 0);
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         mol.setAtoms(atoms);
         mol.setBonds(bonds);
         return mol;

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactoryTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -61,7 +62,7 @@ class GeometricCumulativeDoubleBondFactoryTest {
 
     @Test
     void testCreate() throws Exception {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(carbonAt(-0.2994, 3.2084));
         m.addAtom(carbonAt(-1.1244, 3.2084));
         m.addAtom(carbonAt(-1.9494, 3.2084));

--- a/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactoryTest.java
+++ b/tool/hash/src/test/java/org/openscience/cdk/hash/stereo/GeometricCumulativeDoubleBondFactoryTest.java
@@ -35,7 +35,6 @@ import javax.vecmath.Point2d;
 
 import org.junit.jupiter.api.Assertions;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtom;

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/AtomPlacerTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/AtomPlacerTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.CDKConstants;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -76,7 +77,7 @@ class AtomPlacerTest extends CDKTestCase {
 
     @Test
     void cumulated_x2() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3));
         m.addAtom(atom("C", 1));
         m.addAtom(atom("C", 0));
@@ -110,7 +111,7 @@ class AtomPlacerTest extends CDKTestCase {
 
     @Test
     void cumulated_x3() {
-        IAtomContainer m = new AtomContainer(6, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3));
         m.addAtom(atom("C", 1));
         m.addAtom(atom("C", 0));

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/AtomPlacerTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/AtomPlacerTest.java
@@ -37,7 +37,6 @@ import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.silent.AtomContainer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/CorrectGeometricConfigurationTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/CorrectGeometricConfigurationTest.java
@@ -30,7 +30,6 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/CorrectGeometricConfigurationTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/CorrectGeometricConfigurationTest.java
@@ -31,6 +31,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 
 import javax.vecmath.Point2d;
@@ -47,7 +48,7 @@ class CorrectGeometricConfigurationTest {
     // C/C=C/CCC
     @Test
     void cis() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -0.74d, 5.00d));
         m.addAtom(atom("C", 1, -1.49d, 3.70d));
         m.addAtom(atom("C", 1, -0.74d, 2.40d));
@@ -70,7 +71,7 @@ class CorrectGeometricConfigurationTest {
     // C/C=C\CCC
     @Test
     void trans() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -0.74d, 5.00d));
         m.addAtom(atom("C", 1, -1.49d, 3.70d));
         m.addAtom(atom("C", 1, -0.74d, 2.40d));

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/HydrogenPlacerTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/HydrogenPlacerTest.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.layout;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/HydrogenPlacerTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/HydrogenPlacerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;
@@ -47,7 +48,7 @@ class HydrogenPlacerTest extends CDKTestCase {
     void testAtomWithoutCoordinates() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             HydrogenPlacer hydrogenPlacer = new HydrogenPlacer();
-            hydrogenPlacer.placeHydrogens2D(new AtomContainer(), new Atom(), 1.5);
+            hydrogenPlacer.placeHydrogens2D(DefaultChemObjectBuilder.getInstance().newAtomContainer(), new Atom(), 1.5);
         });
     }
 
@@ -62,7 +63,7 @@ class HydrogenPlacerTest extends CDKTestCase {
     @Test
     void testNoConnections() {
         HydrogenPlacer hydrogenPlacer = new HydrogenPlacer();
-        AtomContainer  container      = new AtomContainer();
+        IAtomContainer  container     = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom           atom         = new Atom("C", new Point2d(0, 0));
         container.addAtom(atom);
         hydrogenPlacer.placeHydrogens2D(container, atom, 1.5);
@@ -76,7 +77,7 @@ class HydrogenPlacerTest extends CDKTestCase {
         // h1 has no coordinates
         IAtom h1 = new Atom("H");
         IAtom h2 = new Atom("H", new Point2d(0, 0));
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(h1);
         m.addAtom(h2);
         m.addBond(new Bond(h1, h2));
@@ -92,7 +93,7 @@ class HydrogenPlacerTest extends CDKTestCase {
             // c2 is unplaced
             IAtom c1 = new Atom("C", new Point2d(0, 0));
             IAtom c2 = new Atom("C");
-            IAtomContainer m = new AtomContainer();
+            IAtomContainer m = DefaultChemObjectBuilder.getInstance().newAtomContainer();
             m.addAtom(c1);
             m.addAtom(c2);
             m.addBond(new Bond(c1, c2));
@@ -103,7 +104,7 @@ class HydrogenPlacerTest extends CDKTestCase {
     /** @cdk.bug 933572 */
     @Test
     void testBug933572() throws Exception {
-        IAtomContainer ac = new AtomContainer();
+        IAtomContainer ac = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         ac.addAtom(new Atom("H"));
         ac.getAtom(0).setPoint2d(new Point2d(0, 0));
         addExplicitHydrogens(ac);
@@ -117,7 +118,7 @@ class HydrogenPlacerTest extends CDKTestCase {
     @Test
     void testPlaceHydrogens2D() throws Exception {
         HydrogenPlacer hydrogenPlacer = new HydrogenPlacer();
-        IAtomContainer dichloromethane = new AtomContainer();
+        IAtomContainer dichloromethane = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom carbon = new Atom("C");
         Point2d carbonPos = new Point2d(0.0, 0.0);
         carbon.setPoint2d(carbonPos);

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/IdentityTemplateLibraryTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/IdentityTemplateLibraryTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import javax.vecmath.Point2d;

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/IdentityTemplateLibraryTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/IdentityTemplateLibraryTest.java
@@ -30,6 +30,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import javax.vecmath.Point2d;
 import java.io.ByteArrayOutputStream;
@@ -80,7 +81,7 @@ class IdentityTemplateLibraryTest {
 
     @Test
     void assignEthanolNoEntry() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("O"));
         container.addAtom(new Atom("C"));
         container.addAtom(new Atom("C"));
@@ -95,7 +96,7 @@ class IdentityTemplateLibraryTest {
 
     @Test
     void assignEthanol() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(new Atom("O"));
         container.addAtom(new Atom("C"));
         container.addAtom(new Atom("C"));

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
@@ -69,7 +69,7 @@ class NonPlanarBondsTest {
     // [C@H](C)(N)O
     @Test
     void clockwise_implH_1() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, 0.00d, 1.50d));
         m.addAtom(atom("C", 3, 0.00d, 0.00d));
         m.addAtom(atom("N", 2, -1.30d, 2.25d));
@@ -89,7 +89,7 @@ class NonPlanarBondsTest {
     // N is favoured over CC
     @Test
     void clockwise_implH_2() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -1.30d, 2.25d));
         m.addAtom(atom("C", 2, 0.00d, 1.50d));
         m.addAtom(atom("C", 3, 0.00d, 0.00d));
@@ -111,7 +111,7 @@ class NonPlanarBondsTest {
     // [C@H](C)(N)O
     @Test
     void anticlockwise_implH_1() {
-        IAtomContainer m = new AtomContainer(4, 3, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, 0.00d, 1.50d));
         m.addAtom(atom("C", 3, 0.00d, 0.00d));
         m.addAtom(atom("N", 2, -1.30d, 2.25d));
@@ -131,7 +131,7 @@ class NonPlanarBondsTest {
     // N is favoured over CC
     @Test
     void anticlockwise_implH_2() {
-        IAtomContainer m = new AtomContainer(5, 4, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -1.30d, 2.25d));
         m.addAtom(atom("C", 2, 0.00d, 1.50d));
         m.addAtom(atom("C", 3, 0.00d, 0.00d));
@@ -153,7 +153,7 @@ class NonPlanarBondsTest {
     // [C@@](CCC)(C)(N)O
     @Test
     void clockwise_1() {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -1.47d, 3.62d));
         m.addAtom(atom("C", 2, -1.13d, 2.16d));
         m.addAtom(atom("C", 2, 0.30d, 1.72d));
@@ -179,7 +179,7 @@ class NonPlanarBondsTest {
     // [C@@](CCC)(C1)(C)C1 (favour acyclic)
     @Test
     void clockwise_2() {
-        IAtomContainer m = new AtomContainer(8, 8, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -0.96d, -1.04d));
         m.addAtom(atom("C", 2, 0.18d, -0.08d));
         m.addAtom(atom("C", 2, -0.08d, 1.40d));
@@ -208,7 +208,7 @@ class NonPlanarBondsTest {
     // [C@](CCC)(C)(N)O
     @Test
     void anticlockwise_1() {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -1.47d, 3.62d));
         m.addAtom(atom("C", 2, -1.13d, 2.16d));
         m.addAtom(atom("C", 2, 0.30d, 1.72d));
@@ -234,7 +234,7 @@ class NonPlanarBondsTest {
     // [C@](CCC)(C1)(C)C1 (favour acyclic)
     @Test
     void anticlockwise_2() {
-        IAtomContainer m = new AtomContainer(8, 8, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, -0.96d, -1.04d));
         m.addAtom(atom("C", 2, 0.18d, -0.08d));
         m.addAtom(atom("C", 2, -0.08d, 1.40d));
@@ -262,7 +262,7 @@ class NonPlanarBondsTest {
 
     @Test
     void nonPlanarBondsForAntiClockwsieExtendedTetrahedral() throws CDKException {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 0, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -285,7 +285,7 @@ class NonPlanarBondsTest {
 
     @Test
     void nonPlanarBondsForClockwsieExtendedTetrahedral() throws CDKException {
-        IAtomContainer m = new AtomContainer(7, 6, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, -1.56d, 0.78d));
         m.addAtom(atom("C", 0, -1.13d, 1.49d));
         m.addAtom(atom("C", 0, -0.31d, 1.47d));
@@ -308,7 +308,7 @@ class NonPlanarBondsTest {
 
     @Test
     void clockwiseSortShouldHandleExactlyOppositeAtoms() throws Exception {
-        IAtomContainer m = new AtomContainer(8, 7, 0, 0);
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 0, 4.50d, -14.84d));
         m.addAtom(atom("C", 3, 4.51d, -13.30d));
         m.addAtom(atom("C", 2, 4.93d, -14.13d));
@@ -334,7 +334,7 @@ class NonPlanarBondsTest {
     // ethene is left alone and not marked as crossed
     @Test
     void dontCrossEtheneDoubleBond() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 2, 0.000, 0.000));
         m.addAtom(atom("C", 2, 1.299, -0.750));
         m.addBond(0, 1, IBond.Order.DOUBLE);
@@ -347,7 +347,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void dontMarkTerminalBonds() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, 0.000, 0.000));
         m.addAtom(atom("C", 0, 1.299, -0.750));
         m.addAtom(atom("C", 2, 2.598, -0.000));
@@ -368,7 +368,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void markBut2eneWithWavyBond() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, 0.000, 0.000));
         m.addAtom(atom("C", 1, 1.299, -0.750));
         m.addAtom(atom("C", 1, 2.598, -0.000));
@@ -385,7 +385,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void useCrossedBondIfNeeded() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, 0.000, 0.000));
         m.addAtom(atom("C", 1, 1.299, -0.750));
         m.addAtom(atom("C", 1, 2.598, -0.000));
@@ -422,7 +422,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void dontMarkTetrahedralCentresWithDoubleBondsAsUnspecified() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 3, 2.598, 1.500));
         m.addAtom(atom("S", 0, 2.598, -0.000));
         m.addAtom(atom("C", 1, 1.299, -0.750));
@@ -446,7 +446,7 @@ class NonPlanarBondsTest {
 
     @Test
     void dontMarkRingBondsInBezeneAsUnspecified() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("C", 1, -1.299, 0.750));
         m.addAtom(atom("C", 1, 0.000, 1.500));
         m.addAtom(atom("C", 1, 1.299, 0.750));
@@ -470,7 +470,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void dontMarkGuanidineAsUnspecified() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("R", 0, 0.00, 0.00));
         m.addAtom(atom("C", 2, 1.30, -0.75));
         m.addAtom(atom("N", 0, 2.60, -0.00));
@@ -492,7 +492,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void dontUnspecifiedDueToHRepresentation() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("R", 0, 0.00, 0.00));
         m.addAtom(atom("C", 2, 1.30, -0.75));
         m.addAtom(atom("N", 0, 2.60, -0.00));
@@ -524,7 +524,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void dontMarkUnspecifiedForLinearEqualChains() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("R", 0, 0.00, -0.00));
         m.addAtom(atom("C", 2, 1.30, -0.75));
         m.addAtom(atom("N", 0, 2.60, -0.00));
@@ -554,7 +554,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void markUnspecifiedForCyclicLigands() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("R", 0, -4.22, 3.05));
         m.addAtom(atom("C", 2, -2.92, 2.30));
         m.addAtom(atom("N", 0, -1.62, 3.05));
@@ -587,7 +587,7 @@ class NonPlanarBondsTest {
      */
     @Test
     void unspecifiedMarkedOnDifferentLigands() {
-        IAtomContainer m = new AtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("R", 0, 0.00, -0.00));
         m.addAtom(atom("C", 2, 1.30, -0.75));
         m.addAtom(atom("N", 0, 2.60, -0.00));

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
@@ -34,10 +34,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
-import org.openscience.cdk.io.MDLV2000Reader;
-import org.openscience.cdk.io.MDLV2000Writer;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.stereo.Atropisomeric;
@@ -45,13 +42,9 @@ import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.stereo.ExtendedTetrahedral;
 import org.openscience.cdk.stereo.StereoElementFactory;
 import org.openscience.cdk.stereo.TetrahedralChirality;
-import org.openscience.cdk.tools.ILoggingTool;
-import org.openscience.cdk.tools.LoggingToolFactory;
 
 import javax.vecmath.Point2d;
 
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/NonPlanarBondsTest.java
@@ -579,7 +579,7 @@ class NonPlanarBondsTest {
         for (IBond bond : m.bonds())
             if (bond.getStereo() == IBond.Stereo.UP_OR_DOWN)
                 wavyCount++;
-        assertThat(wavyCount, is(1));
+        assertThat(wavyCount, is(0));
     }
 
     /**

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/OverlapResolverTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/OverlapResolverTest.java
@@ -155,7 +155,7 @@ class OverlapResolverTest extends CDKTestCase {
         IAtomContainer atomContainer = new SmilesParser(DefaultChemObjectBuilder.getInstance())
                 .parseSmiles("OC4C(N2C1=C(C(=NC(=N1)SC)SC)C3=C2N=CN=C3N)OC(C4O)CO");
         StructureDiagramGenerator sdg = new StructureDiagramGenerator();
-        sdg.setMolecule(new AtomContainer(atomContainer));
+        sdg.setMolecule(DefaultChemObjectBuilder.getInstance().newInstance(IAtomContainer.class, atomContainer));
         sdg.generateCoordinates();
         atomContainer = sdg.getMolecule();
         OverlapResolver or = new OverlapResolver();

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/OverlapResolverTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/OverlapResolverTest.java
@@ -23,7 +23,6 @@ import java.util.Vector;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.interfaces.IAtomContainer;

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
@@ -150,7 +150,7 @@ class StructureDiagramGeneratorTest extends CDKTestCase {
     @Test
     void testBridgedHydrogen() throws Exception {
         Assertions.assertTimeout(Duration.ofMillis(2500), () -> {
-            IAtomContainer mol = new AtomContainer();
+            IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
             IAtom carbon1 = new Atom("C");
             IAtom carbon2 = new Atom("C");
             IAtom bridgingHydrogen = new Atom("H");
@@ -326,7 +326,7 @@ class StructureDiagramGeneratorTest extends CDKTestCase {
     @Test
     void testBug780545() throws Exception {
         Assertions.assertTimeout(Duration.ofMillis(2500), () -> {
-            IAtomContainer mol = new AtomContainer();
+            IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
             mol.addAtom(new Atom("C"));
             IAtomContainer ac = layout(mol);
             Assertions.assertTrue(GeometryUtil.has2DCoordinates(ac));
@@ -1090,7 +1090,7 @@ class StructureDiagramGeneratorTest extends CDKTestCase {
 
     @Test
     void placeCrossingSgroupBrackets() throws Exception {
-        IAtomContainer mol = new org.openscience.cdk.silent.AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));
@@ -1122,7 +1122,7 @@ class StructureDiagramGeneratorTest extends CDKTestCase {
 
     @Test
     void placeNonCrossingSgroupBrackets() throws Exception {
-        IAtomContainer mol = new org.openscience.cdk.silent.AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));
@@ -1152,7 +1152,7 @@ class StructureDiagramGeneratorTest extends CDKTestCase {
 
     @Test
     void placeOverlappingCrossingSgroupBrackets() throws Exception {
-        IAtomContainer mol = new org.openscience.cdk.silent.AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));
         mol.addAtom(new org.openscience.cdk.silent.Atom("C"));

--- a/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
+++ b/tool/sdg/src/test/java/org/openscience/cdk/layout/StructureDiagramGeneratorTest.java
@@ -23,7 +23,6 @@ package org.openscience.cdk.layout;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.ChemFile;
 import org.openscience.cdk.ChemObject;

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingsTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/MappingsTest.java
@@ -31,22 +31,18 @@ import org.openscience.cdk.interfaces.*;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.StreamSupport;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/QueryStereoFilterTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/QueryStereoFilterTest.java
@@ -30,7 +30,6 @@ import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
 import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
 import org.openscience.cdk.silent.Atom;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smarts.Smarts;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;

--- a/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/QueryStereoFilterTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/isomorphism/QueryStereoFilterTest.java
@@ -31,6 +31,7 @@ import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
 import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
 import org.openscience.cdk.silent.Atom;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smarts.Smarts;
 import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.stereo.TetrahedralChirality;
@@ -350,7 +351,7 @@ class QueryStereoFilterTest {
     }
 
     static IAtomContainer dimethylpropane() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("C", 0));
         container.addAtom(atom("C", 3));
         container.addAtom(atom("C", 3));
@@ -364,7 +365,7 @@ class QueryStereoFilterTest {
     }
 
     static IAtomContainer but2ene() {
-        IAtomContainer container = new AtomContainer();
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         container.addAtom(atom("C", 1));
         container.addAtom(atom("C", 1));
         container.addAtom(atom("C", 3));

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
@@ -37,7 +37,6 @@ import org.openscience.cdk.isomorphism.matchers.Expr;
 import org.openscience.cdk.isomorphism.matchers.QueryAtom;
 import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
 import org.openscience.cdk.isomorphism.matchers.QueryBond;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import static org.hamcrest.CoreMatchers.anyOf;

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsExprReadTest.java
@@ -38,6 +38,7 @@ import org.openscience.cdk.isomorphism.matchers.QueryAtom;
 import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
 import org.openscience.cdk.isomorphism.matchers.QueryBond;
 import org.openscience.cdk.silent.AtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -71,7 +72,7 @@ class SmartsExprReadTest {
     }
 
     static Expr getAtomExpr(String sma, int flav) {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, sma, flav));
         return getAtomExpr(mol.getAtom(0));
     }
@@ -81,7 +82,7 @@ class SmartsExprReadTest {
     }
 
     static Expr getBondExpr(String sma, int flav) {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, sma, flav));
         return getBondExpr(mol.getBond(0));
     }
@@ -92,7 +93,7 @@ class SmartsExprReadTest {
 
     @Test
     void trailingOperator() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(Smarts.parse(mol, "[a#6,]"));
         Assertions.assertFalse(Smarts.parse(mol, "[a#6;]"));
         Assertions.assertFalse(Smarts.parse(mol, "[a#6&]"));
@@ -101,7 +102,7 @@ class SmartsExprReadTest {
 
     @Test
     void leadingOperator() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(Smarts.parse(mol, "[,a#6]"));
         Assertions.assertFalse(Smarts.parse(mol, "[;a#6]"));
         Assertions.assertFalse(Smarts.parse(mol, "[&a#6]"));
@@ -110,7 +111,7 @@ class SmartsExprReadTest {
 
     @Test
     void trailingBondOperator() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(Smarts.parse(mol, "*-,*"));
         Assertions.assertFalse(Smarts.parse(mol, "*-;*"));
         Assertions.assertFalse(Smarts.parse(mol, "*-&*"));
@@ -119,7 +120,7 @@ class SmartsExprReadTest {
 
     @Test
     void leadingBondOperator() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(Smarts.parse(mol, "*,-*"));
         Assertions.assertFalse(Smarts.parse(mol, "*;-*"));
         Assertions.assertFalse(Smarts.parse(mol, "*&-*"));
@@ -128,7 +129,7 @@ class SmartsExprReadTest {
 
     @Test
     void opPrecedence1() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[a#6,a#7]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = or(and(expr(IS_AROMATIC), expr(ELEMENT, 6)),
@@ -138,7 +139,7 @@ class SmartsExprReadTest {
 
     @Test
     void opPrecedence2() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[a;#6,#7]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = and(expr(IS_AROMATIC),
@@ -148,7 +149,7 @@ class SmartsExprReadTest {
 
     @Test
     void opPrecedence3() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[#6,#7;a]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = and(expr(IS_AROMATIC),
@@ -158,7 +159,7 @@ class SmartsExprReadTest {
 
     @Test
     void opPrecedence4() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[#6,#7a]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = or(expr(ELEMENT, 6),
@@ -168,7 +169,7 @@ class SmartsExprReadTest {
 
     @Test
     void opPrecedence5() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[#6&a,#7]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = or(expr(ELEMENT, 7),
@@ -178,7 +179,7 @@ class SmartsExprReadTest {
 
     @Test
     void orList() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[F,Cl,Br,I]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = or(expr(ELEMENT, 9),
@@ -190,7 +191,7 @@ class SmartsExprReadTest {
 
     @Test
     void explicitHydrogen() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[2H+]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = and(expr(ISOTOPE, 2),
@@ -200,7 +201,7 @@ class SmartsExprReadTest {
 
     @Test
     void explicitHydrogenNeg() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[H-]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = and(expr(ELEMENT, 1),
@@ -210,7 +211,7 @@ class SmartsExprReadTest {
 
     @Test
     void explicitHydrogenWithAtomMap() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[2H+:2]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = and(expr(ISOTOPE, 2),
@@ -224,13 +225,13 @@ class SmartsExprReadTest {
 
     @Test
     void explicitHydrogenWithBadAtomMap() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(Smarts.parse(mol, "[2H+:]"));
     }
 
     @Test
     void nonExplicitHydrogen() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[2&H+]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = and(expr(ISOTOPE, 2),
@@ -241,7 +242,7 @@ class SmartsExprReadTest {
 
     @Test
     void nonExplicitHydrogen2() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[2,H+]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = or(expr(ISOTOPE, 2),
@@ -252,7 +253,7 @@ class SmartsExprReadTest {
 
     @Test
     void nonExplicitHydrogen3() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[2H1+]"));
         Expr actual = getAtomExpr(mol.getAtom(0));
         Expr expected = and(expr(ISOTOPE, 2),
@@ -403,7 +404,7 @@ class SmartsExprReadTest {
 
     @Test
     void ringSmallestInvalid() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[r0]")); // not in ring
         Assertions.assertFalse(Smarts.parse(mol, "[r1]"));
         Assertions.assertFalse(Smarts.parse(mol, "[r2]"));
@@ -427,7 +428,7 @@ class SmartsExprReadTest {
 
     @Test
     void ringSize() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[Z8]", Smarts.FLAVOR_DAYLIGHT));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(RING_SIZE, 8);
@@ -436,7 +437,7 @@ class SmartsExprReadTest {
 
     @Test
     void ringSize0() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[Z0]", Smarts.FLAVOR_DAYLIGHT));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(IS_IN_CHAIN);
@@ -445,7 +446,7 @@ class SmartsExprReadTest {
 
     @Test
     void ringSizeDefault() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[Z]", Smarts.FLAVOR_DAYLIGHT));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(IS_IN_RING);
@@ -454,7 +455,7 @@ class SmartsExprReadTest {
 
     @Test
     void adjacentHeteroCount() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[Z2]", Smarts.FLAVOR_CACTVS));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(ALIPHATIC_HETERO_SUBSTITUENT_COUNT, 2);
@@ -463,7 +464,7 @@ class SmartsExprReadTest {
 
     @Test
     void adjacentHetero() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[Z]", Smarts.FLAVOR_CACTVS));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(HAS_ALIPHATIC_HETERO_SUBSTITUENT);
@@ -472,7 +473,7 @@ class SmartsExprReadTest {
 
     @Test
     void adjacentHetero0() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertTrue(Smarts.parse(mol, "[Z0]", Smarts.FLAVOR_CACTVS));
         Expr actual   = getAtomExpr(mol.getAtom(0));
         Expr expected = expr(HAS_ALIPHATIC_HETERO_SUBSTITUENT).negate();
@@ -702,7 +703,7 @@ class SmartsExprReadTest {
 
     @Test
     void badExprs() {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
         Assertions.assertFalse(Smarts.parse(mol, "*-,*"));
         Assertions.assertFalse(Smarts.parse(mol, "*-;*"));
         Assertions.assertFalse(Smarts.parse(mol, "*-!*"));

--- a/tool/structgen/src/test/java/org/openscience/cdk/atomtype/StructGenAtomTypeGuesserTest.java
+++ b/tool/structgen/src/test/java/org/openscience/cdk/atomtype/StructGenAtomTypeGuesserTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomType;
@@ -37,7 +38,7 @@ class StructGenAtomTypeGuesserTest extends CDKTestCase {
 
     @Test
     void testPossibleAtomTypes_IAtomContainer_IAtom() throws java.lang.Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("C");
         atom.setImplicitHydrogenCount(3);
         Atom atom2 = new Atom("N");

--- a/tool/structgen/src/test/java/org/openscience/cdk/atomtype/StructGenAtomTypeGuesserTest.java
+++ b/tool/structgen/src/test/java/org/openscience/cdk/atomtype/StructGenAtomTypeGuesserTest.java
@@ -21,7 +21,6 @@ package org.openscience.cdk.atomtype;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.Bond;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.test.CDKTestCase;

--- a/tool/structgen/src/test/java/org/openscience/cdk/atomtype/StructGenMatcherTest.java
+++ b/tool/structgen/src/test/java/org/openscience/cdk/atomtype/StructGenMatcherTest.java
@@ -90,7 +90,7 @@ class StructGenMatcherTest extends AbstractAtomTypeTest {
 
     @Test
     void testN3() throws Exception {
-        IAtomContainer mol = new AtomContainer();
+        IAtomContainer mol = DefaultChemObjectBuilder.getInstance().newAtomContainer();
         Atom atom = new Atom("N");
         atom.setImplicitHydrogenCount(3);
         mol.addAtom(atom);

--- a/tool/structgen/src/test/java/org/openscience/cdk/atomtype/StructGenMatcherTest.java
+++ b/tool/structgen/src/test/java/org/openscience/cdk/atomtype/StructGenMatcherTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.openscience.cdk.Atom;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.config.AtomTypeFactory;
 import org.openscience.cdk.interfaces.IAtom;

--- a/tool/structgen/src/test/java/org/openscience/cdk/structgen/SingleStructureRandomGeneratorTest.java
+++ b/tool/structgen/src/test/java/org/openscience/cdk/structgen/SingleStructureRandomGeneratorTest.java
@@ -43,7 +43,7 @@ class SingleStructureRandomGeneratorTest {
         System.out.println("Instantiating SingleStructureRandomGenerator");
         ssrg = new SingleStructureRandomGenerator();
         System.out.println("Assining unbonded set of atoms");
-        AtomContainer ac = getBunchOfUnbondedAtoms();
+        IAtomContainer ac = getBunchOfUnbondedAtoms();
         mf = MolecularFormulaManipulator.getString(MolecularFormulaManipulator.getMolecularFormula(ac));
         System.out.println("Molecular Formula is: " + mf);
         ssrg.setAtomContainer(ac);
@@ -56,11 +56,11 @@ class SingleStructureRandomGeneratorTest {
         return true;
     }
 
-    private AtomContainer getBunchOfUnbondedAtoms() {
+    private IAtomContainer getBunchOfUnbondedAtoms() {
         IAtomContainer molecule = TestMoleculeFactory.makeAlphaPinene();
         fixCarbonHCount(molecule);
         molecule.removeAllElectronContainers();
-        return (AtomContainer) molecule;
+        return molecule;
     }
 
     private void fixCarbonHCount(IAtomContainer mol) {

--- a/tool/tautomer/src/test/java/org/openscience/cdk/tautomers/InChITautomerGeneratorTest.java
+++ b/tool/tautomer/src/test/java/org/openscience/cdk/tautomers/InChITautomerGeneratorTest.java
@@ -185,7 +185,7 @@ class InChITautomerGeneratorTest extends CDKTestCase {
                 + "  7  9  2  0  0  0  0\n" + "  2  9  1  0  0  0  0\n" + "M  END\n";
 
         MDLV2000Reader reader = new MDLV2000Reader(new StringReader(mdlInput));
-        IAtomContainer molecule = reader.read(new AtomContainer());
+        IAtomContainer molecule = reader.read(DefaultChemObjectBuilder.getInstance().newAtomContainer());
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
         CDKHydrogenAdder hAdder = CDKHydrogenAdder.getInstance(molecule.getBuilder());
         hAdder.addImplicitHydrogens(molecule);

--- a/tool/tautomer/src/test/java/org/openscience/cdk/tautomers/InChITautomerGeneratorTest.java
+++ b/tool/tautomer/src/test/java/org/openscience/cdk/tautomers/InChITautomerGeneratorTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
-import org.openscience.cdk.AtomContainer;
 import org.openscience.cdk.test.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;


### PR DESCRIPTION
This PR breaks the API by forcing uses to create AtomContainer's via the builder. This is mainly so we can ensure in our code everything is created via a builder.

When we rename AtomContainer2 -> AtomContainer we will make the requires methods public.