### PR TITLE
Overhaul and optimise the aromaticity procedures in CDK.

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AromaticType.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AromaticType.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2024 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.aromaticity;
+
+/**
+ * Aromatic atom types organized by element and degree, for example
+ * B2 => "Boron Degree 2" <code>SMILES: *B=*</code>.
+ */
+enum AromaticType {
+    UNKNOWN,
+    /** {@code *B=* } */
+    B2,
+    /** {@code *B(*)* } */
+    B3,
+    /** {@code *[C-]=* } */
+    C2_MINUS,
+    /** {@code *[C+]=* } */
+    C2_PLUS,
+    /** {@code *C(*)@=* } */
+    C3,
+    /** {@code *C(*)!@=* } */
+    C3_EXO,
+    /** {@code *C(*)!@=[!#6] } */
+    C3_ENEG_EXO,
+    /** {@code *[C-](*)* } */
+    C3_MINUS,
+    /** {@code *[C+](*)* } */
+    C3_PLUS,
+    /** {@code *N=* } */
+    N2,
+    /** {@code *[N-]* } */
+    N2_MINUS,
+    /** {@code *N(*)* } */
+    N3,
+    /** {@code *N(=O)=* } */
+    N3_OXIDE,
+    /** {@code *[N+]([O-])=* } */
+    N3_OXIDE_PLUS,
+    /** {@code *[N+](*)=* } */
+    N3_PLUS,
+    /** {@code *O* } */
+    O2,
+    /** {@code *[O+]=* } */
+    O2_PLUS,
+    /** {@code *P=* } */
+    P2,
+    /** {@code *[P-]* } */
+    P2_MINUS,
+    /** {@code *P(*)* } */
+    P3,
+    /** {@code *P(=@*)(*)* } */
+    P4,
+    /** {@code *P(=O)=* } */
+    P3_OXIDE,
+    /** {@code *[P+]([O-])=* } */
+    P3_OXIDE_PLUS,
+    /** {@code *[P+](*)=* } */
+    P3_PLUS,
+    /** {@code *S* } */
+    S2,
+    /** {@code *@=S=@* } */
+    S2_CUML,
+    /** {@code *S(*)@=* } */
+    S3,
+    /** {@code *[S+]@=* } */
+    S2_PLUS,
+    /** {@code *[S+](*)* } */
+    S3_PLUS,
+    /** {@code *S(=O)* } */
+    S3_OXIDE,
+    /** {@code *[S+]([O-])* } */
+    S3_OXIDE_PLUS,
+    /** {@code *[Si-]=* } */
+    Si2_MINUS,
+    /** {@code *[Si+]=* } */
+    Si2_PLUS,
+    /** {@code *[Si](*)@=* } */
+    Si3,
+    /** {@code *[Si](*)!@=* } */
+    Si3_EXO,
+    /** {@code *[Si-](*)* } */
+    Si3_MINUS,
+    /** {@code *[Si+](*)* } */
+    Si3_PLUS,
+    /** {@code *[Se]* } */
+    Se2,
+    /** {@code *[Se+]=* } */
+    Se2_PLUS,
+    /** {@code *[Se](=@*)* } */
+    Se3,
+    /** {@code *[Se](=O)* } */
+    Se3_OXIDE,
+    /** {@code *[Se+]([O-])* } */
+    Se3_OXIDE_PLUS,
+    /** {@code *[As]=* } */
+    As2,
+    /** {@code *[As-]* } */
+    As2_MINUS,
+    /** {@code *[As](*)* } */
+    As3,
+    /** {@code *[As+](=*)* } */
+    As3_PLUS,
+    /** {@code *[Te]* } */
+    Te2,
+    /** {@code *[Te+]=* } */
+    Te2_PLUS
+}

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AromaticTypeMatcher.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AromaticTypeMatcher.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright (C) 2024 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.aromaticity;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IBond;
+
+/**
+ * Determine the {@link org.openscience.cdk.aromaticity.AromaticType} of an
+ * atom.
+ */
+final class AromaticTypeMatcher {
+
+    /**
+     * Safely access the charge, defaulting null to 0.
+     * @param atom the atom
+     * @return the formal charge
+     */
+    private static int charge(IAtom atom) {
+        return atom.getFormalCharge() != null ? atom.getFormalCharge() : 0;
+    }
+
+    /**
+     * Safely access the hydrogen count, defaulting null to 0.
+     * @param atom the atom
+     * @return the hydrogen count
+     */
+    private static int hcount(final IAtom atom) {
+        return atom.getImplicitHydrogenCount() != null
+                ? atom.getImplicitHydrogenCount() : 0;
+    }
+
+    /**
+     * Return the packed bond info (binfo) for a give atom. This information
+     * captures the:
+     * <pre>
+     *  - number of attached single bonds (mask:0x000f)
+     *  - number of attached cyclic double bonds (mask:0x00f0)
+     *  - number of attached acyclic double bonds (mask:0x0f00)
+     *  - number of other/error bonds (mask:0xf000)
+     * </pre>
+     * Examples:
+     * <pre>
+     *  - 0x0003 = 3 single bonds
+     *  - 0x0012 = 2 single bonds, 1 double bond (cyclic)
+     *  - 0x0102 = 2 single bonds, 1 double bond (acyclic)
+     * </pre>
+     *
+     * @param atom the atom
+     * @return the bond info
+     */
+    private static int binfo(final IAtom atom) {
+        int binfo = atom.getImplicitHydrogenCount();
+        if (atom.getBondCount() + binfo > 15)
+            return 0x1000; // error
+        for (IBond bond : atom.bonds()) {
+            switch (bond.getOrder()) {
+                case SINGLE: binfo += 0x0001; break;
+                case DOUBLE:
+                    binfo += bond.isInRing() ? 0x0010 : 0x0100;
+                    break;
+                default:
+                    binfo += 0x1000;
+                    break;
+            }
+        }
+        return binfo;
+    }
+
+
+    private static boolean hasExoHet(IAtom atom) {
+        for (IBond bond : atom.bonds()) {
+            if (bond.isInRing() || bond.getOrder() != IBond.Order.DOUBLE)
+                continue;
+            return bond.getOther(atom).getAtomicNumber() != IAtom.C;
+        }
+        return false;
+    }
+
+    private static boolean hasOxide(IAtom atom) {
+        for (IBond bond : atom.bonds()) {
+            if (bond.isInRing())
+                continue;
+            IAtom nbor = bond.getOther(atom);
+            if (nbor.getAtomicNumber() != IAtom.O)
+                return false;
+            // *=O
+            if (bond.getOrder() == IBond.Order.DOUBLE)
+                return true;
+            // [*+]-[O-]
+            return bond.getOrder() == IBond.Order.SINGLE &&
+                    charge(atom) == +1 && charge(nbor) == -1;
+        }
+        return false;
+    }
+
+    /**
+     * Determine the aromatic type of the atom.
+     * <br/>
+     * <b>Prerequisites: the atom and attached bonds should have their
+     * ring membership marked using:
+     * ({@link org.openscience.cdk.graph.Cycles#markRingAtomsAndBonds(org.openscience.cdk.interfaces.IAtomContainer)} )</b>
+     *
+     * @param atom the atom
+     * @return the aromatic atom type
+     */
+    static AromaticType getType(final IAtom atom) {
+
+        // fail-fast preconditions
+        if (!atom.isInRing())
+            return AromaticType.UNKNOWN;
+        // P4 in the CDK_1x model is a special case
+        if (atom.getBondCount() > 3 && atom.getAtomicNumber() != IAtom.P)
+            return AromaticType.UNKNOWN;
+        if (hcount(atom) > 1 && atom.getAtomicNumber() != IAtom.P)
+            return AromaticType.UNKNOWN;
+
+        int q;
+        switch (atom.getAtomicNumber()) {
+            case IAtom.B:
+                if (charge(atom) == 0) {
+                    switch (binfo(atom)) {
+                        case 0x0011: return AromaticType.B2;
+                        case 0x0003: return AromaticType.B3;
+                    }
+                }
+                break;
+
+            case IAtom.C:
+                switch (charge(atom)) {
+                    case -1:
+                        switch (binfo(atom)) {
+                            case 0x0011: return AromaticType.C2_MINUS;
+                            case 0x0003: return AromaticType.C3_MINUS;
+                        }
+                        break;
+                    case 0:
+                        switch (binfo(atom)) {
+                            case 0x0012: return AromaticType.C3;
+                            case 0x0102:
+                                if (hasExoHet(atom))
+                                    return AromaticType.C3_ENEG_EXO;
+                                return AromaticType.C3_EXO;
+                        }
+                        break;
+                    case +1:
+                        switch (binfo(atom)) {
+                            case 0x0011: return AromaticType.C2_PLUS;
+                            case 0x0003: return AromaticType.C3_PLUS;
+                        }
+                        break;
+                }
+                break;
+            case IAtom.Si:
+                switch (charge(atom)) {
+                    case -1:
+                        switch (binfo(atom)) {
+                            case 0x0011: return AromaticType.Si2_MINUS;
+                            case 0x0003: return AromaticType.Si3_MINUS;
+                        }
+                        break;
+                    case 0:
+                        switch (binfo(atom)) {
+                            case 0x0012: return AromaticType.Si3;
+                            case 0x0102: return AromaticType.Si3_EXO;
+                        }
+                        break;
+                    case +1:
+                        switch (binfo(atom)) {
+                            case 0x0011: return AromaticType.Si2_PLUS;
+                            case 0x0003: return AromaticType.Si3_PLUS;
+                        }
+                        break;
+                }
+                break;
+
+            case IAtom.N:
+                q = charge(atom);
+                if (q == -1 && binfo(atom) == 0x0002)
+                    return AromaticType.N2_MINUS;
+                else if (q == 0) {
+                    switch (binfo(atom)) {
+                        case 0x0003: return AromaticType.N3;
+                        case 0x0011: return AromaticType.N2;
+                        case 0x0111:
+                            if (hasOxide(atom))
+                                return AromaticType.N3_OXIDE;
+                            break;
+                    }
+                }
+                else if (q == +1 && binfo(atom) == 0x0012) {
+                    if (hasOxide(atom))
+                        return AromaticType.N3_OXIDE_PLUS;
+                    else
+                        return AromaticType.N3_PLUS;
+                }
+                break;
+            case IAtom.P:
+                q = charge(atom);
+                if (q == -1 && binfo(atom) == 0x0002)
+                    return AromaticType.P2_MINUS;
+                else if (q == 0) {
+                    switch (binfo(atom)) {
+                        case 0x0013: return AromaticType.P4;
+                        case 0x0003: return AromaticType.P3;
+                        case 0x0011: return AromaticType.P2;
+                        case 0x0111:
+                            if (hasOxide(atom))
+                                return AromaticType.P3_OXIDE;
+                    }
+                }
+                else if (q == +1 && binfo(atom) == 0x0012) {
+                    if (hasOxide(atom))
+                        return AromaticType.P3_OXIDE_PLUS;
+                    else
+                        return AromaticType.P3_PLUS;
+                }
+                break;
+            case IAtom.As:
+                q = charge(atom);
+                if (q == -1 && binfo(atom) == 0x0002)
+                    return AromaticType.As2_MINUS;
+                else if (q == 0) {
+                    switch (binfo(atom)) {
+                        case 0x0003: return AromaticType.As3;
+                        case 0x0011: return AromaticType.As2;
+                    }
+                }
+                else if (q == +1) {
+                    switch (binfo(atom)) {
+                        case 0x0012:
+                        case 0x0102: return AromaticType.As3_PLUS;
+                    }
+                }
+                break;
+
+            case IAtom.O:
+                q = charge(atom);
+                if (q == 0 && binfo(atom) == 0x0002)
+                    return AromaticType.O2;
+                if (q == 1 && binfo(atom) == 0x0011)
+                    return AromaticType.O2_PLUS;
+                break;
+            case IAtom.S:
+                q = charge(atom);
+                if (q == 0) {
+                    switch (binfo(atom)) {
+                        case 0x0012: return AromaticType.S3;
+                        case 0x0002: return AromaticType.S2;
+                        case 0x0020: return AromaticType.S2_CUML;
+                        case 0x0102:
+                            if (hasOxide(atom))
+                                return AromaticType.S3_OXIDE;
+                    }
+                }
+                if (q == 1) {
+                    switch (binfo(atom)) {
+                        case 0x0011: return AromaticType.S2_PLUS;
+                        case 0x0003:
+                            if (hasOxide(atom))
+                                return AromaticType.S3_OXIDE_PLUS;
+                            return AromaticType.S3_PLUS;
+                    }
+                }
+                break;
+            case IAtom.Se:
+                q = charge(atom);
+                if (q == 0) {
+                    switch (binfo(atom)) {
+                        case 0x0002:
+                            return AromaticType.Se2;
+                        case 0x0012:
+                            return AromaticType.Se3;
+                        case 0x0102:
+                            if (hasOxide(atom))
+                                return AromaticType.Se3_OXIDE;
+
+                    }
+                }
+                if (q == 1) {
+                    switch (binfo(atom)) {
+                        case 0x0011:
+                            return AromaticType.Se2_PLUS;
+                        case 0x0003:
+                            if (hasOxide(atom))
+                                return AromaticType.Se3_OXIDE_PLUS;
+                    }
+                }
+                break;
+            case IAtom.Te:
+                q = charge(atom);
+                if (q == 0) {
+                    switch (binfo(atom)) {
+                        case 0x0002:
+                            return AromaticType.Te2;
+                    }
+                }
+                if (q == 1) {
+                    if (binfo(atom) == 0x0011) {
+                        return AromaticType.Te2_PLUS;
+                    }
+                }
+                break;
+        }
+        return AromaticType.UNKNOWN;
+    }
+
+
+
+}

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AromaticTypeMatcher.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AromaticTypeMatcher.java
@@ -21,6 +21,7 @@ package org.openscience.cdk.aromaticity;
 
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IElement;
 
 /**
  * Determine the {@link org.openscience.cdk.aromaticity.AromaticType} of an
@@ -36,6 +37,8 @@ final class AromaticTypeMatcher {
     private static int charge(IAtom atom) {
         return atom.getFormalCharge() != null ? atom.getFormalCharge() : 0;
     }
+
+    private AromaticTypeMatcher() {}
 
     /**
      * Safely access the hydrogen count, defaulting null to 0.
@@ -127,14 +130,14 @@ final class AromaticTypeMatcher {
         if (!atom.isInRing())
             return AromaticType.UNKNOWN;
         // P4 in the CDK_1x model is a special case
-        if (atom.getBondCount() > 3 && atom.getAtomicNumber() != IAtom.P)
+        if (atom.getBondCount() > 3 && atom.getAtomicNumber() != IElement.P)
             return AromaticType.UNKNOWN;
-        if (hcount(atom) > 1 && atom.getAtomicNumber() != IAtom.P)
+        if (hcount(atom) > 1 && atom.getAtomicNumber() != IElement.P)
             return AromaticType.UNKNOWN;
 
         int q;
         switch (atom.getAtomicNumber()) {
-            case IAtom.B:
+            case IElement.B:
                 if (charge(atom) == 0) {
                     switch (binfo(atom)) {
                         case 0x0011: return AromaticType.B2;
@@ -143,7 +146,7 @@ final class AromaticTypeMatcher {
                 }
                 break;
 
-            case IAtom.C:
+            case IElement.C:
                 switch (charge(atom)) {
                     case -1:
                         switch (binfo(atom)) {
@@ -168,7 +171,7 @@ final class AromaticTypeMatcher {
                         break;
                 }
                 break;
-            case IAtom.Si:
+            case IElement.Si:
                 switch (charge(atom)) {
                     case -1:
                         switch (binfo(atom)) {
@@ -191,7 +194,7 @@ final class AromaticTypeMatcher {
                 }
                 break;
 
-            case IAtom.N:
+            case IElement.N:
                 q = charge(atom);
                 if (q == -1 && binfo(atom) == 0x0002)
                     return AromaticType.N2_MINUS;
@@ -212,7 +215,7 @@ final class AromaticTypeMatcher {
                         return AromaticType.N3_PLUS;
                 }
                 break;
-            case IAtom.P:
+            case IElement.P:
                 q = charge(atom);
                 if (q == -1 && binfo(atom) == 0x0002)
                     return AromaticType.P2_MINUS;
@@ -233,7 +236,7 @@ final class AromaticTypeMatcher {
                         return AromaticType.P3_PLUS;
                 }
                 break;
-            case IAtom.As:
+            case IElement.As:
                 q = charge(atom);
                 if (q == -1 && binfo(atom) == 0x0002)
                     return AromaticType.As2_MINUS;
@@ -251,14 +254,14 @@ final class AromaticTypeMatcher {
                 }
                 break;
 
-            case IAtom.O:
+            case IElement.O:
                 q = charge(atom);
                 if (q == 0 && binfo(atom) == 0x0002)
                     return AromaticType.O2;
                 if (q == 1 && binfo(atom) == 0x0011)
                     return AromaticType.O2_PLUS;
                 break;
-            case IAtom.S:
+            case IElement.S:
                 q = charge(atom);
                 if (q == 0) {
                     switch (binfo(atom)) {
@@ -280,7 +283,7 @@ final class AromaticTypeMatcher {
                     }
                 }
                 break;
-            case IAtom.Se:
+            case IElement.Se:
                 q = charge(atom);
                 if (q == 0) {
                     switch (binfo(atom)) {
@@ -304,12 +307,11 @@ final class AromaticTypeMatcher {
                     }
                 }
                 break;
-            case IAtom.Te:
+            case IElement.Te:
                 q = charge(atom);
                 if (q == 0) {
-                    switch (binfo(atom)) {
-                        case 0x0002:
-                            return AromaticType.Te2;
+                    if (binfo(atom) == 0x0002) {
+                        return AromaticType.Te2;
                     }
                 }
                 if (q == 1) {

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AromaticTypeModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AromaticTypeModel.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2024 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.aromaticity;
+
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.openscience.cdk.aromaticity.AromaticType.*;
+
+/**
+ * A flexible and configurable aromaticity model based on aromatic atom types.
+ * <br/>
+ * The API for this class is currently only usable internally (package-private).
+ *
+ * @author John Mayfield
+ */
+final class AromaticTypeModel extends ElectronDonation {
+
+    static final List<Map.Entry<AromaticType, Integer>> MDL
+            = Arrays.asList(entry(C2_MINUS, 1),
+                            entry(C2_PLUS, 1),
+                            entry(C3, 1),
+                            entry(N2, 1),
+                            entry(N3_OXIDE, 1),
+                            entry(N3_PLUS, 1));
+
+    static final List<Map.Entry<AromaticType, Integer>> CDK_1x
+            = Arrays.asList(entry(C2_MINUS, 1),
+                            entry(C2_PLUS, 1),
+                            entry(C3, 1),
+                            entry(C3_MINUS, 2),
+                            entry(C3_PLUS, 0),
+                            entry(N2, 1),
+                            entry(N2_MINUS, 2),
+                            entry(N3, 2),
+                            entry(N3_OXIDE, 1),
+                            entry(N3_OXIDE_PLUS, 1),
+                            entry(N3_PLUS, 1),
+                            entry(O2, 2),
+                            entry(O2_PLUS, 1),
+                            entry(P2, 1),
+                            entry(P2_MINUS, 2),
+                            entry(P3, 2),
+                            entry(P4, 1),
+                            entry(P3_OXIDE, 1),
+                            entry(P3_OXIDE_PLUS, 1),
+                            entry(P3_PLUS, 1),
+                            entry(S2, 2),
+                            entry(S2_CUML, 2),
+                            entry(S3, 1),
+                            entry(S3_PLUS, 0),
+                            entry(S2_PLUS, 1),
+                            entry(S3_OXIDE_PLUS, 0), // ?
+                            entry(Se3, 1),
+                            entry(As3, 2));
+
+    static final List<Map.Entry<AromaticType, Integer>> DAYLIGHT
+            = Arrays.asList(entry(C2_MINUS, 1),
+                            entry(C2_PLUS, 1),
+                            entry(C3, 1),
+                            entry(C3_EXO, 1),
+                            entry(C3_ENEG_EXO, 0),
+                            entry(C3_MINUS, 2),
+                            entry(C3_PLUS, 0),
+                            entry(N2, 1),
+                            entry(N2_MINUS, 2),
+                            entry(N3, 2),
+                            entry(N3_OXIDE, 1),
+                            entry(N3_OXIDE_PLUS, 1),
+                            entry(N3_PLUS, 1),
+                            entry(O2, 2),
+                            entry(O2_PLUS, 1),
+                            entry(P2, 1),
+                            entry(P2_MINUS, 2),
+                            entry(P3, 2),
+                            entry(P3_OXIDE, 1),
+                            entry(P3_OXIDE_PLUS, 1),
+                            entry(P3_PLUS, 1),
+                            entry(S2, 2),
+                            entry(S2_PLUS, 1),
+                            entry(S3_OXIDE, 2),
+                            entry(Se2, 2),
+                            entry(Se2_PLUS, 1),
+                            entry(Se3_OXIDE, 2),
+                            entry(As3, 2));
+
+    @SuppressWarnings("unchecked")
+    static final List<Map.Entry<AromaticType, Integer>> OPEN_SMILES
+            = extend(DAYLIGHT,
+                     entry(B2, 1),
+                     entry(B3, 0),
+                     entry(S3_OXIDE_PLUS, 2), // Sp3 but makes sense if you allow S2_OXIDE
+                     entry(Se3_OXIDE_PLUS, 2), // Sp3 but makes sense if you allow Se2_OXIDE
+                     entry(As2, 1),
+                     entry(As3_PLUS, 1));
+
+    @SuppressWarnings("unchecked")
+    static final List<Map.Entry<AromaticType, Integer>> CDK_2x
+            = extend(DAYLIGHT,
+                     entry(B2, 1),
+                     entry(B3, 0),
+                     entry(S3_OXIDE, -1), // Sp3 => not aromatic
+                     entry(Se3_OXIDE, -1), // Sp3 => not aromatic
+                     entry(As2, 1),
+                     entry(As3_PLUS, 1),
+                     entry(Te2, 2),
+                     entry(Te2_PLUS, 1));
+
+    private final static AromaticType[] types = AromaticType.values();
+    private final int[] map;
+
+    AromaticTypeModel(List<Map.Entry<AromaticType, Integer>> vals) {
+        this.map = new int[types.length];
+        Arrays.fill(this.map, -1);
+        for (Map.Entry<AromaticType, Integer> e : vals)
+            this.map[e.getKey().ordinal()] = e.getValue();
+    }
+
+    @Override
+    int[] contribution(IAtomContainer mol) {
+        int[] contrib = new int[mol.getAtomCount()];
+        for (IAtom atom : mol.atoms()) {
+            AromaticType type = AromaticTypeMatcher.getType(atom);
+            contrib[atom.getIndex()] = map[type.ordinal()];
+        }
+        return contrib;
+    }
+
+    // Note: Map.entry and Map.ofEntries in Java 9+
+    private static <K, V> Map.Entry<K, V> entry(K k, V v) {
+        return new AbstractMap.SimpleImmutableEntry<>(k, v);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map.Entry<AromaticType, Integer>>
+        extend(List<Map.Entry<AromaticType, Integer>> vals,
+               Map.Entry<AromaticType, Integer> ... extra) {
+        List<Map.Entry<AromaticType, Integer>> ret = new ArrayList<>(vals);
+        Collections.addAll(ret, extra);
+        return ret;
+    }
+}

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013 European Bioinformatics Institute (EMBL-EBI)
- *                    John May <jwmay@users.sf.net>
+ *                    John Mayfield
+ *               2024 John Mayfield
  *
  * Contact: cdk-devel@lists.sourceforge.net
  *
@@ -25,19 +26,24 @@
 package org.openscience.cdk.aromaticity;
 
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.exception.Intractable;
 import org.openscience.cdk.graph.CycleFinder;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.graph.GraphUtil;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
-import org.openscience.cdk.ringsearch.RingSearch;
+import org.openscience.cdk.tools.LoggingToolFactory;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.openscience.cdk.aromaticity.Aromaticity.*;
 import static org.openscience.cdk.interfaces.IChemObject.AROMATIC;
 import static org.openscience.cdk.graph.GraphUtil.EdgeToBondMap;
 
@@ -47,49 +53,70 @@ import static org.openscience.cdk.graph.GraphUtil.EdgeToBondMap;
  * treat different resonance forms as equivalent. Each has its own implications
  * the first in physicochemical attributes and the second in similarity,
  * depiction and storage.
- * 
+ *
  * To address the resonance forms, several simplified (sometimes conflicting)
  * models have arisen. Generally the models <b>loosely</b> follow
  * <a href="http://en.wikipedia.org/wiki/H%C3%BCckel's_rule">Hückel's rule</a>
  * for determining aromaticity. A common omission being that planarity is not
  * tested and chemical compounds which are non-planar can be perceived
  * as aromatic. An example of one such compound is, cyclodeca-1,3,5,7,9-pentaene.
- * 
+ *
  * Although there is not a single universally accepted model there are models
  * which may better suited for a specific use (<a href="http://www.slideshare.net/NextMoveSoftware/cheminformatics-toolkits-a-personal-perspective">Cheminformatics Toolkits: A Personal Perspective, Roger Sayle</a>).
  * The different models are often ill-defined or unpublished but it is important
  * to acknowledge that there are differences.
- * 
+ *
  * Although models may get more complicated (e.g. considering tautomers)
  * normally the reasons for differences are:
  * <ul>
  *     <li>the atoms allowed and how many electrons each contributes</li>
  *     <li>the rings/cycles are tested</li>
  * </ul>
- * 
+ *
  * This implementation allows configuration of these via an {@link
  * ElectronDonation} model and {@link CycleFinder}. To obtain an instance
- * of the electron donation model use one of the factory methods,
- * {@link ElectronDonation#cdk()}, {@link ElectronDonation#cdkAllowingExocyclic()},
- * {@link ElectronDonation#daylight()} or {@link ElectronDonation#piBonds()}.
+ * of the electron donation model use one of the constants:
+ * <ul>
+ *     <li>{@link Model#Mdl}</li>
+ *     <li>{@link Model#Daylight}</li>
+ *     <li>{@link Model#OpenSmiles}</li>
+ *     <li>{@link Model#CDK_1x}</li>
+ *     <li>{@link Model#CDK_2x}</li>
+ * </ul>
  *
  * <br>
  * <br>
  * <b>Recommended Usage:</b><br>
  * Which model/cycles to use depends on the situation but a good general
- * purpose configuration is shown below:
- * <blockquote><pre>
- * ElectronDonation model       = ElectronDonation.daylight();
- * CycleFinder      cycles      = Cycles.or(Cycles.all(), Cycles.all(6));
- * Aromaticity      aromaticity = new Aromaticity(model, cycles);
- *
- * // apply our configured model to each molecule
+ * purpose configuration is shown below which applies the model to all
+ * cycles/rings in a molecule using a backtracking search:
+ * <blockquote><pre>{@code
  * for (IAtomContainer molecule : molecules) {
- *     aromaticity.apply(molecule);
+ *     Cycles.markRingAtomsAndBonds(molecule);
+ *     if (!Aromaticity.apply(Aromaticity.Model.CDX_2x, molecule)) {
+ *         // molecule has v. complex rings! but aromaitcity
+ *         // will still have been marked on small rings
+ *     }
  * }
- * </pre></blockquote>
+ * }</pre></blockquote>
  *
- * @author John May
+ * Alternative usage which throws an exception when the molecule is too
+ * complex:
+ *
+ * <blockquote><pre>{@code
+ * ElectronDonation model       = ElectronDonation.CDK_2x;
+ * CycleFinder      cycles      = Cycles.all();
+ * Aromaticity      aromaticity = new Aromaticity(model, cycles);
+ * for (IAtomContainer molecule : molecules) {
+ *   try {
+ *      aromaticity.apply(molecule);
+ *   } catch (CDKException ex) {
+ *      // aromaticity failed, molecule to complex
+ *   }
+ * }
+ * }</pre></blockquote>
+ *
+ * @author John Mayfield
  * @cdk.module standard
  * @cdk.githash
  * @see <a href="http://en.wikipedia.org/wiki/H%C3%BCckel's_rule">Hückel's
@@ -99,11 +126,67 @@ import static org.openscience.cdk.graph.GraphUtil.EdgeToBondMap;
  */
 public final class Aromaticity {
 
+    /**
+     * Container for aromaticity models.
+     */
+    public static class Model {
+        private Model() {}
+
+        /**
+         * A model similar to what Daylight used for SMILES/SMARTS. If you are
+         * using SMILES/SMARTS then this is a good model to use.
+         */
+        public static ElectronDonation Daylight      = new AromaticTypeModel(AromaticTypeModel.DAYLIGHT);
+        /**
+         * Any atom connected to a single pi bond in a ring contributes 1
+         * electron.
+         */
+        public static ElectronDonation PiBonds       = new PiBondModel();
+        /**
+         * A model similar to what MDL/Symyx used. This is similar to the PiBonds
+         * model but only allows certain atom types. Exo cyclic pi bonds are not
+         * allowed.
+         */
+        public static ElectronDonation Mdl           = new AromaticTypeModel(AromaticTypeModel.MDL);
+        /**
+         * Similar to the Daylight model but also allows boron and some arsenic
+         * variants as well as charge separated sulfinyl/seleninyl.
+         */
+        public static ElectronDonation OpenSmiles    = new AromaticTypeModel(AromaticTypeModel.OPEN_SMILES);
+        /**
+         * Somewhere in between Mdl/Daylight, allows indole/pyrrole/furan but
+         * does not allow exo-cyclic bonds.
+         */
+        public static ElectronDonation CDK_1x        = new AromaticTypeModel(AromaticTypeModel.CDK_1x);
+        /**
+         * Similar to the Daylight model but also allows boron, tellurium and
+         * some arsenic variants as well not allowing sulfinyl/seleninyl since
+         * these are Sp3.
+         */
+        public static ElectronDonation CDK_2x        = new AromaticTypeModel(AromaticTypeModel.CDK_2x);
+        /**
+         * The old aromatic bond based on CDK atom types, this model requires
+         * atom types have been assigned before calling. Generally the CDK_1x
+         * should be indistinguishable and run faster.
+         */
+        public static ElectronDonation CDK_AtomTypes = new AtomTypeModel(false);
+    }
+
+    // Backtracking search limit, avoids hangs
+    private static final int ALLOWED_STATE_COUNT = 1048576;
+
     /** Find how many electrons each atom contributes. */
     private final ElectronDonation model;
 
     /** The method to find cycles which will be tested for aromaticity. */
     private final CycleFinder      cycles;
+
+    /**
+     * Flag to short circuit the cycle finder and do a backtracking
+     * search.
+     */
+    private final boolean backtracking;
+    private int maxRingSize;
 
     /**
      * Create an aromaticity model using the specified electron donation {@code
@@ -145,14 +228,334 @@ public final class Aromaticity {
      *
      * </pre></blockquote>
      *
-     * @param model
-     * @param cycles
+     * @param model the model
+     * @param cycles the cycles to apply it to
      * @see ElectronDonation
      * @see org.openscience.cdk.graph.Cycles
      */
     public Aromaticity(ElectronDonation model, CycleFinder cycles) {
         this.model = Objects.requireNonNull(model);
         this.cycles = Objects.requireNonNull(cycles);
+
+        // this reflection give users faster speeds without them having to
+        // change their code
+        if (this.cycles instanceof Enum && ((Enum<?>) this.cycles).name().equals("ALL")) {
+            this.backtracking = true;
+        } else if (this.cycles.getClass().getName().equals("org.openscience.cdk.graph.Cycles$AllUpToLength")) {
+            this.backtracking = true;
+            try {
+                Class<?> cls = this.cycles.getClass();
+                Field fld = cls.getDeclaredField("predefinedLength");
+                fld.setAccessible(true);
+                this.maxRingSize = fld.getInt(this.cycles);
+            } catch (Exception ex) {
+                LoggingToolFactory.createLoggingTool(Aromaticity.class)
+                                  .error("Warning: could not access Cycles.all({length}) use aromaticity.applyAllCycles(,{length})");
+                // ignored
+            }
+        } else {
+            this.backtracking = false;
+        }
+    }
+
+    private static boolean isFusionOrBridgeAtom(IAtom atom, int[] contrib) {
+        if (atom.getBondCount() < 3 || contrib[atom.getIndex()] < 0)
+            return false;
+        int count = 0;
+        for (IBond bond : atom.bonds()) {
+            if (!bond.isInRing())
+                continue;
+            if (contrib[bond.getOther(atom).getIndex()] != -1)
+                count++;
+        }
+        return count >= 3;
+    }
+
+    private static void pruneTerminalAromaticAtoms(int[] contrib, IAtom atom)
+    {
+        while (atom != null){
+            IAtom next = null;
+            for (IBond bond : atom.bonds()) {
+                if (!bond.isInRing())
+                    continue;
+                IAtom nbor = bond.getOther(atom);
+                if (contrib[nbor.getIndex()] == -1)
+                    continue;
+                if (next != null)
+                    return; // D2
+                next = nbor;
+            }
+            contrib[atom.getIndex()] = -1;
+            atom = next;
+        }
+    }
+
+    private static void pruneTerminalAromaticAtoms(int[] contrib, IAtomContainer mol)
+    {
+        for (IAtom atom : mol.atoms())
+            if (contrib[atom.getIndex()] != -1)
+                pruneTerminalAromaticAtoms(contrib, atom);
+    }
+
+    private static void floodFill(int[] visit, IAtom atom, IBond prev, int label)
+    {
+        visit[atom.getIndex()] = label;
+        for (IBond bond : atom.bonds()) {
+            if (bond == prev || !bond.isInRing())
+                continue;
+            final IAtom nbor = bond.getOther(atom);
+            if (visit[nbor.getIndex()] == 0)
+                floodFill(visit, nbor, bond, label);
+        }
+    }
+
+    /**
+     * Mark a bond and both end atoms as aromatic.
+     * @param bond the bond
+     */
+    private static void makeAromatic(final IBond bond) {
+        bond.set(AROMATIC);
+        bond.getBegin().set(AROMATIC);
+        bond.getEnd().set(AROMATIC);
+    }
+
+    /**
+     * Mark a molecule is aromatic if it has any aromatic atoms.
+     * @param molecule the molecule
+     */
+    private static void updateMolFlag(final IAtomContainer molecule) {
+        for (IAtom atom : molecule.atoms())
+            if (atom.getFlag(AROMATIC)) {
+                molecule.set(AROMATIC);
+                break;
+            }
+    }
+
+
+    private static final class AllCyclesState {
+        private final int[] visit;
+        private final int[] contrib;
+        private int numStates = 0;
+        private int maxStates = 0;
+        private boolean error = false;
+
+        private AllCyclesState(int[] visit, int[] contrib) {
+            this.visit = visit;
+            this.contrib = contrib;
+        }
+
+        private void setMaxStates(int limit) {
+            this.maxStates = limit;
+        }
+
+        private boolean markPath(IAtom atom, IBond prev, int limit, int pi, int depth) {
+            if (limit != 0 && depth > limit)
+                return false;
+            if (maxStates != 0 && ++numStates >= maxStates)
+                return false;
+            pi += contrib[atom.getIndex()];
+            visit[atom.getIndex()] = 1;
+            for (IBond bond : atom.bonds()) {
+                if (bond == prev || !bond.isInRing())
+                    continue;
+                IAtom nbor = bond.getOther(atom);
+                if (visit[nbor.getIndex()] == 2) {
+                    if (checkHuckelSum(pi)) {
+                        makeAromatic(bond);
+                        visit[atom.getIndex()] = 0;
+                        return true;
+                    }
+                } else if (visit[nbor.getIndex()] == 0) {
+                    if (markPath(nbor, bond, limit, pi, depth + 1)) {
+                        makeAromatic(bond);
+                        visit[atom.getIndex()] = 0;
+                        return true;
+                    }
+                }
+            }
+            visit[atom.getIndex()] = 0;
+            return false;
+        }
+
+        private void processComplexRings(List<IAtom> d3Atoms, int limit) {
+            for (final IAtom atom : d3Atoms) {
+                int pi = contrib[atom.getIndex()];
+                visit[atom.getIndex()] = 2;
+                for (IBond bond : atom.bonds()) {
+                    if (bond.isAromatic() || !bond.isInRing())
+                        continue;
+                    final IAtom nbor = bond.getOther(atom);
+                    if (visit[nbor.getIndex()] != 0)
+                        continue;
+
+                    numStates = 0;
+
+                    if (markPath(nbor, bond, limit, pi, 2))
+                        makeAromatic(bond);
+
+                    if (maxStates != 0 && numStates >= maxStates) {
+                        error = true;
+                        return;
+                    }
+                }
+                visit[atom.getIndex()] = 0;
+            }
+        }
+    }
+
+
+
+    private static void processSimpleRings(IAtomContainer molecule,
+                                           int[] visit,
+                                           int[] contrib) {
+        final List<IBond> ring = new ArrayList<>(molecule.getBondCount());
+        for (IAtom atom : molecule.atoms()) {
+            if (visit[atom.getIndex()] != 0)
+                continue;
+            ring.clear();
+            int sum = 0;
+            IBond prev = null;
+            while (atom != null) {
+                IAtom next = null;
+                visit[atom.getIndex()] = 1;
+                sum += contrib[atom.getIndex()];
+                for (IBond bond : atom.bonds()) {
+                    if (bond == prev || !bond.isInRing())
+                        continue;
+                    final IAtom nbor = bond.getOther(atom);
+                    if (visit[nbor.getIndex()] != 0)
+                        continue;
+                    ring.add(bond);
+                    prev = bond;
+                    next = nbor;
+                }
+                atom = next;
+            }
+            if (!checkHuckelSum(sum))
+                continue;
+            for (IBond bond : ring)
+                makeAromatic(bond);
+        }
+    }
+
+    /**
+     * Apply an aromaticity model to all cycles/rings in a molecule up to the
+     * specified {@code maxRingSize}. This includes rings round the outside of a
+     * fused/bridged cycles (e.g. azulene).
+     *
+     * <pre>{@code
+     * Cycles.markRingAtomsAndBonds(molecule); // required!!
+     * if (!Aromaticity.apply(Aromaticity.Model.Daylight, molecule)) {
+     *     // molecule had some v. complex rings in it!
+     * }
+     * }</pre>
+     *
+     * The return value indicates if the model was applied full or not.
+     * Even if false is returned small rings will have been marked as aromatic.
+     * If is more an indication that there are some bonds of which it is not
+     * possible to know for sure if they should be marked as aromatic. Typical
+     * these molecules are often complex cage like systems with some saturated
+     * atoms, fully unsaturated molecules like fullerene actually run quickly.
+     * Setting a max ring size to something reasonable like 14 (3x fused 6
+     * membered rings) avoids this issue.
+     *
+     * @param model the aromaticity model
+     * @param molecule the molecule
+     * @return if the model could be fully applied (true) or if the computation
+     *         was not possible (false)
+     */
+    public static boolean apply(ElectronDonation model, IAtomContainer molecule) {
+        return apply(model, molecule, Math.max(3, molecule.getAtomCount()));
+    }
+
+    /**
+     * Apply an aromaticity model to all cycles/rings in a molecule up to the
+     * specified {@code maxRingSize}. This includes rings round the outside of a
+     * fused/bridged cycles (e.g. azulene).
+     *
+     * <pre>{@code
+     * Cycles.markRingAtomsAndBonds(molecule); // required!!
+     * if (!Aromaticity.apply(Aromaticity.Model.Daylight, molecule)) {
+     *     // molecule had some v. complex rings in it!
+     * }
+     * }</pre>
+     *
+     * The return value indicates if the model was applied full or not.
+     * Even if false is returned small rings will have been marked as aromatic.
+     * If is more an indication that there are some bonds of which it is not
+     * possible to know for sure if they should be marked as aromatic. Typical
+     * these molecules are often complex cage like systems with some saturated
+     * atoms, fully unsaturated molecules like fullerene actually run quickly.
+     * Setting a max ring size to something reasonable like 14 (3x fused 6
+     * membered rings) avoids this issue.
+     *
+     * @param model the aromaticity model
+     * @param molecule the molecule
+     * @param maxRingSize max ring size to check (optional)
+     * @return if the model could be fully applied (true) or if the computation
+     *         was not possible (false)
+     */
+    public static boolean apply(final ElectronDonation model,
+                                final IAtomContainer molecule,
+                                final int maxRingSize) {
+
+        if (maxRingSize < 3)
+            throw new IllegalArgumentException("maxRingSize="
+                                               + maxRingSize
+                                               + " <3 doesn't make sense");
+
+        // initial ring/cycle search and get the contribution from each atom
+        final int[] contrib = model.contribution(molecule);
+
+        // from the initial contribution assignment prune atoms which are only
+        // connected to < 2 other aromatic atoms these can't be aromatic as
+        // a ring/cycle can not be made, we mark these as having a -1
+        // contribution
+        pruneTerminalAromaticAtoms(contrib, molecule);
+
+        int[] visit = new int[molecule.getAtomCount()];
+        for (int i = 0; i < contrib.length; i++)
+            if (contrib[i] < 0) visit[i] = 1;
+
+        // mark all the "complex" ring systems, these have D3+ aromatic atom
+        // label any atom in a system with a d3 as visit=2, we will process
+        // handle these after first sorting out the simple rings
+        List<IAtom> d3Atoms = new ArrayList<>();
+        for (IAtom atom : molecule.atoms()) {
+            if (isFusionOrBridgeAtom(atom, contrib)) {
+                d3Atoms.add(atom);
+                floodFill(visit, atom, null, 2);
+            }
+        }
+
+        // process the simple cycles (all D2 atoms), we can do this with a
+        // simple non-recursive search, basic benzene, pyrrole rings etc
+        processSimpleRings(molecule, visit, contrib);
+
+        if (d3Atoms.isEmpty())
+            return true;
+
+        // reset the visit=2 to visit=0, we will now process these, we can
+        // skip this but the
+        for (int i=0; i<visit.length; i++)
+            if (visit[i] == 2) visit[i] = 0;
+
+        AllCyclesState state = new AllCyclesState(visit, contrib);
+
+        // now the "hard" work, an iteratively deepening DFS from the D3+
+        // atoms, if the limit it more than 6 we run a 6 member search first to
+        // catch common cases, e.g. benzene's in fulerene. Like wise size 10 is
+        // the outside of napthalene like rings etc.
+        state.setMaxStates(0);
+        if (maxRingSize > 6)
+            state.processComplexRings(d3Atoms, 6);
+        if (maxRingSize > 10)
+            state.processComplexRings(d3Atoms, 10);
+
+        state.setMaxStates(ALLOWED_STATE_COUNT);
+        state.processComplexRings(d3Atoms, maxRingSize);
+
+        return !state.error;
     }
 
     /**
@@ -183,8 +586,8 @@ public final class Aromaticity {
         final int[][] graph = GraphUtil.toAdjList(molecule, bondMap);
 
         // initial ring/cycle search and get the contribution from each atom
-        final RingSearch ringSearch = new RingSearch(molecule, graph);
-        final int[] electrons = model.contribution(molecule, ringSearch);
+        Cycles.markRingAtomsAndBonds(molecule);
+        final int[] electrons = model.contribution(molecule);
 
         final Set<IBond> bonds = new HashSet<>(2*molecule.getBondCount());
 
@@ -215,7 +618,7 @@ public final class Aromaticity {
      * the result is the same irrespective of existing aromatic flags. If you
      * require aromatic flags to be preserved the {@link
      * #findBonds(IAtomContainer)} can be used to find bonds without setting any
-     * flags. 
+     * flags.
      *
      * <blockquote><pre>
      * Aromaticity aromaticity = new Aromaticity(ElectronDonation.cdk(),
@@ -234,26 +637,22 @@ public final class Aromaticity {
      * @return the model found the molecule was aromatic
      */
     public boolean apply(IAtomContainer molecule) throws CDKException {
-
-        Set<IBond> bonds = findBonds(molecule);
-
-        // clear existing flags
-        molecule.setFlag(AROMATIC, false);
-        for (IBond bond : molecule.bonds())
-            bond.setIsAromatic(false);
-        for (IAtom atom : molecule.atoms())
-            atom.setIsAromatic(false);
-
-        // set the new flags
-        for (final IBond bond : bonds) {
-            bond.setIsAromatic(true);
-            bond.getBegin().setIsAromatic(true);
-            bond.getEnd().setIsAromatic(true);
+        clear(molecule);
+        if (backtracking) {
+            Cycles.markRingAtomsAndBonds(molecule);
+            if (!apply(model, molecule, maxRingSize == 0 ? Math.max(molecule.getAtomCount(),3) : maxRingSize)) {
+                throw new Intractable("Molecule is too complex to fully verify aromaticity of all bonds, " +
+                                      "smaller cycles are been marked");
+            }
+            updateMolFlag(molecule);
+        } else {
+            Set<IBond> bonds = findBonds(molecule);
+            for (final IBond bond : bonds)
+                makeAromatic(bond);
+            if (!bonds.isEmpty())
+                molecule.set(AROMATIC);
         }
-
-        molecule.setFlag(AROMATIC, !bonds.isEmpty());
-
-        return !bonds.isEmpty();
+        return molecule.getFlag(AROMATIC);
     }
 
     /**
@@ -267,7 +666,7 @@ public final class Aromaticity {
      * @return the number of electrons indicate they could delocalise
      */
     private static boolean checkElectronSum(final int[] cycle, final int[] contributions, final int[] subset) {
-        return validSum(electronSum(cycle, contributions, subset));
+        return checkHuckelSum(electronSum(cycle, contributions, subset));
     }
 
     /**
@@ -296,7 +695,7 @@ public final class Aromaticity {
      * @return there is an {@code n} such that {@code 4n + 2} is equal to the
      *         provided {@code sum}.
      */
-    static boolean validSum(final int sum) {
+    static boolean checkHuckelSum(final int sum) {
         return (sum - 2) % 4 == 0;
     }
 
@@ -317,8 +716,22 @@ public final class Aromaticity {
         return Arrays.copyOf(vs, n);
     }
 
+    /**
+     * Clear all aromatic flags from the atoms/bonds and molecule.
+     *
+     * @param mol the molecule
+     */
+    public static void clear(IAtomContainer mol) {
+        mol.clear(AROMATIC);
+        for (IBond bond : mol.bonds())
+            bond.clear(AROMATIC);
+        for (IAtom atom : mol.atoms())
+            atom.clear(AROMATIC);
+    }
+
     /** Replicates CDKHueckelAromaticityDetector. */
-    private static final Aromaticity CDK_LEGACY = new Aromaticity(ElectronDonation.cdk(), Cycles.cdkAromaticSet());
+    private static final Aromaticity CDK_LEGACY = new Aromaticity(ElectronDonation.cdk(),
+                                                                  Cycles.cdkAromaticSet());
 
     /**
      * Access an aromaticity instance that replicates the previously utilised -
@@ -351,7 +764,9 @@ public final class Aromaticity {
      *
      * @return aromaticity instance that is configured to perform identically
      *         to the primary aromaticity model in version 1.4.
+     * @deprecated Use a better aromaticity model
      */
+    @Deprecated
     public static Aromaticity cdkLegacy() {
         return CDK_LEGACY;
     }

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/Aromaticity.java
@@ -35,6 +35,7 @@ import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.tools.LoggingToolFactory;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -498,6 +499,7 @@ public final class Aromaticity {
     public static boolean apply(final ElectronDonation model,
                                 final IAtomContainer molecule,
                                 final int maxRingSize) {
+        clear(molecule);
 
         if (maxRingSize < 3)
             throw new IllegalArgumentException("maxRingSize="
@@ -637,7 +639,6 @@ public final class Aromaticity {
      * @return the model found the molecule was aromatic
      */
     public boolean apply(IAtomContainer molecule) throws CDKException {
-        clear(molecule);
         if (backtracking) {
             Cycles.markRingAtomsAndBonds(molecule);
             if (!apply(model, molecule, maxRingSize == 0 ? Math.max(molecule.getAtomCount(),3) : maxRingSize)) {
@@ -646,6 +647,7 @@ public final class Aromaticity {
             }
             updateMolFlag(molecule);
         } else {
+            clear(molecule);
             Set<IBond> bonds = findBonds(molecule);
             for (final IBond bond : bonds)
                 makeAromatic(bond);

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/AtomTypeModel.java
@@ -95,7 +95,7 @@ final class AtomTypeModel extends ElectronDonation {
 
     /**{@inheritDoc} */
     @Override
-    int[] contribution(IAtomContainer container, RingSearch ringSearch) {
+    int[] contribution(IAtomContainer container) {
 
         final int nAtoms = container.getAtomCount();
         final int[] electrons = new int[nAtoms];
@@ -110,7 +110,7 @@ final class AtomTypeModel extends ElectronDonation {
             indexMap.put(atom, i);
 
             // acyclic atom skipped
-            if (!ringSearch.cyclic(i)) continue;
+            if (!atom.isInRing()) continue;
 
             Hybridization hyb = atom.getHybridization();
 
@@ -149,7 +149,7 @@ final class AtomTypeModel extends ElectronDonation {
                 int u = indexMap.get(a1);
                 int v = indexMap.get(a2);
 
-                if (!ringSearch.cyclic(u, v)) {
+                if (!bond.isInRing()) {
 
                     // XXX: single exception - we could make this more general but
                     // for now this mirrors the existing behavior

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/DaylightModel.java
@@ -77,7 +77,7 @@ final class DaylightModel extends ElectronDonation {
 
     /**{@inheritDoc} */
     @Override
-    int[] contribution(IAtomContainer container, RingSearch ringSearch) {
+    int[] contribution(IAtomContainer container) {
 
         int n = container.getAtomCount();
 
@@ -119,7 +119,7 @@ final class DaylightModel extends ElectronDonation {
                 case UNSET:
                     throw new IllegalArgumentException("Aromaticity model requires that bond orders must be set");
                 case DOUBLE:
-                    if (ringSearch.cyclic(u, v)) {
+                    if (bond.isInRing()) {
                         nCyclicPiBonds[u]++;
                         nCyclicPiBonds[v]++;
                     } else {
@@ -138,8 +138,9 @@ final class DaylightModel extends ElectronDonation {
         // now make a decision on how many electrons each atom contributes
         for (int i = 0; i < n; i++) {
 
-            int element = element(container.getAtom(i));
-            int charge = charge(container.getAtom(i));
+            IAtom atom = container.getAtom(i);
+            int element = element(atom);
+            int charge = charge(atom);
 
             // abnormal valence, usually indicated a radical. these cause problems
             // with kekulisations
@@ -151,7 +152,7 @@ final class DaylightModel extends ElectronDonation {
             // non-aromatic element, acyclic atoms, atoms with more than three
             // neighbors and atoms with more than 1 cyclic pi bond are not
             // considered
-            else if (!aromaticElement(element) || !ringSearch.cyclic(i) || degree[i] > 3 || nCyclicPiBonds[i] > 1) {
+            else if (!aromaticElement(element) || !atom.isInRing() || degree[i] > 3 || nCyclicPiBonds[i] > 1) {
                 electrons[i] = -1;
             }
 

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/ElectronDonation.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/ElectronDonation.java
@@ -25,7 +25,8 @@
 package org.openscience.cdk.aromaticity;
 
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.ringsearch.RingSearch;
+
+import static org.openscience.cdk.aromaticity.Aromaticity.*;
 
 /**
  * Defines an electron donation model for perceiving aromatic systems. The model
@@ -68,10 +69,9 @@ public abstract class ElectronDonation {
      * indicates the atom should not contribute at all.
      *
      * @param container  molecule
-     * @param ringSearch ring information
      * @return electron contribution of each atom (-1=none)
      */
-    abstract int[] contribution(IAtomContainer container, RingSearch ringSearch);
+    abstract int[] contribution(IAtomContainer container);
 
     /**
      * Use the preset CDK atom types to determine the electron contribution of
@@ -93,7 +93,9 @@ public abstract class ElectronDonation {
      *
      * @return electron donation model to use for aromaticity perception
      * @see org.openscience.cdk.interfaces.IAtom#getAtomTypeName()
+     * @deprecated Use the newer {@link Model#CDK_1x} or {@link Model#CDK_2x}
      */
+    @Deprecated
     public static ElectronDonation cdk() {
         return new AtomTypeModel(false);
     }
@@ -118,7 +120,9 @@ public abstract class ElectronDonation {
      *
      * @return electron donation model to use for aromaticity perception
      * @see org.openscience.cdk.interfaces.IAtom#getAtomTypeName()
+     * @deprecated Use the newer {@link Model#CDK_1x} or {@link Model#CDK_2x}
      */
+    @Deprecated
     public static ElectronDonation cdkAllowingExocyclic() {
         return new AtomTypeModel(true);
     }
@@ -131,7 +135,9 @@ public abstract class ElectronDonation {
      * a lone pair can not be properly represented.
      *
      * @return electron donation model to use for aromaticity perception
+     * @deprecated Use the newer {@link Model#PiBonds}
      */
+    @Deprecated
     public static ElectronDonation piBonds() {
         return new PiBondModel();
     }
@@ -162,7 +168,9 @@ public abstract class ElectronDonation {
      * but if the exocyclic atom is more electronegative it consumes an
      * electron. As an example ketone groups contribute '0'
      * electrons.</li></ul>
+     * @deprecated Use {@link Model#Daylight}
      */
+    @Deprecated
     public static ElectronDonation daylight() {
         return new DaylightModel();
     }

--- a/base/standard/src/main/java/org/openscience/cdk/aromaticity/PiBondModel.java
+++ b/base/standard/src/main/java/org/openscience/cdk/aromaticity/PiBondModel.java
@@ -43,7 +43,7 @@ final class PiBondModel extends ElectronDonation {
 
     /**{@inheritDoc} */
     @Override
-    int[] contribution(IAtomContainer container, RingSearch ringSearch) {
+    int[] contribution(IAtomContainer container) {
 
         int n = container.getAtomCount();
         int[] electrons = new int[n];
@@ -54,7 +54,7 @@ final class PiBondModel extends ElectronDonation {
             int u = container.indexOf(bond.getBegin());
             int v = container.indexOf(bond.getEnd());
 
-            if (bond.getOrder() == DOUBLE && ringSearch.cyclic(u, v)) {
+            if (bond.getOrder() == DOUBLE && bond.isInRing()) {
                 piBonds[u]++;
                 piBonds[v]++;
             }

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/AromaticTypeMatcherTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/AromaticTypeMatcherTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2024 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.aromaticity;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.graph.Cycles;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AromaticTypeMatcherTest {
+
+    private final Set<AromaticType> REMAINING = Collections.synchronizedSet(EnumSet.allOf(AromaticType.class));
+
+    void assertAtomType(String smi, AromaticType expected) throws InvalidSmilesException {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        SmilesParser sp = new SmilesParser(bldr);
+        IAtomContainer mol = sp.parseSmiles(smi);
+        Cycles.markRingAtomsAndBonds(mol);
+        AromaticType type = AromaticTypeMatcher.getType(mol.getAtom(0));
+        Assertions.assertEquals(expected, type);
+        REMAINING.remove(type);
+    }
+
+    @AfterAll
+    void ensureAllTypesTested() {
+        Assertions.assertTrue(REMAINING.isEmpty(),
+                              "Untested atom types: " + REMAINING);
+    }
+
+    @Test
+    void boronTypes() throws InvalidSmilesException {
+        assertAtomType("B1=NB=NB=N1", AromaticType.B2);
+        assertAtomType("B1NBNBN1", AromaticType.B3);
+        assertAtomType("B", AromaticType.UNKNOWN);
+        assertAtomType("B(N)N", AromaticType.UNKNOWN);
+    }
+
+    @Test
+    void carbonTypes() throws InvalidSmilesException {
+        assertAtomType("[C]1=CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("C1=CC=CC=C1", AromaticType.C3);
+        assertAtomType("[C-]1=CC=CC=C1", AromaticType.C2_MINUS);
+        assertAtomType("[C+]1=CC=CC=C1", AromaticType.C2_PLUS);
+        assertAtomType("[CH-]1CC=CC=C1", AromaticType.C3_MINUS);
+        assertAtomType("[CH+]1CC=CC=C1", AromaticType.C3_PLUS);
+        assertAtomType("C1(=O)CC=CC=C1", AromaticType.C3_ENEG_EXO);
+        assertAtomType("C1(=N)CC=CC=C1", AromaticType.C3_ENEG_EXO);
+        assertAtomType("C1(=C)CC=CC=C1", AromaticType.C3_EXO);
+        assertAtomType("[C-]1CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("C1(=C)=CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("C1(=O)=CC=CC=C1", AromaticType.UNKNOWN);
+    }
+
+    @Test
+    void siliconType() throws InvalidSmilesException {
+        assertAtomType("[Si]1=CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[SiH]1=CC=CC=C1", AromaticType.Si3);
+        assertAtomType("[Si-]1=CC=CC=C1", AromaticType.Si2_MINUS);
+        assertAtomType("[Si+]1=CC=CC=C1", AromaticType.Si2_PLUS);
+        assertAtomType("[SiH-]1CC=CC=C1", AromaticType.Si3_MINUS);
+        assertAtomType("[SiH+]1CC=CC=C1", AromaticType.Si3_PLUS);
+        assertAtomType("[Si]1(=C)CC=CC=C1", AromaticType.Si3_EXO);
+        assertAtomType("[Si-]1CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[Si]1(=C)=CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[Si]1(=O)=CC=CC=C1", AromaticType.UNKNOWN);
+    }
+
+    @Test
+    void nitrogenTypes() throws InvalidSmilesException {
+        assertAtomType("N1=CC=CC=C1", AromaticType.N2);
+        assertAtomType("[N-]1CC=CC=C1", AromaticType.N2_MINUS);
+        assertAtomType("N1CC=CC=C1", AromaticType.N3);
+        assertAtomType("N1(C)CC=CC=C1", AromaticType.N3);
+        assertAtomType("[NH2]1CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[NH3]1CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("N1(=O)=CC=CC=C1", AromaticType.N3_OXIDE);
+        assertAtomType("[N+]1([O-])=CC=CC=C1", AromaticType.N3_OXIDE_PLUS);
+        assertAtomType("[N+]1(=O)CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[NH+]1C=CC=CC=1", AromaticType.N3_PLUS);
+    }
+
+    @Test
+    void phosphorusType() throws InvalidSmilesException {
+        assertAtomType("P1=CC=CC=C1", AromaticType.P2);
+        assertAtomType("[P-]1CC=CC=C1", AromaticType.P2_MINUS);
+        assertAtomType("P1CC=CC=C1", AromaticType.P3);
+        assertAtomType("P1(C)CC=CC=C1", AromaticType.P3);
+        assertAtomType("P1(N)(N)=NC=CC=N1", AromaticType.P4);
+        assertAtomType("P1(=N)(N)NC=CC=N1", AromaticType.UNKNOWN);
+        assertAtomType("[PH2]1CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[PH3]1CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("P1(=O)=CC=CC=C1", AromaticType.P3_OXIDE);
+        assertAtomType("[P+]1([O-])=CC=CC=C1", AromaticType.P3_OXIDE_PLUS);
+        assertAtomType("[P+]1(=O)CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[PH+]1C=CC=CC=1", AromaticType.P3_PLUS);
+    }
+
+    @Test
+    void oxygenTypes() throws InvalidSmilesException {
+        assertAtomType("[O+]1=CC=CC=C1", AromaticType.O2_PLUS);
+        assertAtomType("O1CC=CC=C1", AromaticType.O2);
+        assertAtomType("[OH]1CC=CC=C1", AromaticType.UNKNOWN);
+    }
+
+    @Test
+    void sulphurTypes() throws InvalidSmilesException {
+        assertAtomType("[S+]1=CC=CC=C1", AromaticType.S2_PLUS);
+        assertAtomType("S1CC=CC=C1", AromaticType.S2);
+        assertAtomType("S1(=O)CC=CC=C1", AromaticType.S3_OXIDE);
+        assertAtomType("[S+]1([O-])CC=CC=C1", AromaticType.S3_OXIDE_PLUS);
+        assertAtomType("[S+]1(O)CC=CC=C1", AromaticType.S3_PLUS);
+        assertAtomType("[S+]1([O])CC=CC=C1", AromaticType.S3_PLUS);
+        assertAtomType("[SH]1CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("S=1=CCCCCC1", AromaticType.S2_CUML);
+        assertAtomType("S1=CCCCCC1", AromaticType.S3);
+    }
+
+    @Test
+    void seleniumTypes() throws InvalidSmilesException {
+        assertAtomType("[Se+]1=CC=CC=C1", AromaticType.Se2_PLUS);
+        assertAtomType("[Se]1CC=CC=C1", AromaticType.Se2);
+        assertAtomType("[Se]1(=O)CC=CC=C1", AromaticType.Se3_OXIDE);
+        assertAtomType("[Se+]1([O-])CC=CC=C1", AromaticType.Se3_OXIDE_PLUS);
+        assertAtomType("[Se+]1(O)CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[Se+]1([O])CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[SeH]1CC=CC=C1", AromaticType.UNKNOWN);
+        assertAtomType("[Se]1(C)=CC=CC=C1", AromaticType.Se3);
+    }
+
+    @Test
+    void arsenicTypes() throws InvalidSmilesException {
+        assertAtomType("[As]1=CC=CC=C1", AromaticType.As2);
+        assertAtomType("[As-]1CC=CC=C1", AromaticType.As2_MINUS);
+        assertAtomType("[AsH]1CC=CC=C1", AromaticType.As3);
+        assertAtomType("[As]1(C)CC=CC=C1", AromaticType.As3);
+        assertAtomType("[As+]1(C)=CC=CC=C1", AromaticType.As3_PLUS);
+    }
+
+    @Test
+    void telluriumTypes() throws InvalidSmilesException {
+        assertAtomType("[Te]1C=CC=C1", AromaticType.Te2);
+        assertAtomType("[Te+]1=CC=CC=C1", AromaticType.Te2_PLUS);
+    }
+}

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/AromaticityTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/AromaticityTest.java
@@ -141,6 +141,14 @@ class AromaticityTest {
         Assertions.assertEquals(85, aromBondCount(mol));
     }
 
+    @Test
+    void testPubChem6811flagsCleared() throws Exception {
+        IAtomContainer mol = smiles("c1cccc2c1c(=O)oc(=O)2");
+        Aromaticity.apply(Aromaticity.Model.Daylight, mol);
+        Assertions.assertEquals(6, aromAtomCount(mol));
+        Assertions.assertEquals(6, aromBondCount(mol));
+    }
+
     static int aromAtomCount(IAtomContainer mol) {
         int count = 0;
         for (IAtom atom : mol.atoms())

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/AtomTypeModelTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/AtomTypeModelTest.java
@@ -26,9 +26,8 @@ package org.openscience.cdk.aromaticity;
 
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.exception.CDKException;
-import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.ringsearch.RingSearch;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.templates.TestMoleculeFactory;
@@ -183,9 +182,7 @@ class AtomTypeModelTest {
     /** Check the electron contribution is the same as expected. */
     static void test(IAtomContainer m, int... expected) throws CDKException {
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(m);
-        assertThat(model.contribution(m, new RingSearch(m)), is(expected));
-        // check stability
-        AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(m);
-        assertThat(model.contribution(m, new RingSearch(m)), is(expected));
+        Cycles.markRingAtomsAndBonds(m);
+        assertThat(model.contribution(m), is(expected));
     }
 }

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/DaylightModelTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/DaylightModelTest.java
@@ -26,6 +26,7 @@ package org.openscience.cdk.aromaticity;
 
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.ringsearch.RingSearch;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
@@ -236,6 +237,7 @@ class DaylightModelTest {
     /** Check the electron contribution is the same as expected. */
     static void test(IAtomContainer m, int... expected) throws CDKException {
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(m);
-        assertThat(model.contribution(m, new RingSearch(m)), is(expected));
+        Cycles.markRingAtomsAndBonds(m);
+        assertThat(model.contribution(m), is(expected));
     }
 }

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/ExocyclicAtomTypeModelTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/ExocyclicAtomTypeModelTest.java
@@ -26,6 +26,7 @@ package org.openscience.cdk.aromaticity;
 
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.ringsearch.RingSearch;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
@@ -177,6 +178,7 @@ class ExocyclicAtomTypeModelTest {
     /** Check the electron contribution is the same as expected. */
     static void test(IAtomContainer m, int... expected) throws CDKException {
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(m);
-        assertThat(model.contribution(m, new RingSearch(m)), is(expected));
+        Cycles.markRingAtomsAndBonds(m);
+        assertThat(model.contribution(m), is(expected));
     }
 }

--- a/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/PiBondModelTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/aromaticity/PiBondModelTest.java
@@ -26,6 +26,7 @@ package org.openscience.cdk.aromaticity;
 
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.ringsearch.RingSearch;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
@@ -188,6 +189,7 @@ class PiBondModelTest {
     /** Check the electron contribution is the same as expected. */
     static void test(IAtomContainer m, int... expected) throws CDKException {
         AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(m);
-        assertThat(model.contribution(m, new RingSearch(m)), is(expected));
+        Cycles.markRingAtomsAndBonds(m);
+        assertThat(model.contribution(m), is(expected));
     }
 }

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsPattern.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsPattern.java
@@ -261,7 +261,7 @@ public final class SmartsPattern extends Pattern {
     @Override
     public Mappings matchAll(final IAtomContainer target) {
 
-        prepare(target);
+        prepare(target, requires);
 
         // Note: Mappings is lazy, we can't reset aromaticity etc as the
         // substructure match may not have finished

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsPattern.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsPattern.java
@@ -80,12 +80,6 @@ public final class SmartsPattern extends Pattern {
      */
     private boolean doPrep = true;
 
-    /** Aromaticity model. */
-    private static final Aromaticity    arom = new Aromaticity(ElectronDonation.daylight(),
-                                                               Cycles.or(Cycles.all(), Cycles.relevant()));
-
-
-
     /**
      * Internal constructor.
      *

--- a/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsPattern.java
+++ b/tool/smarts/src/main/java/org/openscience/cdk/smarts/SmartsPattern.java
@@ -104,13 +104,11 @@ public final class SmartsPattern extends Pattern {
     }
 
     public static void prepare(IAtomContainer target) {
-        // apply the daylight aromaticity model
-        try {
-            Cycles.markRingAtomsAndBonds(target);
-            arom.apply(target);
-        } catch (CDKException e) {
-            LoggingToolFactory.createLoggingTool(SmartsPattern.class).error(e);
-        }
+        // mark rings and apply the daylight aromaticity model
+        Cycles.markRingAtomsAndBonds(target);
+        if (!Aromaticity.apply(Aromaticity.Model.Daylight, target))
+            LoggingToolFactory.createLoggingTool(SmartsPattern.class)
+                              .error("Molecule had complex rings and aromaticity may not be completely defined");
     }
 
     /**

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
@@ -32,6 +32,7 @@ import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IReaction;
 import org.openscience.cdk.isomorphism.Mappings;
 import org.openscience.cdk.isomorphism.Pattern;
+import org.openscience.cdk.isomorphism.matchers.QueryAtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 
@@ -253,6 +254,33 @@ class SmartsPatternTest {
         assertMatch("[$([C@](C)(CC)(N)O)]", "C[C@@](N)(CC)O", 1, 1);
         assertMatch("[$([C@](C)(CC)(N)O)]", "C[C@](N)(CC)O", 0, 0);
         assertMatch("[$([C@](C)(CC)(N)O)]", "CC(N)(CC)O", 0, 0);
+    }
+
+    @Test
+    void testPrep() throws Exception {
+        IAtomContainer query = SilentChemObjectBuilder.getInstance().newAtomContainer();
+        Assertions.assertTrue(Smarts.parse(query, "*"));
+        Assertions.assertEquals(SmartsPattern.getRequiredPrep(query), 0);
+
+        query.removeAllElements();
+        Assertions.assertTrue(Smarts.parse(query, "a"));
+        Assertions.assertEquals(SmartsPattern.getRequiredPrep(query),
+                                SmartsPattern.AROM_REQUIRED);
+
+        query.removeAllElements();
+        Assertions.assertTrue(Smarts.parse(query, "*@*"));
+        Assertions.assertEquals(SmartsPattern.getRequiredPrep(query),
+                                SmartsPattern.RING_REQUIRED);
+
+        query.removeAllElements();
+        Assertions.assertTrue(Smarts.parse(query, "*!@*"));
+        Assertions.assertEquals(SmartsPattern.getRequiredPrep(query),
+                                SmartsPattern.RING_REQUIRED);
+
+        query.removeAllElements();
+        Assertions.assertTrue(Smarts.parse(query, "Cl"));
+        Assertions.assertEquals(SmartsPattern.getRequiredPrep(query),
+                                0);
     }
 
     IAtomContainer smi(String smi) throws Exception {


### PR DESCRIPTION
1. The ElectronDontation models now no longer requires a RingSearch instance and instead use the ring flags on atom/bonds, this avoid doing twice the work if we already have done the ring perception.
2. Models/calling of the aromaticity varied but a good set of cycles was Cycles.or(Cycles.all(), Cycles.all(6)) which meant "try all cycles or fall back and only do small cycles (up to size 6). We now do this by default but in reverse. Check small cycles first and only then if there is more work to do we check longer cycles. This is now done internally with a backtracking searching. Intractability is checked with a state counter and the return value rather than an exception. An exception is still thrown on the existing API ``apply(mol)``. If the user provides Cycles.all() we detect this and use the backtracking search.
3. Add a new configurable aromaticity type model. This more efficient model does the aromatic atom type on-the-fly and returns an Enum type. Thought was given to make this a fully fledged AtomTypeMatcher but it would require returning/implementing IAtomType instances which is too heavy weight for this use case. Also for now the model is keep package-private.

Overall this gives us a ~5x performance improvement.


@egonw What goes around comes around, I am warming to the idea of centralised atom types. Will see how much time I have but I think a lighter weight split API (e.g. one that returns enum types and then one that configures these) would be useful. 