### PR TITLE
add DefaultChemObjectReaderErrorHandler

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/io/DefaultChemObjectReader.java
+++ b/base/core/src/main/java/org/openscience/cdk/io/DefaultChemObjectReader.java
@@ -38,7 +38,7 @@ public abstract class DefaultChemObjectReader extends ChemObjectIO implements IS
     private ReaderEvent                     frameReadEvent = null;
 
     protected IChemObjectReader.Mode        mode           = IChemObjectReader.Mode.RELAXED;
-    protected IChemObjectReaderErrorHandler errorHandler   = null;
+    protected IChemObjectReaderErrorHandler errorHandler   = new DefaultChemObjectReaderErrorHandler();
 
     /* Extra convenience methods */
 

--- a/base/core/src/main/java/org/openscience/cdk/io/DefaultChemObjectReader.java
+++ b/base/core/src/main/java/org/openscience/cdk/io/DefaultChemObjectReader.java
@@ -38,7 +38,7 @@ public abstract class DefaultChemObjectReader extends ChemObjectIO implements IS
     private ReaderEvent                     frameReadEvent = null;
 
     protected IChemObjectReader.Mode        mode           = IChemObjectReader.Mode.RELAXED;
-    protected IChemObjectReaderErrorHandler errorHandler   = new DefaultChemObjectReaderErrorHandler();
+    protected IChemObjectReaderErrorHandler errorHandler   = new DefaultChemObjectReaderErrorHandler(getClass());
 
     /* Extra convenience methods */
 

--- a/base/core/src/main/java/org/openscience/cdk/io/iterator/DefaultIteratingChemObjectReader.java
+++ b/base/core/src/main/java/org/openscience/cdk/io/iterator/DefaultIteratingChemObjectReader.java
@@ -22,6 +22,7 @@ package org.openscience.cdk.io.iterator;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IChemObject;
 import org.openscience.cdk.io.ChemObjectIO;
+import org.openscience.cdk.io.DefaultChemObjectReaderErrorHandler;
 import org.openscience.cdk.io.IChemObjectReaderErrorHandler;
 
 /**
@@ -35,11 +36,11 @@ public abstract class DefaultIteratingChemObjectReader<T extends IChemObject> ex
         IIteratingChemObjectReader<T> {
 
     protected Mode        mode         = Mode.RELAXED;
-    protected IChemObjectReaderErrorHandler errorHandler = null;
+    protected IChemObjectReaderErrorHandler errorHandler = new DefaultChemObjectReaderErrorHandler();
 
     @Override
     public boolean accepts(Class<? extends IChemObject> objectClass) {
-        return false; // it's an iterator, idiot.
+        return false; // it's an iterator
     }
 
     /* Extra convenience methods */

