### PR TITLE
RDKit atropisomers

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
@@ -466,7 +466,7 @@ public final class Stereocenters {
                     if (deg == 4 && nUnique == 1 && terminal) stereocenters[element.focus] = Stereocenter.Non;
                 } else if (element.type == Type.Tricoordinate) {
                     Tricoordinate either = (Tricoordinate) element;
-                    if (stereocenters[either.other] == Stereocenter.True) paraElements.add(element);
+                    if (either.other >= 0 && stereocenters[either.other] == Stereocenter.True) paraElements.add(element);
                 }
             }
 

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/Stereocenters.java
@@ -268,7 +268,7 @@ public final class Stereocenters {
 
             if (x < 2 || x > 4 || h > 1) continue;
 
-            int piNeighbor = 0;
+            int piNeighbor = -1;
             for (int w : g[i]) {
                 if (atomicNumber(container.getAtom(w)) == 1 &&
                     container.getAtom(w).getMassNumber() == null)
@@ -286,6 +286,7 @@ public final class Stereocenters {
                         continue VERTICES;
                 }
             }
+
 
             // check the type of stereo chemistry supported
             switch (supportedType(i, v, d, h, x)) {
@@ -308,21 +309,25 @@ public final class Stereocenters {
 
                     u = i;
                     w = piNeighbor;
-
                     tricoordinate[u] = true;
 
-                    if (!tricoordinate[w]) {
-                        if (elements[w] != null && elements[w].type == Type.Bicoordinate) {
-                            stereocenters[u] = Stereocenter.Potential;
-                            elements[u] = new Tricoordinate(u, w, g[u]);
+                    if (piNeighbor >= 0) {
+                        if (!tricoordinate[w]) {
+                            if (elements[w] != null && elements[w].type == Type.Bicoordinate) {
+                                stereocenters[u] = Stereocenter.Potential;
+                                elements[u] = new Tricoordinate(u, w, g[u]);
+                            }
+                            continue;
                         }
-                        continue;
-                    }
 
-                    stereocenters[w] = Stereocenter.Potential;
-                    stereocenters[u] = Stereocenter.Potential;
-                    elements[u] = new Tricoordinate(u, w, g[u]);
-                    elements[w] = new Tricoordinate(w, u, g[w]);
+                        stereocenters[w] = Stereocenter.Potential;
+                        stereocenters[u] = Stereocenter.Potential;
+                        elements[u] = new Tricoordinate(u, w, g[u]);
+                        elements[w] = new Tricoordinate(w, u, g[w]);
+                    } else {
+                        stereocenters[u] = Stereocenter.Potential;
+                        elements[u] = new Tricoordinate(u, -1, g[u]);
+                    }
                     nElements++;
                     break;
 
@@ -337,7 +342,7 @@ public final class Stereocenters {
             }
         }
 
-        // link up tetracoordinate atoms accross cumulate systems
+        // link up tetracoordinate atoms across cumulate systems
         for (int v = 0; v < g.length; v++) {
             if (elements[v] != null && elements[v].type == Type.Bicoordinate) {
                 int u = elements[v].neighbors[0];
@@ -525,8 +530,10 @@ public final class Stereocenters {
                 if (x == 4 && h == 0 && (q == 0 && v == 5 || q == 1 && v == 4))
                     return verifyTerminalHCount(i) ? Type.Tetracoordinate : Type.None;
                 // note: bridgehead not allowed by InChI but makes sense
-                return x == 3 && h == 0 && v == 3 && q == 0 &&
-                        (isBridgeHead(i) || inThreeMemberRing(i)) ? Type.Tetracoordinate : Type.None;
+                if (x == 3 && h == 0 && v == 3 && q == 0) {
+                    return (isBridgeHead(i) || inThreeMemberRing(i)) ? Type.Tetracoordinate : Type.Tricoordinate;
+                }
+                return Type.None;
 
             case 14: // silicon
                 if (v != 4 || q != 0) return Type.None;
@@ -883,7 +890,7 @@ public final class Stereocenters {
             this.focus = v;
             this.other = w;
             this.type = Type.Tricoordinate;
-            this.neighbors = new int[neighbors.length - 1];
+            this.neighbors = new int[w < 0 ? neighbors.length : neighbors.length - 1];
             int n = 0;
 
             // remove the other neighbor from neighbors when checking
@@ -891,6 +898,8 @@ public final class Stereocenters {
             for (int neighbor : neighbors) {
                 if (neighbor != other) this.neighbors[n++] = neighbor;
             }
+            if (n != this.neighbors.length)
+                this.neighbors[n] = other;
         }
     }
 }

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereoElementFactoryTest.java
@@ -45,11 +45,13 @@ import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.OPPOSITE;
 import static org.openscience.cdk.interfaces.IDoubleBondStereochemistry.Conformation.TOGETHER;
 
@@ -199,6 +201,7 @@ class StereoElementFactoryTest {
 
     /**
      * (E)-hexa-2,3,4-triene
+     *
      * @cdk.smiles C/C=C=C=C/C
      */
     @Test
@@ -210,11 +213,11 @@ class StereoElementFactoryTest {
         mol.addAtom(atom("C", 1, 0.00d, 0.00d));
         mol.addAtom(atom("C", 3, -0.41d, -0.71d));
         mol.addAtom(atom("C", 3, 2.89d, 0.71d));
-        mol.addBond(0,1,IBond.Order.DOUBLE);
-        mol.addBond(1,2,IBond.Order.DOUBLE);
-        mol.addBond(2,3,IBond.Order.DOUBLE);
-        mol.addBond(3,4,IBond.Order.SINGLE);
-        mol.addBond(0,5,IBond.Order.SINGLE);
+        mol.addBond(0, 1, IBond.Order.DOUBLE);
+        mol.addBond(1, 2, IBond.Order.DOUBLE);
+        mol.addBond(2, 3, IBond.Order.DOUBLE);
+        mol.addBond(3, 4, IBond.Order.SINGLE);
+        mol.addBond(0, 5, IBond.Order.SINGLE);
         StereoElementFactory factory = StereoElementFactory.using2DCoordinates(mol);
         List<IBond> dbs = new ArrayList<>();
         dbs.add(mol.getBond(0));
@@ -227,6 +230,7 @@ class StereoElementFactoryTest {
 
     /**
      * (Z)-hexa-2,3,4-triene
+     *
      * @cdk.smiles C/C=C=C=C\C
      */
     @Test
@@ -238,11 +242,11 @@ class StereoElementFactoryTest {
         mol.addAtom(atom("C", 1, 0.00d, 0.00d));
         mol.addAtom(atom("C", 3, -0.41d, -0.71d));
         mol.addAtom(atom("C", 3, 2.92d, -0.69d));
-        mol.addBond(0,1,IBond.Order.DOUBLE);
-        mol.addBond(1,2,IBond.Order.DOUBLE);
-        mol.addBond(2,3,IBond.Order.DOUBLE);
-        mol.addBond(3,4,IBond.Order.SINGLE);
-        mol.addBond(0,5,IBond.Order.SINGLE);
+        mol.addBond(0, 1, IBond.Order.DOUBLE);
+        mol.addBond(1, 2, IBond.Order.DOUBLE);
+        mol.addBond(2, 3, IBond.Order.DOUBLE);
+        mol.addBond(3, 4, IBond.Order.SINGLE);
+        mol.addBond(0, 5, IBond.Order.SINGLE);
         StereoElementFactory factory = StereoElementFactory.using2DCoordinates(mol);
         List<IBond> dbs = new ArrayList<>();
         dbs.add(mol.getBond(0));
@@ -255,6 +259,7 @@ class StereoElementFactoryTest {
 
     /**
      * (E)-hexa-2,3,4-triene
+     *
      * @cdk.smiles C/C=C=C=C/C
      */
     @Test
@@ -266,11 +271,11 @@ class StereoElementFactoryTest {
         mol.addAtom(atom("C", 1, -2.24d, -2.65d, 0.67d));
         mol.addAtom(atom("C", 3, -3.66d, -2.36d, 0.68d));
         mol.addAtom(atom("C", 3, 1.69d, -0.32d, -0.11d));
-        mol.addBond(0,1,IBond.Order.DOUBLE);
-        mol.addBond(1,2,IBond.Order.DOUBLE);
-        mol.addBond(2,3,IBond.Order.DOUBLE);
-        mol.addBond(3,4,IBond.Order.SINGLE);
-        mol.addBond(0,5,IBond.Order.SINGLE);
+        mol.addBond(0, 1, IBond.Order.DOUBLE);
+        mol.addBond(1, 2, IBond.Order.DOUBLE);
+        mol.addBond(2, 3, IBond.Order.DOUBLE);
+        mol.addBond(3, 4, IBond.Order.SINGLE);
+        mol.addBond(0, 5, IBond.Order.SINGLE);
         StereoElementFactory factory = StereoElementFactory.using3DCoordinates(mol);
         List<IBond> dbs = new ArrayList<>();
         dbs.add(mol.getBond(0));
@@ -283,6 +288,7 @@ class StereoElementFactoryTest {
 
     /**
      * (Z)-hexa-2,3,4-triene
+     *
      * @cdk.smiles C/C=C=C=C\C
      */
     @Test
@@ -294,11 +300,11 @@ class StereoElementFactoryTest {
         mol.addAtom(atom("C", 1, -1.84d, -2.17d, 1.74d));
         mol.addAtom(atom("C", 3, -3.13d, -1.73d, 2.21d));
         mol.addAtom(atom("C", 3, -0.70d, 0.69d, -1.73d));
-        mol.addBond(0,1,IBond.Order.DOUBLE);
-        mol.addBond(1,2,IBond.Order.DOUBLE);
-        mol.addBond(2,3,IBond.Order.DOUBLE);
-        mol.addBond(3,4,IBond.Order.SINGLE);
-        mol.addBond(0,5,IBond.Order.SINGLE);
+        mol.addBond(0, 1, IBond.Order.DOUBLE);
+        mol.addBond(1, 2, IBond.Order.DOUBLE);
+        mol.addBond(2, 3, IBond.Order.DOUBLE);
+        mol.addBond(3, 4, IBond.Order.SINGLE);
+        mol.addBond(0, 5, IBond.Order.SINGLE);
         StereoElementFactory factory = StereoElementFactory.using3DCoordinates(mol);
         List<IBond> dbs = new ArrayList<>();
         dbs.add(mol.getBond(0));
@@ -651,13 +657,13 @@ class StereoElementFactoryTest {
             mdlr.getSetting("AddStereoElements").setSetting("false");
             IAtomContainer mol = mdlr.read(builder.newAtomContainer());
             int numStereo = 0;
-            for (IStereoElement<?,?> se : mol.stereoElements())
+            for (IStereoElement<?, ?> se : mol.stereoElements())
                 numStereo++;
-            Assertions.assertEquals(0, numStereo);
+            assertEquals(0, numStereo);
             StereoElementFactory stereoFactory = StereoElementFactory.using2DCoordinates(mol);
-            Assertions.assertEquals(1, stereoFactory.createAll().size());
+            assertEquals(1, stereoFactory.createAll().size());
             stereoFactory.withStrictMode();
-            Assertions.assertEquals(1, stereoFactory.createAll().size());
+            assertEquals(1, stereoFactory.createAll().size());
         }
     }
 
@@ -669,13 +675,13 @@ class StereoElementFactoryTest {
             mdlr.getSetting("AddStereoElements").setSetting("false");
             IAtomContainer mol = mdlr.read(builder.newAtomContainer());
             int numStereo = 0;
-            for (IStereoElement<?,?> se : mol.stereoElements())
+            for (IStereoElement<?, ?> se : mol.stereoElements())
                 numStereo++;
-            Assertions.assertEquals(0, numStereo);
+            assertEquals(0, numStereo);
             StereoElementFactory stereoFactory = StereoElementFactory.using2DCoordinates(mol);
-            Assertions.assertEquals(1, stereoFactory.createAll().size());
+            assertEquals(1, stereoFactory.createAll().size());
             stereoFactory.withStrictMode();
-            Assertions.assertEquals(0, stereoFactory.createAll().size());
+            assertEquals(0, stereoFactory.createAll().size());
         }
     }
 
@@ -687,13 +693,13 @@ class StereoElementFactoryTest {
             mdlr.getSetting("AddStereoElements").setSetting("false");
             IAtomContainer mol = mdlr.read(builder.newAtomContainer());
             int numStereo = 0;
-            for (IStereoElement<?,?> se : mol.stereoElements())
+            for (IStereoElement<?, ?> se : mol.stereoElements())
                 numStereo++;
-            Assertions.assertEquals(0, numStereo);
+            assertEquals(0, numStereo);
             StereoElementFactory stereoFactory = StereoElementFactory.using2DCoordinates(mol);
-            Assertions.assertEquals(1, stereoFactory.createAll().size());
+            assertEquals(1, stereoFactory.createAll().size());
             stereoFactory.withStrictMode();
-            Assertions.assertEquals(0, stereoFactory.createAll().size());
+            assertEquals(0, stereoFactory.createAll().size());
         }
     }
 
@@ -705,13 +711,13 @@ class StereoElementFactoryTest {
             mdlr.getSetting("AddStereoElements").setSetting("false");
             IAtomContainer mol = mdlr.read(builder.newAtomContainer());
             int numStereo = 0;
-            for (IStereoElement<?,?> se : mol.stereoElements())
+            for (IStereoElement<?, ?> se : mol.stereoElements())
                 numStereo++;
-            Assertions.assertEquals(0, numStereo);
+            assertEquals(0, numStereo);
             StereoElementFactory stereoFactory = StereoElementFactory.using2DCoordinates(mol);
-            Assertions.assertEquals(1, stereoFactory.createAll().size());
+            assertEquals(1, stereoFactory.createAll().size());
             stereoFactory.withStrictMode();
-            Assertions.assertEquals(1, stereoFactory.createAll().size());
+            assertEquals(1, stereoFactory.createAll().size());
         }
     }
 
@@ -723,19 +729,20 @@ class StereoElementFactoryTest {
             mdlr.getSetting("AddStereoElements").setSetting("false");
             IAtomContainer mol = mdlr.read(builder.newAtomContainer());
             int numStereo = 0;
-            for (IStereoElement<?,?> se : mol.stereoElements())
+            for (IStereoElement<?, ?> se : mol.stereoElements())
                 numStereo++;
-            Assertions.assertEquals(0, numStereo);
+            assertEquals(0, numStereo);
             StereoElementFactory stereoFactory = StereoElementFactory.using2DCoordinates(mol);
-            Assertions.assertEquals(1, stereoFactory.createAll().size());
+            assertEquals(1, stereoFactory.createAll().size());
             stereoFactory.withStrictMode();
-            Assertions.assertEquals(0, stereoFactory.createAll().size());
+            assertEquals(0, stereoFactory.createAll().size());
         }
     }
 
     /**
      * MetaCyc CPD-7272 D-dopachrome
      * http://metacyc.org/META/NEW-IMAGE?type=NIL&object=CPD-7272
+     *
      * @cdk.inchi InChI=1S/C9H7NO4/c11-7-2-4-1-6(9(13)14)10-5(4)3-8(7)12/h1,3,6,10H,2H2,(H,13,14)/p-1
      */
     @Test
@@ -774,7 +781,7 @@ class StereoElementFactoryTest {
         m.addBond(3, 5, IBond.Order.SINGLE);
 
         ExtendedTetrahedral et = StereoElementFactory.using2DCoordinates(m).createExtendedTetrahedral(2,
-                Stereocenters.of(m));
+                                                                                                      Stereocenters.of(m));
         assertThat(et.winding(), is(ITetrahedralChirality.Stereo.CLOCKWISE));
         assertThat(et.peripherals(), is(new IAtom[]{m.getAtom(0), m.getAtom(6), m.getAtom(4), m.getAtom(5)}));
         assertThat(et.focus(), is(m.getAtom(2)));
@@ -798,7 +805,7 @@ class StereoElementFactoryTest {
         m.addBond(3, 5, IBond.Order.SINGLE);
 
         ExtendedTetrahedral et = StereoElementFactory.using2DCoordinates(m).createExtendedTetrahedral(2,
-                Stereocenters.of(m));
+                                                                                                      Stereocenters.of(m));
         assertThat(et.winding(), is(ITetrahedralChirality.Stereo.ANTI_CLOCKWISE));
         assertThat(et.peripherals(), is(new IAtom[]{m.getAtom(0), m.getAtom(6), m.getAtom(4), m.getAtom(5)}));
         assertThat(et.focus(), is(m.getAtom(2)));
@@ -818,7 +825,7 @@ class StereoElementFactoryTest {
         m.addBond(3, 4, IBond.Order.SINGLE);
 
         ExtendedTetrahedral et = StereoElementFactory.using2DCoordinates(m).createExtendedTetrahedral(2,
-                Stereocenters.of(m));
+                                                                                                      Stereocenters.of(m));
         assertThat(et.winding(), is(ITetrahedralChirality.Stereo.CLOCKWISE));
         assertThat(et.peripherals(), is(new IAtom[]{m.getAtom(0), m.getAtom(1), m.getAtom(4), m.getAtom(3)}));
         assertThat(et.focus(), is(m.getAtom(2)));
@@ -838,7 +845,7 @@ class StereoElementFactoryTest {
         m.addBond(3, 4, IBond.Order.SINGLE);
 
         ExtendedTetrahedral et = StereoElementFactory.using2DCoordinates(m).createExtendedTetrahedral(2,
-                Stereocenters.of(m));
+                                                                                                      Stereocenters.of(m));
         assertThat(et.winding(), is(ITetrahedralChirality.Stereo.ANTI_CLOCKWISE));
         assertThat(et.peripherals(), is(new IAtom[]{m.getAtom(0), m.getAtom(1), m.getAtom(4), m.getAtom(3)}));
         assertThat(et.focus(), is(m.getAtom(2)));
@@ -862,7 +869,7 @@ class StereoElementFactoryTest {
         m.addBond(3, 5, IBond.Order.SINGLE);
 
         ExtendedTetrahedral et = StereoElementFactory.using2DCoordinates(m).createExtendedTetrahedral(2,
-                Stereocenters.of(m));
+                                                                                                      Stereocenters.of(m));
         Assertions.assertNull(et);
     }
 
@@ -1077,6 +1084,7 @@ class StereoElementFactoryTest {
 
     /**
      * glyceraldehyde
+     *
      * @cdk.inchi InChI=1/C3H6O3/c4-1-3(6)2-5/h1,3,5-6H,2H2/t3-/s2
      */
     @Test
@@ -1117,6 +1125,7 @@ class StereoElementFactoryTest {
 
     /**
      * beta-D-glucose
+     *
      * @cdk.inchi InChI=1/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2/t2-,3-,4+,5-,6-/s2
      */
     @Test
@@ -1163,9 +1172,10 @@ class StereoElementFactoryTest {
                                                    .createAll()
                                                    .isEmpty());
     }
-    
+
     /**
      * beta-D-glucose
+     *
      * @cdk.inchi InChI=1/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2/t2-,3-,4+,5-,6-/s2
      */
     @Test
@@ -1338,7 +1348,8 @@ class StereoElementFactoryTest {
 
     /**
      * BiNOL - SMILES/InChI can't represent the atropoisomerism but the single
-     *         bond rotation is restricted.
+     * bond rotation is restricted.
+     *
      * @cdk.smiles OC1=CC=C2C=CC=CC2=C1C1=C(O)C=CC2=C1C=CC=C2
      */
     @Test
@@ -1392,18 +1403,18 @@ class StereoElementFactoryTest {
         m.addBond(4, 19, IBond.Order.SINGLE);
         m.addBond(18, 5, IBond.Order.SINGLE);
         List<IStereoElement> stereo =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereo.size(), is(0));
         m.getBond(12).setStereo(IBond.Stereo.UP);
         List<IStereoElement> stereoUp =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereoUp.size(), is(1));
         m.getBond(12).setStereo(IBond.Stereo.DOWN);
         List<IStereoElement> stereoDown =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereoDown.size(), is(1));
         IStereoElement s1 = stereoUp.get(0);
         IStereoElement s2 = stereoDown.get(0);
@@ -1416,8 +1427,8 @@ class StereoElementFactoryTest {
         m.getBond(12).setStereo(IBond.Stereo.NONE);
         m.getBond(m.getAtom(9), m.getAtom(12)).setStereo(IBond.Stereo.UP);
         List<IStereoElement> stereoUpOther =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereoUpOther.size(), is(1));
         IStereoElement s3 = stereoUpOther.get(0);
         assertThat(s3.getFocus(), is(s2.getFocus()));
@@ -1426,14 +1437,151 @@ class StereoElementFactoryTest {
 
         m.getBond(m.getAtom(9), m.getAtom(12)).setStereo(IBond.Stereo.DOWN);
         List<IStereoElement> stereoDownOther =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereoDownOther.size(), is(1));
         IStereoElement s4 = stereoDownOther.get(0);
         assertThat(s4.getFocus(), is(s1.getFocus()));
         assertThat(s4.getCarriers(), is(s1.getCarriers()));
         assertThat(s4.getConfigOrder(), is(s1.getConfigOrder()));
     }
+
+    /**
+     * sotorasib - Daylight SMILES/InChI can't represent the atropoisomerism but the single
+     * bond rotation is restricted. RDKit has added a CXSMILES extensions which
+     * we currently support for reading only. This test case is checking the
+     * perception from 2D coordinates (as currently displayed on wikipedia).
+     *
+     * @cdk.smiles C=CC(=O)N1CCN(c2nc(=O)n(-c3c(C)ccnc3C(C)C)c3nc(-c4c(O)cccc4F)c(F)cc23)[C@@H](C)C1 |wU:12.23| (m)-sotorasib
+     * @see <a href="https://en.wikipedia.org/wiki/Sotorasib">Sotorasib Wikipedia Page</a>
+     */
+    @Test
+    void testSotorasib() throws CDKException {
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(24.3615, -20.4375));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(24.3615, -21.9375));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(23.0625, -22.6875));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(21.7635, -21.9375));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(21.7635, -20.4375));
+        m.newAtom(IAtom.N, 0).setPoint2d(new Point2d(23.0625, -10.6875));
+        m.newAtom(IAtom.C, 2).setPoint2d(new Point2d(24.3615, -11.4375));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(24.3615, -12.9375));
+        m.newAtom(IAtom.N, 0).setPoint2d(new Point2d(23.0625, -13.6875));
+        m.newAtom(IAtom.C, 2).setPoint2d(new Point2d(21.7635, -12.9375));
+        m.newAtom(IAtom.C, 2).setPoint2d(new Point2d(21.7635, -11.4375));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(23.0625, -9.1875));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(24.3615, -8.4375));
+        m.newAtom(IAtom.O, 0).setPoint2d(new Point2d(21.7635, -8.4375));
+        m.newAtom(IAtom.C, 2).setPoint2d(new Point2d(24.3615, -6.9375));
+        m.newAtom(IAtom.C, 3).setPoint2d(new Point2d(25.6606, -13.6875));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(23.0625, -15.1875));
+        m.newAtom(IAtom.N, 0).setPoint2d(new Point2d(24.3615, -15.9375));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(24.3615, -17.4375));
+        m.newAtom(IAtom.N, 0).setPoint2d(new Point2d(23.0625, -18.1875));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(21.7635, -17.4375));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(21.7635, -15.9375));
+        m.newAtom(IAtom.O, 0).setPoint2d(new Point2d(25.6606, -18.1875));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(23.0625, -19.6875));
+        m.newAtom(IAtom.C, 3).setPoint2d(new Point2d(20.4644, -19.6875));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(25.6606, -19.6875));
+        m.newAtom(IAtom.C, 3).setPoint2d(new Point2d(26.9596, -20.4375));
+        m.newAtom(IAtom.C, 3).setPoint2d(new Point2d(26.3825, -18.4219));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(20.4644, -15.1875));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(19.1654, -15.9375));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(19.1654, -17.4375));
+        m.newAtom(IAtom.N, 0).setPoint2d(new Point2d(20.4644, -18.1875));
+        m.newAtom(IAtom.F, 0).setPoint2d(new Point2d(17.8663, -15.1875));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(17.8663, -18.1875));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(17.8663, -19.6875));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(16.5673, -20.4375));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(15.2683, -19.6875));
+        m.newAtom(IAtom.C, 1).setPoint2d(new Point2d(15.2683, -18.1875));
+        m.newAtom(IAtom.C, 0).setPoint2d(new Point2d(16.5673, -17.4375));
+        m.newAtom(IAtom.F, 0).setPoint2d(new Point2d(19.1654, -20.4375));
+        m.newAtom(IAtom.O, 1).setPoint2d(new Point2d(16.5673, -15.9375));
+        m.addBond(23, 0, IBond.Order.DOUBLE);
+        m.addBond(0, 1, IBond.Order.SINGLE);
+        m.addBond(1, 2, IBond.Order.DOUBLE);
+        m.addBond(2, 3, IBond.Order.SINGLE);
+        m.addBond(3, 4, IBond.Order.DOUBLE);
+        m.addBond(23, 4, IBond.Order.SINGLE, IBond.Stereo.UP);
+        m.addBond(5, 6, IBond.Order.SINGLE);
+        m.addBond(6, 7, IBond.Order.SINGLE);
+        m.addBond(7, 8, IBond.Order.SINGLE);
+        m.addBond(8, 9, IBond.Order.SINGLE);
+        m.addBond(9, 10, IBond.Order.SINGLE);
+        m.addBond(10, 5, IBond.Order.SINGLE);
+        m.addBond(5, 11, IBond.Order.SINGLE);
+        m.addBond(11, 12, IBond.Order.SINGLE);
+        m.addBond(11, 13, IBond.Order.DOUBLE);
+        m.addBond(12, 14, IBond.Order.DOUBLE);
+        m.addBond(7, 15, IBond.Order.SINGLE, IBond.Stereo.DOWN);
+        m.addBond(8, 16, IBond.Order.SINGLE);
+        m.addBond(16, 17, IBond.Order.DOUBLE);
+        m.addBond(17, 18, IBond.Order.SINGLE);
+        m.addBond(18, 19, IBond.Order.SINGLE);
+        m.addBond(19, 20, IBond.Order.SINGLE);
+        m.addBond(20, 21, IBond.Order.DOUBLE);
+        m.addBond(21, 16, IBond.Order.SINGLE);
+        m.addBond(18, 22, IBond.Order.DOUBLE);
+        m.addBond(19, 23, IBond.Order.SINGLE);
+        m.addBond(4, 24, IBond.Order.SINGLE);
+        m.addBond(0, 25, IBond.Order.SINGLE);
+        m.addBond(25, 26, IBond.Order.SINGLE);
+        m.addBond(25, 27, IBond.Order.SINGLE);
+        m.addBond(21, 28, IBond.Order.SINGLE);
+        m.addBond(28, 29, IBond.Order.DOUBLE);
+        m.addBond(29, 30, IBond.Order.SINGLE);
+        m.addBond(30, 31, IBond.Order.DOUBLE);
+        m.addBond(31, 20, IBond.Order.SINGLE);
+        m.addBond(29, 32, IBond.Order.SINGLE);
+        m.addBond(30, 33, IBond.Order.SINGLE);
+        m.addBond(33, 34, IBond.Order.DOUBLE);
+        m.addBond(34, 35, IBond.Order.SINGLE);
+        m.addBond(35, 36, IBond.Order.DOUBLE);
+        m.addBond(36, 37, IBond.Order.SINGLE);
+        m.addBond(37, 38, IBond.Order.DOUBLE);
+        m.addBond(38, 33, IBond.Order.SINGLE);
+        m.addBond(34, 39, IBond.Order.SINGLE);
+        m.addBond(38, 40, IBond.Order.SINGLE);
+        m.getBond(12).setStereo(IBond.Stereo.UP);
+        List<IStereoElement> stereo =
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
+        assertThat(stereo.size(), is(2));
+
+        IStereoElement s1 = stereo.get(0);
+        IStereoElement s2 = stereo.get(1);
+
+        if (s1.getConfigClass() == IStereoElement.Tetrahedral) {
+            assertEquals(IStereoElement.Atropisomeric, s2.getConfigClass());
+            assertEquals(IStereoElement.RIGHT, s2.getConfigOrder());
+            IBond bond = (IBond)s2.getFocus();
+            assertEquals(m.getBond(25), bond);
+            assertEquals(m.getAtom(19), bond.getBegin());
+            assertEquals(m.getAtom(23), bond.getEnd());
+            List<IAtom> carriers = s2.<IAtom>getCarriers();
+            assertEquals(Arrays.asList(m.getAtom(18),
+                                       m.getAtom(20),
+                                       m.getAtom(0),
+                                       m.getAtom(4)),
+                         carriers);
+        } else {
+            assertEquals(IStereoElement.Atropisomeric, s1.getConfigClass());
+            assertEquals(IStereoElement.RIGHT, s1.getConfigOrder());
+            IBond bond = (IBond)s1.getFocus();
+            assertEquals(m.getBond(25), bond);
+            assertEquals(m.getAtom(19), bond.getBegin());
+            assertEquals(m.getAtom(23), bond.getEnd());
+            List<IAtom> carriers = s1.<IAtom>getCarriers();
+            assertEquals(Arrays.asList(m.getAtom(18),
+                                       m.getAtom(20),
+                                       m.getAtom(0),
+                                       m.getAtom(4)),
+                         carriers);
+        }
+    }
+
 
     /**
      * @cdk.smiles CC1=C(C=CC=C1)C1=C(C)C=CC=C1O
@@ -1473,8 +1621,8 @@ class StereoElementFactoryTest {
         m.addBond(7, 13, IBond.Order.SINGLE);
         m.addBond(5, 14, IBond.Order.SINGLE);
         List<IStereoElement> stereo =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereo.size(), is(1));
     }
 
@@ -1514,8 +1662,8 @@ class StereoElementFactoryTest {
         m.addBond(11, 12, IBond.Order.SINGLE);
         m.addBond(7, 13, IBond.Order.SINGLE);
         List<IStereoElement> stereo =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereo.size(), is(0));
     }
 
@@ -1555,8 +1703,8 @@ class StereoElementFactoryTest {
         m.addBond(11, 12, IBond.Order.SINGLE);
         m.addBond(5, 13, IBond.Order.SINGLE);
         List<IStereoElement> stereo =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereo.size(), is(0));
     }
 
@@ -1615,8 +1763,8 @@ class StereoElementFactoryTest {
         m.addBond(16, 21, IBond.Order.SINGLE);
         m.addBond(12, 13, IBond.Order.SINGLE);
         List<IStereoElement> stereo =
-            StereoElementFactory.using2DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using2DCoordinates(m)
+                                    .createAll();
         assertThat(stereo.size(), is(0));
     }
 
@@ -1658,14 +1806,14 @@ class StereoElementFactoryTest {
         m.addBond(8, 13, IBond.Order.DOUBLE);
         m.addBond(13, 14, IBond.Order.SINGLE);
         List<IStereoElement> stereo =
-            StereoElementFactory.using3DCoordinates(m)
-                                .createAll();
+                StereoElementFactory.using3DCoordinates(m)
+                                    .createAll();
         assertThat(stereo.size(), is(1));
     }
-    
+
     @Test
     void samePositionWithStereocenter() throws Exception {
-    	IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
+        IAtomContainer m = SilentChemObjectBuilder.getInstance().newAtomContainer();
         m.addAtom(atom("F", 0, -1, -1));
         m.addAtom(atom("Cl", 0, 1, -1));
         m.addAtom(atom("C", 0, 0, 0));
@@ -1676,52 +1824,52 @@ class StereoElementFactoryTest {
         m.addBond(2, 3, IBond.Order.SINGLE);
         m.addBond(2, 4, IBond.Order.SINGLE);
         m.getBond(2).setStereo(IBond.Stereo.DOWN);
-        
+
         List<IStereoElement> ses = StereoElementFactory.using2DCoordinates(m).createAll();
         boolean flag = false;
         for (IStereoElement se : ses) {
-        	if (se != null) {
-        		flag = true;
-        		break;
-        	}
+            if (se != null) {
+                flag = true;
+                break;
+            }
         }
         assertThat(flag, is(true));
     }
 
 
     @Test
-    void warnOnAmbiguousStereo() throws Exception{
+    void warnOnAmbiguousStereo() throws Exception {
         IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
         try (InputStream in = getClass().getResourceAsStream("ambig-wedge.mol");
              MDLV2000Reader mdlr = new MDLV2000Reader(in)) {
             mdlr.getSetting("AddStereoElements").setSetting("false");
             IAtomContainer mol = mdlr.read(builder.newAtomContainer());
             int numStereo = 0;
-            for (IStereoElement<?,?> se : mol.stereoElements())
+            for (IStereoElement<?, ?> se : mol.stereoElements())
                 numStereo++;
-            Assertions.assertEquals(0, numStereo);
+            assertEquals(0, numStereo);
             StereoElementFactory stereoFactory = StereoElementFactory.using2DCoordinates(mol);
             List<IStereoElement> stereoElements = stereoFactory.createAll();
-            Assertions.assertEquals(1, stereoElements.size());
+            assertEquals(1, stereoElements.size());
         }
     }
 
     @Test
-    void ignoreInverseWedgeWhenStrict() throws Exception{
+    void ignoreInverseWedgeWhenStrict() throws Exception {
         IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
         try (InputStream in = getClass().getResourceAsStream("inverse-wedge.mol");
              MDLV2000Reader mdlr = new MDLV2000Reader(in)) {
             mdlr.getSetting("AddStereoElements").setSetting("false");
             IAtomContainer mol = mdlr.read(builder.newAtomContainer());
             int numStereo = 0;
-            for (IStereoElement<?,?> se : mol.stereoElements())
+            for (IStereoElement<?, ?> se : mol.stereoElements())
                 numStereo++;
-            Assertions.assertEquals(0, numStereo);
+            assertEquals(0, numStereo);
             StereoElementFactory stereoFactory = StereoElementFactory.using2DCoordinates(mol);
             stereoFactory.checkSymmetry(true);
-            Assertions.assertEquals(1, stereoFactory.createAll().size());
+            assertEquals(1, stereoFactory.createAll().size());
             stereoFactory.withStrictMode();
-            Assertions.assertEquals(0, stereoFactory.createAll().size());
+            assertEquals(0, stereoFactory.createAll().size());
         }
     }
 

--- a/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereocentersTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/stereo/StereocentersTest.java
@@ -31,6 +31,7 @@ import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -160,7 +161,7 @@ class StereocentersTest {
 
         // nitrogen inversion -> reject
         none("N");
-        none("N(C)(N)(O)");
+        nonTetrahedral("N(C)(N)(O)");
         none("N(=C)(C)");
     }
 
@@ -173,7 +174,7 @@ class StereocentersTest {
     @Test
     void nitrogen_v3_neutral_in_larger_ring() throws Exception {
         none("N(C)(C1)CCCC1"); // n.b. equivalence checked later
-        none("N(C)(C1)CCCC1C");
+        nonTetrahedral("N(C)(C1)CCCC1C");
     }
 
     /**
@@ -785,7 +786,7 @@ class StereocentersTest {
     void bridgehead_nitrogens() throws Exception {
         tetrahedral("N1(CC2)CC2CC1");
         // fused
-        none("N1(CCCC2)CCCC12");
+        nonTetrahedral("N1(CCCC2)CCCC12"); // OKAY - it is not tetrahedral
         // adjacent to fused (but not fused)
         tetrahedral("N1(c(cccc3)c32)CC2CC1");
 
@@ -796,6 +797,11 @@ class StereocentersTest {
     void tetrahedral(String smi) throws Exception {
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         test(sp.parseSmiles(smi), Stereocenters.Type.Tetracoordinate, smi + " was not accepted", true);
+    }
+
+    void nonTetrahedral(String smi) throws Exception {
+        SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        testNot(sp.parseSmiles(smi), Stereocenters.Type.Tetracoordinate, smi + " was not accepted", true);
     }
 
     // assert the first atom of the SMILES is accepted as a geometric center
@@ -822,6 +828,14 @@ class StereocentersTest {
         if (hnorm) {
             AtomContainerManipulator.convertImplicitToExplicitHydrogens(container);
             assertThat(mesg + " (unsupressed hydrogens)", Stereocenters.of(container).elementType(0), is(type));
+        }
+    }
+
+    void testNot(IAtomContainer container, Stereocenters.Type type, String mesg, boolean hnorm) {
+        assertThat(mesg, Stereocenters.of(container).elementType(0), is(not(type)));
+        if (hnorm) {
+            AtomContainerManipulator.convertImplicitToExplicitHydrogens(container);
+            assertThat(mesg + " (unsupressed hydrogens)", Stereocenters.of(container).elementType(0), is(not(type)));
         }
     }
 

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesState.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesState.java
@@ -23,6 +23,8 @@
 
 package org.openscience.cdk.smiles;
 
+import org.openscience.cdk.interfaces.IBond;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -43,6 +45,7 @@ final class CxSmilesState {
     Map<Integer, Radical>       atomRads    = null;
     Map<Integer, List<Integer>> ligandOrdering = null;
     Map<Integer, List<Integer>> positionVar = null;
+    List<Map.Entry<Map.Entry<Integer,Integer>,IBond.Display>> bondDisplay = null;
     List<CxSgroup>              mysgroups   = null;
     boolean                     coordFlag   = false;
     boolean                     racemic     = false;

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -26,6 +26,7 @@ package org.openscience.cdk.smiles;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.graph.ConnectivityChecker;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
@@ -42,6 +43,7 @@ import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.sgroup.SgroupType;
 import org.openscience.cdk.smiles.CxSmilesState.CxDataSgroup;
 import org.openscience.cdk.smiles.CxSmilesState.CxPolymerSgroup;
+import org.openscience.cdk.stereo.Atropisomeric;
 import org.openscience.cdk.tools.ILoggingTool;
 import org.openscience.cdk.tools.LoggingToolFactory;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
@@ -54,6 +56,7 @@ import javax.vecmath.Point3d;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -252,7 +255,7 @@ public final class SmilesParser {
      * <pre>{@code
      * {reactant}>{agent_1}>{product_1}>{agent_2}>{product_2}
      * }</pre>
-     *
+     * <p>
      * Results in a reaction set with two reactions:
      * <pre>{@code
      * {reactant}>{agent_1}>{product_1} step 1
@@ -275,7 +278,7 @@ public final class SmilesParser {
         }
 
         String[] parts = smiles.substring(0, delim).split(">", -1);
-        String   title = smiles.substring(delim).trim();
+        String title = smiles.substring(delim).trim();
 
         if (parts.length < 3 || parts.length % 2 == 0)
             throw new IllegalArgumentException("Unexpected number of parts: " + parts.length + ", should be 3,5,7,..");
@@ -284,7 +287,7 @@ public final class SmilesParser {
         IReaction reaction = builder.newReaction();
 
         for (int i = 0; i < parts.length; i++) {
-            IAtomContainer    mol  = parseSmiles(parts[i], true);
+            IAtomContainer mol = parseSmiles(parts[i], true);
             IAtomContainerSet mols = ConnectivityChecker.partitionIntoMolecules(mol);
             if (i == 0) {
                 // first step's reactants
@@ -342,7 +345,7 @@ public final class SmilesParser {
             // convert the Beam object model to the CDK - note exception thrown
             // if a kekule structure could not be assigned.
             IAtomContainer mol = beamToCDK.toAtomContainer(kekulise ? g.kekule() : g,
-                    kekulise);
+                                                           kekulise);
 
             if (!isRxnPart) {
                 try {
@@ -390,7 +393,7 @@ public final class SmilesParser {
                 // set the correct title
                 mol.setTitle(title.substring(pos));
 
-                final Map<IAtom, IAtomContainer> atomToMol = new HashMap<>(2*mol.getAtomCount());
+                final Map<IAtom, IAtomContainer> atomToMol = new HashMap<>(2 * mol.getAtomCount());
                 final List<IAtom> atoms = new ArrayList<>(mol.getAtomCount());
                 final List<IBond> bonds = new ArrayList<>(mol.getBondCount());
 
@@ -450,10 +453,18 @@ public final class SmilesParser {
             if (arrowType != null && !arrowType.isEmpty()) {
                 for (IReaction rxn : rxns.reactions()) {
                     switch (arrowType) {
-                        case "RES": rxn.setDirection(IReaction.Direction.RESONANCE); break;
-                        case "EQU": rxn.setDirection(IReaction.Direction.BIDIRECTIONAL); break;
-                        case "RET": rxn.setDirection(IReaction.Direction.RETRO_SYNTHETIC); break;
-                        case "NGO": rxn.setDirection(IReaction.Direction.NO_GO); break;
+                        case "RES":
+                            rxn.setDirection(IReaction.Direction.RESONANCE);
+                            break;
+                        case "EQU":
+                            rxn.setDirection(IReaction.Direction.BIDIRECTIONAL);
+                            break;
+                        case "RET":
+                            rxn.setDirection(IReaction.Direction.RETRO_SYNTHETIC);
+                            break;
+                        case "NGO":
+                            rxn.setDirection(IReaction.Direction.NO_GO);
+                            break;
                     }
                 }
             }
@@ -473,8 +484,8 @@ public final class SmilesParser {
             return; // nothing to do here
 
         final int reactant = 1;
-        final int agent    = 2;
-        final int product  = 3;
+        final int agent = 2;
+        final int product = 3;
 
         Set<IAtomContainer> unique = new HashSet<>();
         List<IAtomContainer> fragments = new ArrayList<>();
@@ -549,7 +560,7 @@ public final class SmilesParser {
 
                 for (IAtomContainer mol : fragments) {
                     List<IReaction> reactions = molToReaction.get(mol);
-                    List<Integer>   roles     = roleMap.get(mol);
+                    List<Integer> roles = roleMap.get(mol);
                     if (roles.isEmpty())
                         continue;
                     for (int i = 0; i < reactions.size(); i++) {
@@ -676,21 +687,29 @@ public final class SmilesParser {
         }
 
         if (cxstate.bondDisplay != null) {
-            for (Map.Entry<Map.Entry<Integer,Integer>, IBond.Display> e : cxstate.bondDisplay) {
+            for (Map.Entry<Map.Entry<Integer, Integer>, IBond.Display> e : cxstate.bondDisplay) {
                 Integer atmIdx = e.getKey().getKey();
                 Integer bndIdx = e.getKey().getValue();
                 IBond.Display style = e.getValue();
-                IAtom atom = atmIdx < atoms.size() ? atoms.get(atmIdx) : null;
-                IBond bond = bndIdx < bonds.size() ? bonds.get(bndIdx) : null;
-                if (bond.getBegin().equals(atom)) {
-                    bond.setDisplay(style);
-                } else if (bond.getEnd().equals(atom)) {
-                    if (style == IBond.Display.WedgeBegin)
-                        bond.setDisplay(IBond.Display.WedgeEnd);
-                    else if (style == IBond.Display.WedgedHashBegin)
-                        bond.setDisplay(IBond.Display.WedgedHashEnd);
-                    else
-                        bond.setDisplay(style);
+                IAtom atomToWedgeFrom = atmIdx < atoms.size() ? atoms.get(atmIdx) : null;
+                IBond bondToWedge = bndIdx < bonds.size() ? bonds.get(bndIdx) : null;
+                if (bondToWedge == null)
+                    continue;
+                if (atomToWedgeFrom == null)
+                    continue;
+                if (cxstate.atomCoords == null) {
+                  handleRdkitAtropisomerExtension(atomToMol, atomToWedgeFrom, bondToWedge, style);
+                } else {
+                    if (bondToWedge.getBegin().equals(atomToWedgeFrom)) {
+                        bondToWedge.setDisplay(style);
+                    } else if (bondToWedge.getEnd().equals(atomToWedgeFrom)) {
+                        if (style == IBond.Display.WedgeBegin)
+                            bondToWedge.setDisplay(IBond.Display.WedgeEnd);
+                        else if (style == IBond.Display.WedgedHashBegin)
+                            bondToWedge.setDisplay(IBond.Display.WedgedHashEnd);
+                        else
+                            bondToWedge.setDisplay(style);
+                    }
                 }
             }
         }
@@ -944,7 +963,7 @@ public final class SmilesParser {
                 for (IStereoElement<?, ?> stereo : mol.stereoElements()) {
                     // maybe also Al and AT?
                     if (stereo.getConfigClass() == IStereoElement.TH &&
-                            stereo.getFocus().equals(atm)) {
+                        stereo.getFocus().equals(atm)) {
                         stereo.setGroupInfo(e.getValue());
                     }
                 }
@@ -954,6 +973,140 @@ public final class SmilesParser {
         // assign Sgroups
         for (Map.Entry<IAtomContainer, List<Sgroup>> e : sgroupMap.entrySet())
             e.getKey().setProperty(CDKConstants.CTAB_SGROUPS, new ArrayList<>(e.getValue()));
+    }
+
+
+    /**
+     * This logic is used to allow reading of Atropisomer configurations (e.g.
+     * BiNOL) from CXSMILES.
+     *
+     * @param atomToMol mapping from atom to the containing molecule
+     * @param atomToWedgeFrom atom at small end of wedge
+     * @param bondToWedge the bond being wedged
+     * @param style the wedge style
+     */
+    private void handleRdkitAtropisomerExtension(Map<IAtom, IAtomContainer> atomToMol,
+                                                 IAtom atomToWedgeFrom,
+                                                 IBond bondToWedge,
+                                                 IBond.Display style) {
+        // check for RDKit atropisomers
+        if (!isAtropisomerAtom(atomToWedgeFrom))
+            return;
+
+        // We need ring flags set, this is not cached but
+        // (hopefully) there are only a few wedges
+        Cycles.markRingAtomsAndBonds(atomToMol.get(atomToWedgeFrom));
+
+        // Find the bond to apply the atropisomerism to
+        IBond atropisomerBond = null;
+        for (IBond b : atomToWedgeFrom.bonds()) {
+            if (!b.equals(bondToWedge) &&
+                b.getOrder() == IBond.Order.SINGLE &&
+                isAtropisomerAtom(b.getOther(atomToWedgeFrom)) &&
+                Cycles.smallRingSize(b, 7) == 0) {
+                if (atropisomerBond != null) {
+                    atropisomerBond = null;
+                    break;
+                }
+                atropisomerBond = b;
+            }
+        }
+
+        if (atropisomerBond != null) {
+            IAtom atBeg = atropisomerBond.getBegin();
+            IAtom atEnd = atropisomerBond.getEnd();
+            if (bondToWedge.contains(atBeg) ||
+                bondToWedge.contains(atEnd)) {
+                List<IAtom> storeOrder = new ArrayList<>();
+
+                for (IBond b : atBeg.bonds()) {
+                    if (b.equals(atropisomerBond))
+                        continue;
+                    IAtom nbor = b.getOther(atBeg);
+                    storeOrder.add(nbor);
+                }
+                for (IBond b : atEnd.bonds()) {
+                    if (b.equals(atropisomerBond))
+                        continue;
+                    IAtom nbor = b.getOther(atEnd);
+                    storeOrder.add(nbor);
+                }
+
+                if (storeOrder.size() == 4) {
+
+                    if (storeOrder.get(0).getIndex() > storeOrder.get(1).getIndex())
+                        swap(storeOrder, 0, 1);
+                    if (storeOrder.get(2).getIndex() > storeOrder.get(3).getIndex())
+                        swap(storeOrder, 2, 3);
+
+                    IBond.Display bond1dir = IBond.Display.Solid;
+                    IBond.Display bond2dir = IBond.Display.Solid;
+                    if (bondToWedge.contains(atBeg)) {
+                        if (bondToWedge.contains(storeOrder.get(0))) {
+                            bond1dir = style;
+                        } else if (bondToWedge.contains(storeOrder.get(1))) {
+                            bond1dir = flip(style);
+                        }
+                    } else if (bondToWedge.contains(atEnd)) {
+                        if (bondToWedge.contains(storeOrder.get(2))) {
+                            bond2dir = style;
+                        } else if (bondToWedge.contains(storeOrder.get(3))) {
+                            bond2dir = flip(style);
+                        }
+                    }
+
+                    int cfg = 0;
+                    if (bond1dir == IBond.Display.WedgeBegin ||
+                        bond2dir == IBond.Display.WedgedHashBegin) {
+                        cfg = IStereoElement.LEFT;
+                    } else if (bond1dir == IBond.Display.WedgedHashBegin ||
+                               bond2dir == IBond.Display.WedgeBegin) {
+                        cfg = IStereoElement.RIGHT;
+                    }
+
+                    IAtomContainer mol = atomToMol.get(atomToWedgeFrom);
+                    mol.addStereoElement(new Atropisomeric(atropisomerBond,
+                                                           storeOrder.toArray(new IAtom[4]),
+                                                           cfg));
+                }
+            }
+        }
+    }
+
+    private static void swap(List<IAtom> atoms, int i, int j) {
+        IAtom tmp = atoms.get(i);
+        atoms.set(i, atoms.get(j));
+        atoms.set(j, tmp);
+    }
+
+    private static IBond.Display flip(IBond.Display disp) {
+        if (disp == IBond.Display.WedgeBegin)
+            return IBond.Display.WedgedHashBegin;
+        else if (disp == IBond.Display.WedgeEnd)
+            return IBond.Display.WedgedHashEnd;
+        else if (disp == IBond.Display.WedgedHashBegin)
+            return IBond.Display.WedgeBegin;
+        else if (disp == IBond.Display.WedgedHashEnd)
+            return IBond.Display.WedgeEnd;
+        return IBond.Display.Solid;
+    }
+
+    // Check if an atom can potentially by part of an atropisomer
+    private boolean isAtropisomerAtom(IAtom atom) {
+        if (atom.getBondCount() != 3)
+            return false;
+        if (atom.isAromatic())
+            return true;
+        int dbcount = 0;
+        for (IBond bond : atom.bonds()) {
+            if (bond.getOrder() == IBond.Order.DOUBLE)
+                dbcount++;
+        }
+        return dbcount == 1 || (dbcount == 0 &&
+                                atom.getFormalCharge() == 0 &&
+                                (atom.getAtomicNumber() == IAtom.N ||
+                                 atom.getAtomicNumber() == IAtom.P ||
+                                 atom.getAtomicNumber() == IAtom.As));
     }
 
     /**


### PR DESCRIPTION
RDKit support atropisomer from SMILES using a custom extension and abusing wedges in CXSMILES where there no coordinates. I'm not a massive fan of this approach but I don't have anything better and so Roger convinced me to add support. 

You can therefore now depict and test CIP rules on atropisomers in CDK depict.

Some examples from Roger:

```
Cc1c(C)c(C)c(-c2c(C)c(C)c(C)c(C)c2Br)c(Br)c1C |wU:6.5|  ABEFET
Oc1ccc2ccccc2c1-c1c(O)ccc2ccccc12 |wU:10.10|    (S)-(−)-1,1′-Bi(2-napthol)
Oc1ccc2ccccc2c1-c1c(O)ccc2ccccc12 |wU:10.11|    (R)-(+)-1,1'-Bi(2-napthol)
Oc1ccc2ccccc2c1-c1c(O)ccc2ccccc12 |wU:10.10|    (S)-BINOL
Oc1ccc2ccccc2c1-c1c(O)ccc2ccccc12 |wU:10.11|    (R)-BINOL
O=C(O)CSc1nnc(Br)n1-c1ccc(C2CC2)c2ccccc12 |wU:10.10|    TIPQER01
O=C(O)CSc1nnc(Br)n1-c1ccc(C2CC2)c2ccccc12 |wU:10.9|     TIPQER03
O=C(O)CSc1nnc(Br)n1-c1ccc(C2CC2)c2ccccc12 |wU:10.9|     (+)-lesinurad
O=C(O)CSc1nnc(Br)n1-c1ccc(C2CC2)c2ccccc12 |wU:10.10|    (-)-lesinurad
C=CC(=O)N1CCN(c2nc(=O)n(-c3c(C)ccnc3C(C)C)c3nc(-c4c(O)cccc4F)c(F)cc23)[C@@H](C)C1 |wU:12.23|    (m)-sotorasib
C=CC(=O)N1CCN(c2nc(=O)n(-c3c(C)ccnc3C(C)C)c3nc(-c4c(O)cccc4F)c(F)cc23)[C@@H](C)C1 |wU:12.11|    (p)-sotorasib
Cc1c(-c2c(-c3ccc(F)o3)sc3ncnc(O[C@H](Cc4ccccc4OCc4ccnn4CC(F)(F)F)C(=O)O)c23)ccc(OCCN2CCN(C)CC2)c1Cl |wU:17.18|  S-63845
```

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=Oc1ccc2ccccc2c1-c1c(O)ccc2ccccc12%20%7CwU%3A10.10%7C%20%20%20%20(S)-(%E2%88%92)-1%2C1%E2%80%B2-Bi(2-napthol)&w=-1&h=-1&abbr=on&hdisp=S&zoom=1.3&annotate=cip&r=0)
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=Oc1ccc2ccccc2c1-c1c(O)ccc2ccccc12%20%7CwU%3A10.11%7C%20%20%20%20(R)-(%2B)-1%2C1%27-Bi(2-napthol)&w=-1&h=-1&abbr=on&hdisp=S&zoom=1.3&annotate=cip&r=0)
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=C%3DCC(%3DO)N1CCN(c2nc(%3DO)n(-c3c(C)ccnc3C(C)C)c3nc(-c4c(O)cccc4F)c(F)cc23)%5BC%40%40H%5D(C)C1%20%7CwU%3A12.23%7C%20%20%20%20(m)-sotorasib&w=-1&h=-1&abbr=on&hdisp=S&zoom=1.3&annotate=cip&r=0)
![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=C%3DCC(%3DO)N1CCN(c2nc(%3DO)n(-c3c(C)ccnc3C(C)C)c3nc(-c4c(O)cccc4F)c(F)cc23)%5BC%40%40H%5D(C)C1%20%7CwU%3A12.11%7C%20%20%20%20(p)-sotorasib&w=-1&h=-1&abbr=on&hdisp=S&zoom=1.3&annotate=cip&r=0)
