### PR TITLE
Testing the debug messages of DebugAtom constructors

### DIFF
--- a/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugAtomTest.java
+++ b/base/datadebug/src/test/java/org/openscience/cdk/debug/DebugAtomTest.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 1997-2007  The Chemistry Development Kit (CDK) project
+ *                    2024  2024  Egon Willighagen <egonw@users.sf.net>
  *
  * Contact: cdk-devel@lists.sourceforge.net
  *
@@ -24,11 +25,14 @@ import javax.vecmath.Point3d;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openscience.cdk.test.interfaces.AbstractAtomTest;
+import org.openscience.cdk.debug.logging.DebugLoggingSink;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.interfaces.IElement;
+import org.openscience.cdk.test.interfaces.AbstractAtomTest;
+import org.openscience.cdk.tools.LoggingToolFactory;
 
 /**
  * Checks the functionality of the {@link DebugAtom}.
@@ -40,6 +44,12 @@ class DebugAtomTest extends AbstractAtomTest {
     @BeforeAll
     static void setUp() {
         setTestObjectBuilder(DebugAtom::new);
+        LoggingToolFactory.setLoggingToolClass(DebugLoggingSink.class);
+    }
+
+    @BeforeEach
+    void resetLog() {
+        DebugLoggingSink.reset();
     }
 
     @Test
@@ -63,6 +73,8 @@ class DebugAtomTest extends AbstractAtomTest {
         Assertions.assertNull(a.getPoint2d());
         Assertions.assertNull(a.getPoint3d());
         Assertions.assertNull(a.getFractionalPoint3d());
+        Assertions.assertTrue(DebugLoggingSink.getLog().contains("org.openscience.cdk.debug.DebugAtom DEBUG"));
+        Assertions.assertTrue(DebugLoggingSink.getLog().contains("symbol= C"));
     }
 
     @Test
@@ -74,6 +86,9 @@ class DebugAtomTest extends AbstractAtomTest {
         Assertions.assertEquals(point3d, a.getPoint3d());
         Assertions.assertNull(a.getPoint2d());
         Assertions.assertNull(a.getFractionalPoint3d());
+        Assertions.assertTrue(DebugLoggingSink.getLog().contains("org.openscience.cdk.debug.DebugAtom DEBUG"));
+        Assertions.assertTrue(DebugLoggingSink.getLog().contains("point3d=(1.0, 2.0, 3.0)"));
+        System.out.println(DebugLoggingSink.getLog());
     }
 
     @Test

--- a/base/datadebug/src/test/java/org/openscience/cdk/debug/logging/DebugLoggingSink.java
+++ b/base/datadebug/src/test/java/org/openscience/cdk/debug/logging/DebugLoggingSink.java
@@ -1,0 +1,114 @@
+/* Copyright (C) 2024  Egon Willighagen <egonw@users.sf.net>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.openscience.cdk.debug.logging;
+
+import org.openscience.cdk.tools.ILoggingTool;
+
+/**
+ * Helper class for the 'datadebug' classes to test that the report debug info.
+ */
+public class DebugLoggingSink implements ILoggingTool {
+
+	private static StringBuffer log = new StringBuffer();
+	private final String classname;
+
+	public DebugLoggingSink(Class<?> sourceClass) {
+		this.classname = sourceClass.getName();
+	}
+
+	public static ILoggingTool create(Class<?> sourceClass) {
+        return new DebugLoggingSink(sourceClass);
+    }
+
+	public static void reset() {
+		log = new StringBuffer();
+	}
+
+	public static String getLog() {
+		return log.toString();
+	}
+
+	@Override
+	public void dumpSystemProperties() {}
+
+	@Override
+	public void setStackLength(int length) {}
+
+	@Override
+	public void dumpClasspath() {}
+
+	@Override
+	public void debug(Object object) {
+        if (object instanceof Throwable) {
+            // don't capture this for now
+        } else {
+            debugString("" + object);
+        }
+    }
+
+	private void debugString(String message) {
+		for (String line : message.split("\n"))
+            log.append(classname + " DEBUG: " + line + "\n");
+	}
+
+	@Override
+	public void debug(Object object, Object... objects) {
+		StringBuilder result = new StringBuilder();
+        result.append(object);
+        for (Object obj : objects) {
+            result.append(obj);
+        }
+        debugString(result.toString());
+	}
+
+	@Override
+	public void error(Object object) {}
+
+	@Override
+	public void error(Object object, Object... objects) {}
+
+	@Override
+	public void fatal(Object object) {}
+
+	@Override
+	public void info(Object object) {}
+
+	@Override
+	public void info(Object object, Object... objects) {}
+
+	@Override
+	public void warn(Object object) {}
+
+	@Override
+	public void warn(Object object, Object... objects) {}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return true;
+	}
+
+	@Override
+	public void setLevel(int level) {}
+
+	@Override
+	public int getLevel() {
+		return 0;
+	}
+
+}


### PR DESCRIPTION
There was a report somewhere (by me) with an indication that the debugdata classes would not be sending log messages. But I cannot confirm this with these new test. The new testing code will serve as framework to do specific testing of the debug messages.