### PR TITLE
add test dependencies assertj and mockito-junit-jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,7 @@
     <scm>
         <url>https://github.com/cdk/cdk</url>
         <connection>scm:git:git://github.com/cdk/cdk.git</connection>
-        <developerConnection>scm:git:git@github.com:cdk/cdk.git
-        </developerConnection>
+        <developerConnection>scm:git:git@github.com:cdk/cdk.git</developerConnection>
     </scm>
     <issueManagement>
         <url>https://github.com/cdk/cdk/issues</url>
@@ -64,7 +63,7 @@
              url is provided but the field is needed to stage the site. -->
         <site>
             <id>cdk.github.com</id>
-            <url>http://cdk.github.io/cdk/</url>
+            <url>https://cdk.github.io/cdk/</url>
         </site>
     </distributionManagement>
     <repositories>
@@ -510,9 +509,19 @@
                 <version>2.2</version>
             </dependency>
             <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.26.3</version>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>4.11.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>5.14.2</version>
             </dependency>
             <dependency>
                 <groupId>javax.vecmath</groupId>


### PR DESCRIPTION
I would like to add two dependencies to the parent `pom.xml` that facilitate writing tests:
- `assertj` with its fluent api is more modern and powerful compared to `hamcrest` when it comes to writing assertions
- `mockito-junit-jupiter` ties into the Junit5 lifecycle and provides annotations for mock instantiation and injection; this makes writing tests that use mockito mocks easier and more reliable

Both of these dependencies are only relevant for the maven scope `test` and would thus not impact on the size of shipped jars.