--- a/base/core/src/main/java/org/openscience/cdk/io/iterator/DefaultIteratingChemObjectReader.java
+++ b/base/core/src/main/java/org/openscience/cdk/io/iterator/DefaultIteratingChemObjectReader.java
@@ -36,7 +36,7 @@ public abstract class DefaultIteratingChemObjectReader<T extends IChemObject> ex
         IIteratingChemObjectReader<T> {
 
     protected Mode        mode         = Mode.RELAXED;
-    protected IChemObjectReaderErrorHandler errorHandler = new DefaultChemObjectReaderErrorHandler();
+    protected IChemObjectReaderErrorHandler errorHandler = new DefaultChemObjectReaderErrorHandler(getClass());
 
     @Override
     public boolean accepts(Class<? extends IChemObject> objectClass) {

--- a/base/interfaces/src/main/java/org/openscience/cdk/io/DefaultChemObjectReaderErrorHandler.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/io/DefaultChemObjectReaderErrorHandler.java
@@ -29,6 +29,7 @@ import org.openscience.cdk.tools.LoggingToolFactory;
  * Emits log entries using the {@link LoggingToolFactory}.
  *
  * @cdk.module io
+ * @cdk.githash
  *
  * @author Uli Fechner
  */

--- a/base/interfaces/src/main/java/org/openscience/cdk/io/DefaultChemObjectReaderErrorHandler.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/io/DefaultChemObjectReaderErrorHandler.java
@@ -1,0 +1,77 @@
+/* Copyright (C) 2024 Uli Fechner
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version. All we ask is that proper credit is given for our work,
+ * which includes - but is not limited to - adding the above copyright notice to
+ * the beginning of your source code files, and to any copyright notice that you
+ * may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.openscience.cdk.io;
+
+import org.openscience.cdk.tools.ILoggingTool;
+import org.openscience.cdk.tools.LoggingToolFactory;
+
+/**
+ * Default implementation of the {@link IChemObjectReaderErrorHandler} interface.
+ * Emits log entries using the {@link LoggingToolFactory}.
+ *
+ * @cdk.module io
+ *
+ * @author Uli Fechner
+ */
+public class DefaultChemObjectReaderErrorHandler implements IChemObjectReaderErrorHandler {
+    private static final ILoggingTool logger = LoggingToolFactory.createLoggingTool(DefaultChemObjectReaderErrorHandler.class);
+
+    @Override
+    public void handleError(String message) {
+        logger.error(message);
+    }
+
+    @Override
+    public void handleError(String message, Exception exception) {
+        logger.error(message, exception);
+    }
+
+    @Override
+    public void handleError(String message, int row, int colStart, int colEnd) {
+        logger.error(message + ", row " + row + " column " + colStart + "-" + colEnd);
+    }
+
+    @Override
+    public void handleError(String message, int row, int colStart, int colEnd, Exception exception) {
+        logger.error(message + ", row " + row + " column " + colStart + "-" + colEnd + ", " + exception);
+    }
+
+    @Override
+    public void handleFatalError(String message) {
+        logger.fatal(message);
+    }
+
+    @Override
+    public void handleFatalError(String message, Exception exception) {
+        logger.fatal(message + ", " + exception);
+    }
+
+    @Override
+    public void handleFatalError(String message, int row, int colStart, int colEnd) {
+        logger.fatal(message + ", row " + row + " column " + colStart + "-" + colEnd);
+    }
+
+    @Override
+    public void handleFatalError(String message, int row, int colStart, int colEnd, Exception exception) {
+        logger.fatal(message + ", row " + row + " column " + colStart + "-" + colEnd + ", " + exception);
+    }
+}

--- a/base/interfaces/src/main/java/org/openscience/cdk/io/DefaultChemObjectReaderErrorHandler.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/io/DefaultChemObjectReaderErrorHandler.java
@@ -42,17 +42,17 @@ public class DefaultChemObjectReaderErrorHandler implements IChemObjectReaderErr
 
     @Override
     public void handleError(String message, Exception exception) {
-        logger.error(message, exception);
+        logger.error(message, ", ", exception);
     }
 
     @Override
     public void handleError(String message, int row, int colStart, int colEnd) {
-        logger.error(message + ", row " + row + " column " + colStart + "-" + colEnd);
+        logger.error(message, ", row ", row, " column ", colStart, "-", colEnd);
     }
 
     @Override
     public void handleError(String message, int row, int colStart, int colEnd, Exception exception) {
-        logger.error(message + ", row " + row + " column " + colStart + "-" + colEnd + ", " + exception);
+        logger.error(message + ", row ", row, " column ", colStart, "-", colEnd, ", ", exception);
     }
 
     @Override

--- a/base/interfaces/src/main/java/org/openscience/cdk/io/DefaultChemObjectReaderErrorHandler.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/io/DefaultChemObjectReaderErrorHandler.java
@@ -34,7 +34,33 @@ import org.openscience.cdk.tools.LoggingToolFactory;
  * @author Uli Fechner
  */
 public class DefaultChemObjectReaderErrorHandler implements IChemObjectReaderErrorHandler {
-    private static final ILoggingTool logger = LoggingToolFactory.createLoggingTool(DefaultChemObjectReaderErrorHandler.class);
+    private final ILoggingTool logger;
+
+    /**
+     * Constructs a new instance using the {@code DefaultChemObjectReaderErrorHandler} class as the
+     * source for logging purposes.
+     */
+    public DefaultChemObjectReaderErrorHandler() {
+        this(DefaultChemObjectReaderErrorHandler.class);
+    }
+
+    /**
+     * Constructs a new instance using a given class as the source for logging purposes.
+     *
+     * @param clazz the class for which the {@link ILoggingTool} should be constructed
+     */
+    public DefaultChemObjectReaderErrorHandler(final Class<?> clazz) {
+        this(LoggingToolFactory.createLoggingTool(clazz));
+    }
+
+    /**
+     * Constructs a new instance using the provided logging tool.
+     *
+     * @param logger the logger to be used for emitting log entries
+     */
+    public DefaultChemObjectReaderErrorHandler(final ILoggingTool logger) {
+        this.logger = logger;
+    }
 
     @Override
     public void handleError(String message) {

--- a/base/interfaces/src/main/java/org/openscience/cdk/tools/ILoggingTool.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/tools/ILoggingTool.java
@@ -28,9 +28,11 @@ package org.openscience.cdk.tools;
  *   private static ILoggingTool logger = LoggingToolFactory.createLoggingTool(SomeClass.class);
  * }
  * </pre>
- *
- * <p>The logger has five logging levels:
+ * <p>
+ * The logger has six logging levels:
  * <dl>
+ *  <dt>TRACE
+ *  <dd>Emits the largest number of log entries.
  *  <dt>DEBUG
  *  <dd>Default mode. Used for information you might need to track down the
  *      cause of a bug in the source code, or to understand how an algorithm
@@ -52,8 +54,15 @@ package org.openscience.cdk.tools;
  *      that lead to a situation where this program can no longer function
  *      (rare in Java).
  * </dl>
- *
- * <p>Consider that debugging will not always be turned on. Therefore, it is
+ * </p>
+ * <p>
+ * Logging library might implement less logging levels than the six levels
+ * defined here. This may result in logging levels being merged.
+ * For example, slf4j has five logging levels. Logging level fatal is not supported
+ * so that calls to error and fatal are both logged with slf4j logging level error.
+ * </p>
+ * <p>
+ * Consider that debugging will not always be turned on. Therefore, it is
  * better not to concatenate string in the logger.debug() call, but have the
  * ILoggingTool do this when appropriate. In other words, use:
  * <pre>
@@ -65,8 +74,9 @@ package org.openscience.cdk.tools;
  * logger.debug("The String X has this value: " + someString);
  * logger.debug("The int Y has this value: " + y);
  * </pre>
- *
- * <p>For logging calls that require even more computation you can use the
+ * </p>
+ * <p>
+ * For logging calls that require even more computation you can use the
  * <code>isDebugEnabled()</code> method:
  * <pre>
  * if (logger.isDebugEnabled()) {
@@ -74,11 +84,13 @@ package org.openscience.cdk.tools;
  *     calculatePrime(1056389822));
  * }
  * </pre>
- *
- * <p>In addition to the methods specific in the interface, implementations
+ * </p>
+ * <p>
+ * In addition to the methods specific in the interface, implementations
  * must also implement the static method {@code create(Class<?>)} which
  * is called by {@link LoggingToolFactory} to instantiate the
  * implementation.
+ * </p>
  *
  * @cdk.module  interfaces
  * @cdk.githash

--- a/base/interfaces/src/main/java/org/openscience/cdk/tools/ILoggingTool.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/tools/ILoggingTool.java
@@ -20,20 +20,14 @@
 package org.openscience.cdk.tools;
 
 /**
- * Useful for logging messages. Often used as a class static variable
- * instantiated like (see {@link LoggingToolFactory}):
+ * Useful for logging messages.
+ * Recommended to be used as a private static variable instantiated using
+ * {@link LoggingToolFactory#createLoggingTool(Class)}:
  * <pre>
  * public class SomeClass {
- *   private static ILoggingTool logger;
- *
- *   static {
- *     logger = LoggingToolFactory.createLoggingTool(SomeClass.class);
- *   }
+ *   private static ILoggingTool logger = LoggingToolFactory.createLoggingTool(SomeClass.class);
  * }
  * </pre>
- * There is no special reason not to make the logger private and static, as the
- * logging information is closely bound to one specific Class, not subclasses
- * and not instances.
  *
  * <p>The logger has five logging levels:
  * <dl>
@@ -41,25 +35,25 @@ package org.openscience.cdk.tools;
  *  <dd>Default mode. Used for information you might need to track down the
  *      cause of a bug in the source code, or to understand how an algorithm
  *      works.
+ *  <dt>INFO
+ *  <dd>For reporting informative information to the user that he might easily
+ *      disregard. Real important information should be given to the user using
+ *      a GUI element.
  *  <dt>WARNING
  *  <dd>This indicates a special situation which is unlike to happen, but for
  *      which no special actions need to be taken. E.g. missing information in
  *      files, or an unknown atom type. The action is normally something user
  *      friendly.
- *  <dt>INFO
- *  <dd>For reporting informative information to the user that he might easily
- *      disregard. Real important information should be given to the user using
- *      a GUI element.
+ *  <dt>ERROR
+ *  <dd>This level is used for situations that should not have happened *and*
+ *      thus indicate a bug.
  *  <dt>FATAL
  *  <dd>This level is used for situations that should not have happened *and*
  *      that lead to a situation where this program can no longer function
  *      (rare in Java).
- *  <dt>ERROR
- *  <dd>This level is used for situations that should not have happened *and*
- *      thus indicate a bug.
  * </dl>
  *
- * <p>Consider that the debugging will not always be turned on. Therefore, it is
+ * <p>Consider that debugging will not always be turned on. Therefore, it is
  * better not to concatenate string in the logger.debug() call, but have the
  * ILoggingTool do this when appropriate. In other words, use:
  * <pre>
@@ -81,9 +75,9 @@ package org.openscience.cdk.tools;
  * }
  * </pre>
  *
- * <p>In addition to the methods specific in the interfance, implementations
+ * <p>In addition to the methods specific in the interface, implementations
  * must also implement the static method {@code create(Class<?>)} which
- * can be used by the {@link LoggingToolFactory} to instantiate the
+ * is called by {@link LoggingToolFactory} to instantiate the
  * implementation.
  *
  * @cdk.module  interfaces
@@ -139,7 +133,7 @@ public interface ILoggingTool {
      * {@link Throwable} it will output the trace. Otherwise it will use the
      * toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     void debug(Object object);
 
@@ -147,15 +141,15 @@ public interface ILoggingTool {
      * Shows DEBUG output for the given Object's. It uses the
      * toString() method to concatenate the objects.
      *
-     * @param object  Object to apply toString() too and output
-     * @param objects Object... to apply toString() too and output
+     * @param object  Object to apply toString() to and output
+     * @param objects Object... to apply toString() to and output
      */
     void debug(Object object, Object... objects);
 
     /**
      * Shows ERROR output for the Object. It uses the toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     void error(Object object);
 
@@ -163,22 +157,22 @@ public interface ILoggingTool {
      * Shows ERROR output for the given Object's. It uses the
      * toString() method to concatenate the objects.
      *
-     * @param object  Object to apply toString() too and output
-     * @param objects Object... to apply toString() too and output
+     * @param object  Object to apply toString() to and output
+     * @param objects Object... to apply toString() to and output
      */
     void error(Object object, Object... objects);
 
     /**
      * Shows FATAL output for the Object. It uses the toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     void fatal(Object object);
 
     /**
      * Shows INFO output for the Object. It uses the toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     void info(Object object);
 
@@ -186,15 +180,15 @@ public interface ILoggingTool {
      * Shows INFO output for the given Object's. It uses the
      * toString() method to concatenate the objects.
      *
-     * @param object  Object to apply toString() too and output
-     * @param objects Object... to apply toString() too and output
+     * @param object  Object to apply toString() to and output
+     * @param objects Object... to apply toString() to and output
      */
     void info(Object object, Object... objects);
 
     /**
      * Shows WARN output for the Object. It uses the toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     void warn(Object object);
 
@@ -202,8 +196,8 @@ public interface ILoggingTool {
      * Shows WARN output for the given Object's. It uses the
      * toString() method to concatenate the objects.
      *
-     * @param object Object to apply toString() too and output
-     * @param objects Object... to apply toString() too and output
+     * @param object Object to apply toString() to and output
+     * @param objects Object... to apply toString() to and output
      */
     void warn(Object object, Object... objects);
 

--- a/base/interfaces/src/main/java/org/openscience/cdk/tools/StdErrLogger.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/tools/StdErrLogger.java
@@ -37,7 +37,7 @@ import java.util.Locale;
 final class StdErrLogger implements ILoggingTool {
 
     /** The logging level, default anything above warnings. */
-    private int level = ILoggingTool.WARN;
+    private int level;
 
     /** Name of the class for which this {@link ILoggingTool} is reporting. */
     private final String              classname;
@@ -73,6 +73,9 @@ final class StdErrLogger implements ILoggingTool {
                 break;
             case "fatal":
                 level = ILoggingTool.FATAL;
+                break;
+            default:
+                level = ILoggingTool.WARN;
                 break;
         }
         if (System.getProperty("cdk.debugging", "false").equals("true")
@@ -274,7 +277,7 @@ final class StdErrLogger implements ILoggingTool {
      * @deprecated use {@link #setLevel(int)}
      */
     @Deprecated
-    protected void setDebugEnabled(boolean enabled) {
+    void setDebugEnabled(boolean enabled) {
         if (enabled)
             setLevel(DEBUG);
         else

--- a/base/interfaces/src/main/java/org/openscience/cdk/tools/StdErrLogger.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/tools/StdErrLogger.java
@@ -25,9 +25,11 @@ import java.io.StringWriter;
 import java.util.Locale;
 
 /**
- * You should not use this class directly.
  * Implementation of the {@link ILoggingTool} interface that sends output to
  * the {@link System#err} channel.
+ * <p>
+ * It is <b>strongly recommended to not use this class directly</b>.
+ * </p>
  *
  * @cdk.module core
  * @cdk.githash

--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/Log4jLoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/Log4jLoggingTool.java
@@ -35,59 +35,7 @@ import java.util.Map;
  * interface to Log4J. You can use it by including the <code>cdk-log4j</code>
  * <b>AND</b> <code>log4j-core</code> in you library.
  * <br/>
- * <p>
- * You should not use this class directly, it is created by the LoggingToolFactory
- * as follows:
- * <pre>
- * public class SomeClass {
- *     private static ILoggingTool logger =
- *         LoggingToolFactory.createLoggingTool(SomeClass.class);
- * }
- * </pre>
- * There is no special reason not to make the logger private and static, as the logging
- * information is closely bound to one specific Class, not subclasses and not instances.
- *
- * <p>The logger has five logging levels:
- * <dl>
- *  <dt>DEBUG
- *  <dd>Default mode. Used for information you might need to track down the cause of a
- *      bug in the source code, or to understand how an algorithm works.
- *  <dt>WARNING
- *  <dd>This indicates a special situation which is unlike to happen, but for which no
- *      special actions need to be taken. E.g. missing information in files, or an
- *      unknown atom type. The action is normally something user friendly.
- *  <dt>INFO
- *  <dd>For reporting informative information to the user that he might easily disregard.
- *      Real important information should be given to the user using a GUI element.
- *  <dt>FATAL
- *  <dd>This level is used for situations that should not have happened *and* that
- *      lead to a situation where this program can no longer function (rare in Java).
- *  <dt>ERROR
- *  <dd>This level is used for situations that should not have happened *and* thus
- *      indicate a bug.
- * </dl>
- *
- * <p>Consider that the debugging will not always be turned on. Therefore, it is better
- * not to concatenate string in the logger.debug() call, but have the LoggingTool do
- * this when appropriate. In other words, use:
- * <pre>
- * logger.debug("The String X has this value: ", someString);
- * logger.debug("The int Y has this value: ", y);
- * </pre>
- * instead of:
- * <pre>
- * logger.debug("The String X has this value: " + someString);
- * logger.debug("The int Y has this value: " + y);
- * </pre>
- *
- * <p>For logging calls that require even more computation you can use the
- * <code>isDebugEnabled()</code> method:
- * <pre>
- * if (logger.isDebugEnabled()) {
- *   logger.info("The 1056389822th prime that is used is: ",
- *     calculatePrime(1056389822));
- * }
- * </pre>
+ * See interface {@link ILoggingTool} for more details.
  *
  * @cdk.module cdk-log4j
  * @cdk.githash

--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/Log4jLoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/Log4jLoggingTool.java
@@ -48,7 +48,7 @@ final class Log4jLoggingTool implements ILoggingTool {
 
     /**
      * Log4J2 has customer levels and no longer has "TRACE_INT" etc so we can't know the values at compile
-     * time and therefore it's not possible use a switch.
+     * time. It's therefore not possible to use a switch.
      */
     private static final Map<Level, Integer> LOG4J2_LEVEL_TO_CDK_LEVEL = new HashMap<>();
 
@@ -107,7 +107,7 @@ final class Log4jLoggingTool implements ILoggingTool {
     /**
      * Sets the number of StackTraceElements to be printed in DEBUG mode when
      * calling <code>debug(Throwable)</code>.
-     * The default value is DEFAULT_STACK_LENGTH.
+     * The default value is {@link #DEFAULT_STACK_LENGTH}.
      *
      * @param length the new stack length
      * @see #DEFAULT_STACK_LENGTH
@@ -344,7 +344,7 @@ final class Log4jLoggingTool implements ILoggingTool {
      */
     @Override
     public void setLevel(int level) {
-        throw new IllegalArgumentException("Log4J does not let you set the level at runtime via the API");
+        throw new UnsupportedOperationException("Log4J does not let you set the level at runtime via the API");
     }
 
     /**
@@ -357,7 +357,7 @@ final class Log4jLoggingTool implements ILoggingTool {
             level = LogManager.getRootLogger().getLevel();
         Integer res = LOG4J2_LEVEL_TO_CDK_LEVEL.get(level);
         if (res == null)
-            throw new IllegalArgumentException("Unsupported log4j level: " + level);
+            throw new IllegalStateException("Unsupported log4j level: " + level);
         return res;
     }
 }

--- a/misc/log4j/src/main/java/org/openscience/cdk/tools/Log4jLoggingTool.java
+++ b/misc/log4j/src/main/java/org/openscience/cdk/tools/Log4jLoggingTool.java
@@ -47,11 +47,6 @@ final class Log4jLoggingTool implements ILoggingTool {
     private int stackLength;
 
     /**
-     * Default number of StackTraceElements to be printed by debug(Exception).
-     */
-    public final int DEFAULT_STACK_LENGTH = 5;
-
-    /**
      * Log4J2 has customer levels and no longer has "TRACE_INT" etc so we can't know the values at compile
      * time and therefore it's not possible use a switch.
      */
@@ -248,7 +243,7 @@ final class Log4jLoggingTool implements ILoggingTool {
      */
     @Override
     public void fatal(Object object) {
-        log4jLogger.fatal("" + object.toString());
+        log4jLogger.fatal(object.toString());
     }
 
     /**
@@ -258,7 +253,7 @@ final class Log4jLoggingTool implements ILoggingTool {
      */
     @Override
     public void info(Object object) {
-        infoString("" + object);
+        infoString(object.toString());
     }
 
     /**

--- a/misc/slf4j/src/main/java/org/openscience/cdk/tools/Slf4jLoggingTool.java
+++ b/misc/slf4j/src/main/java/org/openscience/cdk/tools/Slf4jLoggingTool.java
@@ -44,12 +44,6 @@ final class Slf4jLoggingTool implements ILoggingTool {
 
     private int stackLength;
 
-    /**
-     * Default number of StackTraceElements to be printed by debug(Exception).
-     */
-    public final int DEFAULT_STACK_LENGTH = 5;
-
-
     private final Marker fatal = MarkerFactory.getMarker("FATAL");
 
     /**
@@ -235,7 +229,7 @@ final class Slf4jLoggingTool implements ILoggingTool {
     @Override
     public void fatal(Object object)
     {
-        slf4jlogger.error(fatal, "" + object.toString());
+        slf4jlogger.error(fatal, object.toString());
     }
 
     /**
@@ -245,7 +239,7 @@ final class Slf4jLoggingTool implements ILoggingTool {
      */
     @Override
     public void info(Object object) {
-        infoString("" + object);
+        infoString(object.toString());
     }
 
     /**

--- a/misc/slf4j/src/main/java/org/openscience/cdk/tools/Slf4jLoggingTool.java
+++ b/misc/slf4j/src/main/java/org/openscience/cdk/tools/Slf4jLoggingTool.java
@@ -33,59 +33,7 @@ import java.io.StringReader;
  * <b>AND</b> some implementation e.g. <code>slf4j-simple</code>,
  * <code>log4j-over-slf4j</code>, etc. in you library.
  * <br/>
- * <p>
- * You should not use this class directly, it is created by the LoggingToolFactory
- * as follows:
- * <pre>
- * public class SomeClass {
- *     private static ILoggingTool logger =
- *         LoggingToolFactory.createLoggingTool(SomeClass.class);
- * }
- * </pre>
- * There is no special reason not to make the logger private and static, as the logging
- * information is closely bound to one specific Class, not subclasses and not instances.
- *
- * <p>The logger has five logging levels:
- * <dl>
- *  <dt>DEBUG
- *  <dd>Default mode. Used for information you might need to track down the cause of a
- *      bug in the source code, or to understand how an algorithm works.
- *  <dt>WARNING
- *  <dd>This indicates a special situation which is unlike to happen, but for which no
- *      special actions need to be taken. E.g. missing information in files, or an
- *      unknown atom type. The action is normally something user friendly.
- *  <dt>INFO
- *  <dd>For reporting informative information to the user that he might easily disregard.
- *      Real important information should be given to the user using a GUI element.
- *  <dt>FATAL
- *  <dd>This level is used for situations that should not have happened *and* that
- *      lead to a situation where this program can no longer function (rare in Java).
- *  <dt>ERROR
- *  <dd>This level is used for situations that should not have happened *and* thus
- *      indicate a bug.
- * </dl>
- *
- * <p>Consider that the debugging will not always be turned on. Therefore, it is better
- * not to concatenate string in the logger.debug() call, but have the LoggingTool do
- * this when appropriate. In other words, use:
- * <pre>
- * logger.debug("The String X has this value: ", someString);
- * logger.debug("The int Y has this value: ", y);
- * </pre>
- * instead of:
- * <pre>
- * logger.debug("The String X has this value: " + someString);
- * logger.debug("The int Y has this value: " + y);
- * </pre>
- *
- * <p>For logging calls that require even more computation you can use the
- * <code>isDebugEnabled()</code> method:
- * <pre>
- * if (logger.isDebugEnabled()) {
- *   logger.info("The 1056389822th prime that is used is: ",
- *     calculatePrime(1056389822));
- * }
- * </pre>
+ * See interface {@link ILoggingTool} for more details.
  *
  * @cdk.module cdk-slf4j
  * @cdk.githash

--- a/misc/slf4j/src/main/java/org/openscience/cdk/tools/Slf4jLoggingTool.java
+++ b/misc/slf4j/src/main/java/org/openscience/cdk/tools/Slf4jLoggingTool.java
@@ -92,7 +92,7 @@ final class Slf4jLoggingTool implements ILoggingTool {
     /**
      * Sets the number of StackTraceElements to be printed in DEBUG mode when
      * calling <code>debug(Throwable)</code>.
-     * The default value is DEFAULT_STACK_LENGTH.
+     * The default value is {@link #DEFAULT_STACK_LENGTH}.
      *
      * @param length the new stack length
      * @see #DEFAULT_STACK_LENGTH
@@ -191,7 +191,7 @@ final class Slf4jLoggingTool implements ILoggingTool {
     /**
      * Shows ERROR output for the Object. It uses the toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     @Override
     public void error(Object object) {
@@ -202,8 +202,8 @@ final class Slf4jLoggingTool implements ILoggingTool {
      * Shows ERROR output for the given Object's. It uses the
      * toString() method to concatenate the objects.
      *
-     * @param object  Object to apply toString() too and output
-     * @param objects Object[] to apply toString() too and output
+     * @param object  Object to apply toString() to and output
+     * @param objects Object[] to apply toString() to and output
      */
     @Override
     public void error(Object object, Object... objects) {
@@ -224,7 +224,7 @@ final class Slf4jLoggingTool implements ILoggingTool {
     /**
      * Shows FATAL output for the Object. It uses the toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     @Override
     public void fatal(Object object)
@@ -235,7 +235,7 @@ final class Slf4jLoggingTool implements ILoggingTool {
     /**
      * Shows INFO output for the Object. It uses the toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     @Override
     public void info(Object object) {
@@ -246,8 +246,8 @@ final class Slf4jLoggingTool implements ILoggingTool {
      * Shows INFO output for the given Object's. It uses the
      * toString() method to concatenate the objects.
      *
-     * @param object  Object to apply toString() too and output
-     * @param objects Object[] to apply toString() too and output
+     * @param object  Object to apply toString() to and output
+     * @param objects Object[] to apply toString() to and output
      */
     @Override
     public void info(Object object, Object... objects) {
@@ -268,7 +268,7 @@ final class Slf4jLoggingTool implements ILoggingTool {
     /**
      * Shows WARN output for the Object. It uses the toString() method.
      *
-     * @param object Object to apply toString() too and output
+     * @param object Object to apply toString() to and output
      */
     @Override
     public void warn(Object object) {
@@ -283,8 +283,8 @@ final class Slf4jLoggingTool implements ILoggingTool {
      * Shows WARN output for the given Object's. It uses the
      * toString() method to concatenate the objects.
      *
-     * @param object  Object to apply toString() too and output
-     * @param objects Object[] to apply toString() too and output
+     * @param object  Object to apply toString() to and output
+     * @param objects Object[] to apply toString() to and output
      */
     @Override
     public void warn(Object object, Object... objects) {
@@ -330,7 +330,7 @@ final class Slf4jLoggingTool implements ILoggingTool {
      */
     @Override
     public void setLevel(int level) {
-        throw new IllegalArgumentException("slf4j does not let you set the level at runtime via the API");
+        throw new UnsupportedOperationException("slf4j does not let you set the level at runtime via the API");
     }
 
     /**


### PR DESCRIPTION
Adds `DefaultChemObjectReaderErrorHandler` and sets as default for `DefaultChemObjectReader` and `DefaultIteratingChemObjectReader`. Misc javadoc fixes and small code changes in ILoggingTool and implementing classes.