### PR TITLE
add getAgentCount method to IReaction interface

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/Reaction.java
+++ b/base/data/src/main/java/org/openscience/cdk/Reaction.java
@@ -108,6 +108,16 @@ public class Reaction extends ChemObject implements Serializable, IReaction, Clo
     }
 
     /**
+     * Returns the number of agents in this reaction.
+     *
+     * @return The number of agents in this reaction
+     */
+    @Override
+    public int getAgentCount() {
+        return agents.getAtomContainerCount();
+    }
+
+    /**
      * Returns a MoleculeSet containing the reactants in this reaction.
      *
      * @return A MoleculeSet containing the reactants in this reaction

--- a/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugReaction.java
+++ b/base/datadebug/src/main/java/org/openscience/cdk/debug/DebugReaction.java
@@ -194,6 +194,13 @@ public class DebugReaction extends Reaction implements IReaction {
 
     /** {@inheritDoc} */
     @Override
+    public int getAgentCount() {
+        logger.debug("Getting agent count: ", super.getAgentCount());
+        return super.getAgentCount();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public IAtomContainerSet getReactants() {
         logger.debug("Getting reactants: ", super.getReactants());
         return super.getReactants();

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IReaction.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IReaction.java
@@ -89,6 +89,13 @@ public interface IReaction extends IChemObject, Iterable<IAtomContainer> {
     int getProductCount();
 
     /**
+     * Returns the number of agents in this reaction.
+     *
+     * @return The number of agents in this reaction
+     */
+    int getAgentCount();
+
+    /**
      * Returns a IAtomContaineSet containing the reactants in this reaction.
      *
      * @return A IAtomContaineSet containing the reactants in this reaction

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Reaction.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Reaction.java
@@ -108,6 +108,16 @@ public class Reaction extends ChemObject implements Serializable, IReaction, Clo
     }
 
     /**
+     * Returns the number of agents in this reaction.
+     *
+     * @return The number of agents in this reaction
+     */
+    @Override
+    public int getAgentCount() {
+        return agents.getAtomContainerCount();
+    }
+
+    /**
      * Returns a MoleculeSet containing the reactants in this reaction.
      *
      * @return A MoleculeSet containing the reactants in this reaction
@@ -462,15 +472,13 @@ public class Reaction extends ChemObject implements Serializable, IReaction, Clo
      */
     @Override
     public String toString() {
-        StringBuilder description = new StringBuilder(64);
-        description.append("Reaction(");
-        description.append(getID());
-        description.append(", #M:").append(mappingCount);
-        description.append(", reactants=").append(reactants.toString());
-        description.append(", products=").append(products.toString());
-        description.append(", agents=").append(agents.toString());
-        description.append(')');
-        return description.toString();
+        return "Reaction(" +
+                getID() +
+                ", #M:" + mappingCount +
+                ", reactants=" + reactants.toString() +
+                ", products=" + products.toString() +
+                ", agents=" + agents.toString() +
+                ')';
     }
 
     /**

--- a/base/test/src/test/java/org/openscience/cdk/test/interfaces/AbstractReactionTest.java
+++ b/base/test/src/test/java/org/openscience/cdk/test/interfaces/AbstractReactionTest.java
@@ -39,6 +39,20 @@ public abstract class AbstractReactionTest extends AbstractChemObjectTest {
     }
 
     @Test
+    void getAgentCount_test() {
+        IReaction reaction = (IReaction) newChemObject();
+        Assertions.assertEquals(0, reaction.getAgentCount());
+
+        reaction.addReactant(reaction.getBuilder().newInstance(IAtomContainer.class));
+        reaction.addReactant(reaction.getBuilder().newInstance(IAtomContainer.class));
+        reaction.addProduct(reaction.getBuilder().newInstance(IAtomContainer.class));
+        Assertions.assertEquals(0, reaction.getAgentCount());
+
+        reaction.addAgent(reaction.getBuilder().newInstance(IAtomContainer.class));
+        Assertions.assertEquals(1, reaction.getAgentCount());
+    }
+
+    @Test
     public void testAddReactant_IAtomContainer() {
         IReaction reaction = (IReaction) newChemObject();
         IAtomContainer sodiumhydroxide = reaction.getBuilder().newInstance(IAtomContainer.class);
@@ -296,7 +310,7 @@ public abstract class AbstractReactionTest extends AbstractChemObjectTest {
         IReaction reaction = (IReaction) newChemObject();
         Object clone = reaction.clone();
         Assertions.assertNotNull(clone);
-        Assertions.assertTrue(clone instanceof IReaction);
+        Assertions.assertInstanceOf(IReaction.class, clone);
     }
 
     @Test


### PR DESCRIPTION
As this changes an interface it is technically a breaking change.

I also replaced `StringBuilder` with a String concatenation as recommended for fixed number of string concatenations.