### PR TITLE
Increase the max fragment count when generating abbreviations.

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -140,7 +140,7 @@ public class Abbreviations implements Iterable<String> {
         AUTO_CONTRACT_LINKERS,
     }
 
-    private static final int MAX_FRAG = 50;
+    private static final int MAX_FRAG = 256;
 
     /**
      * Symbol for joining disconnected fragments.


### PR DESCRIPTION

I spotted a minor bug on CDK depict, if you load a large enough molecule and refresh multiple times to get different depictions:

https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.%5BNa%2B%5D.CCCCc1ccc(CO%5BC%40H%5D2O%5BC%40H%5D(COS(%3DO)(%3DO)%5BO-%5D)%5BC%40%40H%5D(OS(%3DO)(%3DO)%5BO-%5D)%5BC%40H%5D(OS(%3DO)(%3DO)%5BO-%5D)%5BC%40%40H%5D2O%5BC%40H%5D3O%5BC%40H%5D(COS(%3DO)(%3DO)%5BO-%5D)%5BC%40%40H%5D(OS(%3DO)(%3DO)%5BO-%5D)%5BC%40H%5D(O%5BC%40H%5D4O%5BC%40H%5D(COS(%3DO)(%3DO)%5BO-%5D)%5BC%40%40H%5D(OS(%3DO)(%3DO)%5BO-%5D)%5BC%40H%5D(O%5BC%40H%5D5O%5BC%40H%5D(COS(%3DO)(%3DO)%5BO-%5D)%5BC%40%40H%5D(OS(%3DO)(%3DO)%5BO-%5D)%5BC%40H%5D(OS(%3DO)(%3DO)%5BO-%5D)%5BC%40%40H%5D5OS(%3DO)(%3DO)%5BO-%5D)%5BC%40%40H%5D4OS(%3DO)(%3DO)%5BO-%5D)%5BC%40%40H%5D3OS(%3DO)(%3DO)%5BO-%5D)cc1%20CHEMBL590010&w=-1&h=-1&abbr=on&hdisp=bridgehead&zoom=1.3&annotate=none&r=0


This was due to a limit on the number of fragments.