### PR TITLE
fix issue with empty annotation in depiction

### DIFF
--- a/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/DepictionTest.java
@@ -53,7 +53,7 @@ class DepictionTest {
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer ac = sp.parseSmiles("[nH]1cccc1");
         String eps = dg.depict(ac).toPsStr();
-        String nl = System.getProperty("line.separator");
+        String nl = System.lineSeparator();
         String[] lines = eps.split(nl,3);
         Assertions.assertEquals("%!PS-Adobe-3.0", lines[0]);
         Assertions.assertEquals("%%Creator: FreeHEP Graphics2D Driver", lines[1]);
@@ -65,7 +65,7 @@ class DepictionTest {
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer ac = sp.parseSmiles("[nH]1cccc1");
         String eps = dg.depict(ac).toEpsStr();
-        String nl = System.getProperty("line.separator");
+        String nl = System.lineSeparator();
         String[] lines = eps.split(nl,3);
         Assertions.assertEquals("%!PS-Adobe-3.0 EPSF-3.0", lines[0]);
         Assertions.assertTrue(lines[1].startsWith("%%BoundingBox: 0 0"));
@@ -77,7 +77,7 @@ class DepictionTest {
         SmilesParser sp = new SmilesParser(SilentChemObjectBuilder.getInstance());
         IAtomContainer ac = sp.parseSmiles("C1CCCCC1CCCCC");
         String eps = dg.depict(ac).toEpsStr();
-        String nl = System.getProperty("line.separator");
+        String nl = System.lineSeparator();
         String[] lines = eps.split(nl,3);
         Assertions.assertEquals("%!PS-Adobe-3.0 EPSF-3.0", lines[0]);
         Assertions.assertEquals("%%BoundingBox: 0 0 92 33", lines[1]);
@@ -123,8 +123,8 @@ class DepictionTest {
         );
         List<String> foundmatches =
             Stream.of(targetLines)
-                .map(el -> el.trim())
-                .filter(el -> stringsToFind.indexOf(el) != -1).collect(Collectors.toList());
+                .map(String::trim)
+                .filter(stringsToFind::contains).collect(Collectors.toList());
         Assertions.assertIterableEquals(stringsToFind, foundmatches);
     }
 
@@ -142,9 +142,9 @@ class DepictionTest {
     void testAtomPropertyEmptyStringAnnotationLabel() throws CDKException {
         DepictionGenerator depictionGenerator = new DepictionGenerator().withAtomValues();
         SmilesParser smilesParser = new SmilesParser(SilentChemObjectBuilder.getInstance());
-        IAtomContainer atomContainer = smilesParser.parseSmiles("C1CCCCC1CCCCC");
-        atomContainer.atoms().forEach(a -> a.setProperty(CDKConstants.COMMENT, ""));
-        depictionGenerator.depict(atomContainer);
+        IAtomContainer molecule = smilesParser.parseSmiles("C1CCCCC1CCCCC");
+        molecule.atoms().forEach(a -> a.setProperty(CDKConstants.COMMENT, ""));
+        depictionGenerator.depict(molecule);
     }
 
     @Disabled("Not stable between systems")

--- a/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
+++ b/display/renderbasic/src/main/java/org/openscience/cdk/renderer/generators/standard/StandardGenerator.java
@@ -25,15 +25,12 @@
 package org.openscience.cdk.renderer.generators.standard;
 
 import org.openscience.cdk.CDKConstants;
-import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObject;
-import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IPseudoAtom;
-import org.openscience.cdk.interfaces.IRing;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.renderer.RendererModel;
 import org.openscience.cdk.renderer.SymbolVisibility;
@@ -57,19 +54,15 @@ import org.openscience.cdk.renderer.generators.parameter.AbstractGeneratorParame
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupType;
 
-import javax.lang.model.element.Element;
 import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
 import java.awt.*;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
-import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,16 +75,12 @@ import static org.openscience.cdk.renderer.generators.standard.HydrogenPosition.
  * diagram. These are generated together allowing the bonds to drawn cleanly without overlap. The
  * generate is heavily based on ideas documented in {@cdk.cite Brecher08} and {@cdk.cite Clark13}.
  *
- *
- *
  * Atom symbols are provided as {@link GeneralPath} outlines. This allows the depiction to be
  * independent of the system used to view the diagram (primarily important for vector graphic
  * depictions). The font used to generate the diagram must be provided to the constructor.
  *
  * Atoms and bonds can be highlighted by setting the {@link #HIGHLIGHT_COLOR}. The style of
  * highlight is set with the {@link Highlighting} parameter.
- *
- *
  *
  * The <a href="https://github.com/cdk/cdk/wiki/Standard-Generator">Standard Generator - CDK Wiki
  * page</a> provides extended details of using and configuring this generator.
@@ -169,7 +158,7 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
          *  HO
          * </pre>
          */
-        Right;
+        Right
     }
 
     /**
@@ -583,7 +572,6 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
         final double halfStroke = stroke / 2;
 
         AtomSymbol[] symbols = new AtomSymbol[container.getAtomCount()];
-        IChemObjectBuilder builder = container.getBuilder();
 
         // check if we should annotate attachment point numbers (maxAttach>1)
         // and queue them all up for processing
@@ -783,7 +771,6 @@ public final class StandardGenerator implements IGenerator<IAtomContainer> {
                                                    outline.getCenter().getY() - radius,
                                                    2*radius,
                                                    2*radius);
-                Area area1 = new Area(shape);
                 group.add(GeneralPath.shapeOf(shape, Color.white));
                 group.add(GeneralPath.outlineOf(shape, 0.2*stroke, foreground));
                 group.add(GeneralPath.shapeOf(outline.getOutline(), foreground));


### PR DESCRIPTION
Without any code changes in the non-test space of the code `DepictionTest::testAtomPropertyEmptyStringAnnotationLabel` fails:

```
java.lang.ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 2

	at java.desktop/sun.font.StandardGlyphVector.getGlyphsOutline(StandardGlyphVector.java:1173)
	at java.desktop/sun.font.StandardGlyphVector.getGlyphOutline(StandardGlyphVector.java:433)
	at org.openscience.cdk.renderer.generators.standard.TextOutline.getGlyphCenter(TextOutline.java:196)
	at org.openscience.cdk.renderer.generators.standard.TextOutline.getLastGlyphCenter(TextOutline.java:183)
	at org.openscience.cdk.renderer.generators.standard.StandardGenerator.generateAnnotation(StandardGenerator.java:824)
	at org.openscience.cdk.renderer.generators.standard.StandardGenerator.generateAtomSymbols(StandardGenerator.java:684)
	at org.openscience.cdk.renderer.generators.standard.StandardGenerator.generate(StandardGenerator.java:272)
	at org.openscience.cdk.renderer.generators.standard.StandardGenerator.generate(StandardGenerator.java:103)
	at org.openscience.cdk.depict.DepictionGenerator.generate(DepictionGenerator.java:771)
	at org.openscience.cdk.depict.DepictionGenerator.generate(DepictionGenerator.java:787)
	at org.openscience.cdk.depict.DepictionGenerator.depict(DepictionGenerator.java:384)
	at org.openscience.cdk.depict.DepictionGenerator.depict(DepictionGenerator.java:326)
	at org.openscience.cdk.depict.DepictionTest.testAtomPropertyEmptyStringAnnotationLabel(DepictionTest.java:147)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

I looked through the stack trace and put in a simple check that prevents the `ArrayIndexOutOfBoundsException`. However, I am not sure if this is the proper place to fix this.

One could ask the question if it is a user input mistake to add an empty `String` as a property to an atom (`atom.setProperty(CDKConstants.COMMENT, "")`). In this particular case, preventing the exception from bubbling to the surface seems like a good choice to me.

I also implemented a few code cleanups in the 2nd commit (unused imports, API call simplifications, method references).