### PR TITLE
Only copy mapped bonds when deciding how to align the structure.

### DIFF
--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -291,6 +291,14 @@ public class StructureDiagramGenerator {
             for (IAtom atom : cpy.atoms())
                 afix.add(atom);
 
+            // Nothing to align to
+            if (afix.size() <= 1) {
+                Cycles.markRingAtomsAndBonds(mol);
+                setMolecule(mol, false);
+                generateCoordinates();
+                return;
+            }
+
             // initialize any coordinates that are store in the pattern if
             // there was no reference molecule provided (i.e. they have been
             // cached for substructure layout)


### PR DESCRIPTION
```java
IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
        SmilesParser smipar = new SmilesParser(builder);
        IAtomContainer mol = smipar.parseSmiles("C1CCC2CCCCC2C1");
        Pattern pattern = SmartsPattern.create("[CR]1-@[CD>2R](-@[CR]-@[CR]-@[CR]-@[CR]-@1)CCCC |(2.42,0.7,;2.42,2.1,;1.21,2.8,;,2.1,;,0.7,;1.21,,;3.64,2.8,;4.85,2.1,;6.06,2.8,;7.27,2.1,)|");
        new StructureDiagramGenerator().generateAlignedCoordinates(mol, pattern);
        new DepictionGenerator()
                .withHighlight(pattern.matchAll(mol).toAtomBondMap().iterator().next().values(), Color.RED)
                .depict(mol)
                .writeTo("/tmp/tmp.svg");
```

Before:
![tmp](https://github.com/cdk/cdk/assets/983232/156d9e8c-17a4-4892-b07d-75eda5a25e86)
After:
![tmp](https://github.com/cdk/cdk/assets/983232/e6c3a04f-4c26-4b22-a081-a18cb3fadc17)
