### PR TITLE
Advanced Inorganic Handling

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/stereo/Octahedral.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/Octahedral.java
@@ -335,7 +335,7 @@ public final class Octahedral extends AbstractStereo<IAtom,IAtom> {
     public Octahedral normalize() {
         int cfg = getConfigOrder();
         if (cfg == 1) {
-            return normalizeImplicit();
+            return this;
         }
         if (cfg < 1 || cfg > 30)
             throw new IllegalArgumentException(
@@ -343,7 +343,7 @@ public final class Octahedral extends AbstractStereo<IAtom,IAtom> {
                 + "1 <= order <= 30!");
         IAtom[] carriers = invapply(getCarriers().toArray(new IAtom[6]),
                                     PERMUTATIONS[cfg-1]);
-        return new Octahedral(getFocus(), carriers, 1).normalizeImplicit();
+        return new Octahedral(getFocus(), carriers, 1);
     }
 
     /**
@@ -406,19 +406,20 @@ public final class Octahedral extends AbstractStereo<IAtom,IAtom> {
     }
 
     public TrigonalBipyramidal asTrigonalBipyramidal() {
-        Octahedral normalized = this.normalize();
+        Octahedral normalized = this.normalize().normalizeImplicit();
         if (!normalized.canBeTrigonalBipyramidal()) {
             return null;
         } else {
             IAtom focus = (IAtom)normalized.getFocus();
             List<IAtom> carriers = normalized.getCarriers();
-            if (((IAtom)carriers.get(1)).equals(focus)) {
+            if (carriers.get(1).equals(focus)) {
                 carriers.remove(1);
-            } else if (((IAtom)carriers.get(2)).equals(focus)) {
+            } else if (carriers.get(2).equals(focus)) {
                 carriers.remove(2);
             }
-
-            return new TrigonalBipyramidal((IAtom)this.getFocus(), (IAtom[])carriers.toArray(new IAtom[5]), 1);
+            return new TrigonalBipyramidal(this.getFocus(),
+                                           carriers.toArray(new IAtom[5]),
+                                           1);
         }
     }
 }

--- a/base/core/src/main/java/org/openscience/cdk/stereo/SquarePlanar.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/SquarePlanar.java
@@ -118,16 +118,22 @@ public final class SquarePlanar extends AbstractStereo<IAtom,IAtom> {
 
     public Octahedral asOctahedral() {
         List<IAtom> carriers = this.getCarriers();
-        int cfg = 24832;
+        int cfg = IStereoElement.Octahedral;
         if (this.getConfigOrder() == 1) {
-            cfg |= 1;
+            cfg = 1;
         } else if (this.getConfigOrder() == 2) {
-            cfg |= 10;
+            cfg = 10;
         } else if (this.getConfigOrder() == 3) {
-            cfg |= 4;
+            cfg = 4;
         }
-
-        return new Octahedral((IAtom)this.getFocus(), new IAtom[]{(IAtom)this.getFocus(), (IAtom)carriers.get(0), (IAtom)carriers.get(1), (IAtom)carriers.get(2), (IAtom)carriers.get(3), (IAtom)this.getFocus()}, cfg);
+        return new Octahedral(this.getFocus(),
+                              new IAtom[]{this.getFocus(),
+                                          carriers.get(0),
+                                          carriers.get(1),
+                                          carriers.get(2),
+                                          carriers.get(3),
+                                          this.getFocus()},
+                              cfg);
     }
 
     /**

--- a/base/core/src/main/java/org/openscience/cdk/stereo/SquarePlanar.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/SquarePlanar.java
@@ -116,6 +116,20 @@ public final class SquarePlanar extends AbstractStereo<IAtom,IAtom> {
                                 SPU);
     }
 
+    public Octahedral asOctahedral() {
+        List<IAtom> carriers = this.getCarriers();
+        int cfg = 24832;
+        if (this.getConfigOrder() == 1) {
+            cfg |= 1;
+        } else if (this.getConfigOrder() == 2) {
+            cfg |= 10;
+        } else if (this.getConfigOrder() == 3) {
+            cfg |= 4;
+        }
+
+        return new Octahedral((IAtom)this.getFocus(), new IAtom[]{(IAtom)this.getFocus(), (IAtom)carriers.get(0), (IAtom)carriers.get(1), (IAtom)carriers.get(2), (IAtom)carriers.get(3), (IAtom)this.getFocus()}, cfg);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/base/core/src/main/java/org/openscience/cdk/stereo/TrigonalBipyramidal.java
+++ b/base/core/src/main/java/org/openscience/cdk/stereo/TrigonalBipyramidal.java
@@ -159,11 +159,8 @@ public final class TrigonalBipyramidal extends AbstractStereo<IAtom,IAtom> {
 
     public boolean canBeOctahedral() {
         int numExplicit = 0;
-        IAtom focus = (IAtom)this.getFocus();
-        Iterator var3 = this.getCarriers().iterator();
-
-        while(var3.hasNext()) {
-            IAtom atom = (IAtom)var3.next();
+        IAtom focus = this.getFocus();
+        for (IAtom atom : getCarriers()) {
             if (!atom.equals(focus)) {
                 ++numExplicit;
             }
@@ -177,7 +174,7 @@ public final class TrigonalBipyramidal extends AbstractStereo<IAtom,IAtom> {
             int numEquatorial = 0;
 
             for(int i = 1; i < 4; ++i) {
-                if (!((IAtom)carriers.get(i)).equals(focus)) {
+                if (!carriers.get(i).equals(focus)) {
                     ++numEquatorial;
                 }
             }
@@ -191,10 +188,10 @@ public final class TrigonalBipyramidal extends AbstractStereo<IAtom,IAtom> {
         if (!normalized.canBeOctahedral()) {
             return null;
         } else {
-            IAtom focus = (IAtom)normalized.getFocus();
+            IAtom focus = normalized.getFocus();
             List<IAtom> carriers = normalized.getCarriers();
             carriers.add(1, focus);
-            return new Octahedral((IAtom)this.getFocus(), (IAtom[])carriers.toArray(new IAtom[6]), 1);
+            return new Octahedral(this.getFocus(), carriers.toArray(new IAtom[6]), 1);
         }
     }
 }

--- a/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
+++ b/base/isomorphism/src/main/java/org/openscience/cdk/isomorphism/QueryStereoFilter.java
@@ -287,8 +287,8 @@ final class QueryStereoFilter implements Predicate<int[]> {
                 currentOrdering.add(mapped.contains(atom) ? atom : targetAtom);
             }
             Octahedral oc = new Octahedral(targetAtom,
-                                            currentOrdering.<IAtom>toArray(new IAtom[0]),
-                                            targetElement.getConfigOrder());
+                                           currentOrdering.<IAtom>toArray(new IAtom[0]),
+                                           targetElement.getConfigOrder());
             TrigonalBipyramidal tbpy = oc.asTrigonalBipyramidal();
             if (tbpy == null)
                 return false;

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
@@ -483,8 +483,9 @@ final class BeamToCDK {
 
     private IStereoElement newSquarePlanar(int u, int[] vs, IAtom[] atoms, Configuration c) {
 
-        if (vs.length != 4)
-            return null;
+        if (vs.length != 4) {
+            vs = insert(u, vs, 4);
+        }
 
         int order;
         switch (c) {
@@ -507,8 +508,9 @@ final class BeamToCDK {
     }
 
     private IStereoElement newTrigonalBipyramidal(int u, int[] vs, IAtom[] atoms, Configuration c) {
-        if (vs.length != 5)
-            return null;
+        if (vs.length != 5) {
+            vs = insert(u, vs, 5);
+        }
         int order = 1 + c.ordinal() - Configuration.TB1.ordinal();
         if (order < 1 || order > 20)
             return null;
@@ -518,8 +520,9 @@ final class BeamToCDK {
     }
 
     private IStereoElement newOctahedral(int u, int[] vs, IAtom[] atoms, Configuration c) {
-        if (vs.length != 6)
-            return null;
+        if (vs.length != 6) {
+            vs = insert(u, vs, 6);
+        }
         int order = 1 + c.ordinal() - Configuration.OH1.ordinal();
         if (order < 1 || order > 30)
             return null;
@@ -606,6 +609,18 @@ final class BeamToCDK {
             ws[i - 1] = tmp;
         }
 
+        return ws;
+    }
+
+    private static int[] insert(int v, int[] vs, int n2) {
+        int n = vs.length;
+        int[] ws = Arrays.copyOf(vs, n2);
+
+        for(int j = n; j < n2; ++j) {
+            ws[j] = v;
+        }
+
+        Arrays.sort(ws);
         return ws;
     }
 

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
@@ -345,6 +345,12 @@ class SmartsPatternTest {
                     "N[Co@OH1]N", 2, 1);
         assertMatch("N[Co@TB1]N",
                     "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 2, 1);
+        assertMatch("N[Co@TB1]N",
+                    "N[Co@SP3](Cl)(Cl)N", 2, 1);
+        assertMatch("N[Co@TB1](Cl)N",
+                    "N[Co@SP3](Cl)(Cl)N", 4, 2);
+        assertMatch("N[Co@TB1](Cl)N",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 8, 4);
     }
 
     IAtomContainer smi(String smi) throws Exception {

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
@@ -283,6 +283,59 @@ class SmartsPatternTest {
                                 0);
     }
 
+    @Test
+    void testOctahedralMatching() throws Exception {
+        // octahedral vs octahedral
+        // U
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 8, 1);
+        assertMatch("N[Co@OH2](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 8, 1);
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH2](Cl)(Cl)(Cl)(Cl)N", 8, 1);
+        // Z
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH4](Cl)(Cl)(Cl)(Cl)N", 8, 1);
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH14](Cl)(Cl)(Cl)(Cl)N", 8, 1);
+        // 4
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH4](Cl)(Cl)(Cl)(Cl)N", 8, 1);
+        assertMatch("N[Co@OH10](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH8](Cl)(Cl)(Cl)(Cl)N", 8, 1);
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH3](Cl)(Cl)(Cl)(Cl)N", 0, 0);
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH5](Cl)(Cl)(Cl)(Cl)N", 0, 0);
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH6](Cl)(Cl)(Cl)(Cl)N", 0, 0);
+        // ... and all the rest ...
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH29](Cl)(Cl)(Cl)(Cl)N", 0, 0);
+        assertMatch("N[Co@OH1](Cl)(Cl)(Cl)(Cl)N",
+                    "N[Co@OH30](Cl)(Cl)(Cl)(Cl)N", 0, 0);
+    }
+
+    @Test
+    void testDegenerateOctahedralMatching() throws Exception {
+        // trans-N-Co-N (match)
+        assertMatch("N[Co@OH1]N",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 2, 1);
+        assertMatch("N[Co@OH1]N",
+                    "N[Co@OH1]N", 2, 1);
+        assertMatch("N[Co@OH1]N",
+                    "N[Co@OH3]N", 0, 0);
+        // trans-N-Co-Cl (no match)
+        assertMatch("N[Co@OH1]Cl",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 0, 0);
+        // trans-Cl-Co-Cl
+        assertMatch("Cl[Co@OH1]Cl",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 4, 2);
+        // cis-N-Co-Cl
+        assertMatch("N[Co@OH3]Cl",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 8, 8);
+    }
+
     IAtomContainer smi(String smi) throws Exception {
         return new SmilesParser(bldr).parseSmiles(smi);
     }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
@@ -353,6 +353,14 @@ class SmartsPatternTest {
                     "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 8, 4);
     }
 
+    @Test
+    void testSpVsOC() throws Exception {
+        assertMatch("N[Co@SP3](Cl)(Cl)N",
+                    "N[Co@SP3](Cl)(Cl)N", 4, 1);
+        assertMatch("N[Co@SP3](Cl)(Cl)N",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 8, 2);
+    }
+
     IAtomContainer smi(String smi) throws Exception {
         return new SmilesParser(bldr).parseSmiles(smi);
     }

--- a/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
+++ b/tool/smarts/src/test/java/org/openscience/cdk/smarts/SmartsPatternTest.java
@@ -336,6 +336,17 @@ class SmartsPatternTest {
                     "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 8, 8);
     }
 
+    @Test
+    void testOcVsTbpy() throws Exception {
+        // trans-N-Co-N (match)
+        assertMatch("N[Co@OH1]N",
+                    "N[Co@TB1](Cl)(Cl)(Cl)N", 2, 1);
+        assertMatch("N[Co@TB1]N",
+                    "N[Co@OH1]N", 2, 1);
+        assertMatch("N[Co@TB1]N",
+                    "N[Co@OH1](Cl)(Cl)(Cl)(Cl)N", 2, 1);
+    }
+
     IAtomContainer smi(String smi) throws Exception {
         return new SmilesParser(bldr).parseSmiles(smi);
     }


### PR DESCRIPTION
An extension originally proposed by Roger [here](https://nextmovesoftware.com/talks/Sayle_Inorganics_RDKITUGM_202110.pdf) allow implicit neighbours on inorganic stereochemistry. I had most of this done a while ago but needed to patch RDKit since some wire got crossed when I conveyed it to and Roger and the RDKit version put implicit neighbours at the end rather than next to the central atom (https://github.com/rdkit/rdkit/pull/6777). Should all be up and live on CDK depict with the SMARTS matching.

For example a normal octahedral has 6 neighbors:


```N[Co@OH1](Cl)(Cl)(Cl)(Cl)N```

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N&w=-1&h=-1&abbr=on&hdisp=S&zoom=1.3&annotate=none&r=0)

You can (now) also represent square-pyramidal:

```N[Co@OH25](Cl)(Cl)(Cl)(Cl)```

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH25%5D(Cl)(Cl)(Cl)Cl&w=-1&h=-1&abbr=on&hdisp=S&zoom=1.3&annotate=none&r=0)

The the way this works is the implicit neighbors are where the central atom is, in all these cases the Nitrogens are across/trans to each other:

```
N[Co@OH1]([H])([H])([H])([H])N
N[Co@OH1H]([H])([H])([H])N
N[Co@OH1H2]([H])([H])N
N[Co@OH1H4]N
N[Co@OH1]N
```

Beyond representation you can also match them with smarts, a common technique with inorganic is matching the "across/trans" atoms or "cis" (right angle). You can do this with SMARTS:

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N.N%5BCo%40OH25%5D(Cl)(Cl)(Cl)Cl%20query%3A%20N%5BCo%40OH1%5DN&w=-1&h=-1&abbr=on&hdisp=S&showtitle=true&sma=N%5BCo%40OH1%5DN&zoom=1.3&annotate=none&r=0)

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N.N%5BCo%40OH25%5D(Cl)(Cl)(Cl)Cl%20query%3A%20Cl%5BCo%40OH1%5DCl&w=-1&h=-1&abbr=on&hdisp=S&showtitle=true&sma=Cl%5BCo%40OH1%5DCl&zoom=1.3&annotate=none&r=0)

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N.N%5BCo%40OH25%5D(Cl)(Cl)(Cl)Cl%20query%3A%20N%5BCo%40OH1%5DCl%20(no%20match)&w=-1&h=-1&abbr=on&hdisp=S&showtitle=true&sma=N%5BCo%40OH1%5DCl&zoom=1.3&annotate=none&r=0)

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N.N%5BCo%40OH25%5D(Cl)(Cl)(Cl)Cl%20query%3A%20N%5BCo%40OH3%5DCl&w=-1&h=-1&abbr=on&hdisp=S&showtitle=true&sma=N%5BCo%40OH3%5DCl&zoom=1.3&annotate=none&r=0)

You can also match a square planar against an octahedral:

```
N[Co@OH1](Cl)(Cl)(Cl)(Cl)N.N[Co@SP3](Cl)(Cl)N
```

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N.N%5BCo%40SP3%5D(Cl)(Cl)N%20query%3A%20N%5BCo%40SP3%5D(Cl)(Cl)N&w=-1&h=-1&abbr=on&hdisp=S&showtitle=true&sma=N%5BCo%40SP3%5D(Cl)(Cl)N&zoom=1.300&annotate=none&r=0)

And TBPY vs SP vs OH:

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N.N%5BCo%40SP3%5D(Cl)(Cl)N.N%5BCo%40TB1%5D(Cl)(Cl)(Cl)N%20query%3A%20N%5BCo%40TB1%5DN&w=-1&h=-1&abbr=on&hdisp=S&showtitle=true&sma=N%5BCo%40TB1%5DN&zoom=1.300&annotate=none&r=0) - might need browser refresh
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N.N%5BCo%40SP3%5D(Cl)(Cl)N.N%5BCo%40TB1%5D(Cl)(Cl)(Cl)N%20query%3A%20N%5BCo%40OH1%5DN&w=-1&h=-1&abbr=on&hdisp=S&showtitle=true&sma=N%5BCo%40OH1%5DN&zoom=1.300&annotate=none&r=0)
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=N%5BCo%40OH1%5D(Cl)(Cl)(Cl)(Cl)N.N%5BCo%40SP3%5D(Cl)(Cl)N.N%5BCo%40TB1%5D(Cl)(Cl)(Cl)N%20query%3A%20N%5BCo%40SP3%5DN&w=-1&h=-1&abbr=on&hdisp=S&showtitle=true&sma=N%5BCo%40SP3%5DN&zoom=1.300&annotate=none&r=0)


