### PR TITLE
dependency updates 08-Aug-2025, use <release> instead of <source> and <target>

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -301,8 +301,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>8</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -519,12 +519,12 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.18.0</version>
+                <version>4.11.0</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>5.15.2</version>
+                <version>4.11.0</version>
             </dependency>
             <dependency>
                 <groupId>javax.vecmath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -489,17 +489,17 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
-                <version>5.13.3</version>
+                <version>5.13.4</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-params</artifactId>
-                <version>5.13.3</version>
+                <version>5.13.4</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.13.3</version>
+                <version>5.13.4</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -514,12 +514,12 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.27.3</version>
+                <version>3.27.4</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.11.0</version>
+                <version>5.18.0</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
- bumped test dependencies junit, assertj, and mockito to latest versions
- `cdk-bundle.pom`: update maven-compiler-plugin configuration to use <release> instead of <source> and <target>