### PR TITLE
Fix #1174. We need better logic when the ring closures are near exten…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -479,12 +479,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-core</artifactId>
-                <version>1.3.8</version>
+                <version>1.3.9</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.beam</groupId>
                 <artifactId>beam-func</artifactId>
-                <version>1.3.8</version>
+                <version>1.3.9</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/BeamToCDK.java
@@ -568,24 +568,41 @@ final class BeamToCDK {
     private IStereoElement newExtendedTetrahedral(int u, Graph g, IAtom[] atoms) {
 
         int[] terminals = findExtendedTetrahedralEnds(g, u);
-        int[] xs = new int[]{-1, terminals[0], -1, terminals[1]};
+        int[] xs = new int[]{-1, -1, -1, -1};
 
         int n = 0;
         for (Edge e : g.edges(terminals[0])) {
             if (e.bond().order() == 1) xs[n++] = e.other(terminals[0]);
         }
+        if (n == 1) {
+            if (xs[0] > terminals[0]) {
+                xs[1] = xs[0];
+                xs[0] = terminals[0];
+            } else {
+                xs[1] = terminals[0];
+            }
+        }
         n = 2;
         for (Edge e : g.edges(terminals[1])) {
             if (e.bond().order() == 1) xs[n++] = e.other(terminals[1]);
         }
-
-        Arrays.sort(xs);
+        if (n == 3) {
+            if (xs[2] > terminals[1]) {
+                xs[3] = xs[2];
+                xs[2] = terminals[1];
+            } else {
+                xs[3] = terminals[1];
+            }
+        }
 
         Stereo stereo = g.configurationOf(u).shorthand() == Configuration.CLOCKWISE ? Stereo.CLOCKWISE
                 : Stereo.ANTI_CLOCKWISE;
 
-        return new org.openscience.cdk.stereo.ExtendedTetrahedral(atoms[u], new IAtom[]{atoms[xs[0]], atoms[xs[1]],
-                atoms[xs[2]], atoms[xs[3]]}, stereo);
+        return new org.openscience.cdk.stereo.ExtendedTetrahedral(atoms[u],
+                                                                  new IAtom[]{atoms[xs[0]],
+                                                                              atoms[xs[1]],
+                                                                              atoms[xs[2]],
+                                                                              atoms[xs[3]]}, stereo);
     }
 
     /**


### PR DESCRIPTION
…ded tetrahedral inserting the implicit neighbours in two different locations.

```
C(=[C@]=CBr)F.C1=[C@]=CBr.F1.F1.C1=[C@]=CBr.C([H])(F)=[C@]=CBr
```

Before:

![image](https://github.com/user-attachments/assets/b11c31ef-85fd-480f-94c2-741c4a00ee41)

After:

![image](https://github.com/user-attachments/assets/12bb529c-7726-405b-a4ee-747a832aae74)
