### PR TITLE
fix crash in SmilesGenerator when calling with reaction not having one or more reaction components

### DIFF
--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ReactionManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/ReactionManipulatorTest.java
@@ -151,22 +151,22 @@ class ReactionManipulatorTest extends CDKTestCase {
     }
 
     @Test
-    void testGetAtomCount_IReaction() throws Exception {
+    void testGetAtomCount_IReaction() {
         Assertions.assertEquals(19, ReactionManipulator.getAtomCount(reaction));
     }
 
     @Test
-    void testGetBondCount_IReaction() throws Exception {
+    void testGetBondCount_IReaction() {
         Assertions.assertEquals(18, ReactionManipulator.getBondCount(reaction));
     }
 
     @Test
-    void testGetAllAtomContainers_IReaction() throws Exception {
+    void testGetAllAtomContainers_IReaction() {
         Assertions.assertEquals(3, ReactionManipulator.getAllAtomContainers(reaction).size());
     }
 
     @Test
-    void testSetAtomProperties_IReactionSet_Object_Object() throws Exception {
+    void testSetAtomProperties_IReactionSet_Object_Object() {
         ReactionManipulator.setAtomProperties(reaction, "test", "ok");
         for (IAtomContainer container : ReactionManipulator.getAllAtomContainers(reaction)) {
             for (IAtom atom : container.atoms()) {
@@ -284,7 +284,7 @@ class ReactionManipulatorTest extends CDKTestCase {
         IAtomContainer mol = ReactionManipulator.toMolecule(reaction);
         assertThat(smigen.create(mol),
                 is("CCO.CC(=O)O.[H+].CCOC(=O)C.O"));
-        assertThat(smigen.createReactionSMILES(ReactionManipulator.toReaction(mol)),
+        assertThat(smigen.create(ReactionManipulator.toReaction(mol)),
                 is("CCO.CC(=O)O>[H+]>CCOC(=O)C.O"));
     }
 
@@ -298,7 +298,7 @@ class ReactionManipulatorTest extends CDKTestCase {
         IAtomContainer mol = ReactionManipulator.toMolecule(reaction);
         assertThat(smigen.create(mol),
                 is("[CH2]CO.CC(=O)O.[H+].CCOC(=O)C.O |^1:0|"));
-        assertThat(smigen.createReactionSMILES(ReactionManipulator.toReaction(mol)),
+        assertThat(smigen.create(ReactionManipulator.toReaction(mol)),
                 is("[CH2]CO.CC(=O)O>[H+]>CCOC(=O)C.O |^1:0|"));
     }
 

--- a/storage/inchi/pom.xml
+++ b/storage/inchi/pom.xml
@@ -115,6 +115,11 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/storage/inchi/src/main/java/org/openscience/cdk/graph/invariant/InChINumbersTools.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/graph/invariant/InChINumbersTools.java
@@ -74,10 +74,14 @@ public class InChINumbersTools {
      * hydrogens are labelled as 0.
      *
      * @param container the structure to obtain the numbers of
-     * @return the atom numbers
+     * @return the atom numbers or an array of length 0 if the container is empty
      * @throws CDKException
      */
     public static long[] getUSmilesNumbers(IAtomContainer container) throws CDKException {
+        if (container.isEmpty()) {
+            return new long[0];
+        }
+
         String aux = auxInfo(container, InchiFlag.RecMet, InchiFlag.FixedH,
                              InchiFlag.LargeMolecules);
         return parseUSmilesNumbers(aux, container);
@@ -222,8 +226,7 @@ public class InChINumbersTools {
     }
     
     /**
-     * Obtain the InChI auxiliary info for the provided structure using
-     * using the specified InChI options.
+     * Obtain the InChI auxiliary info for the provided structure using the specified InChI options.
      *
      * @param  container the structure to obtain the numbers of
      * @param  flags varargs ... the JNA InChI flags

--- a/storage/inchi/src/test/java/org/openscience/cdk/graph/invariant/InChINumbersToolsTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/graph/invariant/InChINumbersToolsTest.java
@@ -109,13 +109,13 @@ class InChINumbersToolsTest extends CDKTestCase {
     }
 
     @Test
-    void parseStandard() throws Exception {
+    void parseStandard() {
         assertThat(InChINumbersTools.parseUSmilesNumbers("AuxInfo=1/0/N:3,2,1/rA:3OCC/rB:s1;s2;/rC:;;;", mock(3)),
                 is(new long[]{3, 2, 1}));
     }
 
     @Test
-    void parseRecMet() throws Exception {
+    void parseRecMet() {
 
         // C(=O)O[Pt](N)(N)Cl
         assertThat(
@@ -125,7 +125,7 @@ class InChINumbersToolsTest extends CDKTestCase {
     }
 
     @Test
-    void parseFixedH() throws Exception {
+    void parseFixedH() {
         // N1C=NC=C1
         assertThat(InChINumbersTools.parseUSmilesNumbers(
                 "AuxInfo=1/1/N:4,5,2,3,1/E:(1,2)(4,5)/F:5,4,2,1,3/rA:5NCNCC/rB:s1;d2;s3;s1d4;/rC:;;;;;", mock(5)),
@@ -133,7 +133,7 @@ class InChINumbersToolsTest extends CDKTestCase {
     }
 
     @Test
-    void parseDisconnected() throws Exception {
+    void parseDisconnected() {
         // O.N1C=NC=C1
         assertThat(InChINumbersTools.parseUSmilesNumbers(
                 "AuxInfo=1/1/N:5,6,3,4,2;1/E:(1,2)(4,5);/F:6,5,3,2,4;m/rA:6ONCNCC/rB:;s2;d3;s4;s2d5;/rC:;;;;;;",
@@ -141,7 +141,7 @@ class InChINumbersToolsTest extends CDKTestCase {
     }
 
     @Test
-    void parseMultipleDisconnected() throws Exception {
+    void parseMultipleDisconnected() {
         // O.N1C=NC=C1.O.O=O
         assertThat(
                 InChINumbersTools.parseUSmilesNumbers(
@@ -175,6 +175,12 @@ class InChINumbersToolsTest extends CDKTestCase {
         IAtomContainer container = new SmilesParser(SilentChemObjectBuilder.getInstance())
             .parseSmiles("[H+].[H+].F[Si-2](F)(F)(F)(F)F");
         assertThat(InChINumbersTools.getUSmilesNumbers(container), is(new long[]{8, 9, 1, 7, 2, 3, 4, 5, 6}));
+    }
+
+    @Test
+    void emptyAtomContainer_test() throws Exception {
+        IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
+        assertThat(InChINumbersTools.getUSmilesNumbers(container), is(new long[0]));
     }
 
     static IAtomContainer mock(int nAtoms) {

--- a/storage/inchi/src/test/java/org/openscience/cdk/smiles/EmptyReactionSmilesGenerationTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/smiles/EmptyReactionSmilesGenerationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 Uli Fechner
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * your option) any later version. All we ask is that proper credit is given
+ * for our work, which includes - but is not limited to - adding the above
+ * copyright notice to the beginning of your source code files, and to any
+ * copyright notice that you may distribute with programs based on this work.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 U
+ */
+package org.openscience.cdk.smiles;
+
+import org.junit.jupiter.api.Test;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IReaction;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Uli
+ * @cdk.module test-inchi
+ */
+class EmptyReactionSmilesGenerationTest {
+
+    @Test
+    public void emptyReactionInstance_smilesFlavorCanonical_test() throws CDKException {
+        SmilesGenerator smilesGenerator = new SmilesGenerator(SmiFlavor.Canonical);
+        IReaction reaction = SilentChemObjectBuilder.getInstance().newReaction();
+        assertThat(smilesGenerator.create(reaction)).isEqualTo(">>");
+    }
+
+    @Test
+    public void emptyReactionInstance_smilesFlavorStereo_test() throws CDKException {
+        SmilesGenerator smilesGenerator = new SmilesGenerator(SmiFlavor.Stereo);
+        IReaction reaction = SilentChemObjectBuilder.getInstance().newReaction();
+        assertThat(smilesGenerator.create(reaction)).isEqualTo(">>");
+    }
+
+    @Test
+    public void emptyReactionInstance_smilesFlavorCanonicalStereo_test() throws CDKException {
+        SmilesGenerator smilesGenerator = new SmilesGenerator(SmiFlavor.Canonical | SmiFlavor.Stereo);
+        IReaction reaction = SilentChemObjectBuilder.getInstance().newReaction();
+        assertThat(smilesGenerator.create(reaction)).isEqualTo(">>");
+    }
+
+}

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesGenerator.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesGenerator.java
@@ -579,9 +579,9 @@ public final class SmilesGenerator {
 
         // we need to make sure we generate without the CXSMILES layers
         int adjustedFlav = flavour & ~(SmiFlavor.CxSmilesWithCoords & ~SmiFlavor.StereoTetrahedral);
-        String smi = create(reactantPart, adjustedFlav, reactantOrder) + ">" +
-                     create(agentPart, adjustedFlav, agentOrder) + ">" +
-                     create(productPart, adjustedFlav, productOrder);
+        String smi = (reactantPart.isEmpty() ? "" : create(reactantPart, adjustedFlav, reactantOrder)) + ">" +
+                     (agentPart.isEmpty() ? "" : create(agentPart, adjustedFlav, agentOrder)) + ">" +
+                     (productPart.isEmpty() ? "" : create(productPart, adjustedFlav, productOrder));
 
         // copy ordering back to unified array and adjust values
         int agentBeg = reactantOrder.length;

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesGenerator.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesGenerator.java
@@ -579,9 +579,9 @@ public final class SmilesGenerator {
 
         // we need to make sure we generate without the CXSMILES layers
         int adjustedFlav = flavour & ~(SmiFlavor.CxSmilesWithCoords & ~SmiFlavor.StereoTetrahedral);
-        String smi = (reactantPart.isEmpty() ? "" : create(reactantPart, adjustedFlav, reactantOrder)) + ">" +
-                     (agentPart.isEmpty() ? "" : create(agentPart, adjustedFlav, agentOrder)) + ">" +
-                     (productPart.isEmpty() ? "" : create(productPart, adjustedFlav, productOrder));
+        String smi = create(reactantPart, adjustedFlav, reactantOrder) + ">" +
+                     create(agentPart, adjustedFlav, agentOrder) + ">" +
+                     create(productPart, adjustedFlav, productOrder);
 
         // copy ordering back to unified array and adjust values
         int agentBeg = reactantOrder.length;

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/SmilesGeneratorTest.java
@@ -1184,7 +1184,7 @@ class SmilesGeneratorTest extends CDKTestCase {
         IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
         IAtomContainer ethanol = new SmilesParser(bldr).parseSmiles("C[CH2:6]O");
         assertThat(SmilesGenerator.generic().create(ethanol), is("CCO"));
-        assertThat(SmilesGenerator.generic().withAtomClasses().create(ethanol), is("C[CH2:6]O"));
+        assertThat(new SmilesGenerator(SmiFlavor.Generic | SmiFlavor.AtomAtomMap).create(ethanol), is("C[CH2:6]O"));
     }
 
     /**


### PR DESCRIPTION
Without the change in `SmilesGenerator::String create(IReaction,int[])` the test method `EmptyReactionSmilesGenerationTest.java::emptyReactionInstance_smilesFlavorCanonicalStereo_test` fails.