### PR TITLE
Copy charges of original atoms when creating functional group atoms and add test subroutine for correct charges

### DIFF
--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -549,7 +549,6 @@ public class FunctionalGroupsFinder {
                 cpyAtom.setValency(atom.getValency());
                 cpyAtom.setAtomTypeName(atom.getAtomTypeName());
                 cpyAtom.setFormalCharge(atom.getFormalCharge());
-                cpyAtom.setCharge(atom.getCharge());
                 amap.put(atom, cpyAtom);
             }
             // bonds

--- a/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
+++ b/tool/fragment/src/main/java/org/openscience/cdk/fragment/FunctionalGroupsFinder.java
@@ -548,6 +548,8 @@ public class FunctionalGroupsFinder {
                 cpyAtom.setIsAromatic(atom.isAromatic());
                 cpyAtom.setValency(atom.getValency());
                 cpyAtom.setAtomTypeName(atom.getAtomTypeName());
+                cpyAtom.setFormalCharge(atom.getFormalCharge());
+                cpyAtom.setCharge(atom.getCharge());
                 amap.put(atom, cpyAtom);
             }
             // bonds

--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
@@ -805,12 +805,6 @@ class FunctionalGroupsFinderTest {
                                 + ":"
                                 + tmpExpectedAtom.getSymbol() + tmpExpectedAtom.getFormalCharge()
                                 + ")");
-                Assertions.assertEquals(tmpExpectedAtom.getCharge(), tmpActualAtom.getCharge(),
-                        "Groups #" + i + ": Atom charge does not match ("
-                                + tmpActualAtom.getSymbol() + tmpActualAtom.getCharge()
-                                + ":"
-                                + tmpExpectedAtom.getSymbol() + tmpExpectedAtom.getCharge()
-                                + ")");
             }
             Map<IBond, IBond> tmpBondMap = tmpExpFGinActFGmappings.toBondMap().iterator().next();
             for (Map.Entry<IBond, IBond> tmpMapEntry : tmpBondMap.entrySet()) {

--- a/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
+++ b/tool/fragment/src/test/java/org/openscience/cdk/fragment/FunctionalGroupsFinderTest.java
@@ -799,7 +799,19 @@ class FunctionalGroupsFinderTest {
                                  + ":"
                                  + tmpExpectedAtom.getSymbol() + tmpExpectedAtom.isAromatic()
                                  + ")");
-             }
+                Assertions.assertEquals(tmpExpectedAtom.getFormalCharge(), tmpActualAtom.getFormalCharge(),
+                        "Groups #" + i + ": Atom formal charge does not match ("
+                                + tmpActualAtom.getSymbol() + tmpActualAtom.getFormalCharge()
+                                + ":"
+                                + tmpExpectedAtom.getSymbol() + tmpExpectedAtom.getFormalCharge()
+                                + ")");
+                Assertions.assertEquals(tmpExpectedAtom.getCharge(), tmpActualAtom.getCharge(),
+                        "Groups #" + i + ": Atom charge does not match ("
+                                + tmpActualAtom.getSymbol() + tmpActualAtom.getCharge()
+                                + ":"
+                                + tmpExpectedAtom.getSymbol() + tmpExpectedAtom.getCharge()
+                                + ")");
+            }
             Map<IBond, IBond> tmpBondMap = tmpExpFGinActFGmappings.toBondMap().iterator().next();
             for (Map.Entry<IBond, IBond> tmpMapEntry : tmpBondMap.entrySet()) {
                  IBond tmpExpectedBond = tmpMapEntry.getKey();


### PR DESCRIPTION
I noticed that charges were disappearing when extracting functional groups. A bit of digging made me realise that were are not correctly testing for it, the Vento-Foggia isomorphism check is not enough. This PR adds the copying of atomic charges and also a test subroutine for asserting that charges are not lost anymore.

@johnmay and @egonw what is the interplay of charge and formal charge? Setting the formal charge seems to also set the charge but not vice-versa. Is this observation/behaviour correct and should I therefore copy both as I am currently doing?