### PR TITLE
Binconnected - faster ring atom/bond marking

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -445,7 +445,7 @@ public class Abbreviations implements Iterable<String> {
         final EdgeToBondMap bmap = EdgeToBondMap.withSpaceFor(mol);
         final int[][] adjlist = GraphUtil.toAdjList(mol, bmap);
 
-        Cycles.markRingAtomsAndBonds(mol, adjlist, bmap);
+        Cycles.markRingAtomsAndBonds(mol);
 
         Set<IBond> cuts = findCutBonds(mol, bmap, adjlist);
 

--- a/base/core/src/main/java/org/openscience/cdk/graph/BiconnectedComponents.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/BiconnectedComponents.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2024 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.graph;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+
+/**
+ * Internal API - use {@link Cycles#markRingAtomsAndBonds}.
+ * <br/>
+ * Find and mark the atom/bonds in a molecule use the standard Hopcroft/Tarjan
+ * algorithm to find biconnected components using articulation points.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Biconnected_component">
+ *      Biconnected Component (Wiki)</a>
+ * @author John Mayfield (né May)
+ */
+final class BiconnectedComponents {
+
+    private int   remaining;
+    private int   numBackEdges;
+    private final int[] visit;
+
+    private BiconnectedComponents(final IAtomContainer mol)
+    {
+        visit = new int[mol.getAtomCount()];
+        remaining = mol.getAtomCount();
+    }
+
+    /**
+     * Visit the next atom.
+     *
+     * @param atom  current atom
+     * @param prev  bond we came from (nullable)
+     * @param depth current depth
+     * @return the lowest point reached
+     */
+    private int visit(final IAtom atom, final IBond prev, final int depth) {
+        visit[atom.getIndex()] = depth;
+        remaining--;
+        int lo = depth + 1;
+        for (IBond bond : atom.bonds()) {
+            if (bond == prev)
+                continue;
+            final IAtom nbr   = bond.getOther(atom);
+            final int   visit = this.visit[nbr.getIndex()];
+            if (visit == 0) {
+                final int res = visit(nbr, bond, depth + 1);
+                bond.setIsInRing(res <= depth);
+                lo = Math.min(res, lo);
+            } else if (visit < depth) {
+                numBackEdges++;
+                bond.setIsInRing(true);
+                lo = Math.min(visit, lo);
+            }
+        }
+        atom.setIsInRing(lo <= depth);
+        return lo;
+    }
+
+    static int mark(IAtomContainer mol)
+    {
+        BiconnectedComponents state = new BiconnectedComponents(mol);
+        for (IAtom atom : mol.atoms()) {
+            if (state.visit[atom.getIndex()] == 0)
+                state.visit(atom, null, 1);
+            // commonly we have a single connected component and visit all atoms
+            // in the first traversal
+            if (state.remaining == 0)
+                break;
+        }
+        return state.numBackEdges;
+    }
+}

--- a/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
@@ -570,8 +570,7 @@ public final class Cycles {
      * @see <a href="https://en.wikipedia.org/wiki/Circuit_rank">Circuit Rank</a>
      */
     public static int markRingAtomsAndBonds(IAtomContainer mol) {
-        EdgeToBondMap bonds = EdgeToBondMap.withSpaceFor(mol);
-        return markRingAtomsAndBonds(mol, GraphUtil.toAdjList(mol, bonds), bonds);
+        return BiconnectedComponents.mark(mol);
     }
 
     /**

--- a/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
@@ -585,6 +585,7 @@ public final class Cycles {
      * @see <a href="https://en.wikipedia.org/wiki/Circuit_rank">Circuit Rank</a>
      * @deprecated Use {@link #markRingAtomsAndBonds(org.openscience.cdk.interfaces.IAtomContainer)}
      */
+    @Deprecated
     public static int markRingAtomsAndBonds(IAtomContainer mol, int[][] adjList, EdgeToBondMap bondMap) {
         return markRingAtomsAndBonds(mol);
     }

--- a/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
+++ b/base/core/src/main/java/org/openscience/cdk/graph/Cycles.java
@@ -583,24 +583,10 @@ public final class Cycles {
      * @see IAtom#isInRing()
      * @return Number of rings found (circuit rank)
      * @see <a href="https://en.wikipedia.org/wiki/Circuit_rank">Circuit Rank</a>
+     * @deprecated Use {@link #markRingAtomsAndBonds(org.openscience.cdk.interfaces.IAtomContainer)}
      */
     public static int markRingAtomsAndBonds(IAtomContainer mol, int[][] adjList, EdgeToBondMap bondMap) {
-        RingSearch ringSearch = new RingSearch(mol, adjList);
-        for (int v = 0; v < mol.getAtomCount(); v++) {
-            mol.getAtom(v).setIsInRing(false);
-            for (int w : adjList[v]) {
-                // note we only mark the bond on second visit (first v < w) and
-                // clear flag on first visit (or if non-cyclic)
-                if (v > w && ringSearch.cyclic(v, w)) {
-                    bondMap.get(v, w).setIsInRing(true);
-                    mol.getAtom(v).setIsInRing(true);
-                    mol.getAtom(w).setIsInRing(true);
-                } else {
-                    bondMap.get(v, w).setIsInRing(false);
-                }
-            }
-        }
-        return ringSearch.numRings();
+        return markRingAtomsAndBonds(mol);
     }
 
     /**


### PR DESCRIPTION
Full circle, one of the first optimisations to the CDK I added was faster marking of ring atoms/bonds (10 years ago - https://jcheminf.biomedcentral.com/articles/10.1186/1758-2946-6-3). While this works well, hindsight is 20/20 and a much similar (main logic is 20 lines!) implementation on the new and improved IAtomContainer runs significantly faster for the common case.

This doesn't support the splitting of simple/complex cycles like [RingSearch](https://cdk.github.io/cdk/1.5/docs/api/org/openscience/cdk/ringsearch/RingSearch.html) but we can do that as well with a little more logic - and it makes sense to make that an optional calculation.

# Results 

Single threaded, Macbook M1 Pro.

I time'd ChEMBL 23 SMILES in chunks of 100k molecules. The "baseline" is the SmilesParsing/Kekulization speed. We see calling RingSearch significantly slows down our throughput. 

![image](https://github.com/cdk/cdk/assets/983232/64ae5bd1-f91f-4399-9ffb-5fd011f05345)

Subtracting the baseline to demonstrate the "speed" of just the part being tested we see
it runs ~2 million molecules per second. 

![image](https://github.com/cdk/cdk/assets/983232/a34e4a1c-0075-4dce-9db9-fa9c51979cba)







