### PR TITLE
Update BEAM to v1.3.7 to fix a corner case with reading SMILES and ar…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -476,12 +476,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-core</artifactId>
-                <version>1.3.5</version>
+                <version>1.3.7</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-func</artifactId>
-                <version>1.3.5</version>
+                <version>1.3.7</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
@@ -153,6 +153,14 @@ final class BeamToCDK {
                     checkBondStereo = true;
                     bond.setOrder(IBond.Order.SINGLE);
                     break;
+                case UP_AROMATIC:
+                case DOWN_AROMATIC:
+                    checkBondStereo = true;
+                    bond.setOrder(IBond.Order.SINGLE);
+                    bond.setIsAromatic(true);
+                    atoms[u].setIsAromatic(true);
+                    atoms[v].setIsAromatic(true);
+                    break;
                 case IMPLICIT:
                     bond.setOrder(IBond.Order.SINGLE);
                     if (!kekule && atoms[u].isAromatic() && atoms[v].isAromatic()) {

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesParserTest.java
@@ -2734,6 +2734,15 @@ class SmilesParserTest extends CDKTestCase {
     }
 
     @Test
+    void testDirectionalBondAromaticity() throws InvalidSmilesException {
+        IAtomContainer mol = load("C=c1ccccc/1=C/C");
+        int count = 0;
+        for (IBond bond : mol.bonds())
+            count += bond.isAromatic() ? 1 : 0;
+        Assertions.assertEquals(6, count);
+    }
+
+    @Test
     void testMultiStepSmiles() throws Exception {
         SmilesParser smipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         SmilesGenerator smigen = new SmilesGenerator(SmiFlavor.Default);


### PR DESCRIPTION
…omatic flags.

Directional bonds / and \ in SMILES are aromatic if both end atoms are aromatic - this is because the double bond MUST be exo.

Note: need to wait for Central to sync.