### PR TITLE
Correct Singlet (2 electron) vs Doublet (1 single electron)

### DIFF
--- a/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/inchi/InChIToStructure.java
@@ -230,9 +230,9 @@ public class InChIToStructure {
             addHydrogenIsotopes(builder, cAt, 3, iAt.getImplicitTritium());
 
             InchiRadical radical = iAt.getRadical();
-            if (radical == InchiRadical.SINGLET) {
+            if (radical == InchiRadical.DOUBLET) {
                 molecule.addSingleElectron(molecule.indexOf(cAt));
-            } else if (radical == InchiRadical.DOUBLET ||
+            } else if (radical == InchiRadical.SINGLET ||
                        radical == InchiRadical.TRIPLET) {
                 // Information loss - we should make MDL SPIN_MULTIPLICITY avaliable to this API
                 molecule.addSingleElectron(molecule.indexOf(cAt));

--- a/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIToStructureTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/inchi/InChIToStructureTest.java
@@ -190,7 +190,7 @@ class InChIToStructureTest extends CDKTestCase {
         try (MDLV2000Writer wtr = new MDLV2000Writer(sw)) {
             wtr.write(mol);
         }
-        assertThat(sw.toString(), containsString("M  RAD"));
+        assertThat(sw.toString(), containsString("M  RAD  1   1   2"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1024 - the Singlet/Double logic was the wrong way around