### PR TITLE
Ring fill better rxn layout

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/ReactionManipulator.java
@@ -484,14 +484,20 @@ public class ReactionManipulator {
     public static Set<IBond> findMappedBonds(IReaction reaction) {
         Set<IBond> mapped = new HashSet<>();
 
+        List<IAtomContainer> leftSide = new ArrayList<>();
+        for (IAtomContainer mol : reaction.getReactants())
+            leftSide.add(mol);
+        for (IAtomContainer mol : reaction.getAgents())
+            leftSide.add(mol);
+
         // first we collect the occurrance of mapped bonds from reacants then products
         Set<IntTuple> mappedReactantBonds = new HashSet<>();
         Set<IntTuple> mappedProductBonds  = new HashSet<>();
-        for (IAtomContainer reactant : reaction.getReactants().atomContainers()) {
+        for (IAtomContainer reactant : leftSide) {
             for (IBond bond : reactant.bonds()) {
-                Integer begidx = bond.getBegin().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                if (begidx != null && endidx != null)
+                int begidx = bond.getBegin().getMapIdx();
+                int endidx = bond.getEnd().getMapIdx();
+                if (begidx != 0 && endidx != 0)
                     mappedReactantBonds.add(new IntTuple(begidx, endidx));
             }
         }
@@ -499,11 +505,11 @@ public class ReactionManipulator {
         if (mappedReactantBonds.isEmpty())
             return Collections.emptySet();
 
-        for (IAtomContainer product : reaction.getProducts().atomContainers()) {
+        for (IAtomContainer product : reaction.getProducts()) {
             for (IBond bond : product.bonds()) {
-                Integer begidx = bond.getBegin().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                if (begidx != null && endidx != null)
+                int begidx = bond.getBegin().getMapIdx();
+                int endidx = bond.getEnd().getMapIdx();
+                if (begidx != 0 && endidx != 0)
                     mappedProductBonds.add(new IntTuple(begidx, endidx));
             }
         }
@@ -512,19 +518,19 @@ public class ReactionManipulator {
             return Collections.emptySet();
 
         // repeat above but now store any that are different or unmapped as being mapped
-        for (IAtomContainer reactant : reaction.getReactants().atomContainers()) {
+        for (IAtomContainer reactant : leftSide) {
             for (IBond bond : reactant.bonds()) {
-                Integer begidx = bond.getBegin().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                if (begidx != null && endidx != null && mappedProductBonds.contains(new IntTuple(begidx, endidx)))
+                int begidx = bond.getBegin().getMapIdx();
+                int endidx = bond.getEnd().getMapIdx();
+                if (begidx != 0 && endidx != 0 && mappedProductBonds.contains(new IntTuple(begidx, endidx)))
                     mapped.add(bond);
             }
         }
-        for (IAtomContainer product : reaction.getProducts().atomContainers()) {
+        for (IAtomContainer product : reaction.getProducts()) {
             for (IBond bond : product.bonds()) {
-                Integer begidx = bond.getBegin().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                Integer endidx = bond.getEnd().getProperty(CDKConstants.ATOM_ATOM_MAPPING);
-                if (begidx != null && endidx != null && mappedReactantBonds.contains(new IntTuple(begidx, endidx)))
+                int begidx = bond.getBegin().getMapIdx();
+                int endidx = bond.getEnd().getMapIdx();
+                if (begidx != 0 && endidx != 0 && mappedReactantBonds.contains(new IntTuple(begidx, endidx)))
                     mapped.add(bond);
             }
         }

--- a/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
+++ b/tool/sdg/src/main/java/org/openscience/cdk/layout/StructureDiagramGenerator.java
@@ -61,6 +61,7 @@ import org.openscience.cdk.tools.manipulator.RingSetManipulator;
 
 import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
+import java.awt.Color;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -77,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Stack;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -388,6 +390,7 @@ public class StructureDiagramGenerator {
         generateAlignedCoordinates(mol, null, pattern);
     }
 
+
     /**
      * <p>Convenience method to generate 2D coordinates for a reaction. If atom-atom
      * maps are present on a reaction, the substructures are automatically aligned.</p>
@@ -399,18 +402,22 @@ public class StructureDiagramGenerator {
     public final void generateCoordinates(final IReaction reaction) throws CDKException {
 
         // layout products and agents
-        for (IAtomContainer mol : reaction.getProducts().atomContainers())
-            generateCoordinates(mol);
+        for (IAtomContainer mol : reaction.getProducts().atomContainers()) {
+            if (!GeometryUtil.has2DCoordinates(mol))
+                generateCoordinates(mol);
+        }
+        List<IAtomContainer> leftSide = new ArrayList<>();
+        for (IAtomContainer mol : reaction.getReactants().atomContainers())
+            leftSide.add(mol);
         for (IAtomContainer mol : reaction.getAgents().atomContainers())
-            generateCoordinates(mol);
+            leftSide.add(mol);
 
         // do not align = simple layout of reactants
         if (alignMappedReaction) {
             final Set<IBond> mapped = ReactionManipulator.findMappedBonds(reaction);
-
             Map<Integer, List<Map<Integer, IAtom>>> refmap = new HashMap<>();
 
-            for (IAtomContainer mol : reaction.getProducts().atomContainers()) {
+            for (IAtomContainer mol : reaction.getProducts()) {
                 Cycles.markRingAtomsAndBonds(mol);
                 final ConnectedComponents cc = new ConnectedComponents(GraphUtil.toAdjListSubgraph(mol, mapped));
                 final IAtomContainerSet parts = ConnectivityChecker.partitionIntoMolecules(mol, cc.components());
@@ -421,7 +428,7 @@ public class StructureDiagramGenerator {
                     final Map<Integer, IAtom> map = new HashMap<>();
                     for (IAtom atom : part.atoms()) {
                         // safe as substructure should only be mapped bonds and therefore atoms!
-                        int idx = atom.getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                        int idx = atom.getMapIdx();
                         if (map.put(idx, atom) == null)
                             refmap.computeIfAbsent(idx, k -> new ArrayList<>()).add(map);
                     }
@@ -431,7 +438,7 @@ public class StructureDiagramGenerator {
             Map<IAtom,IAtom> afix = new HashMap<>();
             Set<IBond>       bfix = new HashSet<>();
 
-            for (IAtomContainer mol : reaction.getReactants().atomContainers()) {
+            for (IAtomContainer mol : leftSide) {
                 Cycles.markRingAtomsAndBonds(mol);
                 final ConnectedComponents cc = new ConnectedComponents(GraphUtil.toAdjListSubgraph(mol, mapped));
                 final IAtomContainerSet parts = ConnectivityChecker.partitionIntoMolecules(mol, cc.components());
@@ -450,12 +457,12 @@ public class StructureDiagramGenerator {
 
                 if (largest != null && largest.getAtomCount() > 1) {
 
-                    int idx = largest.getAtom(0).getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                    int idx = largest.getAtom(0).getMapIdx();
 
                     // select the largest and use those coordinates
                     Map<Integer, IAtom> reference = select(refmap.getOrDefault(idx, Collections.emptyList()));
                     for (IAtom atom : largest.atoms()) {
-                        idx = atom.getProperty(CDKConstants.ATOM_ATOM_MAPPING);
+                        idx = atom.getMapIdx();
                         final IAtom src = reference.get(idx);
                         if (src == null) continue;
                         if (!aggresive) {
@@ -496,6 +503,7 @@ public class StructureDiagramGenerator {
                             }
                         }
                     } else {
+
                         for (IBond bond : mol.bonds()) {
                             if (afix.containsKey(bond.getBegin()) && afix.containsKey(bond.getEnd())) {
                                 // only fix bonds that match their ring membership status
@@ -504,7 +512,7 @@ public class StructureDiagramGenerator {
                                 for (IAtomContainer product : reaction.getProducts().atomContainers()) {
                                     IBond srcBond = product.getBond(srcBeg, srcEnd);
                                     if (srcBond != null) {
-                                        if (srcBond.isInRing() == bond.isInRing())
+                                        if (srcBond.isInRing() == bond.isInRing() || !bond.isInRing())
                                             bfix.add(bond);
                                         break;
                                     }
@@ -571,20 +579,14 @@ public class StructureDiagramGenerator {
             }
 
             // reorder reactants such that they are in the same order they appear on the right
-            reaction.getReactants().sortAtomContainers(new Comparator<IAtomContainer>() {
-                @Override
-                public int compare(IAtomContainer a, IAtomContainer b) {
-                    Point2d aCenter = GeometryUtil.get2DCenter(a);
-                    Point2d bCenter = GeometryUtil.get2DCenter(b);
-                    if (aCenter == null || bCenter == null)
-                        return 0;
-                    else
-                        return Double.compare(aCenter.x, bCenter.x);
-                }
+            reaction.getReactants().sortAtomContainers((a, b) -> {
+                Point2d aCenter = GeometryUtil.get2DCenter(a);
+                Point2d bCenter = GeometryUtil.get2DCenter(b);
+                return Double.compare(aCenter.x, bCenter.x);
             });
 
         } else {
-            for (IAtomContainer mol : reaction.getReactants().atomContainers())
+            for (IAtomContainer mol : leftSide)
                 generateCoordinates(mol);
         }
     }
@@ -1191,7 +1193,7 @@ public class StructureDiagramGenerator {
         }
     }
 
-    private List<IBond> getNonContractedNonTerminalBonds(IAtomContainer mol) {
+    private List<IBond> getNonContractedNonTerminalBonds(IAtomContainer mol, boolean includeRingBonds) {
         List<Sgroup> sgroups = mol.getProperty(CDKConstants.CTAB_SGROUPS);
         List<IBond> result = new ArrayList<>();
         Set<IBond> xbonds = new HashSet<>();
@@ -1213,6 +1215,8 @@ public class StructureDiagramGenerator {
                 if ((begDeg == 1 && endDeg > 2) ||
                     (endDeg == 1 && begDeg > 2))
                     continue;
+                if (!includeRingBonds && bond.isInRing() || begDeg != 2 && endDeg != 2)
+                    continue;
                 result.add(bond);
             }
         } else {
@@ -1221,6 +1225,8 @@ public class StructureDiagramGenerator {
                 int endDeg = mol.getConnectedBondsCount(bond.getEnd());
                 if ((begDeg == 1 && endDeg > 2) ||
                     (endDeg == 1 && begDeg > 2))
+                    continue;
+                if (!includeRingBonds && bond.isInRing() || begDeg != 2 && endDeg != 2)
                     continue;
                 result.add(bond);
             }
@@ -1244,8 +1250,8 @@ public class StructureDiagramGenerator {
     private void selectOrientation(IAtomContainer mol, double widthDiff, int alignDiff) {
 
         // only select based on non-contracted non-terminal bonds
-        List<IBond> bonds = getNonContractedNonTerminalBonds(mol);
-        if (bonds.size() == 0)
+        List<IBond> bonds = getNonContractedNonTerminalBonds(mol, true);
+        if (bonds.isEmpty())
             return;
 
         double[] minmax  = GeometryUtil.getMinMax(mol);


### PR DESCRIPTION
Note: Merge in #1154 first! This is only for the ring fill colouring and improved reaction layout.

This patch improves aligned reaction layout and adds an option to highlight atoms/bonds and fill in small rings:

![tmp](https://github.com/user-attachments/assets/3cb09dd4-ee30-4735-8a33-ab7a510a809a)
