### PR TITLE
Add the option to locate a IChemObject builder using reflection. Enfo…

### DIFF
--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/ChemObjectBuilderCache.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/ChemObjectBuilderCache.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 John Mayfield
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+package org.openscience.cdk.interfaces;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * This enum is used to provide a cache of silent/default ChemObjectBuilder's
+ * that are loaded via reflection. It should not be made public and servers only
+ * to provide for {@link IChemObjectBuilder#find()}.
+ */
+enum ChemObjectBuilderCache {
+    INSTANCE;
+
+    private final IChemObjectBuilder silentBuilder;
+    private final IChemObjectBuilder defaultBuilder;
+
+    ChemObjectBuilderCache() {
+        silentBuilder = load("org.openscience.cdk.silent.SilentChemObjectBuilder");
+        defaultBuilder = load("org.openscience.cdk.DefaultChemObjectBuilder");
+    }
+
+    private static IChemObjectBuilder load(String path)
+    {
+        try {
+            Class<?> cls = Class.forName(path);
+            Method method = cls.getDeclaredMethod("getInstance");
+            return  (IChemObjectBuilder) method.invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException |
+                 IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    public IChemObjectBuilder get() {
+        if (silentBuilder != null)
+            return silentBuilder;
+        return defaultBuilder;
+    }
+}

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IChemObjectBuilder.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IChemObjectBuilder.java
@@ -18,6 +18,11 @@
  */
 package org.openscience.cdk.interfaces;
 
+import org.openscience.cdk.tools.LoggingToolFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 /**
  * A helper class to instantiate a {@link ICDKObject} instance for a specific
  * implementation.
@@ -79,4 +84,15 @@ public interface IChemObjectBuilder {
      */
     IReaction newReaction();
 
+    /**
+     * This function is used to find an IChemObject builder using reflection. It
+     * first tries to create a SilentChemObjectBuilder and failing that a
+     * DefaultChemObjectBuilder. It should be used sparingly since APIs should
+     * require a builder is passed in.
+     *
+     * @return the IChemObject builder
+     */
+    static IChemObjectBuilder find() {
+        return ChemObjectBuilderCache.INSTANCE.get();
+    }
 }

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IChemObjectBuilder.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IChemObjectBuilder.java
@@ -18,11 +18,6 @@
  */
 package org.openscience.cdk.interfaces;
 
-import org.openscience.cdk.tools.LoggingToolFactory;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 /**
  * A helper class to instantiate a {@link ICDKObject} instance for a specific
  * implementation.

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/RdfileReader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/RdfileReader.java
@@ -137,7 +137,7 @@ public final class RdfileReader implements Closeable, Iterator<RdfileRecord> {
      * @param reader the Reader providing the RDfile data
      */
     public RdfileReader(Reader reader) {
-        this(reader, null, true);
+        this(reader, IChemObjectBuilder.find(), true);
     }
 
     /**
@@ -158,6 +158,8 @@ public final class RdfileReader implements Closeable, Iterator<RdfileRecord> {
             this.bufferedReader = new BufferedReader(reader);
         }
 
+        if (chemObjectBuilder == null)
+            throw new NullPointerException("A ChemObjectBuilder must be provided or available on the class path!");
         this.chemObjectBuilder = chemObjectBuilder;
         this.continueOnError = continueOnError;
     }

--- a/storage/ctab/src/main/java/org/openscience/cdk/io/RdfileReader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/RdfileReader.java
@@ -133,15 +133,6 @@ public final class RdfileReader implements Closeable, Iterator<RdfileRecord> {
 
     /**
      * Creates a new RdfileReader instance with the given InputStream and IChemObjectBuilder.
-     *
-     * @param reader the Reader providing the RDfile data
-     */
-    public RdfileReader(Reader reader) {
-        this(reader, IChemObjectBuilder.find(), true);
-    }
-
-    /**
-     * Creates a new RdfileReader instance with the given InputStream and IChemObjectBuilder.
      * <p>
      * If {@code continueOnError} is {@code true} remaining records are processed when an error
      * is encountered; if {@code false} all remaining records in the file are skipped.


### PR DESCRIPTION
…rce the RDfile reader has one.

Different Java version's didn't like a piece of code the the RDfile reader constructor - I spotted it when I wrote the sample code for the release and accidentally committed it here: https://github.com/cdk/cdk/commit/f351dd020de0786a3dffb8aba30a6325905f5176#diff-c8b0d51b33ab2fde91ce878d3b9887e6063201b65be2fa98b6a842643a4b4fceL138-R140.

I have added the option for the IChemObjectBuilder to look one up via reflection, @egonw  and I have talked about this previously.