### PR TITLE
Depict background

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/SvgDrawVisitor.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/SvgDrawVisitor.java
@@ -201,11 +201,19 @@ final class SvgDrawVisitor implements IDrawVisitor {
         }
     }
 
-    String toStr(Color col) {
+    String getFill(Color col) {
         if (col.getAlpha() == 255) {
-            return String.format("#%06X", (0xFFFFFF & col.getRGB()));
+            return String.format(" fill='#%06X'", (0xFFFFFF & col.getRGB()));
         } else {
-            return String.format(Locale.ROOT, "rgba(%d,%d,%d,%.2f)", col.getRed(), col.getGreen(), col.getBlue(), col.getAlpha()/255d);
+            return String.format(" fill='#%06X' opacity='%.2f'", (0xFFFFFF & col.getRGB()), col.getAlpha()/255d);
+        }
+    }
+
+    String getStroke(Color col) {
+        if (col.getAlpha() == 255) {
+            return String.format(" stroke='#%06X'", (0xFFFFFF & col.getRGB()));
+        } else {
+            return String.format(" stroke='#%06X' stroke-opacity='%.2f'", (0xFFFFFF & col.getRGB()), col.getAlpha()/255d);
         }
     }
 
@@ -327,11 +335,11 @@ final class SvgDrawVisitor implements IDrawVisitor {
         if (elem.fill) {
             sb.append(" stroke='none'");
             if (defaultFill == null || !defaultFill.equals(elem.color))
-                sb.append(" fill='").append(toStr(elem.color)).append("'");
+                sb.append(getFill(elem.color));
         } else {
             sb.append(" fill='none'");
-            sb.append(" stroke='").append(toStr(elem.color)).append("'");
-            sb.append(" stroke-width='").append(toStr(scaled(elem.stroke))).append("'");
+            sb.append(getStroke(elem.color));
+            sb.append(" stroke-width='").append(toStr(scaled(elem.stroke)));
         }
         sb.append("/>\n");
     }
@@ -352,7 +360,7 @@ final class SvgDrawVisitor implements IDrawVisitor {
           .append(" x2='").append(toStr(points[2])).append("'")
           .append(" y2='").append(toStr(points[3])).append("'");
         if (defaultStroke == null || !defaultStroke.equals(elem.color))
-            sb.append(" stroke='").append(toStr(elem.color)).append("'");
+            sb.append(getStroke(elem.color));
         if (defaultStroke == null || !defaultStrokeWidth.equals(toStr(scaled(elem.width))))
             sb.append(" stroke-width='").append(toStr(scaled(elem.width))).append("'");
         sb.append("/>\n");
@@ -401,6 +409,8 @@ final class SvgDrawVisitor implements IDrawVisitor {
     }
 
     private void visit(RectangleElement elem) {
+        if (elem.color == null)
+            return;
         appendIdent();
         double[] points = new double[]{elem.xCoord, elem.yCoord};
         transform(points, 1);
@@ -411,11 +421,11 @@ final class SvgDrawVisitor implements IDrawVisitor {
         sb.append(" width='").append(toStr(scaled(elem.width))).append("'");
         sb.append(" height='").append(toStr(height)).append("'");
         if (elem.filled) {
-            sb.append(" fill='").append(toStr(elem.color)).append("'");
+            sb.append(getFill(elem.color));
             sb.append(" stroke='none'");
         } else {
             sb.append(" fill='none'");
-            sb.append(" stroke='").append(toStr(elem.color)).append("'");
+            sb.append(getStroke(elem.color));
         }
         sb.append("/>\n");
     }
@@ -430,11 +440,11 @@ final class SvgDrawVisitor implements IDrawVisitor {
         sb.append(" rx='").append(toStr(scaled(elem.radius))).append("'");
         sb.append(" ry='").append(toStr(scaled(elem.radius))).append("'");
         if (elem.fill) {
-            sb.append(" fill='").append(toStr(elem.color)).append("'");
+            sb.append(getFill(elem.color));
             sb.append(" stroke='none'");
         } else {
             sb.append(" fill='none'");
-            sb.append(" stroke='").append(toStr(elem.color)).append("'");
+            sb.append(getStroke(elem.color));
         }
         sb.append("/>\n");
     }
@@ -469,7 +479,7 @@ final class SvgDrawVisitor implements IDrawVisitor {
         sb.append("<text ");
         sb.append(" x='").append(toStr(points[0])).append("'");
         sb.append(" y='").append(toStr(points[1])).append("'");
-        sb.append(" fill='").append(toStr(elem.color)).append("'");
+        sb.append(getFill(elem.color));
         sb.append(" text-anchor='middle'");
         // todo need font manager for scaling...
         sb.append(">");
@@ -486,11 +496,11 @@ final class SvgDrawVisitor implements IDrawVisitor {
               .append(" stroke-linecap='round'")
               .append(" stroke-linejoin='round'");
             if (defaultStroke != null)
-                sb.append(" stroke='").append(toStr(defaultStroke)).append("'");
+                sb.append(getStroke(defaultStroke));
             if (defaultStrokeWidth != null)
                 sb.append(" stroke-width='").append(defaultStrokeWidth).append("'");
             if (defaultFill != null)
-                sb.append(" fill='").append(toStr(defaultFill)).append("'");
+                sb.append(getFill(defaultFill));
             sb.append(">\n");
             indentLvl += 2;
             defaultsWritten = true;

--- a/app/depict/src/test/java/org/openscience/cdk/depict/SvgDrawVisitorTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/SvgDrawVisitorTest.java
@@ -147,7 +147,15 @@ class SvgDrawVisitorTest {
         final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50, Depiction.UNITS_MM);
         visitor.setTransform(AffineTransform.getTranslateInstance(15, 15));
         visitor.visit(GeneralPath.shapeOf(new RoundRectangle2D.Double(0, 0, 10, 10, 2, 2), new Color(255,0,0,126)));
-        assertThat(visitor.toString(), StringContains.containsString("rgba(255,0,0,0.49)"));
+        assertThat(visitor.toString(), StringContains.containsString("fill='#FF0000' opacity='0.49'"));
+    }
+
+    @Test
+    void testStrokeTransparencyLocaleEncoding() {
+        final SvgDrawVisitor visitor = new SvgDrawVisitor(50, 50, Depiction.UNITS_MM);
+        visitor.setTransform(AffineTransform.getTranslateInstance(15, 15));
+        visitor.visit(GeneralPath.outlineOf(new RoundRectangle2D.Double(0, 0, 10, 10, 2, 2), 1.0, new Color(255,0,0,126)));
+        assertThat(visitor.toString(), StringContains.containsString("stroke='#FF0000' stroke-opacity='0.49'"));
     }
 
 }

--- a/display/renderawt/src/main/java/org/openscience/cdk/renderer/visitor/AWTDrawVisitor.java
+++ b/display/renderawt/src/main/java/org/openscience/cdk/renderer/visitor/AWTDrawVisitor.java
@@ -429,6 +429,8 @@ public class AWTDrawVisitor extends AbstractAWTDrawVisitor {
     }
 
     private void visit(RectangleElement rectangle) {
+        if (rectangle.color == null)
+            return;
         this.graphics.setColor(rectangle.color);
         int width = scaleX(rectangle.width);
         int height = scaleY(rectangle.height);


### PR DESCRIPTION
A small fix but some users complained that in CDK it would give strange colours in InkScape when using a transparent background. The ``rgba`` I think is only correct in web SVG and we should use the ``opacity=`` attribute.

I also added a null check to the Rectangle generation to allow setting of "no" background.