### PR TITLE
Update some into in PeriodicTable and reorder the Elements enum.

### DIFF
--- a/base/core/src/main/java/org/openscience/cdk/config/Elements.java
+++ b/base/core/src/main/java/org/openscience/cdk/config/Elements.java
@@ -153,20 +153,21 @@ public enum Elements {
     Darmstadtium(110, "Ds", 7, 10, null, null, null),
     Roentgenium(111, "Rg", 7, 11, null, null, null),
     Copernicium(112, "Cn", 7, 12, null, null, null),
-    @Deprecated
-    Ununtrium(113, "Uut", 7, 13, null, null, null),
     Nihonium(113, "Nh", 7, 13, null, null, null),
     Flerovium(114, "Fl", 7, 14, null, null, null),
-    @Deprecated
-    Ununpentium(115, "Uup", 7, 15, null, null, null),
     Moscovium(115, "Mc", 7, 15, null, null, null),
     Livermorium(116, "Lv", 7, 16, null, null, null),
+    Tennessine(117, "Ts", 7, 17, null, null, null),
+    Oganesson(118, "Og", 7, 18, null, null, null),
+    @Deprecated
+    Ununtrium(113, "Uut", 7, 13, null, null, null),
+    @Deprecated
+    Ununpentium(115, "Uup", 7, 15, null, null, null),
     @Deprecated
     Ununseptium(117, "Uus", 7, 17, null, null, null),
-    Tennessine(117, "Ts", 7, 17, null, null, null),
     @Deprecated
-    Ununoctium(118, "Uuo", 7, 18, null, null, null),
-    Oganesson(118, "Og", 7, 18, null, null, null);
+    Ununoctium(118, "Uuo", 7, 18, null, null, null);
+
 
     /**
      * Atomic number, periodic table period and group.
@@ -202,7 +203,9 @@ public enum Elements {
     static {
         // index elements
         for (final Elements e : values()) {
-            NUMER_MAP[e.number] = e;
+            // first defined takes priority
+            if (NUMER_MAP[e.number] == null)
+                NUMER_MAP[e.number] = e;
             SYMBOL_MAP.put(e.symbol.toLowerCase(Locale.ENGLISH), e);
             SYMBOL_MAP.put(e.name().toLowerCase(Locale.ENGLISH), e);
         }

--- a/base/core/src/main/java/org/openscience/cdk/tools/periodictable/PeriodicTable.java
+++ b/base/core/src/main/java/org/openscience/cdk/tools/periodictable/PeriodicTable.java
@@ -223,7 +223,8 @@ public final class PeriodicTable {
 
         Synthetic(Fermium, Seaborgium, Plutonium, Roentgenium, Lawrencium, Meitnerium, Einsteinium, Nobelium, Actinium,
                 Rutherfordium, Americium, Curium, Bohrium, Berkelium, Promethium, Copernicium, Technetium, Hassium,
-                Californium, Mendelevium, Neptunium, Darmstadtium, Dubnium);
+                Californium, Mendelevium, Neptunium, Darmstadtium, Dubnium, Copernicium, Flerovium, Nihonium,
+                Moscovium, Livermorium, Tennessine, Oganesson);
 
         private final Set<Elements> elements;
 
@@ -353,12 +354,12 @@ public final class PeriodicTable {
         ids.put(Darmstadtium, "54083-77-1");
         ids.put(Roentgenium, "54386-24-2");
         ids.put(Copernicium, "54084-26-3");
-        ids.put(Ununtrium, "");
+        ids.put(Nihonium, "54084-70-7");
         ids.put(Flerovium, "54085-16-4");
-        ids.put(Ununpentium, "");
+        ids.put(Moscovium, "54085-64-2");
         ids.put(Livermorium, "54100-71-9");
-        ids.put(Ununseptium, "");
-        ids.put(Ununoctium, "");
+        ids.put(Tennessine, "54101-14-3");
+        ids.put(Oganesson, "54144-19-3");
         return ids;
     }
 


### PR DESCRIPTION
This is related to a JChemPaint bug reported (periodic table resizing). I thought decent idea to also make it more up to date.