### PR TITLE
Sugar Detection Utility

### DIFF
--- a/misc/extra/src/main/java/org/openscience/cdk/tools/SugarDetectionUtility.java
+++ b/misc/extra/src/main/java/org/openscience/cdk/tools/SugarDetectionUtility.java
@@ -1,0 +1,1975 @@
+/*
+ * Copyright (c) 2025 Jonas Schaub <jonas.schaub@uni-jena.de>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.openscience.cdk.tools;
+
+import org.openscience.cdk.Bond;
+import org.openscience.cdk.graph.ConnectivityChecker;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.interfaces.IElement;
+import org.openscience.cdk.interfaces.ILonePair;
+import org.openscience.cdk.interfaces.IPseudoAtom;
+import org.openscience.cdk.interfaces.ISingleElectron;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.isomorphism.Mappings;
+import org.openscience.cdk.smarts.SmartsPattern;
+
+import javax.vecmath.Point2d;
+import javax.vecmath.Point3d;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Utility class for detecting and extracting sugar moieties from molecular structures.
+ *
+ * <p>This class extends {@link SugarRemovalUtility} to provide functionality for separating
+ * glycosides into their aglycone and glycosidic components.
+ * The main feature is the ability to create copies of both the aglycone
+ * and individual sugar fragments from a given molecule, with proper handling of attachment
+ * points and stereochemistry, and some optional postprocessing possibilities.
+ *
+ * <p>The extraction process supports:
+ * <ul>
+ *   <li>Detection and extraction of both circular and linear sugar moieties</li>
+ *   <li>Preservation of stereochemistry at connection points</li>
+ *   <li>Proper saturation of broken bonds with either R-groups or implicit hydrogen atoms</li>
+ *   <li>Post-processing of sugar fragments including bond splitting (O-glycosidic, ether, ester, peroxide)</li>
+ *   <li>Duplication of connecting heteroatoms (oxygen, nitrogen, sulfur) in glycosidic bonds, to produce more sensible educts</li>
+ *   <li>Optional mapping of atoms and bonds from the original molecule to their copies in the aglycone and sugar fragments</li>
+ * </ul>
+ *
+ * <p>All sugar detection and removal operations respect the settings inherited from the
+ * parent {@link SugarRemovalUtility} class, including terminal vs. non-terminal sugar
+ * removal, preservation mode settings, various detection thresholds, etc. In two cases, the initial
+ * {@link SugarRemovalUtility} results are corrected for extraction:
+ * <ul>
+ *     <li>When a sugar would lose its C6</li>
+ *     <li>When a sugar is on the "carboxy end" of an ester bond to the aglycone</li>
+ * </ul>
+ *
+ * <p><strong>Usage Example:</strong>
+ * <pre>{@code
+ * SugarDetectionUtility utility = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+ * //check the overloaded variants of this method for more options
+ * List<IAtomContainer> fragments = utility.copyAndExtractAglyconeAndSugars(molecule);
+ * IAtomContainer aglycone = fragments.get(0);  // First element is always the aglycone
+ * // Subsequent elements are individual sugar fragments
+ * }</pre>
+ *
+ * @author Jonas Schaub (jonas.schaub@uni-jena.de | jonas-schaub@gmx.de | <a href="https://github.com/JonasSchaub">JonasSchaub on GitHub</a>)
+ */
+public class SugarDetectionUtility extends SugarRemovalUtility {
+
+    /**
+     * SMARTS pattern for detecting glycosidic bonds (ether bonds) between circular sugar moieties for postprocessing after extraction.
+     * Defines an aliphatic C in a ring with degree 3 or 4 and no charge, connected to an aliphatic O not in a ring
+     * with degree 2 and no charge, connected to an aliphatic C with no charge (this side is left more promiscuous for
+     * matching cases like linear sugars connected to circular sugars or some corner cases).
+     */
+    public static final String O_GLYCOSIDIC_BOND_CIRCULAR_SUGARS_SMARTS = "[C;R;D3,D4;+0]-!@[O;!R;D2;+0]-!@[C;+0]";
+
+    /**
+     * SMARTS pattern for detecting ester bonds between circular sugar moieties for postprocessing after extraction.
+     * Defines an aliphatic C in a ring with degree 3 or 4 and no charge, connected to a carbonyl oxygen (environment)
+     * and to another oxygen atom via a non-ring bond, which is connected in turn to another aliphatic carbon atom
+     * (this side is left more promiscuous for matching cases like linear sugars connected to circular sugars or some corner cases).
+     */
+    public static final String ESTER_BOND_CIRCULAR_SUGARS_SMARTS = "[C;R;D3,D4;+0;$(C=!@[O;!R;+0])]-!@[O;!R;D2;+0]-!@[C;+0]";
+
+    /**
+     * SMARTS pattern for detecting peroxide bonds between circular sugar moieties for postprocessing after extraction.
+     * Defines an aliphatic C in a ring with degree 3 or 4 and no charge, connected to an oxygen atom via a non-ring bond,
+     * which is connected in turn to another oxygen atom and that to another aliphatic carbon atom
+     * (this side is left more promiscuous for matching cases like linear sugars connected to circular sugars or some corner cases).
+     */
+    public static final String PEROXIDE_BOND_CIRCULAR_SUGARS_SMARTS = "[C;R;D3,D4;+0]-!@[O;!R;D2;+0]-!@[O;!R;D2;+0]-!@[C;+0]";
+
+    /**
+     * SMARTS pattern for detecting ester bonds between linear sugar moieties for postprocessing after extraction.
+     * Defines an aliphatic C not in a ring, with no charge, connected to a carbonyl oxygen (environment) and to another
+     * oxygen atom via a non-ring bond, which is connected in turn to another aliphatic carbon atom.
+     */
+    public static final String ESTER_BOND_LINEAR_SUGARS_SMARTS = "[C;!R;+0;$(C=!@[O;!R;+0])]-!@[O;!R;D2;+0]-!@[C;!R;+0]";
+
+    /**
+     * SMARTS pattern for detecting cross-linking ether bonds between linear sugar moieties for postprocessing after extraction.
+     * Defines an aliphatic C not in a ring, with no charge, connected to the ether oxygen atom
+     * via a non-ring bond, which is connected in turn to another aliphatic carbon atom that also has a hydroxy group
+     * connected to it (to define the cross-linking nature).
+     */
+    public static final String CROSS_LINKING_ETHER_BOND_LINEAR_SUGARS_SMARTS = "[C;!R;+0]-!@[O;!R;D2;+0]-!@[C;!R;+0;$(C-!@[OH1;!R;+0])]";
+
+    /**
+     * SMARTS pattern for detecting ether bonds between linear sugar moieties for postprocessing after extraction.
+     * Defines an aliphatic C not in a ring, with no charge, connected to an oxygen atom
+     * via a non-ring bond, which is connected in turn to another aliphatic carbon atom.
+     */
+    public static final String ETHER_BOND_LINEAR_SUGARS_SMARTS = "[C;!R;+0]-!@[O;!R;D2;+0]-!@[C;!R;+0]";
+
+    /**
+     * SMARTS pattern for detecting peroxide bonds between linear sugar moieties for postprocessing after extraction.
+     * Defines an aliphatic C not in a ring, with no charge, connected to an oxygen atom
+     * via a non-ring bond, which is connected in turn to another oxygen atom and that to another aliphatic carbon atom.
+     */
+    public static final String PEROXIDE_BOND_LINEAR_SUGARS_SMARTS = "[C;!R;+0]-!@[O;!R;D2;+0]-!@[O;!R;D2;+0]-!@[C;!R;+0]";
+
+    /**
+     * Default for extractCircularSugars parameter in copyAndExtractAglyconeAndSugars methods.
+     */
+    public static final boolean EXTRACT_CIRCULAR_SUGARS_DEFAULT = true;
+
+    /**
+     * Default for extractLinearSugars parameter in copyAndExtractAglyconeAndSugars methods.
+     */
+    public static final boolean EXTRACT_LINEAR_SUGARS_DEFAULT = false;
+
+    /**
+     * Default for markAttachPointsByR parameter in copyAndExtractAglyconeAndSugars methods.
+     */
+    public static final boolean MARK_ATTACH_POINTS_BY_R_DEFAULT = false;
+
+    /**
+     * Default for postProcessSugars parameter in copyAndExtractAglyconeAndSugars methods.
+     */
+    public static final boolean POST_PROCESS_SUGARS_DEFAULT = false;
+
+    /**
+     * Default for limitPostProcessingBySize parameter in copyAndExtractAglyconeAndSugars methods.
+     */
+    public static final boolean LIMIT_POST_PROCESSING_BY_SIZE_DEFAULT = false;
+
+    /**
+     * Logger of this class.
+     */
+    private static final ILoggingTool LOGGER = LoggingToolFactory.createLoggingTool(SugarDetectionUtility.class);
+
+    /**
+     * Sole constructor of this class. All settings are set to their default
+     * values as declared in the {@link SugarRemovalUtility} class.
+     *
+     * @param builder IChemObjectBuilder for i.a. parsing SMILES strings of
+     *                sugar patterns into atom containers
+     */
+    public SugarDetectionUtility(IChemObjectBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Extracts copies of the aglycone and sugar parts of the given molecule (if there are any).
+     * <p>
+     * This method creates a deep copy of the input molecule and removes circular
+     * sugar moieties to produce an aglycone. It then creates
+     * a second copy to extract the sugar fragments that were removed. The attachment
+     * points between the aglycone and sugars are saturated with implicit hydrogen atoms.
+     * No postprocessing of the sugar fragments is performed, i.e. they are not separated
+     * from each other if they are connected in the original structure.
+     * Check the overloaded versions of this method for more options.
+     *
+     * <p>The method preserves stereochemistry information at connection points and
+     * handles glycosidic bonds appropriately. When bonds are broken between sugar
+     * moieties and the aglycone, connecting heteroatoms (such as glycosidic oxygen,
+     * nitrogen, or sulfur atoms) are copied to both the aglycone and sugar fragments
+     * to maintain chemical validity.
+     *
+     * <p>The extraction process respects all current sugar detection settings as described in
+     * {@link SugarRemovalUtility}, including terminal vs. non-terminal sugar removal,
+     * preservation mode settings, various detection thresholds, etc.
+     *
+     * <p>Note that atom types are not copied, they have to be re-perceived if needed.</p>
+     *
+     * @param mol The input molecule to separate into aglycone and sugar components.
+     *            Must not be null but can be empty; a list containing only the empty given
+     *            atom container is returned in the latter case.
+     * @return A list of atom containers where the first element is the aglycone
+     *         (copy molecule with sugars removed) and subsequent elements are the
+     *         individual sugar fragments that were extracted (also copies). If no sugars were
+     *         detected or removed, returns a list containing only a copy of the
+     *         original molecule. Sugar fragments may be disconnected from each
+     *         other if they were not directly linked in the original structure.
+     * @throws NullPointerException if the input molecule is null
+     * @see SugarRemovalUtility#removeCircularSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeLinearSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeCircularAndLinearSugars(IAtomContainer)
+     */
+    public List<IAtomContainer> copyAndExtractAglyconeAndSugars(
+            IAtomContainer mol
+    ) {
+        return this.copyAndExtractAglyconeAndSugars(
+                mol,
+                SugarDetectionUtility.EXTRACT_CIRCULAR_SUGARS_DEFAULT,
+                SugarDetectionUtility.EXTRACT_LINEAR_SUGARS_DEFAULT,
+                SugarDetectionUtility.MARK_ATTACH_POINTS_BY_R_DEFAULT,
+                SugarDetectionUtility.POST_PROCESS_SUGARS_DEFAULT,
+                SugarDetectionUtility.LIMIT_POST_PROCESSING_BY_SIZE_DEFAULT,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Extracts copies of the aglycone and sugar parts of the given molecule (if there are any).
+     * <p>
+     * This method creates a deep copy of the input molecule and removes circular and/or linear
+     * sugar moieties to produce an aglycone. It then creates
+     * a second copy to extract the sugar fragments that were removed. The attachment
+     * points between the aglycone and sugars are saturated with implicit hydrogen atoms.
+     * No postprocessing of the sugar fragments is performed, i.e. they are not separated
+     * from each other if they are connected in the original structure.
+     * Check the overloaded versions of this method for more options.
+     *
+     * <p>The method preserves stereochemistry information at connection points and
+     * handles glycosidic bonds appropriately. When bonds are broken between sugar
+     * moieties and the aglycone, connecting heteroatoms (such as glycosidic oxygen,
+     * nitrogen, or sulfur atoms) are copied to both the aglycone and sugar fragments
+     * to maintain chemical validity.
+     *
+     * <p>The extraction process respects all current sugar detection settings as described in
+     * {@link SugarRemovalUtility}, including terminal vs. non-terminal sugar removal,
+     * preservation mode settings, various detection thresholds, etc.
+     *
+     * <p>Note that atom types are not copied, they have to be re-perceived if needed.</p>
+     *
+     * @param mol The input molecule to separate into aglycone and sugar components.
+     *            Must not be null but can be empty; a list containing only the empty given
+     *            atom container is returned in the latter case.
+     * @param extractCircularSugars If true, circular sugar moieties will be detected
+     *                             and extracted according to current settings.
+     * @param extractLinearSugars If true, linear sugar moieties will be detected
+     *                           and extracted according to current settings.
+     * @return A list of atom containers where the first element is the aglycone
+     *         (copy molecule with sugars removed) and subsequent elements are the
+     *         individual sugar fragments that were extracted (also copies). If no sugars were
+     *         detected or removed, returns a list containing only a copy of the
+     *         original molecule. Sugar fragments may be disconnected from each
+     *         other if they were not directly linked in the original structure.
+     * @throws NullPointerException if the input molecule is null
+     * @see SugarRemovalUtility#removeCircularSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeLinearSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeCircularAndLinearSugars(IAtomContainer)
+     */
+    public List<IAtomContainer> copyAndExtractAglyconeAndSugars(
+            IAtomContainer mol,
+            boolean extractCircularSugars,
+            boolean extractLinearSugars
+    ) {
+        return this.copyAndExtractAglyconeAndSugars(
+                mol,
+                extractCircularSugars,
+                extractLinearSugars,
+                SugarDetectionUtility.MARK_ATTACH_POINTS_BY_R_DEFAULT,
+                SugarDetectionUtility.POST_PROCESS_SUGARS_DEFAULT,
+                SugarDetectionUtility.LIMIT_POST_PROCESSING_BY_SIZE_DEFAULT,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Extracts copies of the aglycone and sugar parts of the given molecule (if there are any).
+     * <p>
+     * This method creates a deep copy of the input molecule and removes circular and/or linear
+     * sugar moieties to produce an aglycone. It then creates
+     * a second copy to extract the sugar fragments that were removed. The attachment
+     * points between the aglycone and sugars are handled by either adding R-groups
+     * (pseudo atoms) or implicit hydrogen atoms to saturate the broken bonds.
+     * No postprocessing of the sugar fragments is performed, i.e. they are not separated
+     * from each other if they are connected in the original structure.
+     * Check the overloaded versions of this method for more options.
+     *
+     * <p>The method preserves stereochemistry information at connection points and
+     * handles glycosidic bonds appropriately. When bonds are broken between sugar
+     * moieties and the aglycone, connecting heteroatoms (such as glycosidic oxygen,
+     * nitrogen, or sulfur atoms) are copied to both the aglycone and sugar fragments
+     * to maintain chemical validity.
+     *
+     * <p>The extraction process respects all current sugar detection settings as described in
+     * {@link SugarRemovalUtility}, including terminal vs. non-terminal sugar removal,
+     * preservation mode settings, various detection thresholds, etc.
+     *
+     * <p>Note that atom types are not copied, they have to be re-perceived if needed.</p>
+     *
+     * @param mol The input molecule to separate into aglycone and sugar components.
+     *            Must not be null but can be empty; a list containing only the empty given
+     *            atom container is returned in the latter case.
+     * @param extractCircularSugars If true, circular sugar moieties will be detected
+     *                             and extracted according to current settings.
+     * @param extractLinearSugars If true, linear sugar moieties will be detected
+     *                           and extracted according to current settings.
+     * @param markAttachPointsByR If true, attachment points where sugars and the aglycone were connected
+     *                           are marked with R-groups (pseudo atoms). If false,
+     *                           implicit hydrogen atoms are added to saturate the connections.
+     * @return A list of atom containers where the first element is the aglycone
+     *         (copy molecule with sugars removed) and subsequent elements are the
+     *         individual sugar fragments that were extracted (also copies). If no sugars were
+     *         detected or removed, returns a list containing only a copy of the
+     *         original molecule. Sugar fragments may be disconnected from each
+     *         other if they were not directly linked in the original structure.
+     * @throws NullPointerException if the input molecule is null
+     * @see SugarRemovalUtility#removeCircularSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeLinearSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeCircularAndLinearSugars(IAtomContainer)
+     */
+    public List<IAtomContainer> copyAndExtractAglyconeAndSugars(
+            IAtomContainer mol,
+            boolean extractCircularSugars,
+            boolean extractLinearSugars,
+            boolean markAttachPointsByR
+    ) {
+        return this.copyAndExtractAglyconeAndSugars(
+                mol,
+                extractCircularSugars,
+                extractLinearSugars,
+                markAttachPointsByR,
+                SugarDetectionUtility.POST_PROCESS_SUGARS_DEFAULT,
+                SugarDetectionUtility.LIMIT_POST_PROCESSING_BY_SIZE_DEFAULT,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Extracts copies of the aglycone and sugar parts of the given molecule (if there are any).
+     * <p>
+     * This method creates a deep copy of the input molecule and removes circular and/or linear
+     * sugar moieties to produce an aglycone. It then creates
+     * a second copy to extract the sugar fragments that were removed. The attachment
+     * points between the aglycone and sugars are handled by either adding R-groups
+     * (pseudo atoms) or implicit hydrogen atoms to saturate the broken bonds.
+     * Optionally, postprocessing of the sugar fragments is performed, i.e. they are separated
+     * from each other if they are connected in the original structure via O-glycosidic (ether),
+     * ester, or peroxide bonds.
+     * Check the overloaded versions of this method for more options.
+     *
+     * <p>The method preserves stereochemistry information at connection points and
+     * handles glycosidic bonds appropriately. When bonds are broken between sugar
+     * moieties and the aglycone, connecting heteroatoms (such as glycosidic oxygen,
+     * nitrogen, or sulfur atoms) are copied to both the aglycone and sugar fragments
+     * to maintain chemical validity.
+     *
+     * <p>The extraction process respects all current sugar detection settings as described in
+     * {@link SugarRemovalUtility}, including terminal vs. non-terminal sugar removal,
+     * preservation mode settings, various detection thresholds, etc.
+     *
+     * <p>Note that atom types are not copied, they have to be re-perceived if needed.</p>
+     *
+     * @param mol The input molecule to separate into aglycone and sugar components.
+     *            Must not be null but can be empty; a list containing only the empty given
+     *            atom container is returned in the latter case.
+     * @param extractCircularSugars If true, circular sugar moieties will be detected
+     *                             and extracted according to current settings.
+     * @param extractLinearSugars If true, linear sugar moieties will be detected
+     *                           and extracted according to current settings.
+     * @param markAttachPointsByR If true, attachment points where sugars and the aglycone were connected
+     *                           are marked with R-groups (pseudo atoms). If false,
+     *                           implicit hydrogen atoms are added to saturate the connections.
+     * @param postProcessSugars If true, postprocessing of sugar fragments is performed, i.e. splitting O-glycosidic
+     *                          (ether), ester, and peroxide bonds between sugar moieties
+     * @return A list of atom containers where the first element is the aglycone
+     *         (copy molecule with sugars removed) and subsequent elements are the
+     *         individual sugar fragments that were extracted (also copies). If no sugars were
+     *         detected or removed, returns a list containing only a copy of the
+     *         original molecule. Sugar fragments may be disconnected from each
+     *         other if they were not directly linked in the original structure or were disconnected in postprocessing.
+     * @throws NullPointerException if the input molecule is null
+     * @see SugarRemovalUtility#removeCircularSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeLinearSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeCircularAndLinearSugars(IAtomContainer)
+     */
+    public List<IAtomContainer> copyAndExtractAglyconeAndSugars(
+            IAtomContainer mol,
+            boolean extractCircularSugars,
+            boolean extractLinearSugars,
+            boolean markAttachPointsByR,
+            boolean postProcessSugars
+    ) {
+        return this.copyAndExtractAglyconeAndSugars(
+                mol,
+                extractCircularSugars,
+                extractLinearSugars,
+                markAttachPointsByR,
+                postProcessSugars,
+                SugarDetectionUtility.LIMIT_POST_PROCESSING_BY_SIZE_DEFAULT,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Extracts copies of the aglycone and sugar parts of the given molecule (if there are any).
+     * <p>
+     * This method creates a deep copy of the input molecule and removes circular and/or linear
+     * sugar moieties to produce an aglycone. It then creates
+     * a second copy to extract the sugar fragments that were removed. The attachment
+     * points between the aglycone and sugars are handled by either adding R-groups
+     * (pseudo atoms) or implicit hydrogen atoms to saturate the broken bonds.
+     * Optionally, postprocessing of the sugar fragments is performed, i.e. they are separated
+     * from each other if they are connected in the original structure via O-glycosidic (ether),
+     * ester, or peroxide bonds. Optionally, this postprocessing
+     * is limited by size, i.e. sugars and their substituents are only split if both resulting
+     * parts are larger than the set preservation mode threshold for circular sugars and
+     * the minimum size for linear sugar candidates, respectively, to prevent smaller substituents
+     * being split off of the sugars.
+     * Check the overloaded versions of this method for more options.
+     *
+     * <p>The method preserves stereochemistry information at connection points and
+     * handles glycosidic bonds appropriately. When bonds are broken between sugar
+     * moieties and the aglycone, connecting heteroatoms (such as glycosidic oxygen,
+     * nitrogen, or sulfur atoms) are copied to both the aglycone and sugar fragments
+     * to maintain chemical validity.
+     *
+     * <p>The extraction process respects all current sugar detection settings as described in
+     * {@link SugarRemovalUtility}, including terminal vs. non-terminal sugar removal,
+     * preservation mode settings, various detection thresholds, etc.
+     *
+     * <p>Note that atom types are not copied, they have to be re-perceived if needed.</p>
+     *
+     * @param mol The input molecule to separate into aglycone and sugar components.
+     *            Must not be null but can be empty; a list containing only the empty given
+     *            atom container is returned in the latter case.
+     * @param extractCircularSugars If true, circular sugar moieties will be detected
+     *                             and extracted according to current settings.
+     * @param extractLinearSugars If true, linear sugar moieties will be detected
+     *                           and extracted according to current settings.
+     * @param markAttachPointsByR If true, attachment points where sugars and the aglycone were connected
+     *                           are marked with R-groups (pseudo atoms). If false,
+     *                           implicit hydrogen atoms are added to saturate the connections.
+     * @param postProcessSugars If true, postprocessing of sugar fragments is performed, i.e. splitting O-glycosidic
+     *                          (ether), ester, and peroxide bonds between sugar moieties
+     * @param limitPostProcessingBySize If true, sugar moieties will only be separated/split in postprocessing if they are larger
+     *                                  than the set preservation mode threshold (see {@link SugarRemovalUtility}). This is
+     *                                  to prevent smaller substituents like, e.g. methyl ethers, being separated from the
+     *                                  sugars. For linear sugars, the minimum size for linear sugar candidates is applied
+     *                                  as a criterion.
+     * @return A list of atom containers where the first element is the aglycone
+     *         (copy molecule with sugars removed) and subsequent elements are the
+     *         individual sugar fragments that were extracted (also copies). If no sugars were
+     *         detected or removed, returns a list containing only a copy of the
+     *         original molecule. Sugar fragments may be disconnected from each
+     *         other if they were not directly linked in the original structure or were disconnected in postprocessing.
+     * @throws NullPointerException if the input molecule is null
+     * @see SugarRemovalUtility#removeCircularSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeLinearSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeCircularAndLinearSugars(IAtomContainer)
+     */
+    public List<IAtomContainer> copyAndExtractAglyconeAndSugars(
+            IAtomContainer mol,
+            boolean extractCircularSugars,
+            boolean extractLinearSugars,
+            boolean markAttachPointsByR,
+            boolean postProcessSugars,
+            boolean limitPostProcessingBySize
+    ) {
+        return this.copyAndExtractAglyconeAndSugars(
+                mol,
+                extractCircularSugars,
+                extractLinearSugars,
+                markAttachPointsByR,
+                postProcessSugars,
+                limitPostProcessingBySize,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    //do not copy the aglycone? -> too much of a hassle because for postprocessing, we repeatedly need the original structure
+    //implement alternative method that directly returns group indices? -> blows up the code too much and the atom container fragments are the main point of reference
+    /**
+     * Extracts copies of the aglycone and sugar parts of the given molecule (if there are any).
+     * <p>
+     * This method creates a deep copy of the input molecule and removes circular and/or linear
+     * sugar moieties to produce an aglycone. It then creates
+     * a second copy to extract the sugar fragments that were removed. The attachment
+     * points between the aglycone and sugars are handled by either adding R-groups
+     * (pseudo atoms) or implicit hydrogen atoms to saturate the broken bonds.
+     * Optionally, postprocessing of the sugar fragments is performed, i.e. they are separated
+     * from each other if they are connected in the original structure via O-glycosidic (ether),
+     * ester, or peroxide bonds. Optionally, this postprocessing
+     * is limited by size, i.e. sugars and their substituents are only split if both resulting
+     * parts are larger than the set preservation mode threshold for circular sugars and
+     * the minimum size for linear sugar candidates, respectively, to prevent smaller substituents
+     * being split off of the sugars.
+     *
+     * <p>The method preserves stereochemistry information at connection points and
+     * handles glycosidic bonds appropriately. When bonds are broken between sugar
+     * moieties and the aglycone, connecting heteroatoms (such as glycosidic oxygen,
+     * nitrogen, or sulfur atoms) are copied to both the aglycone and sugar fragments
+     * to maintain chemical validity.
+     *
+     * <p>The extraction process respects all current sugar detection settings as described in
+     * {@link SugarRemovalUtility}, including terminal vs. non-terminal sugar removal,
+     * preservation mode settings, various detection thresholds, etc.
+     *
+     * <p>Note that atom types are not copied, they have to be re-perceived if needed.</p>
+     *
+     * <p>This method additionally gives you the option to supply four maps as parameters that will be filled with a
+     * mapping of atoms and bonds in the original molecule to the atoms and bonds in the aglycone and sugar copies. They
+     * should be of sufficient size and empty when given.</p>
+     *
+     * @param mol The input molecule to separate into aglycone and sugar components.
+     *            Must not be null but can be empty; a list containing only the empty given
+     *            atom container is returned in the latter case.
+     * @param extractCircularSugars If true, circular sugar moieties will be detected
+     *                             and extracted according to current settings.
+     * @param extractLinearSugars If true, linear sugar moieties will be detected
+     *                           and extracted according to current settings.
+     * @param markAttachPointsByR If true, attachment points where sugars and the aglycone were connected
+     *                           are marked with R-groups (pseudo atoms). If false,
+     *                           implicit hydrogen atoms are added to saturate the connections.
+     * @param postProcessSugars If true, postprocessing of sugar fragments is performed, i.e. splitting O-glycosidic
+     *                          (ether), ester, and peroxide bonds between sugar moieties
+     * @param limitPostProcessingBySize If true, sugar moieties will only be separated/split in postprocessing if they are larger
+     *                                  than the set preservation mode threshold (see {@link SugarRemovalUtility}). This is
+     *                                  to prevent smaller substituents like, e.g. methyl ethers, being separated from the
+     *                                  sugars. For linear sugars, the minimum size for linear sugar candidates is applied
+     *                                  as a criterion.
+     * @param inputAtomToAtomCopyInAglyconeMap Map to be filled with mappings from original atoms to their copies in the aglycone.
+     *                                         Can be null (a new map will be created) but should be an empty map with sufficient capacity.
+     * @param inputBondToBondCopyInAglyconeMap Map to be filled with mappings from original bonds to their copies in the aglycone.
+     *                                         Can be null (a new map will be created) but should be an empty map with sufficient capacity.
+     * @param inputAtomToAtomCopyInSugarsMap Map to be filled with mappings from original atoms to their copies in the sugar fragments.
+     *                                       Can be null (a new map will be created) but should be an empty map with sufficient capacity.
+     * @param inputBondToBondCopyInSugarsMap Map to be filled with mappings from original bonds to their copies in the sugar fragments.
+     *                                       Can be null (a new map will be created) but should be an empty map with sufficient capacity.
+     * @return A list of atom containers where the first element is the aglycone
+     *         (copy molecule with sugars removed) and subsequent elements are the
+     *         individual sugar fragments that were extracted (also copies). If no sugars were
+     *         detected or removed, returns a list containing only a copy of the
+     *         original molecule. Sugar fragments may be disconnected from each
+     *         other if they were not directly linked in the original structure or were disconnected in postprocessing.
+     * @throws NullPointerException if the input molecule is null
+     * @see SugarRemovalUtility#removeCircularSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeLinearSugars(IAtomContainer)
+     * @see SugarRemovalUtility#removeCircularAndLinearSugars(IAtomContainer)
+     */
+    public List<IAtomContainer> copyAndExtractAglyconeAndSugars(
+            IAtomContainer mol,
+            boolean extractCircularSugars,
+            boolean extractLinearSugars,
+            boolean markAttachPointsByR,
+            boolean postProcessSugars,
+            boolean limitPostProcessingBySize,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInAglyconeMap,
+            Map<IBond, IBond> inputBondToBondCopyInAglyconeMap,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInSugarsMap,
+            Map<IBond, IBond> inputBondToBondCopyInSugarsMap
+    ) {
+        //checks:
+        if (mol == null) {
+            throw new NullPointerException("Given molecule is null.");
+        }
+        if (mol.isEmpty() || (!extractCircularSugars && !extractLinearSugars)) {
+            List<IAtomContainer> results = new ArrayList<>(1);
+            results.add(mol);
+            return results;
+        }
+        //setup and copying for aglycone:
+        float loadFactor = 0.75f; //default load factor of HashMaps
+        //ensuring sufficient initial capacity
+        int atomMapInitCapacity = (int)((mol.getAtomCount() / loadFactor) + 3.0f);
+        int bondMapInitCapacity = (int)((mol.getBondCount() / loadFactor) + 3.0f);
+        if (inputAtomToAtomCopyInAglyconeMap == null) {
+            inputAtomToAtomCopyInAglyconeMap = new HashMap<>(atomMapInitCapacity);
+        }
+        if (inputBondToBondCopyInAglyconeMap == null) {
+            inputBondToBondCopyInAglyconeMap = new HashMap<>(bondMapInitCapacity);
+        }
+        IAtomContainer copyForAglycone = this.deeperCopy(mol, inputAtomToAtomCopyInAglyconeMap, inputBondToBondCopyInAglyconeMap);
+        boolean wasSugarRemoved = false;
+        if (extractCircularSugars && extractLinearSugars) {
+            wasSugarRemoved = this.removeCircularAndLinearSugars(copyForAglycone);
+        } else if (extractCircularSugars) {
+            wasSugarRemoved = this.removeCircularSugars(copyForAglycone);
+        } else if (extractLinearSugars) {
+            //note: actually, extractLinearSugars must be true here if this is reached but the code was not simplified to have more clarity
+            wasSugarRemoved = this.removeLinearSugars(copyForAglycone);
+        } //else: wasSugarRemoved remains false, and input structure is returned, same as when no sugars were detected, see below
+        if (!wasSugarRemoved) {
+            List<IAtomContainer> results = new ArrayList<>(1);
+            results.add(copyForAglycone);
+            return results;
+        }
+        //sugars were found and removed from the aglycone, so carry on extracting the sugars:
+        //copying for sugars
+        if (inputAtomToAtomCopyInSugarsMap == null) {
+            inputAtomToAtomCopyInSugarsMap = new HashMap<>(atomMapInitCapacity);
+        }
+        if (inputBondToBondCopyInSugarsMap == null) {
+            inputBondToBondCopyInSugarsMap = new HashMap<>(bondMapInitCapacity);
+        }
+        IAtomContainer copyForSugars = this.deeperCopy(mol, inputAtomToAtomCopyInSugarsMap, inputBondToBondCopyInSugarsMap);
+        //remove aglycone atoms from sugar container:
+        //note: instead of copying the whole structure and removing the aglycone atoms, one could only copy those atoms
+        // and bonds that are not part of the aglycone to form the sugars to save some memory but the code would be much
+        // more complicated, so we don't do it that way for now
+        boolean containsSpiroSugars = false;
+        for (IAtom atom : mol.atoms()) {
+            if (this.areSpiroRingsDetectedAsCircularSugars()
+                    && inputAtomToAtomCopyInAglyconeMap.get(atom).getProperty(SugarRemovalUtility.IS_SPIRO_ATOM_PROPERTY_KEY) != null) {
+                //spiro atom that was marked as part of a circular sugar, so duplicate it (= do not remove it from the sugar) for correct extraction
+                inputAtomToAtomCopyInSugarsMap.get(atom).setProperty(SugarRemovalUtility.IS_SPIRO_ATOM_PROPERTY_KEY, true);
+                //boolean is needed below for postprocessing
+                containsSpiroSugars = true;
+                continue;
+            }
+            if (copyForAglycone.contains(inputAtomToAtomCopyInAglyconeMap.get(atom))) {
+                copyForSugars.removeAtom(inputAtomToAtomCopyInSugarsMap.get(atom));
+            }
+        }
+        //note that the four atom and bond maps still hold references to the atoms and bonds that were removed from the
+        // two copies to get the aglycone and sugars; important for later queries; only cleared at the very end of this method
+        //Preprocessing, correcting the SRU results in special cases:
+        this.preprocessSugarRemovalResults(
+                mol,
+                copyForAglycone,
+                copyForSugars,
+                inputAtomToAtomCopyInAglyconeMap,
+                inputBondToBondCopyInAglyconeMap,
+                inputAtomToAtomCopyInSugarsMap,
+                inputBondToBondCopyInSugarsMap);
+        //general processing that does not need to correct the SRU results:
+        //identify bonds that were broken between sugar moieties and aglycone
+        // -> copy connecting hetero atoms (glycosidic O/N/S etc.) from one part (sugar or aglycone) to the other,
+        // along with its stereo element
+        // -> saturate with R or H, depending on the markAttachPointsByR parameter
+        boolean hasIdentifiedBrokenBond = false;
+        for (IBond bond : mol.bonds()) {
+            //bond not in aglycone or sugars, so it was broken during sugar removal
+            // (there is no else, we just want to find these broken bonds)
+            if (!copyForAglycone.contains(inputBondToBondCopyInAglyconeMap.get(bond))
+                    && !copyForSugars.contains(inputBondToBondCopyInSugarsMap.get(bond))) {
+                hasIdentifiedBrokenBond = true;
+                //if a hetero atom connected sugar and aglycone, copy it to the other side;
+                // do nothing for C-C bonds or hetero-hetero connections like peroxides
+                // (-> else is down below and just takes care of saturation)
+                if ((this.isCarbonAtom(bond.getBegin()) && this.isHeteroAtom(bond.getEnd()))
+                        || (this.isHeteroAtom(bond.getBegin()) && this.isCarbonAtom(bond.getEnd()))) {
+                    //-> copy hetero atom to the other side and saturate it with H or R
+                    //-> saturate "original" hetero atom with H or R
+                    IAtom origHeteroAtom;
+                    IAtom origCarbonAtom;
+                    if (this.isCarbonAtom(bond.getBegin()) && this.isHeteroAtom(bond.getEnd())) {
+                        origHeteroAtom = bond.getEnd();
+                        origCarbonAtom = bond.getBegin();
+                    } else if (this.isCarbonAtom(bond.getEnd()) && this.isHeteroAtom(bond.getBegin())) {
+                        origHeteroAtom = bond.getBegin();
+                        origCarbonAtom = bond.getEnd();
+                    } else {
+                        SugarDetectionUtility.LOGGER.error("Broken bond between sugar and aglycone with one carbon " +
+                                "and one hetero atom found but they cannot be assigned, this should not happen!");
+                        continue;
+                    }
+                    boolean isHeteroAtomInAglycone = copyForAglycone.contains(inputAtomToAtomCopyInAglyconeMap.get(origHeteroAtom));
+                    boolean isHeteroAtomInSugars = copyForSugars.contains(inputAtomToAtomCopyInSugarsMap.get(origHeteroAtom));
+                    if (!(isHeteroAtomInAglycone || isHeteroAtomInSugars)) {
+                        SugarDetectionUtility.LOGGER.error("Hetero atom not found in aglycone or sugars, this should not happen!");
+                        continue;
+                    }
+                    //copy hetero atom to the other part:
+                    IAtom cpyHeteroAtom = this.deeperCopy(origHeteroAtom,
+                            isHeteroAtomInSugars? copyForAglycone : copyForSugars);
+                    IAtom carbonAtomInCopyToBindTo = isHeteroAtomInSugars?
+                            inputAtomToAtomCopyInAglyconeMap.get(origCarbonAtom)
+                            : inputAtomToAtomCopyInSugarsMap.get(origCarbonAtom);
+                    IBond copyBondToHeteroAtom;
+                    if (bond.getBegin().equals(origCarbonAtom)) {
+                        copyBondToHeteroAtom = carbonAtomInCopyToBindTo.getBuilder().newInstance(
+                                IBond.class, carbonAtomInCopyToBindTo, cpyHeteroAtom, bond.getOrder());
+                    } else {
+                        copyBondToHeteroAtom = carbonAtomInCopyToBindTo.getBuilder().newInstance(
+                                IBond.class, cpyHeteroAtom, carbonAtomInCopyToBindTo, bond.getOrder());
+                    }
+                    //add the new bond to the right container and update the maps:
+                    if (isHeteroAtomInSugars) {
+                        copyForAglycone.addBond(copyBondToHeteroAtom);
+                        inputAtomToAtomCopyInAglyconeMap.put(origHeteroAtom, cpyHeteroAtom);
+                        inputBondToBondCopyInAglyconeMap.put(bond, copyBondToHeteroAtom);
+                    } else {
+                        copyForSugars.addBond(copyBondToHeteroAtom);
+                        inputAtomToAtomCopyInSugarsMap.put(origHeteroAtom, cpyHeteroAtom);
+                        inputBondToBondCopyInSugarsMap.put(bond, copyBondToHeteroAtom);
+                    }
+                    //saturate copied hetero atom with H or R:
+                    this.saturate(
+                            cpyHeteroAtom,
+                            isHeteroAtomInSugars? copyForAglycone : copyForSugars,
+                            markAttachPointsByR,
+                            origHeteroAtom,
+                            bond);
+                    //copy stereo elements for the broken bond to preserve the configuration
+                    this.mapBondStereoElement(
+                            mol,
+                            bond,
+                            isHeteroAtomInSugars? copyForAglycone : copyForSugars,
+                            isHeteroAtomInSugars? inputAtomToAtomCopyInAglyconeMap : inputAtomToAtomCopyInSugarsMap,
+                            isHeteroAtomInSugars? inputBondToBondCopyInAglyconeMap : inputBondToBondCopyInSugarsMap);
+                    //saturate the hetero atom in the part it was originally assigned to with H or R
+                    IAtom heteroAtomToBeSaturated = isHeteroAtomInAglycone?
+                            inputAtomToAtomCopyInAglyconeMap.get(origHeteroAtom)
+                            : inputAtomToAtomCopyInSugarsMap.get(origHeteroAtom);
+                    this.saturate(
+                            heteroAtomToBeSaturated,
+                            isHeteroAtomInAglycone? copyForAglycone : copyForSugars,
+                            markAttachPointsByR,
+                            origHeteroAtom,
+                            bond);
+                } else {
+                    //broken bond was a C-C or hetero-hetero bond, just saturate both former bond atoms with R if required
+                    for (IAtom atom : bond.atoms()) {
+                        boolean isAtomInAglycone = copyForAglycone.contains(inputAtomToAtomCopyInAglyconeMap.get(atom));
+                        IAtom copyAtomToSaturate = isAtomInAglycone?
+                                inputAtomToAtomCopyInAglyconeMap.get(atom)
+                                : inputAtomToAtomCopyInSugarsMap.get(atom);
+                        this.saturate(
+                                copyAtomToSaturate,
+                                isAtomInAglycone? copyForAglycone : copyForSugars,
+                                markAttachPointsByR,
+                                atom,
+                                bond
+                        );
+                    }
+                }
+            } //end of if condition looking for bonds broken during sugar extraction
+        } // end of for loop over all bonds in the input molecule
+        //just a check to be safe, there was an issue in the past:
+        if (!hasIdentifiedBrokenBond && !copyForAglycone.isEmpty() && ConnectivityChecker.isConnected(mol) && !containsSpiroSugars) {
+            //note for disconnected glycosides, one could process each component separately, but this seems like
+            // unnecessary overhead just for the sake of this check
+            SugarDetectionUtility.LOGGER.error("No broken bonds found between aglycone and sugars, no saturation performed, this should not happen!");
+        }
+        //postprocessing for spiro sugars, if there were any detected:
+        if (this.areSpiroRingsDetectedAsCircularSugars() && containsSpiroSugars) {
+            for (IAtomContainer part : new IAtomContainer[] {copyForAglycone, copyForSugars}) {
+                for (IAtom atom : part.atoms()) {
+                    if (atom.getProperty(SugarRemovalUtility.IS_SPIRO_ATOM_PROPERTY_KEY) != null
+                            && part.getConnectedBondsCount(atom) != 4) {
+                        //spiro carbon was part of sugar AND aglycone, saturation needed
+                        if (markAttachPointsByR) {
+                            for (int i = 0; i < 2; i++) {
+                                IPseudoAtom tmpRAtom = atom.getBuilder().newInstance(IPseudoAtom.class, "R");
+                                tmpRAtom.setAttachPointNum(1);
+                                tmpRAtom.setImplicitHydrogenCount(0);
+                                part.addAtom(tmpRAtom);
+                                IBond bondToR = atom.getBuilder().newInstance(
+                                        IBond.class, atom, tmpRAtom, IBond.Order.SINGLE);
+                                part.addBond(bondToR);
+                            }
+                        } else {
+                            int implHCount = atom.getImplicitHydrogenCount();
+                            atom.setImplicitHydrogenCount(implHCount + 2);
+                        }
+                    }
+                }
+            }
+        }
+        //postprocessing of extracted sugars, if required:
+        if (postProcessSugars) {
+            if (extractCircularSugars) {
+                this.splitOGlycosidicEsterPeroxideBondsCircularSugarsPostProcessing(copyForSugars, markAttachPointsByR, limitPostProcessingBySize);
+            }
+            if (extractLinearSugars) {
+                this.splitEtherEsterPeroxideBondsLinearSugarsPostProcessing(copyForSugars, markAttachPointsByR, limitPostProcessingBySize);
+            }
+        }
+        //clean up the maps:
+        for (IAtom atom : mol.atoms()) {
+            if (!copyForAglycone.contains(inputAtomToAtomCopyInAglyconeMap.get(atom))) {
+                inputAtomToAtomCopyInAglyconeMap.remove(atom);
+            }
+        }
+        for (IBond bond : mol.bonds()) {
+            if (!copyForAglycone.contains(inputBondToBondCopyInAglyconeMap.get(bond))) {
+                inputBondToBondCopyInAglyconeMap.remove(bond);
+            }
+        }
+        for (IAtom atom : mol.atoms()) {
+            if (!copyForSugars.contains(inputAtomToAtomCopyInSugarsMap.get(atom))) {
+                inputAtomToAtomCopyInSugarsMap.remove(atom);
+            }
+        }
+        for (IBond bond : mol.bonds()) {
+            if (!copyForSugars.contains(inputBondToBondCopyInSugarsMap.get(bond))) {
+                inputBondToBondCopyInSugarsMap.remove(bond);
+            }
+        }
+        //return value preparations, partition disconnected sugars:
+        List<IAtomContainer> resultsList = new ArrayList<>(5); //magic number, totally arbitrary
+        resultsList.add(0, copyForAglycone); //aglycone is always first, even if disconnected
+        if (ConnectivityChecker.isConnected(copyForSugars)) {
+            resultsList.add(copyForSugars);
+        } else {
+            for (IAtomContainer part : ConnectivityChecker.partitionIntoMolecules(copyForSugars)) {
+                if (!part.isEmpty()) {
+                    resultsList.add(part);
+                }
+            }
+        }
+        return resultsList;
+    }
+
+    /**
+     * Returns the indices of atoms in the input molecule that correspond to atoms in the given group.
+     * <p>
+     * This method iterates through all atoms in the input molecule and checks if the corresponding
+     * atom (via the provided mapping) exists in the group container. The indices of matching atoms
+     * are collected and returned as an array.
+     * <p>
+     * Note that the group may contain atoms that are not present in the input molecule mapping
+     * (e.g., R-groups added during processing), which will be ignored.
+     *
+     * @param mol The input molecule containing the original atoms
+     * @param group The group container to check for atom membership, e.g. extracted sugar or aglycone
+     * @param inputAtomToAtomCopyMap Map of original atoms to their copies in the group
+     * @return Array of atom indices in the input molecule that have corresponding atoms in the group.
+     *         Returns empty array if no matching atoms are found or if the group is empty.
+     * @throws NullPointerException if any of the parameters is null
+     */
+    public int[] getAtomIndicesOfGroup(
+            IAtomContainer mol,
+            IAtomContainer group,
+            Map<IAtom, IAtom> inputAtomToAtomCopyMap
+    ) {
+        if (mol == null || group == null || inputAtomToAtomCopyMap == null) {
+            throw new NullPointerException("Given molecule, group, or input atom to atom copy map is null.");
+        }
+        if (group.isEmpty()) {
+            return new int[0];
+        }
+        //cannot immediately use array because the group may contain atoms that are not in the input molecule, e.g. R atoms
+        ArrayList<Integer> groupAtomIndices = new ArrayList<>(group.getAtomCount());
+        for (IAtom atom : mol.atoms()) {
+            if (group.contains(inputAtomToAtomCopyMap.get(atom))) {
+                groupAtomIndices.add(atom.getIndex());
+            }
+        }
+        int[] indices = new int[groupAtomIndices.size()];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = groupAtomIndices.get(i);
+        }
+        return indices;
+    }
+
+    /**
+     * Returns the indices of bonds in the input molecule that correspond to bonds in the given group.
+     * <p>
+     * This method iterates through all bonds in the input molecule and checks if the corresponding
+     * bond (via the provided mapping) exists in the group container. The indices of matching bonds
+     * are collected and returned as an array.
+     * <p>
+     * Note that the group may contain bonds that are not present in the input molecule mapping
+     * (e.g., bonds to R-groups added during processing), which will be ignored.
+     *
+     * @param mol The input molecule containing the original bonds
+     * @param group The group container to check for bond membership, e.g. extracted sugar or aglycone
+     * @param inputBondToBondCopyMap Map from original bonds to their copies in the group
+     * @return Array of bond indices in the input molecule that have corresponding bonds in the group.
+     *         Returns empty array if no matching bonds are found or if the group is empty.
+     * @throws NullPointerException if any of the parameters is null
+     */
+    public int[] getBondIndicesOfGroup(
+            IAtomContainer mol,
+            IAtomContainer group,
+            Map<IBond, IBond> inputBondToBondCopyMap
+    ) {
+        if (mol == null || group == null || inputBondToBondCopyMap == null) {
+            throw new NullPointerException("Given molecule, group, or input bond to bond copy map is null.");
+        }
+        if (group.isEmpty()) {
+            return new int[0];
+        }
+        //cannot immediately use array because the group may contain bonds that are not in the input molecule, e.g. bonds to R atoms
+        ArrayList<Integer> groupBondIndices = new ArrayList<>(group.getBondCount());
+        for (IBond bond : mol.bonds()) {
+            if (group.contains(inputBondToBondCopyMap.get(bond))) {
+                groupBondIndices.add(bond.getIndex());
+            }
+        }
+        int[] indices = new int[groupBondIndices.size()];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = groupBondIndices.get(i);
+        }
+        return indices;
+    }
+
+    /**
+     * Assigns group indices to all atoms in the input molecule based on their membership in the aglycone or sugar fragments.
+     * <p>
+     * This method iterates through the atoms of the input molecule and determines which group (aglycone or sugar fragment)
+     * each atom belongs to. The group indices are assigned as follows:
+     * <ul>
+     *   <li>Index 0 corresponds to the aglycone.</li>
+     *   <li>Indices 1 and above correspond to individual sugar fragments.</li>
+     *   <li>Atoms not belonging to any group are assigned an index of -1 (should actually not happen).</li>
+     * </ul>
+     * <p>
+     * This allows you to, for example, generate SMILES strings with glycosidic moiety annotations and
+     * depictions with glycosidic moiety highlights, e.g.:
+     * <pre>{@code
+     * Map<IAtom, IAtom> inputAtomToAglyconeAtomMap = new HashMap<IAtom, IAtom>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f);
+     * Map<IAtom, IAtom> inputAtomToSugarAtomMap = new HashMap<IAtom, IAtom>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f);
+     * List<IAtomContainer> aglyconeAndSugarsList = sdu.copyAndExtractAglyconeAndSugars(
+     *         molecule,
+     *         true,
+     *         false,
+     *         false,
+     *         true,
+     *         true,
+     *         inputAtomToAglyconeAtomMap,
+     *         new HashMap<IBond, IBond>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f),
+     *         inputAtomToSugarAtomMap,
+     *         new HashMap<IBond, IBond>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f));
+     * int[] groupIndices = sdu.getGroupIndicesForAllAtoms(mol, aglyconeAndSugarsList, inputAtomToAglyconeAtomMap, inputAtomToSugarAtomMap);
+     * for (IAtom atom : mol.atoms()) {
+     *    atom.setMapIdx(groupIndices[atom.getIndex()] + 1);
+     * }
+     * String smi = new SmilesGenerator(SmiFlavor.Isomeric | SmiFlavor.AtomAtomMap).create(mol);
+     * //example output (for Fusacandin B (CNP0295326.4)):
+     * // [CH3:1][CH2:1][CH2:1][CH2:1][CH2:1]/[CH:1]=[CH:1]/[CH:1]=[CH:1]/[C@@H:1]([OH:1])[CH2:1]/[CH:1]=[CH:1]/[CH:1]=[CH:1]/[C:1](=[O:1])[O:1][CH:1]1[CH:1]([OH:1])[C@H:1]([C:1]2=[C:1]([OH:1])[CH:1]=[C:1]([OH:1])[CH:1]=[C:1]2[CH2:1][OH:1])[O:1][C@H:1]([CH2:1][OH:1])[C@H:1]1[O:2][C@@H:2]3[O:2][CH:2]([CH2:2][OH:2])[C@H:2]([OH:2])[C@H:2]([OH:2])[CH:2]3[O:3][C@@H:3]4[O:3][CH:3]([CH2:3][OH:3])[C@H:3]([OH:3])[C@H:3]([OH:3])[CH:3]4[OH:3]
+     * }</pre>
+     * (Check out the "Color Map" option on the CDK depict web app).
+     * <p>The method uses the provided atom-to-atom copy maps to identify the correspondence between atoms in the input molecule
+     * and the aglycone/sugar fragments.</p>
+     * <p>Note that connecting hetero atoms between the aglycone and a sugar moiety are duplicated in the extraction process
+     * but will be assigned to only one of the two structures here.</p>
+     *
+     * @param mol The input molecule containing all atoms to be indexed. Must not be null or empty.
+     * @param aglyconeAndSugars A list of atom containers representing the aglycone (index 0) and sugar fragments (indices 1+).
+     *                          Must not be null or empty.
+     * @param inputAtomToAtomCopyInAglyconeMap A map linking atoms in the input molecule to their corresponding atoms in the aglycone.
+     *                                         Must not be null.
+     * @param inputAtomToAtomCopyInSugarsMap A map linking atoms in the input molecule to their corresponding atoms in the sugar fragments.
+     *                                       Must not be null.
+     * @return An array of integers where each index corresponds to an atom in the input molecule, and the value at that index
+     *         represents the group index (0 for aglycone, 1+ for sugar fragments, -1 for unassigned atoms).
+     *         Returns an empty array if the input molecule or aglyconeAndSugars list is empty, or if no groups are identified.
+     * @throws NullPointerException If any of the input parameters is null.
+     */
+    public int[] getGroupIndicesForAllAtoms(
+            IAtomContainer mol,
+            List<IAtomContainer> aglyconeAndSugars,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInAglyconeMap,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInSugarsMap
+    ) {
+        if (mol == null || aglyconeAndSugars == null || inputAtomToAtomCopyInAglyconeMap == null || inputAtomToAtomCopyInSugarsMap == null) {
+            throw new NullPointerException("Given molecule, extracted structures, or maps are null.");
+        }
+        if (mol.isEmpty() || aglyconeAndSugars.isEmpty() || (aglyconeAndSugars.size() == 1)) {
+            return new int[0];
+        }
+        int[] groupIndices = new int[mol.getAtomCount()];
+        Arrays.fill(groupIndices, -1);
+        for (int i = 0; i < aglyconeAndSugars.size(); i++) {
+            IAtomContainer group = aglyconeAndSugars.get(i);
+            if (group.isEmpty()) {
+                continue; //skip empty groups, e.g. empty aglycone
+            }
+            int[] atomIndices = this.getAtomIndicesOfGroup(mol, group, i == 0 ? inputAtomToAtomCopyInAglyconeMap : inputAtomToAtomCopyInSugarsMap);
+            for (int atomIndex : atomIndices) {
+                groupIndices[atomIndex] = i;
+            }
+        }
+        return groupIndices;
+    }
+
+    /**
+     * Creates a relatively deep ("deeper" than cloning but not as extensive) copy of the given
+     * atom container mol and fills the given maps
+     * with a mapping of the original atoms and bonds to the atoms and bonds in the copy.
+     * Copies:
+     * <br>- Atoms (atomic number, implicit hydrogen count, aromaticity flag, valency, atom type name, formal charge, some primitive-based properties)
+     * <br>- Bonds (begin and end atom, order, aromaticity flag, stereo, display, in ring flag, some primitive-based properties)
+     * <br>- Single electrons
+     * <br>- Lone pairs
+     * <br>- Stereo elements (mapped to the copied atoms and bonds)
+     * <br>- Some primitive-based properties (String, Integer, Boolean)
+     * <br>Note: atom types of the original atoms are not copied and hence, some properties will be unset in the copies.
+     * If you need atom types and their defining properties, you need to re-perceive them after copying.
+     *
+     * @param mol the molecule to copy
+     * @param origToCopyAtomMap empty map to fill with a mapping of the original atoms to the copied atoms
+     * @param origToCopyBondMap empty map to fill with a mapping of the original bonds to the copied bonds
+     * @return a relatively deep copy of the given atom container
+     */
+    protected IAtomContainer deeperCopy(
+            IAtomContainer mol,
+            Map<IAtom, IAtom> origToCopyAtomMap,
+            Map<IBond, IBond> origToCopyBondMap
+    ) {
+        IAtomContainer copy = mol.getBuilder().newAtomContainer();
+        // atoms
+        for (IAtom atom : mol.atoms()) {
+            IAtom cpyAtom = this.deeperCopy(atom, copy);
+            origToCopyAtomMap.put(atom, cpyAtom);
+        }
+        // bonds
+        for (IBond bond : mol.bonds()) {
+            IAtom beg = origToCopyAtomMap.get(bond.getBegin());
+            IAtom end = origToCopyAtomMap.get(bond.getEnd());
+            if (beg == null || end == null || beg.getContainer() != end.getContainer()) {
+                continue;
+            }
+            IBond newBond = this.deeperCopy(bond, beg, end);
+            copy.addBond(newBond);
+            origToCopyBondMap.put(bond, newBond);
+        }
+        // single electrons
+        for (ISingleElectron se : mol.singleElectrons()) {
+            IAtom atom = origToCopyAtomMap.get(se.getAtom());
+            if (!Objects.isNull(atom)) {
+                atom.getContainer().addSingleElectron(atom.getIndex());
+            }
+        }
+        // lone pairs
+        for (ILonePair lp : mol.lonePairs()) {
+            IAtom atom = origToCopyAtomMap.get(lp.getAtom());
+            if (!Objects.isNull(atom)) {
+                atom.getContainer().addLonePair(atom.getIndex());
+            }
+        }
+        // stereo elements
+        for (IStereoElement elem : mol.stereoElements()) {
+            copy.addStereoElement(elem.map(origToCopyAtomMap, origToCopyBondMap));
+        }
+        // properties
+        for (Map.Entry<Object, Object> entry : mol.getProperties().entrySet()) {
+            if ((entry.getKey() instanceof String || entry.getKey() instanceof Integer || entry.getKey() instanceof Boolean)
+                    && (entry.getValue() instanceof String || entry.getValue() instanceof Integer || entry.getValue() instanceof Boolean || entry.getValue() == null)) {
+                copy.setProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        return copy;
+    }
+
+    /**
+     *  Creates a relatively deep ("deeper" than cloning but not as extensive) copy of the given atom and adds it to the given container.
+     *  Copies:
+     *  <br>- atomic number
+     *  <br>- implicit hydrogen count
+     *  <br>- aromaticity flag
+     *  <br>- valency
+     *  <br>- atom type name
+     *  <br>- formal charge
+     *  <br>- point 2D and 3D coordinates
+     *  <br>- flags
+     *  <br>- some primitive-based properties (String, Integer, Boolean)
+     * <br>Note: atom types and isotopes of the original atoms are not copied and hence, some properties will be unset in the copies.
+     * If you need atom types and their defining properties, you need to re-perceive them after copying.
+     *
+     * @param atom the atom to copy
+     * @param container the container to add the copied atom to
+     * @return the copied atom
+     */
+    protected IAtom deeperCopy(IAtom atom, IAtomContainer container) {
+        IAtom cpyAtom = container.newAtom(atom.getAtomicNumber(),
+                atom.getImplicitHydrogenCount());
+        cpyAtom.setIsAromatic(atom.isAromatic());
+        cpyAtom.setValency(atom.getValency());
+        cpyAtom.setAtomTypeName(atom.getAtomTypeName());
+        //setting the formal charge also sets the (partial) charge, see https://github.com/cdk/cdk/pull/1151
+        cpyAtom.setFormalCharge(atom.getFormalCharge());
+        if (atom.getPoint2d() != null) {
+            cpyAtom.setPoint2d(new Point2d(atom.getPoint2d().x, atom.getPoint2d().y));
+        }
+        if (atom.getPoint3d() != null) {
+            cpyAtom.setPoint3d(new Point3d(atom.getPoint3d().x, atom.getPoint3d().y, atom.getPoint3d().z));
+        }
+        cpyAtom.setFlags(atom.getFlags());
+        //fractional point 3D (location in a crystal unit cell) is deliberately not copied; add if needed
+        //fields related to atom type (max bond order, bond order sum, covalent radius, hybridization, formal neighbor count) are deliberately not copied; add if needed
+        //fields related to isotope (exact mass, natural abundance, mass number) are deliberately not copied; add if needed
+        //properties:
+        for (Map.Entry<Object, Object> entry : atom.getProperties().entrySet()) {
+            if ((entry.getKey() instanceof String || entry.getKey() instanceof Integer || entry.getKey() instanceof Boolean)
+                    && (entry.getValue() instanceof String || entry.getValue() instanceof Integer || entry.getValue() instanceof Boolean || entry.getValue() == null)) {
+                cpyAtom.setProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        return cpyAtom;
+    }
+
+    /**
+     * Creates a relatively deep ("deeper" than cloning but not as extensive) copy of the given bond between the given begin and end atoms.
+     * Copies:
+     * <br>- order
+     * <br>- aromaticity flag
+     * <br>- stereo
+     * <br>- display
+     * <br>- in ring flag
+     * <br>- flags
+     * <br>- electron count
+     * <br>- some primitive-based properties (String, Integer, Boolean)
+     * <br>Note: The begin and end atoms are not copied, but the given ones are used in the copy.
+     * <br>Note also: the created bond must be added to the copy atom container by the calling code!
+     *
+     * @param bond the bond to copy
+     * @param begin the begin atom of the bond in the copy(!)
+     * @param end the end atom of the bond in the copy(!)
+     * @return the copied bond
+     */
+    protected IBond deeperCopy(IBond bond, IAtom begin, IAtom end) {
+        //using begin.getContainer().newBond() here caused weird issues sometimes
+        IBond newBond = new Bond(begin, end, bond.getOrder());
+        newBond.setIsAromatic(bond.isAromatic());
+        newBond.setStereo(bond.getStereo());
+        newBond.setDisplay(bond.getDisplay());
+        newBond.setIsInRing(bond.isInRing());
+        newBond.setFlags(bond.getFlags());
+        newBond.setElectronCount(bond.getElectronCount());
+        //properties:
+        for (Map.Entry<Object, Object> entry : bond.getProperties().entrySet()) {
+            if ((entry.getKey() instanceof String || entry.getKey() instanceof Integer || entry.getKey() instanceof Boolean)
+                    && (entry.getValue() instanceof String || entry.getValue() instanceof Integer || entry.getValue() instanceof Boolean || entry.getValue() == null)) {
+                newBond.setProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        return newBond;
+    }
+
+    /**
+     * Checks whether the given atom is a hetero-atom (i.e. non-carbon and
+     * non-hydrogen). Pseudo (R) atoms will also return false.
+     *
+     * @param atom the atom to test
+     * @return true if the given atom is neither a carbon nor a hydrogen or
+     *         pseudo atom
+     */
+    protected boolean isHeteroAtom(IAtom atom) {
+        Integer tmpAtomicNr = atom.getAtomicNumber();
+        if (Objects.isNull(tmpAtomicNr)) {
+            return false;
+        }
+        int tmpAtomicNumberInt = tmpAtomicNr;
+        return tmpAtomicNumberInt != IElement.H && tmpAtomicNumberInt != IElement.C
+                && !this.isPseudoAtom(atom);
+    }
+
+    /**
+     * Checks whether the given atom is a pseudo atom. Very strict, any atom
+     * whose atomic number is null or 0, whose symbol equals "R" or "*", or that
+     * is an instance of an IPseudoAtom implementing class will be classified as
+     * a pseudo atom.
+     *
+     * @param atom the atom to test
+     * @return true if the given atom is identified as a pseudo (R) atom
+     */
+    protected boolean isPseudoAtom(IAtom atom) {
+        Integer tmpAtomicNr = atom.getAtomicNumber();
+        if (Objects.isNull(tmpAtomicNr)) {
+            return true;
+        }
+        String tmpSymbol = atom.getSymbol();
+        return tmpAtomicNr == IElement.Wildcard ||
+                tmpSymbol.equals("R") ||
+                tmpSymbol.equals("*") ||
+                atom instanceof IPseudoAtom;
+    }
+
+    /**
+     * Checks whether the given atom is a carbon atom.
+     *
+     * @param atom the atom to test
+     * @return true if the given atom is a carbon atom
+     */
+    protected boolean isCarbonAtom(IAtom atom) {
+        Integer tmpAtomicNr = atom.getAtomicNumber();
+        if (Objects.isNull(tmpAtomicNr)) {
+            return false;
+        }
+        int tmpAtomicNumberInt = tmpAtomicNr;
+        return tmpAtomicNumberInt == IElement.C;
+    }
+
+    /**
+     * Preprocesses the results of sugar removal to correct special cases where the separation was not chemically optimal.
+     * <p>
+     * The preprocessing handles the following cases:
+     * <ul>
+     *   <li><strong>C6 carbon separation:</strong> Corrects cases where C6 carbon atoms of sugar moieties
+     *       were incorrectly assigned to the aglycone instead of remaining with the sugar fragment.</li>
+     *   <li><strong>Carboxy group separation:</strong> Moves entire carboxy groups (sugar-C(=O)-O-aglycone)
+     *   from the aglycone to the sugar fragment.</li>
+     * </ul>
+     * <p>
+     * The method identifies problematic cases by examining bonds that were broken during sugar removal (bonds between
+     * carbon atoms that are no longer present in either the aglycone or sugar copies). It then applies specific
+     * correction methods in this class.
+     * No checks are performed!
+     *
+     * @param mol The original input molecule containing all atoms and bonds
+     * @param copyForAglycone The aglycone fragment that may need correction
+     * @param copyForSugars The sugar fragment that may receive corrected atoms/bonds
+     * @param inputAtomToAtomCopyInAglyconeMap Map from original atoms to their copies in the aglycone fragment
+     * @param inputBondToBondCopyInAglyconeMap Map from original bonds to their copies in the aglycone fragment
+     * @param inputAtomToAtomCopyInSugarsMap Map from original atoms to their copies in the sugar fragment
+     * @param inputBondToBondCopyInSugarsMap Map from original bonds to their copies in the sugar fragment
+     */
+    protected void preprocessSugarRemovalResults(
+            IAtomContainer mol,
+            IAtomContainer copyForAglycone,
+            IAtomContainer copyForSugars,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInAglyconeMap,
+            Map<IBond, IBond> inputBondToBondCopyInAglyconeMap,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInSugarsMap,
+            Map<IBond, IBond> inputBondToBondCopyInSugarsMap
+    ) {
+        for (IBond bond : mol.bonds()) {
+            //bond not in aglycone or sugars, so it was broken during sugar removal, and both bond atoms are carbons
+            if (!copyForAglycone.contains(inputBondToBondCopyInAglyconeMap.get(bond))
+                    && !copyForSugars.contains(inputBondToBondCopyInSugarsMap.get(bond))
+                    && this.isCarbonAtom(bond.getBegin())
+                    && this.isCarbonAtom(bond.getEnd())) {
+                //detect cases where the C6 carbon was separated from the sugar and cases where the sugar should carry a carboxy group
+                boolean isBeginInAglycone = copyForAglycone.contains(inputAtomToAtomCopyInAglyconeMap.get(bond.getBegin()));
+                IAtom aglyconeCarbon = isBeginInAglycone?
+                        inputAtomToAtomCopyInAglyconeMap.get(bond.getBegin()) : inputAtomToAtomCopyInAglyconeMap.get(bond.getEnd());
+                IAtom aglyconeCarbonOriginalAtom = isBeginInAglycone? bond.getBegin() : bond.getEnd();
+                if (copyForAglycone.getConnectedBondsCount(aglyconeCarbon) == 1) {
+                    //section that corrects C6 separation if the only neighbor is an oxygen atom
+                    if (copyForAglycone.getConnectedAtomsList(aglyconeCarbon).get(0).getAtomicNumber() == IElement.O) {
+                        this.correctC6Separation(
+                                mol,
+                                copyForAglycone,
+                                copyForSugars,
+                                inputAtomToAtomCopyInSugarsMap,
+                                inputBondToBondCopyInSugarsMap,
+                                aglyconeCarbon,
+                                aglyconeCarbonOriginalAtom,
+                                bond);
+                    }
+                } else if (copyForAglycone.getConnectedBondsCount(aglyconeCarbon) == 2) {
+                    //section that corrects carboxy groups being split from the sugar
+                    boolean areBothNeighborsOxygen = true;
+                    IAtom ketoOxygenInAglycone = null;
+                    IAtom etherOxygenInAglycone = null;
+                    //assign the oxygen atoms of the carboxy group:
+                    for (IAtom nbrAtom : copyForAglycone.getConnectedAtomsList(aglyconeCarbon)) {
+                        if (nbrAtom.getAtomicNumber() != IElement.O) {
+                            areBothNeighborsOxygen = false;
+                            break;
+                        }
+                        if (copyForAglycone.getBond(aglyconeCarbon, nbrAtom).getOrder() == IBond.Order.DOUBLE && ketoOxygenInAglycone == null) {
+                            ketoOxygenInAglycone = nbrAtom;
+                        } else if (copyForAglycone.getBond(aglyconeCarbon, nbrAtom).getOrder() == IBond.Order.SINGLE && etherOxygenInAglycone == null) {
+                            etherOxygenInAglycone = nbrAtom;
+                        } else {
+                            areBothNeighborsOxygen = false;
+                            break;
+                        }
+                    }
+                    if (areBothNeighborsOxygen && ketoOxygenInAglycone != null && etherOxygenInAglycone != null) {
+                        //carboxy group, so copy C, keto O, and ether O to sugars and remove everything except ether O from aglycone
+                        this.correctCarboxyGroupSeparation(
+                                mol,
+                                copyForAglycone,
+                                copyForSugars,
+                                inputAtomToAtomCopyInAglyconeMap,
+                                inputBondToBondCopyInAglyconeMap,
+                                inputAtomToAtomCopyInSugarsMap,
+                                inputBondToBondCopyInSugarsMap,
+                                aglyconeCarbon,
+                                aglyconeCarbonOriginalAtom,
+                                ketoOxygenInAglycone,
+                                etherOxygenInAglycone,
+                                bond);
+                    }
+                } //end of carboxy group correction
+            } //end of if that detects broken C-C bond
+        } //end of bond iteration
+    }
+
+    /**
+     * Corrects the separation of C6 carbon atoms that were incorrectly placed in the aglycone during sugar extraction.
+     * <p>
+     * This method addresses cases where a C6 carbon atom of a sugar moiety was incorrectly
+     * assigned to the aglycone fragment instead of remaining with the sugar during extraction. This can
+     * happen when the sugar removal utility breaks bonds between sugar moieties and their substituents.
+     * <p>
+     * The correction process:
+     * <ul>
+     *   <li>Removes the misplaced carbon atom from the aglycone fragment</li>
+     *   <li>Creates a copy of the original carbon atom and adds it to the sugar fragment</li>
+     *   <li>Recreates the bond between the carbon and its connected sugar atom</li>
+     *   <li>Updates the atom and bond mapping tables to reflect the changes</li>
+     *   <li>Preserves stereochemistry information for the moved bond</li>
+     * </ul>
+     * <p>
+     * This method is typically called during preprocessing when a carbon atom in the aglycone has only one
+     * connection, indicating it is likely a terminal carbon that should belong to a sugar moiety.
+     * No checks are performed!
+     *
+     * @param mol The original input molecule containing all atoms and bonds
+     * @param copyForAglycone The aglycone fragment from which the carbon atom will be removed
+     * @param copyForSugars The sugar fragment to which the carbon atom will be added
+     * @param inputAtomToAtomCopyInSugarsMap Map from original atoms to their copies in the sugar fragment
+     * @param inputBondToBondCopyInSugarsMap Map from original bonds to their copies in the sugar fragment
+     * @param aglyconeCarbon The carbon atom in the aglycone fragment to be moved
+     * @param aglyconeCarbonOriginalAtom The original carbon atom from the input molecule corresponding to the atom to be moved
+     * @param bond The bond between the carbon and the sugar fragment that needs to be recreated
+     */
+    protected void correctC6Separation(
+            IAtomContainer mol,
+            IAtomContainer copyForAglycone,
+            IAtomContainer copyForSugars,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInSugarsMap,
+            Map<IBond, IBond> inputBondToBondCopyInSugarsMap,
+            IAtom aglyconeCarbon,
+            IAtom aglyconeCarbonOriginalAtom,
+            IBond bond
+    ) {
+        //remove the carbon from the aglycone and add it to the sugars; also create a new bond in the sugars
+        copyForAglycone.removeAtom(aglyconeCarbon);
+        IAtom newAtomCopyInSugars = this.deeperCopy(aglyconeCarbonOriginalAtom, copyForSugars);
+        IBond newBondInSugars = this.deeperCopy(bond, newAtomCopyInSugars, inputAtomToAtomCopyInSugarsMap.get(bond.getOther(aglyconeCarbonOriginalAtom)));
+        copyForSugars.addBond(newBondInSugars);
+        //update the maps
+        inputAtomToAtomCopyInSugarsMap.put(aglyconeCarbonOriginalAtom, newAtomCopyInSugars);
+        inputBondToBondCopyInSugarsMap.put(bond, newBondInSugars);
+        this.mapBondStereoElement(
+                mol,
+                bond,
+                copyForSugars,
+                inputAtomToAtomCopyInSugarsMap,
+                inputBondToBondCopyInSugarsMap);
+    }
+
+    /**
+     * Corrects the separation of carboxy groups that were incorrectly split between aglycone and sugar fragments during extraction.
+     * <p>
+     * This method addresses cases where a carboxy group (sugar-C(=O)-O-aglycone) was incorrectly separated during sugar removal,
+     * with the formic acid ester remaining in the aglycone.
+     * To maintain chemical validity and keep functional groups intact, this method moves the entire carboxy group
+     * to the sugar fragment.
+     * <p>
+     * The correction process:
+     * <ul>
+     *   <li>Removes the carbonyl carbon and keto oxygen from the aglycone fragment</li>
+     *   <li>Adds copies of both atoms to the sugar fragment</li>
+     *   <li>Recreates the bonds within the carboxy group and to the connecting sugar atom</li>
+     *   <li>Updates the atom and bond mapping tables to reflect the changes</li>
+     *   <li>Preserves stereochemistry information for the moved bonds</li>
+     * </ul>
+     * <p>
+     * This method is typically called during preprocessing to correct sugar removal results in special cases
+     * where functional groups are inadvertently split across fragments.
+     * No checks are performed!
+     *
+     * @param mol The original input molecule containing all atoms and bonds
+     * @param copyForAglycone The aglycone fragment from which the carboxy atoms will be removed
+     * @param copyForSugars The sugar fragment to which the carboxy atoms will be added
+     * @param inputAtomToAtomCopyInAglyconeMap Map from original atoms to their copies in the aglycone fragment
+     * @param inputBondToBondCopyInAglyconeMap Map from original bonds to their copies in the aglycone fragment
+     * @param inputAtomToAtomCopyInSugarsMap Map from original atoms to their copies in the sugar fragment
+     * @param inputBondToBondCopyInSugarsMap Map from original bonds to their copies in the sugar fragment
+     * @param aglyconeCarbon The carbonyl carbon atom in the aglycone fragment to be moved
+     * @param aglyconeCarbonOriginalAtom The original carbonyl carbon atom from the input molecule
+     * @param ketoOxygenInAglycone The keto oxygen atom in the aglycone fragment to be moved
+     * @param etherOxygenInAglycone The ether oxygen atom in the aglycone fragment
+     * @param bond The bond between the carbonyl carbon and the sugar fragment that needs to be recreated
+     */
+    protected void correctCarboxyGroupSeparation(
+            IAtomContainer mol,
+            IAtomContainer copyForAglycone,
+            IAtomContainer copyForSugars,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInAglyconeMap,
+            Map<IBond, IBond> inputBondToBondCopyInAglyconeMap,
+            Map<IAtom, IAtom> inputAtomToAtomCopyInSugarsMap,
+            Map<IBond, IBond> inputBondToBondCopyInSugarsMap,
+            IAtom aglyconeCarbon,
+            IAtom aglyconeCarbonOriginalAtom,
+            IAtom ketoOxygenInAglycone,
+            IAtom etherOxygenInAglycone,
+            IBond bond
+    ) {
+        //determine keto and ether oxygen atoms:
+        IAtom ketoOxygenOriginalAtom = null;
+        IAtom etherOxygenOriginalAtom = null;
+        for (Map.Entry<IAtom, IAtom> entry : inputAtomToAtomCopyInAglyconeMap.entrySet()) {
+            IAtom originalAtom = entry.getKey();
+            IAtom mappedAglyconeAtom = entry.getValue();
+            if (mappedAglyconeAtom.equals(ketoOxygenInAglycone)) {
+                ketoOxygenOriginalAtom = originalAtom;
+            }
+            if (mappedAglyconeAtom.equals(etherOxygenInAglycone)) {
+                etherOxygenOriginalAtom = originalAtom;
+            }
+        }
+        if (ketoOxygenOriginalAtom == null || etherOxygenOriginalAtom == null) {
+            SugarDetectionUtility.LOGGER.error("Could not find original atoms for carboxy group, this should not happen!");
+            return;
+        }
+        //remove C and keto O from aglycone, add both to sugars, also add bond between them and bond between C and other sugar atom:
+        //copy carboxy C to sugar
+        IAtom newAtomCopyInSugars = this.deeperCopy(aglyconeCarbonOriginalAtom, copyForSugars);
+        IBond newBondInSugars = this.deeperCopy(bond, newAtomCopyInSugars, inputAtomToAtomCopyInSugarsMap.get(bond.getOther(aglyconeCarbonOriginalAtom)));
+        copyForSugars.addBond(newBondInSugars);
+        inputAtomToAtomCopyInSugarsMap.put(aglyconeCarbonOriginalAtom, newAtomCopyInSugars);
+        inputBondToBondCopyInSugarsMap.put(bond, newBondInSugars);
+        //copy keto O to sugar
+        IAtom newKetoOCopyInSugars = this.deeperCopy(ketoOxygenOriginalAtom, copyForSugars);
+        IBond originalBondToKetoO = mol.getBond(aglyconeCarbonOriginalAtom, ketoOxygenOriginalAtom);
+        IBond newKetoOBondInSugars = this.deeperCopy(originalBondToKetoO, newAtomCopyInSugars, newKetoOCopyInSugars);
+        copyForSugars.addBond(newKetoOBondInSugars);
+        inputAtomToAtomCopyInSugarsMap.put(ketoOxygenOriginalAtom, newKetoOCopyInSugars);
+        inputBondToBondCopyInSugarsMap.put(originalBondToKetoO, newKetoOBondInSugars);
+        //remove atoms and bonds from aglycone
+        copyForAglycone.removeAtom(ketoOxygenInAglycone);
+        copyForAglycone.removeBond(inputBondToBondCopyInAglyconeMap.get(originalBondToKetoO));
+        copyForAglycone.removeAtom(aglyconeCarbon);
+        IBond originalBondToEtherO = mol.getBond(aglyconeCarbonOriginalAtom, etherOxygenOriginalAtom);
+        copyForAglycone.removeBond(inputBondToBondCopyInAglyconeMap.get(originalBondToEtherO));
+        this.mapBondStereoElement(
+                mol,
+                bond,
+                copyForSugars,
+                inputAtomToAtomCopyInSugarsMap,
+                inputBondToBondCopyInSugarsMap);
+    }
+
+    /**
+     * Maps a stereo element from the original molecule (mol) to the receiving container (a copy of the former) if the
+     * specified bond is involved in it and all its components (focus and carriers) are part of the receiving container.
+     * <p>
+     * This method searches for stereo elements in the original molecule that involve both atoms of the specified bond
+     * and maps them to the corresponding atoms and bonds in the receiving container. Only stereo elements where
+     * the focus atom and all carrier atoms/bonds are present in the receiving container will be mapped.
+     * <p>
+     * This is typically used during the sugar extraction process when atoms and bonds are moved between the aglycone
+     * and sugar fragments to ensure that stereochemistry information is preserved in the correct fragment.
+     * <p>
+     * The method performs the following checks before mapping a stereo element:
+     * <ul>
+     *   <li>The stereo element must contain both atoms of the specified bond</li>
+     *   <li>The focus atom of the stereo element must be present in the receiving container</li>
+     *   <li>All carrier atoms and bonds must be present in the receiving container</li>
+     * </ul>
+     * <p>
+     * If all conditions are met, the stereo element is mapped using the provided atom and bond maps and added
+     * to the receiving container.
+     * No checks are performed!
+     *
+     * @param mol The original molecule containing the stereo elements to be mapped
+     * @param bond The bond whose associated stereo elements should be mapped
+     * @param receivingContainer The container that should receive the mapped stereo elements
+     * @param inputAtomToAtomCopyMap Map from original atoms to their copies in the receiving container
+     * @param inputBondToBondCopyMap Map from original bonds to their copies in the receiving container
+     */
+    protected void mapBondStereoElement(
+            IAtomContainer mol,
+            IBond bond,
+            IAtomContainer receivingContainer,
+            Map<IAtom, IAtom>  inputAtomToAtomCopyMap,
+            Map<IBond, IBond> inputBondToBondCopyMap
+    ) {
+        for (IStereoElement elem : mol.stereoElements()) {
+            if (elem.contains(bond.getBegin()) && elem.contains(bond.getEnd())
+                    && receivingContainer.contains(inputAtomToAtomCopyMap.get(elem.getFocus()))) {
+                boolean areAllCarriersPresent = true;
+                for (Object object : elem.getCarriers()) {
+                    if (object instanceof IAtom) {
+                        if (!receivingContainer.contains(inputAtomToAtomCopyMap.get(object))) {
+                            areAllCarriersPresent = false;
+                            break;
+                        }
+                    } else if (object instanceof IBond) {
+                        if (!receivingContainer.contains(inputBondToBondCopyMap.get(object))) {
+                            areAllCarriersPresent = false;
+                            break;
+                        }
+                    } else {
+                        areAllCarriersPresent = false;
+                        break;
+                    }
+                }
+                if (areAllCarriersPresent) {
+                    receivingContainer.addStereoElement(elem.map(inputAtomToAtomCopyMap, inputBondToBondCopyMap));
+                }
+            }
+        }
+    }
+
+    /**
+     * Saturates a broken bond at an attachment point by either adding an R-group or increasing the implicit hydrogen count.
+     * <p>
+     * This method is used during the sugar extraction process to handle attachment points where bonds between
+     * the aglycone and sugar moieties have been broken.
+     * No checks are performed!
+     *
+     * @param copyAtomToSaturate The atom in the copy container that needs to be saturated due to a broken bond
+     * @param copyContainer The atom container containing the atom to be saturated
+     * @param markAttachPointsByR If true, an R-group pseudo atom is added to mark the attachment point;
+     *                           if false, the implicit hydrogen count is increased.
+     * @param originalAtom The original atom from the input molecule corresponding to the atom to be saturated.
+     *                     Used for determining bond properties
+     * @param originalBond The original bond that was broken during the extraction process.
+     *                     Used for determining the bond order of the new R-group bond
+     */
+    protected void saturate(
+            IAtom copyAtomToSaturate,
+            IAtomContainer copyContainer,
+            boolean markAttachPointsByR,
+            IAtom originalAtom,
+            IBond originalBond
+    ) {
+        if (markAttachPointsByR) {
+            IPseudoAtom tmpRAtom = originalAtom.getBuilder().newInstance(IPseudoAtom.class, "R");
+            tmpRAtom.setAttachPointNum(1);
+            tmpRAtom.setImplicitHydrogenCount(0);
+            IBond bondToR;
+            if (originalBond.getBegin().equals(originalAtom)) {
+                bondToR = originalAtom.getBuilder().newInstance(
+                        IBond.class, copyAtomToSaturate, tmpRAtom, originalBond.getOrder());
+            } else {
+                bondToR = originalAtom.getBuilder().newInstance(
+                        IBond.class, tmpRAtom, copyAtomToSaturate, originalBond.getOrder());
+            }
+            copyContainer.addAtom(tmpRAtom);
+            copyContainer.addBond(bondToR);
+        } else {
+            copyAtomToSaturate.setImplicitHydrogenCount(
+                    copyAtomToSaturate.getImplicitHydrogenCount()
+                    + originalBond.getOrder().numeric());
+        }
+    }
+
+    /**
+     * Splits O-glycosidic (ether), ester, and peroxide bonds in the given molecule (circular sugar moieties) and optionally marks the
+     * attachment points with R-groups.
+     * This method identifies specific bond types (ether, ester, and peroxide) in the molecule using SMARTS patterns and
+     * then breaks these bonds, duplicating oxygen atoms where adequate. The transformation can either mark the attachment points with R-groups or
+     * saturate the resulting open valences with implicit H atoms, depending on the `markAttachPointsByR` parameter.
+     * If bonds are split, an unconnected atom container results. If no matching bonds are found, the original molecule
+     * remains unchanged.
+     * Note: SMIRKS transformations are not used here, since they create a copy of the molecule and that would destroy
+     * the atom and bond mapping to the original molecule.
+     *
+     * @param molecule The molecule in which ether, ester, and peroxide bonds are to be split. Must not be null.
+     * @param markAttachPointsByR If true, the attachment points are marked with R-groups; otherwise, they are saturated with implicit H.
+     * @param limitPostProcessingBySize If true, the bond will only be split if both resulting fragments are large enough
+     *                                  to be preserved according to the set preservation mode threshold
+     * @throws NullPointerException If the input molecule is null.
+     */
+    protected void splitOGlycosidicEsterPeroxideBondsCircularSugarsPostProcessing(
+            IAtomContainer molecule,
+            boolean markAttachPointsByR,
+            boolean limitPostProcessingBySize
+    ) {
+        if (molecule == null) {
+            throw new NullPointerException("The input molecule must not be null.");
+        }
+        if (molecule.isEmpty()) {
+            return; //nothing to do
+        }
+        this.splitEsters(molecule, markAttachPointsByR, limitPostProcessingBySize, true);
+        this.splitPeroxides(molecule, markAttachPointsByR, limitPostProcessingBySize, true);
+        this.splitOGlycosidicBondsAndEthers(molecule, markAttachPointsByR, limitPostProcessingBySize, true);
+    }
+
+    /**
+     * Splits ether, ester, and peroxide bonds in the given molecule (linear sugar moieties) and optionally marks the
+     * attachment points with R-groups.
+     * This method identifies specific bond types (ether, ester, and peroxide) in the molecule using SMARTS patterns and
+     * then breaks these bonds, duplicating oxygen atoms where adequate. The transformation can either mark the attachment points with R-groups or
+     * saturate the resulting open valences with implicit H atoms, depending on the `markAttachPointsByR` parameter.
+     * If bonds are split, an unconnected atom container results. If no matching bonds are found, the original molecule
+     * remains unchanged.
+     * Note: SMIRKS transformations are not used here, since they create a copy of the molecule and that would destroy
+     * the atom and bond mapping to the original molecule.
+     *
+     * @param molecule The molecule in which ether, ester, and peroxide bonds are to be split. Must not be null.
+     * @param markAttachPointsByR If true, the attachment points are marked with R-groups; otherwise, they are saturated with implicit H.
+     * @param limitPostProcessingBySize If true, the bond will only be split if both resulting fragments are large enough
+     *                                  to be preserved according to the set minimum size for linear sugars
+     * @throws NullPointerException If the input molecule is null.
+     */
+    protected void splitEtherEsterPeroxideBondsLinearSugarsPostProcessing(
+            IAtomContainer molecule,
+            boolean markAttachPointsByR,
+            boolean limitPostProcessingBySize
+    ) {
+        if (molecule == null) {
+            throw new NullPointerException("The input molecule must not be null.");
+        }
+        if (molecule.isEmpty()) {
+            return; //nothing to do
+        }
+        //note: the order is important here, since the ether pattern is very promiscuous and matches esters and cross-linking ethers as well
+        this.splitEsters(molecule, markAttachPointsByR, limitPostProcessingBySize, false);
+        this.splitEthersCrossLinking(molecule, markAttachPointsByR, limitPostProcessingBySize);
+        this.splitOGlycosidicBondsAndEthers(molecule, markAttachPointsByR, limitPostProcessingBySize, false);
+        this.splitPeroxides(molecule, markAttachPointsByR, limitPostProcessingBySize, false);
+    }
+
+    /**
+     * Splits ester bonds in the given molecule (circular or linear sugar moieties) and optionally marks the attachment
+     * points with R-groups.
+     * <p>
+     * This method identifies ester bonds in the molecule using a SMARTS pattern and then breaks these bonds while
+     * duplicating the formerly connecting oxygen atom to produce a carboxy acid and an alcohol as educts.
+     * The transformation can either mark the attachment points with R-groups or saturate the resulting open
+     * valences with implicit hydrogen atoms, depending on the `markAttachPointsByR` parameter.
+     * <p>
+     * Depending on the `splitCircularSugars` parameter, the method uses either the SMARTS pattern for circular sugar
+     * ester bonds or the pattern for linear sugar ester bonds (see the public constants).
+     * <p>
+     * If bonds are split, the molecule may become disconnected. If no ester bonds are found, the original
+     * molecule remains unchanged.
+     * Note: SMIRKS transformations are not used here, since they create a copy of the molecule and that would destroy
+     * the atom and bond mapping to the original molecule.
+     *
+     * @param molecule The molecule in which ester bonds are to be split. Must not be null.
+     * @param markAttachPointsByR If true, the attachment points are marked with R-groups; otherwise, they are saturated
+     *                            with implicit hydrogen atoms.
+     * @param limitPostProcessingBySize If true, the bond will only be split if both resulting fragments are large enough
+     *                                  to be preserved according to the set preservation mode threshold or the set
+     *                                  minimum size for linear sugars (depends on 'splitCircularSugars').
+     * @param splitCircularSugars If true, the SMARTS pattern for circular sugar ester bonds is used;
+     *                            if false, the pattern for linear sugar ester bonds is used.
+     * @throws NullPointerException If the input molecule is null.
+     */
+    protected void splitEsters(
+            IAtomContainer molecule,
+            boolean markAttachPointsByR,
+            boolean limitPostProcessingBySize,
+            boolean splitCircularSugars
+    ) {
+        if (molecule == null) {
+            throw new NullPointerException("The input molecule must not be null.");
+        }
+        if (molecule.isEmpty()) {
+            return; //nothing to do
+        }
+        Mappings esterMappings = SmartsPattern.create(
+                splitCircularSugars? SugarDetectionUtility.ESTER_BOND_CIRCULAR_SUGARS_SMARTS : SugarDetectionUtility.ESTER_BOND_LINEAR_SUGARS_SMARTS)
+                .matchAll(molecule).uniqueAtoms();
+        if (esterMappings.atLeast(1)) {
+            for (IAtomContainer esterGroup : esterMappings.toSubstructures()) {
+                IAtom carbonOne = null;
+                IAtom connectingOxygen = null;
+                for (IAtom atom : esterGroup.atoms()) {
+                    if (atom.getAtomicNumber() == IElement.O) {
+                        connectingOxygen = atom;
+                    } else if (carbonOne == null ) {
+                        carbonOne = atom;
+                    }
+                }
+                IBond bondToBreak = molecule.getBond(carbonOne, connectingOxygen);
+                if (limitPostProcessingBySize && this.isFragmentTooSmall(molecule, bondToBreak, splitCircularSugars)) {
+                    continue;
+                }
+                IAtom newOxygen = molecule.newAtom(IElement.O);
+                molecule.newBond(carbonOne, newOxygen, IBond.Order.SINGLE);
+                IStereoElement updatedStereoElement = null;
+                for (IStereoElement stereoElement : molecule.stereoElements()) {
+                    if (stereoElement.getFocus().equals(carbonOne) && stereoElement.contains(connectingOxygen)) {
+                        updatedStereoElement = stereoElement.updateCarriers(connectingOxygen, newOxygen);
+                        break;
+                    }
+                }
+                if (updatedStereoElement != null) {
+                    molecule.addStereoElement(updatedStereoElement);
+                }
+                molecule.removeBond(bondToBreak);
+                IAtom[] oxygens = new IAtom[] {connectingOxygen, newOxygen};
+                for (IAtom oxygen : oxygens) {
+                    this.saturate(
+                            oxygen,
+                            molecule,
+                            markAttachPointsByR,
+                            oxygen,
+                            bondToBreak);
+                }
+            }
+        }
+    }
+
+    /**
+     * Splits cross-linking ether bonds in the given molecule (linear sugar moieties) and optionally marks the attachment points with R-groups.
+     * <p>
+     * This method identifies cross-linking ether bonds in the molecule using a SMARTS pattern and then breaks these bonds
+     * while duplicating the formerly connecting oxygen atom.
+     * The transformation can either mark the attachment points with R-groups or saturate the resulting open valences
+     * with implicit hydrogen atoms, depending on the `markAttachPointsByR` parameter.
+     * <p>
+     * If bonds are split, the molecule may become disconnected. If no matching bonds are found, the original molecule remains unchanged.
+     * Note: SMIRKS transformations are not used here, since they create a copy of the molecule and that would destroy
+     * the atom and bond mapping to the original molecule.
+     *
+     * @param molecule The molecule in which cross-linking ether bonds are to be split. Must not be null.
+     * @param markAttachPointsByR If true, the attachment points are marked with R-groups; otherwise, they are saturated with implicit hydrogen atoms.
+     * @param limitPostProcessingBySize If true, the bond will only be split if both resulting fragments are large enough
+     *                                  to be preserved according to the set minimum size for linear sugars
+     * @throws NullPointerException If the input molecule is null.
+     */
+    protected void splitEthersCrossLinking(
+            IAtomContainer molecule,
+            boolean markAttachPointsByR,
+            boolean limitPostProcessingBySize
+    ) {
+        if (molecule == null) {
+            throw new NullPointerException("The input molecule must not be null.");
+        }
+        if (molecule.isEmpty()) {
+            return; //nothing to do
+        }
+        Mappings mappings = SmartsPattern.create(SugarDetectionUtility.CROSS_LINKING_ETHER_BOND_LINEAR_SUGARS_SMARTS).matchAll(molecule).uniqueAtoms();
+        if (mappings.atLeast(1)) {
+            for (IAtomContainer esterGroup : mappings.toSubstructures()) {
+                IAtom carbonOne = null;
+                IAtom carbonTwo = null;
+                IAtom connectingOxygen = null;
+                for (IAtom atom : esterGroup.atoms()) {
+                    if (atom.getAtomicNumber() == IElement.O) {
+                        connectingOxygen = atom;
+                    } else if (carbonOne == null ) {
+                        carbonOne = atom;
+                    } else {
+                        carbonTwo = atom;
+                    }
+                }
+                //no need to copy stereo elements, the connecting oxygen is not duplicated
+                IBond bondToBreak = molecule.getBond(carbonTwo, connectingOxygen);
+                if (limitPostProcessingBySize && this.isFragmentTooSmall(molecule, bondToBreak, false)) {
+                    continue;
+                }
+                molecule.removeBond(bondToBreak);
+                IAtom[] atoms = new IAtom[] {connectingOxygen, carbonTwo};
+                for (IAtom atom : atoms) {
+                    this.saturate(
+                            atom,
+                            molecule,
+                            markAttachPointsByR,
+                            atom,
+                            bondToBreak);
+                }
+            }
+        }
+    }
+
+    /**
+     * Splits O-glycosidic (ether) groups connecting circular or linear sugars in the given molecule and optionally
+     * marks the attachment points with R-groups.
+     * <p>
+     * This method identifies ether bonds in the molecule using a SMARTS pattern and then breaks these bonds while
+     * duplicating the formerly connecting oxygen atom.
+     * The transformation can either mark the attachment points with R-groups or saturate the resulting open valences
+     * with implicit hydrogen atoms, depending on the `markAttachPointsByR` parameter.
+     * <p>
+     * Depending on the `splitCircularSugars` parameter, the method uses either the SMARTS pattern for circular sugar
+     * ester bonds or the pattern for linear sugar ester bonds (see the public constants).
+     * <p>
+     * If bonds are split, the molecule may become disconnected. If no matching bonds are found, the original molecule remains unchanged.
+     * Note: SMIRKS transformations are not used here, since they create a copy of the molecule and that would destroy
+     * the atom and bond mapping to the original molecule.
+     *
+     * @param molecule The molecule in which O-glycosidic (ether) bonds are to be split. Must not be null.
+     * @param markAttachPointsByR If true, the attachment points are marked with R-groups; otherwise, they are saturated with implicit hydrogen atoms.
+     * @param limitPostProcessingBySize If true, the bond will only be split if both resulting fragments are large enough
+     *                                  to be preserved according to the set preservation mode threshold or the set
+     *                                  minimum size for linear sugars (depends on 'splitCircularSugars').
+     * @param splitCircularSugars If true, the SMARTS pattern for circular sugar ester bonds is used;
+     *                            if false, the pattern for linear sugar ester bonds is used.
+     * @throws NullPointerException If the input molecule is null.
+     */
+    protected void splitOGlycosidicBondsAndEthers(
+            IAtomContainer molecule,
+            boolean markAttachPointsByR,
+            boolean limitPostProcessingBySize,
+            boolean splitCircularSugars
+    ) {
+        if (molecule == null) {
+            throw new NullPointerException("The input molecule must not be null.");
+        }
+        if (molecule.isEmpty()) {
+            return; //nothing to do
+        }
+        Mappings mappings = SmartsPattern.create(
+                splitCircularSugars? SugarDetectionUtility.O_GLYCOSIDIC_BOND_CIRCULAR_SUGARS_SMARTS : SugarDetectionUtility.ETHER_BOND_LINEAR_SUGARS_SMARTS)
+                .matchAll(molecule).uniqueAtoms();
+        if (mappings.atLeast(1)) {
+            for (IAtomContainer esterGroup : mappings.toSubstructures()) {
+                IAtom carbonOne = null;
+                IAtom connectingOxygen = null;
+                for (IAtom atom : esterGroup.atoms()) {
+                    if (atom.getAtomicNumber() == IElement.O) {
+                        connectingOxygen = atom;
+                    } else if (carbonOne == null ) {
+                        carbonOne = atom;
+                    }
+                }
+                IBond bondToBreak = molecule.getBond(carbonOne, connectingOxygen);
+                if (limitPostProcessingBySize && this.isFragmentTooSmall(molecule, bondToBreak, splitCircularSugars)) {
+                    continue;
+                }
+                IAtom newOxygen = molecule.newAtom(IElement.O);
+                molecule.newBond(carbonOne, newOxygen, IBond.Order.SINGLE);
+                IStereoElement updatedStereoElement = null;
+                for (IStereoElement stereoElement : molecule.stereoElements()) {
+                    if (stereoElement.getFocus().equals(carbonOne) && stereoElement.contains(connectingOxygen)) {
+                        updatedStereoElement = stereoElement.updateCarriers(connectingOxygen, newOxygen);
+                        break;
+                    }
+                }
+                if (updatedStereoElement != null) {
+                    molecule.addStereoElement(updatedStereoElement);
+                }
+                molecule.removeBond(bondToBreak);
+                IAtom[] oxygens = new IAtom[] {connectingOxygen, newOxygen};
+                for (IAtom oxygen : oxygens) {
+                    this.saturate(
+                            oxygen,
+                            molecule,
+                            markAttachPointsByR,
+                            oxygen,
+                            bondToBreak);
+                }
+            }
+        }
+    }
+
+    /**
+     * Splits peroxide groups in the given molecule (circular or linear sugar moieties) and
+     * optionally marks the attachment points with R-groups.
+     * <p>
+     * This method identifies peroxide bonds in the molecule using a SMARTS pattern and then breaks these bonds.
+     * The transformation can either mark the attachment points with R-groups or saturate the resulting open valences
+     * with implicit hydrogen atoms, depending on the `markAttachPointsByR` parameter.
+     * <p>
+     * Depending on the `splitCircularSugars` parameter, the method uses either the SMARTS pattern for circular sugar
+     * ester bonds or the pattern for linear sugar ester bonds (see the public constants).
+     * <p>
+     * If bonds are split, the molecule may become disconnected. If no matching bonds are found, the original molecule remains unchanged.
+     * Note: SMIRKS transformations are not used here, since they create a copy of the molecule and that would destroy
+     * the atom and bond mapping to the original molecule.
+     *
+     * @param molecule The molecule in which peroxide bonds are to be split. Must not be null.
+     * @param markAttachPointsByR If true, the attachment points are marked with R-groups; otherwise, they are saturated with implicit hydrogen atoms.
+     * @param limitPostProcessingBySize If true, the bond will only be split if both resulting fragments are large enough
+     *                                  to be preserved according to the set preservation mode threshold or the set
+     *                                  minimum size for linear sugars (depends on 'splitCircularSugars').
+     * @param splitCircularSugars If true, the SMARTS pattern for circular sugar ester bonds is used;
+     *                            if false, the pattern for linear sugar ester bonds is used.
+     * @throws NullPointerException If the input molecule is null.
+     */
+    protected void splitPeroxides(
+            IAtomContainer molecule,
+            boolean markAttachPointsByR,
+            boolean limitPostProcessingBySize,
+            boolean splitCircularSugars
+    ) {
+        if (molecule == null) {
+            throw new NullPointerException("The input molecule must not be null.");
+        }
+        if (molecule.isEmpty()) {
+            return; //nothing to do
+        }
+        Mappings mappings = SmartsPattern.create(
+                splitCircularSugars? SugarDetectionUtility.PEROXIDE_BOND_CIRCULAR_SUGARS_SMARTS: SugarDetectionUtility.PEROXIDE_BOND_LINEAR_SUGARS_SMARTS)
+                .matchAll(molecule).uniqueAtoms();
+        if (mappings.atLeast(1)) {
+            for (IAtomContainer esterGroup : mappings.toSubstructures()) {
+                IAtom oxygenOne = null;
+                IAtom oxygenTwo = null;
+                for (IAtom atom : esterGroup.atoms()) {
+                    if (atom.getAtomicNumber() == IElement.O) {
+                        if (oxygenOne == null) {
+                            oxygenOne = atom;
+                        } else {
+                            oxygenTwo = atom;
+                        }
+                    }
+                }
+                IBond bondToBreak = molecule.getBond(oxygenOne, oxygenTwo);
+                if (limitPostProcessingBySize && this.isFragmentTooSmall(molecule, bondToBreak, splitCircularSugars)) {
+                    continue;
+                }
+                //no need to copy stereo elements, the connecting oxygen is not duplicated
+                molecule.removeBond(bondToBreak);
+                IAtom[] atoms = new IAtom[] {oxygenOne, oxygenTwo};
+                for (IAtom atom : atoms) {
+                    this.saturate(
+                            atom,
+                            molecule,
+                            markAttachPointsByR,
+                            atom,
+                            bondToBreak);
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks whether breaking the specified bond would result in a fragment that is too small by the set criterion.
+     * <p>
+     * This method creates a temporary copy of the input molecule, removes the specified bond, and then
+     * checks if any of the resulting disconnected fragments would be smaller than the preservation
+     * threshold for circular sugars or smaller than the linear sugar candidate minimum size for linear sugars.
+     * This is used during postprocessing to prevent the splitting of bonds that would
+     * create fragments too small to be meaningful (e.g., small substituents like methyl groups).
+     * <p>
+     * This method is typically called before actually breaking bonds during postprocessing to ensure
+     * that only bonds connecting sufficiently large fragments are split.
+     * <p>
+     * No checks are performed!
+     *
+     * @param molecule The molecule containing the bond to be evaluated
+     * @param bondToBreak The bond whose removal would be tested for fragment size
+     * @param isCriterionForCircularSugars if true, the size evaluated based on the set preservation mode
+     *                                     threshold; otherwise, the linear sugar candidate minimum size is used
+     * @return True if breaking the bond would result in at least one fragment that is too small
+     *         to preserve according to the applied criterion; false if all resulting
+     *         fragments would be large enough to preserve.
+     */
+    protected boolean isFragmentTooSmall(IAtomContainer molecule, IBond bondToBreak, boolean isCriterionForCircularSugars) {
+        //split the detected bond in a copy first to see whether the resulting fragment is large enough
+        float loadFactor = 0.75f; //default load factor for HashMaps
+        //ensuring sufficient initial capacity
+        int atomMapInitCapacity = (int)((molecule.getAtomCount() / loadFactor) + 3.0f);
+        int bondMapInitCapacity = (int)((molecule.getBondCount() / loadFactor) + 3.0f);
+        Map<IAtom, IAtom> inputAtomToAtomCopyMap = new HashMap<>(atomMapInitCapacity);
+        Map<IBond, IBond> inputBondToBondCopyMap = new HashMap<>(bondMapInitCapacity);
+        IAtomContainer moleculeCopy = this.deeperCopy(molecule, inputAtomToAtomCopyMap, inputBondToBondCopyMap);
+        moleculeCopy.removeBond(inputBondToBondCopyMap.get(bondToBreak));
+        //do not split the bond if a resulting fragment is too small
+        for (IAtomContainer fragment : ConnectivityChecker.partitionIntoMolecules(moleculeCopy)) {
+            if (isCriterionForCircularSugars) {
+                if (this.isTooSmallToPreserve(fragment)) {
+                    return true;
+                }
+            } else {
+                //criterion for LINEAR sugars
+                if (fragment.getAtomCount() < this.getLinearSugarCandidateMinSizeSetting()) {
+                    return true;
+                }
+            }
+
+        }
+        return false;
+    }
+}

--- a/misc/extra/src/test/java/org/openscience/cdk/tools/SugarDetectionUtilityTest.java
+++ b/misc/extra/src/test/java/org/openscience/cdk/tools/SugarDetectionUtilityTest.java
@@ -1,0 +1,1691 @@
+/*
+ * Copyright (c) 2025 Jonas Schaub <jonas.schaub@uni-jena.de>
+ *
+ * Contact: cdk-devel@lists.sourceforge.net
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openscience.cdk.tools;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmiFlavor;
+import org.openscience.cdk.smiles.SmilesGenerator;
+import org.openscience.cdk.smiles.SmilesParser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * JUnit test class for testing the functionalities of the SugarDetectionUtility
+ * class.
+ * <p>
+ *     Identifiers starting with 'CHEMBL' refer to molecules in the
+ *     <a href="https://www.ebi.ac.uk/chembl/">ChEMBL database</a>.
+ *     <br>Identifiers starting with 'CNP' refer to molecules in the
+ *     <a href="https://coconut.naturalproducts.net">COCONUT database</a>.
+ *     <br>Identifiers starting with 'CID' refer to molecules in the
+ *     <a href="https://pubchem.ncbi.nlm.nih.gov">PubChem database</a>.
+ * </p>
+ *
+ * @author Jonas Schaub (jonas.schaub@uni-jena.de | jonas-schaub@gmx.de | <a href="https://github.com/JonasSchaub">JonasSchaub on GitHub</a>)
+ */
+class SugarDetectionUtilityTest {
+
+    /**
+     * Tests the correct circular sugar extraction on some examples.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        // Map of input SMILES codes to list of expected aglycone and sugar SMILES codes
+        Map<String, List<String>> testCases = new HashMap<>((int) ((60.0/0.75) + 3.0));
+        //most structures were taken from an earlier version of COCONUT
+        testCases.put(
+                "CC(=O)N[C@H]1[C@H](O[C@H]2[C@H](O)[C@@H](NC(C)=O)[C@@H](OP(=O)(O)OP(=O)(O)OCCC(C)CC/C=C(\\C)CC/C=C(\\C)CC/C=C(\\C)CCC=C(C)C)O[C@@H]2CO)O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO[C@H]3O[C@H](CO[C@H]4O[C@H](CO)[C@@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]5O)[C@H](O)[C@@H]4O)[C@@H](O)[C@H](O[C@H]4O[C@H](CO)[C@@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]5O)[C@H](O)[C@@H]4O)[C@@H]3O)[C@@H](O)[C@H](O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]3O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]3O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O[C@H]4O[C@H](CO)[C@@H](O)[C@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@H]5O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@H]5O)[C@H]4O)[C@@H]3O)[C@@H]2O)[C@@H]1O",
+                Arrays.asList(
+                        "OP(=O)(O)OP(=O)(O)OCCC(C)CC/C=C(\\C)/CC/C=C(\\C)/CC/C=C(\\C)/CCC=C(C)C",
+                        "CC(=O)N[C@H]1[C@H](O[C@H]2[C@H](O)[C@@H](NC(C)=O)[C@H](O[C@@H]2CO)O)O[C@H](CO)[C@@H](O[C@@H]3O[C@H](CO[C@H]4O[C@H](CO[C@H]5O[C@H](CO)[C@@H](O[C@H]6O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]6O)[C@H](O)[C@@H]5O)[C@@H](O)[C@H](O[C@H]7O[C@H](CO)[C@@H](O[C@H]8O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]8O)[C@H](O)[C@@H]7O)[C@@H]4O)[C@@H](O)[C@H](O[C@H]9O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]9O[C@H]%10O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]%10O[C@H]%11O[C@H](CO)[C@@H](O)[C@H](O[C@H]%12O[C@H](CO)[C@@H](O)[C@H](O[C@H]%13O[C@H](CO)[C@@H](O)[C@H](O)[C@H]%13O[C@H]%14O[C@H](CO)[C@@H](O)[C@H](O)[C@H]%14O)[C@H]%12O)[C@@H]%11O)[C@@H]3O)[C@@H]1O"
+                )
+        );
+        testCases.put(
+                "C=CC1C(C[C@@H]2NCCC3=C2NC2=CC=CC=C32)C(C(=O)O)=CO[C@H]1O[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O",
+                Arrays.asList(
+                        "C=CC1C(C[C@@H]2NCCC3=C2NC4=CC=CC=C34)C(C(=O)O)=CO[C@H]1O",
+                        "[C@H]1(O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O)O"
+                )
+        );
+        testCases.put(
+                "CC(N)C(=O)NC(CCC(N)=O)C(=O)NOC1OC(O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "CC(N)C(=O)NC(CCC(N)=O)C(=O)NO",
+                        "C1(OC(O)C(O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "CCCCCC=CC=CC(O)CC=CC=CC(=O)OC1C(O)C(C2=C(O)C=C(O)C=C2CO)OC(CO)C1OC1OC(C)C(O)C(O)C1OC1OC(O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "CCCCCC=CC=CC(O)CC=CC=CC(=O)OC1C(O)C(C2=C(O)C=C(O)C=C2CO)OC(CO)C1O",
+                        "C1(OC(C)C(O)C(O)C1OC2OC(O)C(O)C(O)C2O)O"
+                )
+        );
+        testCases.put(
+                "OC1OC(O)C(O)C1OC1C(OCCCCCCCCCCCCCCCCC)OC(OCCCCCCCCCCC)C(O)C1OC1C(O)C(O)C(O)OC(O)C1O",
+                Arrays.asList(
+                        "OC1C(OCCCCCCCCCCCCCCCCC)OC(OCCCCCCCCCCC)C(O)C1O",
+                        "OC1OC(O)C(O)C1O",
+                        "C1(C(O)C(O)C(O)OC(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "[H]OC1([H])C([H])(OC2=C3C(OC(=O)C4=C3C([H])([H])C([H])([H])C4([H])[H])=C([H])C(=C2[H])C([H])([H])[H])OC([H])(C([H])(O[H])C1([H])O[H])C([H])([H])O[H]",
+                Arrays.asList(
+                        "OC1=C2C(OC(=O)C3=C2C([H])([H])C([H])([H])C3([H])[H])=C([H])C(=C1[H])C([H])([H])[H]",
+                        "[H]OC1([H])C([H])(OC([H])(C([H])(O[H])C1([H])O[H])C([H])([H])O[H])O"
+                )
+        );
+        testCases.put(
+                "O=C(OC1C(OCC2=COC(OC(=O)CC(C)C)C3C2CC(O)C3(O)COC(=O)C)OC(CO)C(O)C1O)C=CC4=CC=C(O)C=C4",
+                Collections.singletonList(
+                        "O=C(OC1C(OCC2=COC(OC(=O)CC(C)C)C3C2CC(O)C3(O)COC(=O)C)OC(CO)C(O)C1O)C=CC4=CC=C(O)C=C4"
+                )
+        );
+        testCases.put(
+                "O=P(O)(O)OCC1OC(OP(=O)(O)O)C(O)C1O",
+                Collections.singletonList(
+                        "O=P(O)(O)OCC1OC(OP(=O)(O)O)C(O)C1O"
+                )
+        );
+        testCases.put(
+                "O=C1OC2C(CCO)CCC3(C=C4C=CCC5C(C=CC(C45)C23)CCCC(C)(CC6=CN=C(N)C=C6)CC=7C=CC=C8C(=O)C9(OC19C(=O)C87)CC(=C(C)CC%10C=%11C=CN=C%12NC(NC)CC(C%12%11)CC%10)CO)NCC",
+                Collections.singletonList(
+                        "O=C1OC2C(CCO)CCC3(C=C4C=CCC5C(C=CC(C45)C23)CCCC(C)(CC6=CN=C(N)C=C6)CC=7C=CC=C8C(=O)C9(OC19C(=O)C87)CC(=C(C)CC%10C=%11C=CN=C%12NC(NC)CC(C%12%11)CC%10)CO)NCC"
+                )
+        );
+        testCases.put(
+                "O=CCC12OC(OC1=O)C3(C)C(C)CCC3(C)C2",
+                Collections.singletonList(
+                        "O=CCC12OC(OC1=O)C3(C)C(C)CCC3(C)C2"
+                )
+        );
+        testCases.put(
+                "O=C(O)C12OC(OC3=CC=4OCC5C6=C(OC5C4C(=C3)C7=CC=CC(O)=C7)C(OC)=C(OC)C=C6CNC)(CO)C(O)C(O)(NCC1NC)C2O",
+                Collections.singletonList(
+                        "O=C(O)C12OC(OC3=CC=4OCC5C6=C(OC5C4C(=C3)C7=CC=CC(O)=C7)C(OC)=C(OC)C=C6CNC)(CO)C(O)C(O)(NCC1NC)C2O"
+                )
+        );
+        testCases.put(
+                "O=C(O)C1OC(OC=2C=CC=3C(=O)[C-](C=[O+]C3C2)C4=CC=C(O)C=C4)C(O)(CNCC(CC=5C=NCC5)C(C)C)C(O)C1O",
+                Collections.singletonList(
+                        "O=C(O)C1OC(OC=2C=CC=3C(=O)[C-](C=[O+]C3C2)C4=CC=C(O)C=C4)C(O)(CNCC(CC=5C=NCC5)C(C)C)C(O)C1O"
+                )
+        );
+        testCases.put(
+                "O=C1OC(C2=COC=C2)CC3(C)C1CCC4(C)C3C5OC(=O)C4(O)C=C5",
+                Collections.singletonList(
+                        "O=C1OC(C2=COC=C2)CC3(C)C1CCC4(C)C3C5OC(=O)C4(O)C=C5"
+                )
+        );
+        testCases.put(
+                "O=C1OC2CC3(OC4(O)C(CC5(OC45C(=O)OC)CCCCCCCCCCCCCCCC)C2(O3)C1)CCCCCCCCCCCCCCCC",
+                Collections.singletonList(
+                        "O=C1OC2CC3(OC4(O)C(CC5(OC45C(=O)OC)CCCCCCCCCCCCCCCC)C2(O3)C1)CCCCCCCCCCCCCCCC"
+                )
+        );
+        testCases.put(
+                "O=C1C2=CC=CC3=C2CN1CC(=O)C4=C(O)C5=C6OC7OC(COC(C=CC6=C(OC)C8=C5C=9C(=CC%10CCCC%10C49)CC8)C%11=CNC=%12C=CC(=CC%12%11)CNC)C(O)C(OC#CC3)C7(O)CO",
+                Collections.singletonList(
+                        "O=C1C2=CC=CC3=C2CN1CC(=O)C4=C(O)C5=C6OC7OC(COC(C=CC6=C(OC)C8=C5C=9C(=CC%10CCCC%10C49)CC8)C%11=CNC=%12C=CC(=CC%12%11)CNC)C(O)C(OC#CC3)C7(O)CO"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(OC1OC(CO)C(O)C(O)C1O)(C)CC(=O)OCC=CC2=CC(OC)=C(OC3OC(CO)C(O)C(O)C3O)C(OC)=C2",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OCC=CC1=CC(OC)=C(O)C(OC)=C1",
+                        "C1(OC(CO)C(O)C(O)C1O)O",
+                        "C1(OC(CO)C(O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OCC1=CC=C(OC2OC(CO)C(O)C(O)C2O)C=C1",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OCC1=CC=C(O)C=C1",
+                        "C1(OC(CO)C(O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(C(=O)O)C(OCC1C(=C)CCC2C(C)(COC(=O)C(CC(=O)O)C(OCC3C(=C)CCC4C(C)(C)CCCC34C)C(=O)OC)CCCC12C)C(=O)OC",
+                Collections.singletonList(
+                        "O=C(O)CC(C(=O)O)C(OCC1C(=C)CCC2C(C)(COC(=O)C(CC(=O)O)C(OCC3C(=C)CCC4C(C)(C)CCCC34C)C(=O)OC)CCCC12C)C(=O)OC"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OC1COC(OC2C(O)C(OC(OC3C(O)C(O)C(OC4CC5CCC6C(CCC7(C)C6CC8OC9(OCC(C)CC9)C(C)C87)C5(C)CC4O)OC3CO)C2OC%10OC(CO)C(O)C(O)C%10O)CO)C(O)C1O",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OC1COC(OC2C(O)C(OC(OC3C(O)C(O)C(OC4CC5CCC6C(CCC7(C)C6CC8OC9(OCC(C)CC9)C(C)C87)C5(C)CC4O)OC3CO)C2O)CO)C(O)C1O",
+                        "C1(OC(CO)C(O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OCC1OC(OCC2OC(OC(=O)C34CCC(C)(C)CC4C5=CCC6C7(C)CCC(O)C(C(=O)OC8OC(CO)C(O)C(O)C8O)(C)C7CCC6(C)C5(C)CC3)C(O)C(OC9OC(CO)C(O)C(O)C9O)C2O)C(OC%10OC(CO)C(O)C(O)C%10O)C(O)C1O",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OCC1OC(OCC2OC(OC(=O)C34CCC(C)(C)CC3C5=CCC6C7(C)CCC(O)C(C(=O)O)(C)C7CCC6(C)C5(C)CC4)C(O)C(O)C2O)C(O)C(O)C1O",
+                        "C1(OC(CO)C(O)C(O)C1O)O",
+                        "C1(OC(CO)C(O)C(O)C1O)O",
+                        "C1(OC(CO)C(O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OC1C(O)C(OC2C3=C(O)C(=CC=C3OC2C(=C)CO)C(=O)C)OC(CO)C1O",
+                Collections.singletonList(
+                        "O=C(O)CC(O)(C)CC(=O)OC1C(O)C(OC2C3=C(O)C(=CC=C3OC2C(=C)CO)C(=O)C)OC(CO)C1O"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OCC1OC(C=2C(O)=CC(O)=C3C(=O)C=C(OC32)C=4C=CC(O)=C(O)C4)C(O)C(O)C1O",
+                Collections.singletonList(
+                        "O=C(O)CC(O)(C)CC(=O)OCC1OC(C=2C(O)=CC(O)=C3C(=O)C=C(OC32)C=4C=CC(O)=C(O)C4)C(O)C(O)C1O"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OCC1(O)COC(OC2C(O)C(OC(C)C2OC3OCC(O)C(OC4OCC(O)C(O)C4O)C3O)OC5C(OC(=O)C67CCC(C)(C)CC7C8=CCC9C%10(C)CC(O)C(OC%11OC(CO)C(O)C(O)C%11O)C(C(=O)O)(C)C%10CCC9(C)C8(CO)CC6)OC(C)C(OC(=O)C=CC%12=CC(OC)=C(OC)C(OC)=C%12)C5OC%13OC(C)C(O)C(O)C%13O)C1O",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OCC1(O)COC(OC2C(O)C(OC(C)C2O)OC3C(OC(=O)C45CCC(C)(C)CC4C6=CCC7C8(C)CC(O)C(O)C(C(=O)O)(C)C8CCC7(C)C6(CO)CC5)OC(C)C(OC(=O)C=CC9=CC(OC)=C(OC)C(OC)=C9)C3O)C1O",
+                        "C1(OCC(O)C(OC2OCC(O)C(O)C2O)C1O)O",
+                        "C1(OC(CO)C(O)C(O)C1O)O",
+                        "C1(OC(C)C(O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "O=C(O)C1OC(O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "",
+                        "O=C(O)C1OC(O)C(O)C(O)C1O"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(C(=O)O)C(OCC1C(=C)CCC2C(C)(C)CCCC12C)C(=O)O",
+                Collections.singletonList(
+                        "O=C(O)CC(C(=O)O)C(OCC1C(=C)CCC2C(C)(C)CCCC12C)C(=O)O"
+                )
+        );
+        testCases.put(
+                "O=C1C=C(OC=2C=C3OC(C)(CCC4CNC(=O)C4)C(OOCC(O)C(O)C(O)C(O)CO)CC3=CC12)C",
+                Collections.singletonList(
+                        "O=C1C=C(OC=2C=C3OC(C)(CCC4CNC(=O)C4)C(OOCC(O)C(O)C(O)C(O)CO)CC3=CC12)C"
+                )
+        );
+        testCases.put(
+                "O=C1C=C(OC=2C1=CC3=C(OC(C)(C)C(OOCC(O)C(O)C(O)C(O)CO)C3)C2[N+]=4C=C5N=CC=C5C4CC)C",
+                Collections.singletonList(
+                        "O=C1C=C(OC=2C1=CC3=C(OC(C)(C)C(OOCC(O)C(O)C(O)C(O)CO)C3)C2[N+]=4C=C5N=CC=C5C4CC)C"
+                )
+        );
+        testCases.put(
+                "O=C1C=C(OC2=CC(OC(=O)C3OC(O)C(O)C(O)C3O)=C(O)C(O)=C12)C=4C=CC(O)=CC4",
+                Arrays.asList(
+                        "O=C1C=C(OC2=CC(O)=C(O)C(O)=C12)C=3C=CC(O)=CC3",
+                        "C1(OC(O)C(O)C(O)C1O)C(=O)O"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C(=O)O)C(C(=O)O)CCCCCCCCCCCCCC",
+                Collections.singletonList(
+                        "O=C(O)CC(O)(C(=O)O)C(C(=O)O)CCCCCCCCCCCCCC"
+                )
+        );
+        testCases.put(
+                "O=CC1(C)C(OC2OC(C(=O)O)C(O)C(OC3OCC(O)C(O)C3O)C2OC4OC(CO)C(O)C(O)C4O)CCC5(C)C6CC=C7C8CC(C)(C)CCC8(C(=O)OC9OC(C)C(OC(=O)CC(O)CC(OC(=O)CC(O)CC(OC%10OC(CO)C(O)C%10O)C(C)CC)C(C)CC)C(O)C9OC%11OC(C)C(OC%12OCC(O)C(O)C%12O)C(O)C%11O)C(O)CC7(C)C6(C)CCC15",
+                Arrays.asList(
+                        "O=CC1(C)C(O)CCC2(C)C3CC=C4C5CC(C)(C)CCC5(C(=O)OC6OC(C)C(OC(=O)CC(O)CC(OC(=O)CC(O)CC(O)C(C)CC)C(C)CC)C(O)C6O)C(O)CC4(C)C3(C)CCC12",
+                        "C1(OC(C(=O)O)C(O)C(OC2OCC(O)C(O)C2O)C1OC3OC(CO)C(O)C(O)C3O)O",
+                        "C1(OC(CO)C(O)C1O)O",
+                        "C1(OC(C)C(OC2OCC(O)C(O)C2O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "O=C(NC1C(O)OC(CO)C(O)C1OC2OC(CO)C(OC)C(O)C2OC3OC(C)C(O)C(O)C3OC)C",
+                Arrays.asList(
+                        "",
+                        "O=C(NC1C(O)OC(CO)C(O)C1OC2OC(CO)C(OC)C(O)C2OC3OC(C)C(O)C(O)C3OC)C"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(C)(O)CC(=O)OCc1ccc(cc1)OC1C(CO)OC(OC(C(=O)OCc2ccc(OC3OC(CO)CC(O)C3O)cc2)C(O)(CC(C)C)C(=O)OC2CCc3cc4cc(O)c(C)c(O)c4c(O)c3C2=O)C(O)C1O",
+                Arrays.asList(
+                        "O=C(O)CC(C)(O)CC(=O)OCC1=CC=C(C=C1)OC2C(CO)OC(OC(C(=O)OCC3=CC=C(O)C=C3)C(O)(CC(C)C)C(=O)OC4CCC5=CC6=CC(O)=C(C)C(O)=C6C(O)=C5C4=O)C(O)C2O",
+                        "C1(OC(CO)CC(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "OCC(O)C(O)C(O)C(O)C1OC(CO)C(O)C(O)C1O",
+                Arrays.asList(
+                        "OCC(O)C(O)C(O)CO",
+                        "C1OC(CO)C(O)C(O)C1O"
+                )
+        );
+        testCases.put(
+                "OCC(O)C(O)C(O)C(O)C(O)C1OC(O)C(O)C(O)C1N",
+                Arrays.asList(
+                        "OCC(O)C(O)C(O)C(O)CO",
+                        "C1OC(O)C(O)C(O)C1N"
+                )
+        );
+        testCases.put(
+                "O=C(O)C1=CC(O)C(O)C(OC(=O)C2C(=CC=3C=C(O)C(OC4OC(CO)C(O)C(O)C4O)=CC3C2C5=CC=C(O)C(O)=C5)C(=O)OCC(O)C(O)C(O)C(O)C(O)CO)C1",
+                Arrays.asList(
+                        "O=C(O)C1=CC(O)C(O)C(OC(=O)C2C(=CC=3C=C(O)C(O)=CC3C2C4=CC=C(O)C(O)=C4)C(=O)OCC(O)C(O)C(O)C(O)C(O)CO)C1",
+                        "C1(OC(CO)C(O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "O=C1N=C2C(=NC=3C=C(C(=CC3N2CC(O)C(O)C(O)COC4OC(CO)C(O)C(O)C4O)C)C)C(=O)N1",
+                Arrays.asList(
+                        "O=C1N=C2C(=NC=3C=C(C(=CC3N2CC(O)C(O)C(O)CO)C)C)C(=O)N1",
+                        "C1(OC(CO)C(O)C(O)C1O)O"
+                )
+        );
+        testCases.put(
+                "O=C(C1(CC2=C3C=CC4C5(CCC(C(CO)(C5CCC4(C3(CC(C2(CC1)CO)O)C)C)C)OC6OC(C(C(C6O)OC7OC(C(C(C7O)O)O)CO)O)C)C)C)OCC(C(C(CO)O)O)O",
+                Arrays.asList(
+                        "O=C(C1(CC2=C3C=CC4C5(CCC(C(CO)(C5CCC4(C3(CC(C2(CC1)CO)O)C)C)C)O)C)C)OCC(C(C(CO)O)O)O",
+                        "C1(OC(C(C(C1O)OC2OC(C(C(C2O)O)O)CO)O)C)O"
+                )
+        );
+        testCases.put(
+                "CC(CCC=C(C)CCC=C(C)CCC=C(C)CCC=C(C)C)CCOP(=O)(O)OP(=O)(O)OC1C(C(C(C(O1)CO)OC2C(C(C(C(O2)CO)OC3C(C(C(C(O3)COC4C(C(C(C(O4)COC5C(C(C(C(O5)CO)OC6C(C(C(C(O6)CO)O)O)O)O)O)O)OC7C(C(C(C(O7)CO)OC8C(C(C(C(O8)CO)O)O)O)O)O)O)O)OC9C(C(C(C(O9)CO)O)O)OC1C(C(C(C(O1)CO)O)O)OC1C(C(C(C(O1)CO)O)OC1C(C(C(C(O1)CO)O)OC1C(C(C(C(O1)CO)O)O)OC1C(C(C(C(O1)CO)O)O)O)O)O)O)O)NC(=O)C)O)NC(=O)C",
+                Arrays.asList(
+                        "CC(CCC=C(C)CCC=C(C)CCC=C(C)CCC=C(C)C)CCOP(=O)(O)OP(=O)(O)O",
+                        "C1(C(C(C(C(O1)CO)OC2C(C(C(C(O2)CO)OC3C(C(C(C(O3)COC4C(C(C(C(O4)COC5C(C(C(C(O5)CO)OC6C(C(C(C(O6)CO)O)O)O)O)O)O)OC7C(C(C(C(O7)CO)OC8C(C(C(C(O8)CO)O)O)O)O)O)O)O)OC9C(C(C(C(O9)CO)O)O)OC%10C(C(C(C(O%10)CO)O)O)OC%11C(C(C(C(O%11)CO)O)OC%12C(C(C(C(O%12)CO)O)OC%13C(C(C(C(O%13)CO)O)O)OC%14C(C(C(C(O%14)CO)O)O)O)O)O)O)O)NC(=O)C)O)NC(=O)C)O"
+                )
+        );
+        testCases.put(
+                "O=C(C=CC1=CC=C(O)C=C1)C=2C(=O)C(C(=O)C(O)(C2O)C3OC(CO)C(O)C(O)C3O)C(O)C4OCC(O)C(O)C4O",
+                Arrays.asList(
+                        "O=C(C=CC1=CC=C(O)C=C1)C=2C(=O)C(C(=O)C(O)C2O)CO",
+                        "C1OC(CO)C(O)C(O)C1O",
+                        "C1OCC(O)C(O)C1O"
+                )
+        );
+        // CNP0194094.4
+        testCases.put(
+                "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O.N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O.O=S(=O)(O)O.[Cl-].[Cl-].[K+].[K+]",
+                Arrays.asList(
+                        "O=S(=O)(O)O.[Cl-].[Cl-].[K+].[K+]",
+                        "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O",
+                        "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O"
+                )
+        );
+        // CNP0194094.5
+        testCases.put(
+                "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O.N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O.O=S(=O)(O)O.[Cl-].[Cl-].[Na+].[Na+]",
+                Arrays.asList(
+                        "O=S(=O)(O)O.[Cl-].[Cl-].[Na+].[Na+]",
+                        "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O",
+                        "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O"
+                )
+        );
+        // CNP0491043.0
+        testCases.put(
+                "CCC(O)COCC1OC(OC2C(COCC(O)CC)OC(OCC(O)CC)C(OCC(O)CC)C2OCC(O)CC)C(OCC(O)CC)C(OCC(O)CC)C1OCC(O)CC.COCC1OC(OC2C(COC)OC(OC)C(OC)C2OC)C(OC)C(OC)C1OC",
+                Arrays.asList(
+                        "CCC(O)COCC1OC(OC2C(COCC(O)CC)OC(OCC(O)CC)C(OCC(O)CC)C2OCC(O)CC)C(OCC(O)CC)C(OCC(O)CC)C1OCC(O)CC",
+                        "COCC1OC(OC2C(COC)OC(OC)C(OC)C2OC)C(OC)C(OC)C1OC"
+                )
+        );
+        // CNP0585724.0
+        testCases.put(
+                "COC1=CC(C(=O)OC2C3C=COC(C)C3C3(CO)OC23)=CC=C1O.OCC1OC(O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "COC1=CC(C(=O)OC2C3C=COC(C)C3C4(CO)OC24)=CC=C1O",
+                        "OCC1OC(O)C(O)C(O)C1O"
+                )
+        );
+        // CNP0570079.0
+        testCases.put(
+                "CC(=O)OCC1OC(OC2C(COC(C)=O)OC(OC(C)=O)C(OC(C)=O)C2OC(C)=O)C(OC(C)=O)C(OC(C)=O)C1OC(C)=O.CCC(=O)OCC1OC(OC2C(COC(=O)CC)OC(OC(=O)CC)C(OC(=O)CC)C2OC(=O)CC)C(OC(=O)CC)C(OC(=O)CC)C1OC(=O)CC.OCC1OC(OC2C(CO)OC(O)C(O)C2O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "CC(=O)OCC1OC(OC2C(COC(C)=O)OC(OC(C)=O)C(OC(C)=O)C2OC(C)=O)C(OC(C)=O)C(OC(C)=O)C1OC(C)=O.CCC(=O)OCC1OC(OC2C(COC(=O)CC)OC(OC(=O)CC)C(OC(=O)CC)C2OC(=O)CC)C(OC(=O)CC)C(OC(=O)CC)C1OC(=O)CC",
+                        "OCC1OC(OC2C(CO)OC(O)C(O)C2O)C(O)C(O)C1O"
+                )
+        );
+        // CNP0577894.0
+        testCases.put(
+                "O=C([O-])C1OC(O)C(O)C(O)C1O.[Na+]",
+                Arrays.asList(
+                        "[Na+]",
+                        "O=C([O-])C1OC(O)C(O)C(O)C1O"
+                )
+        );
+        // CNP0495754.0
+        testCases.put(
+                "CC1OC(O)C(O)C(N)C1O.CNC1=CC=C(C(C)=O)C=C1",
+                Arrays.asList(
+                        "CNC1=CC=C(C(C)=O)C=C1",
+                        "CC1OC(O)C(O)C(N)C1O"
+                )
+        );
+        // CNP0305679.8
+        testCases.put(
+                "CCCCCC(=O)O.OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O",
+                Arrays.asList(
+                        "CCCCCC(=O)O",
+                        "OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O"
+                )
+        );
+        // CNP0305679.9
+        testCases.put(
+                "CCCCCCCC(=O)O.OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O",
+                Arrays.asList(
+                        "CCCCCCCC(=O)O",
+                        "OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O"
+                )
+        );
+        // Process each test case
+        for (Map.Entry<String, List<String>> entry : testCases.entrySet()) {
+            String inputSmiles = entry.getKey();
+            List<String> expectedSmilesList = entry.getValue();
+            List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(inputSmiles), true, false, false);
+            List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+            Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+        }
+    }
+
+    /**
+     * Tests the correct circular sugar extraction with R saturation on some examples.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionWithRTestAsserting() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        // Map of input SMILES codes to list of expected aglycone and sugar SMILES codes
+        Map<String, List<String>> testCases = new HashMap<>((int) ((60.0/0.75) + 3.0));
+        //most structures were taken from an earlier version of COCONUT
+        testCases.put(
+                "CC(=O)N[C@H]1[C@H](O[C@H]2[C@H](O)[C@@H](NC(C)=O)[C@@H](OP(=O)(O)OP(=O)(O)OCCC(C)CC/C=C(\\C)CC/C=C(\\C)CC/C=C(\\C)CCC=C(C)C)O[C@@H]2CO)O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO[C@H]3O[C@H](CO[C@H]4O[C@H](CO)[C@@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]5O)[C@H](O)[C@@H]4O)[C@@H](O)[C@H](O[C@H]4O[C@H](CO)[C@@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]5O)[C@H](O)[C@@H]4O)[C@@H]3O)[C@@H](O)[C@H](O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]3O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]3O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O[C@H]4O[C@H](CO)[C@@H](O)[C@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@H]5O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@H]5O)[C@H]4O)[C@@H]3O)[C@@H]2O)[C@@H]1O",
+                Arrays.asList(
+                        "O(P(=O)(O)OP(=O)(O)OCCC(C)CC/C=C(\\C)/CC/C=C(\\C)/CC/C=C(\\C)/CCC=C(C)C)*",
+                        "CC(=O)N[C@H]1[C@H](O[C@H]2[C@H](O)[C@@H](NC(C)=O)[C@H](O[C@@H]2CO)O*)O[C@H](CO)[C@@H](O[C@@H]3O[C@H](CO[C@H]4O[C@H](CO[C@H]5O[C@H](CO)[C@@H](O[C@H]6O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]6O)[C@H](O)[C@@H]5O)[C@@H](O)[C@H](O[C@H]7O[C@H](CO)[C@@H](O[C@H]8O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]8O)[C@H](O)[C@@H]7O)[C@@H]4O)[C@@H](O)[C@H](O[C@H]9O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]9O[C@H]%10O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]%10O[C@H]%11O[C@H](CO)[C@@H](O)[C@H](O[C@H]%12O[C@H](CO)[C@@H](O)[C@H](O[C@H]%13O[C@H](CO)[C@@H](O)[C@H](O)[C@H]%13O[C@H]%14O[C@H](CO)[C@@H](O)[C@H](O)[C@H]%14O)[C@H]%12O)[C@@H]%11O)[C@@H]3O)[C@@H]1O"
+                )
+        );
+        testCases.put(
+                "C=CC1C(C[C@@H]2NCCC3=C2NC2=CC=CC=C32)C(C(=O)O)=CO[C@H]1O[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O",
+                Arrays.asList(
+                        "C=CC1C(C[C@@H]2NCCC3=C2NC4=CC=CC=C34)C(C(=O)O)=CO[C@H]1O*",
+                        "[C@H]1(O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O)O*"
+                )
+        );
+        testCases.put(
+                "CC(N)C(=O)NC(CCC(N)=O)C(=O)NOC1OC(O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "CC(N)C(=O)NC(CCC(N)=O)C(=O)NO*",
+                        "C1(OC(O)C(O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "CCCCCC=CC=CC(O)CC=CC=CC(=O)OC1C(O)C(C2=C(O)C=C(O)C=C2CO)OC(CO)C1OC1OC(C)C(O)C(O)C1OC1OC(O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "CCCCCC=CC=CC(O)CC=CC=CC(=O)OC1C(O)C(C2=C(O)C=C(O)C=C2CO)OC(CO)C1O*",
+                        "C1(OC(C)C(O)C(O)C1OC2OC(O)C(O)C(O)C2O)O*"
+                )
+        );
+        testCases.put(
+                "OC1OC(O)C(O)C1OC1C(OCCCCCCCCCCCCCCCCC)OC(OCCCCCCCCCCC)C(O)C1OC1C(O)C(O)C(O)OC(O)C1O",
+                Arrays.asList(
+                        "O(C1C(OCCCCCCCCCCCCCCCCC)OC(OCCCCCCCCCCC)C(O)C1O*)*",
+                        "OC1OC(O)C(O)C1O*",
+                        "C1(C(O)C(O)C(O)OC(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "[H]OC1([H])C([H])(OC2=C3C(OC(=O)C4=C3C([H])([H])C([H])([H])C4([H])[H])=C([H])C(=C2[H])C([H])([H])[H])OC([H])(C([H])(O[H])C1([H])O[H])C([H])([H])O[H]",
+                Arrays.asList(
+                        "O(C1=C2C(OC(=O)C3=C2C([H])([H])C([H])([H])C3([H])[H])=C([H])C(=C1[H])C([H])([H])[H])*",
+                        "[H]OC1([H])C([H])(OC([H])(C([H])(O[H])C1([H])O[H])C([H])([H])O[H])O*"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(OC1OC(CO)C(O)C(O)C1O)(C)CC(=O)OCC=CC2=CC(OC)=C(OC3OC(CO)C(O)C(O)C3O)C(OC)=C2",
+                Arrays.asList(
+                        "O=C(O)CC(O*)(C)CC(=O)OCC=CC1=CC(OC)=C(O*)C(OC)=C1",
+                        "C1(OC(CO)C(O)C(O)C1O)O*",
+                        "C1(OC(CO)C(O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OCC1=CC=C(OC2OC(CO)C(O)C(O)C2O)C=C1",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OCC1=CC=C(O*)C=C1",
+                        "C1(OC(CO)C(O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OC1COC(OC2C(O)C(OC(OC3C(O)C(O)C(OC4CC5CCC6C(CCC7(C)C6CC8OC9(OCC(C)CC9)C(C)C87)C5(C)CC4O)OC3CO)C2OC%10OC(CO)C(O)C(O)C%10O)CO)C(O)C1O",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OC1COC(OC2C(O)C(OC(OC3C(O)C(O)C(OC4CC5CCC6C(CCC7(C)C6CC8OC9(OCC(C)CC9)C(C)C87)C5(C)CC4O)OC3CO)C2O*)CO)C(O)C1O",
+                        "C1(OC(CO)C(O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OCC1OC(OCC2OC(OC(=O)C34CCC(C)(C)CC4C5=CCC6C7(C)CCC(O)C(C(=O)OC8OC(CO)C(O)C(O)C8O)(C)C7CCC6(C)C5(C)CC3)C(O)C(OC9OC(CO)C(O)C(O)C9O)C2O)C(OC%10OC(CO)C(O)C(O)C%10O)C(O)C1O",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OCC1OC(OCC2OC(OC(=O)C34CCC(C)(C)CC3C5=CCC6C7(C)CCC(O)C(C(=O)O*)(C)C7CCC6(C)C5(C)CC4)C(O)C(O*)C2O)C(O*)C(O)C1O",
+                        "C1(OC(CO)C(O)C(O)C1O)O*",
+                        "C1(OC(CO)C(O)C(O)C1O)O*",
+                        "C1(OC(CO)C(O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "O=C(O)CC(O)(C)CC(=O)OCC1(O)COC(OC2C(O)C(OC(C)C2OC3OCC(O)C(OC4OCC(O)C(O)C4O)C3O)OC5C(OC(=O)C67CCC(C)(C)CC7C8=CCC9C%10(C)CC(O)C(OC%11OC(CO)C(O)C(O)C%11O)C(C(=O)O)(C)C%10CCC9(C)C8(CO)CC6)OC(C)C(OC(=O)C=CC%12=CC(OC)=C(OC)C(OC)=C%12)C5OC%13OC(C)C(O)C(O)C%13O)C1O",
+                Arrays.asList(
+                        "O=C(O)CC(O)(C)CC(=O)OCC1(O)COC(OC2C(O)C(OC(C)C2O*)OC3C(OC(=O)C45CCC(C)(C)CC4C6=CCC7C8(C)CC(O)C(O*)C(C(=O)O)(C)C8CCC7(C)C6(CO)CC5)OC(C)C(OC(=O)C=CC9=CC(OC)=C(OC)C(OC)=C9)C3O*)C1O",
+                        "C1(OCC(O)C(OC2OCC(O)C(O)C2O)C1O)O*",
+                        "C1(OC(CO)C(O)C(O)C1O)O*",
+                        "C1(OC(C)C(O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "O=C(O)C1OC(O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "",
+                        "O=C(O)C1OC(O)C(O)C(O)C1O")
+        );
+        testCases.put(
+                "O=C1C=C(OC2=CC(OC(=O)C3OC(O)C(O)C(O)C3O)=C(O)C(O)=C12)C=4C=CC(O)=CC4",
+                Arrays.asList(
+                        "O=C1C=C(OC2=CC(O*)=C(O)C(O)=C12)C=3C=CC(O)=CC3",
+                        "C1(OC(O)C(O)C(O)C1O)C(=O)O*"
+                )
+        );
+        testCases.put(
+                "O=CC1(C)C(OC2OC(C(=O)O)C(O)C(OC3OCC(O)C(O)C3O)C2OC4OC(CO)C(O)C(O)C4O)CCC5(C)C6CC=C7C8CC(C)(C)CCC8(C(=O)OC9OC(C)C(OC(=O)CC(O)CC(OC(=O)CC(O)CC(OC%10OC(CO)C(O)C%10O)C(C)CC)C(C)CC)C(O)C9OC%11OC(C)C(OC%12OCC(O)C(O)C%12O)C(O)C%11O)C(O)CC7(C)C6(C)CCC15",
+                Arrays.asList(
+                        "O=CC1(C)C(O*)CCC2(C)C3CC=C4C5CC(C)(C)CCC5(C(=O)OC6OC(C)C(OC(=O)CC(O)CC(OC(=O)CC(O)CC(O*)C(C)CC)C(C)CC)C(O)C6O*)C(O)CC4(C)C3(C)CCC12",
+                        "C1(OC(C(=O)O)C(O)C(OC2OCC(O)C(O)C2O)C1OC3OC(CO)C(O)C(O)C3O)O*",
+                        "C1(OC(CO)C(O)C1O)O*",
+                        "C1(OC(C)C(OC2OCC(O)C(O)C2O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "O=C(NC1C(O)OC(CO)C(O)C1OC2OC(CO)C(OC)C(O)C2OC3OC(C)C(O)C(O)C3OC)C",
+                Arrays.asList(
+                        "",
+                        "O=C(NC1C(O)OC(CO)C(O)C1OC2OC(CO)C(OC)C(O)C2OC3OC(C)C(O)C(O)C3OC)C")
+        );
+        testCases.put(
+                "O=C(O)CC(C)(O)CC(=O)OCc1ccc(cc1)OC1C(CO)OC(OC(C(=O)OCc2ccc(OC3OC(CO)CC(O)C3O)cc2)C(O)(CC(C)C)C(=O)OC2CCc3cc4cc(O)c(C)c(O)c4c(O)c3C2=O)C(O)C1O",
+                Arrays.asList(
+                        "O=C(O)CC(C)(O)CC(=O)OCC1=CC=C(C=C1)OC2C(CO)OC(OC(C(=O)OCC3=CC=C(O*)C=C3)C(O)(CC(C)C)C(=O)OC4CCC5=CC6=CC(O)=C(C)C(O)=C6C(O)=C5C4=O)C(O)C2O",
+                        "C1(OC(CO)CC(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "OCC(O)C(O)C(O)C(O)C1OC(CO)C(O)C(O)C1O",
+                Arrays.asList(
+                        "OCC(O)C(O)C(O)C(O)*",
+                        "C1(OC(CO)C(O)C(O)C1O)*"
+                )
+        );
+        testCases.put(
+                "OCC(O)C(O)C(O)C(O)C(O)C1OC(O)C(O)C(O)C1N",
+                Arrays.asList(
+                        "OCC(O)C(O)C(O)C(O)C(O)*",
+                        "C1(OC(O)C(O)C(O)C1N)*"
+                )
+        );
+        testCases.put(
+                "O=C(O)C1=CC(O)C(O)C(OC(=O)C2C(=CC=3C=C(O)C(OC4OC(CO)C(O)C(O)C4O)=CC3C2C5=CC=C(O)C(O)=C5)C(=O)OCC(O)C(O)C(O)C(O)C(O)CO)C1",
+                Arrays.asList(
+                        "O=C(O)C1=CC(O)C(O)C(OC(=O)C2C(=CC=3C=C(O)C(O*)=CC3C2C4=CC=C(O)C(O)=C4)C(=O)OCC(O)C(O)C(O)C(O)C(O)CO)C1",
+                        "C1(OC(CO)C(O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "O=C1N=C2C(=NC=3C=C(C(=CC3N2CC(O)C(O)C(O)COC4OC(CO)C(O)C(O)C4O)C)C)C(=O)N1",
+                Arrays.asList(
+                        "O=C1N=C2C(=NC=3C=C(C(=CC3N2CC(O)C(O)C(O)CO*)C)C)C(=O)N1",
+                        "C1(OC(CO)C(O)C(O)C1O)O*"
+                )
+        );
+        testCases.put(
+                "O=C(C1(CC2=C3C=CC4C5(CCC(C(CO)(C5CCC4(C3(CC(C2(CC1)CO)O)C)C)C)OC6OC(C(C(C6O)OC7OC(C(C(C7O)O)O)CO)O)C)C)C)OCC(C(C(CO)O)O)O",
+                Arrays.asList(
+                        "O=C(C1(CC2=C3C=CC4C5(CCC(C(CO)(C5CCC4(C3(CC(C2(CC1)CO)O)C)C)C)O*)C)C)OCC(C(C(CO)O)O)O",
+                        "C1(OC(C(C(C1O)OC2OC(C(C(C2O)O)O)CO)O)C)O*"
+                )
+        );
+        testCases.put(
+                "CC(CCC=C(C)CCC=C(C)CCC=C(C)CCC=C(C)C)CCOP(=O)(O)OP(=O)(O)OC1C(C(C(C(O1)CO)OC2C(C(C(C(O2)CO)OC3C(C(C(C(O3)COC4C(C(C(C(O4)COC5C(C(C(C(O5)CO)OC6C(C(C(C(O6)CO)O)O)O)O)O)O)OC7C(C(C(C(O7)CO)OC8C(C(C(C(O8)CO)O)O)O)O)O)O)O)OC9C(C(C(C(O9)CO)O)O)OC1C(C(C(C(O1)CO)O)O)OC1C(C(C(C(O1)CO)O)OC1C(C(C(C(O1)CO)O)OC1C(C(C(C(O1)CO)O)O)OC1C(C(C(C(O1)CO)O)O)O)O)O)O)O)NC(=O)C)O)NC(=O)C",
+                Arrays.asList(
+                        "CC(CCC=C(C)CCC=C(C)CCC=C(C)CCC=C(C)C)CCOP(=O)(O)OP(=O)(O)O*",
+                        "C1(C(C(C(C(O1)CO)OC2C(C(C(C(O2)CO)OC3C(C(C(C(O3)COC4C(C(C(C(O4)COC5C(C(C(C(O5)CO)OC6C(C(C(C(O6)CO)O)O)O)O)O)O)OC7C(C(C(C(O7)CO)OC8C(C(C(C(O8)CO)O)O)O)O)O)O)O)OC9C(C(C(C(O9)CO)O)O)OC%10C(C(C(C(O%10)CO)O)O)OC%11C(C(C(C(O%11)CO)O)OC%12C(C(C(C(O%12)CO)O)OC%13C(C(C(C(O%13)CO)O)O)OC%14C(C(C(C(O%14)CO)O)O)O)O)O)O)O)NC(=O)C)O)NC(=O)C)O*"
+                )
+        );
+        testCases.put(
+                "O=C(C=CC1=CC=C(O)C=C1)C=2C(=O)C(C(=O)C(O)(C2O)C3OC(CO)C(O)C(O)C3O)C(O)C4OCC(O)C(O)C4O",
+                Arrays.asList(
+                        "O=C(C=CC1=CC=C(O)C=C1)C=2C(=O)C(C(=O)C(O)(C2O)*)C(O)*",
+                        "C1(OC(CO)C(O)C(O)C1O)*",
+                        "C1(OCC(O)C(O)C1O)*"
+                )
+        );
+        testCases.put(
+                "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O.N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O.O=S(=O)(O)O.[Cl-].[Cl-].[K+].[K+]",
+                Arrays.asList(
+                        "O=S(=O)(O)O.[Cl-].[Cl-].[K+].[K+]",
+                        "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O",
+                        "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O"
+                )
+        );
+        testCases.put(
+                "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O.N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O.O=S(=O)(O)O.[Cl-].[Cl-].[Na+].[Na+]",
+                Arrays.asList(
+                        "O=S(=O)(O)O.[Cl-].[Cl-].[Na+].[Na+]",
+                        "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O",
+                        "N[C@H]1C(O)O[C@H](CO)[C@@H](O)[C@@H]1O"
+                )
+        );
+        testCases.put(
+                "CCC(O)COCC1OC(OC2C(COCC(O)CC)OC(OCC(O)CC)C(OCC(O)CC)C2OCC(O)CC)C(OCC(O)CC)C(OCC(O)CC)C1OCC(O)CC.COCC1OC(OC2C(COC)OC(OC)C(OC)C2OC)C(OC)C(OC)C1OC",
+                Arrays.asList(
+                        "CCC(O)COCC1OC(OC2C(COCC(O)CC)OC(OCC(O)CC)C(OCC(O)CC)C2OCC(O)CC)C(OCC(O)CC)C(OCC(O)CC)C1OCC(O)CC",
+                        "COCC1OC(OC2C(COC)OC(OC)C(OC)C2OC)C(OC)C(OC)C1OC"
+                )
+        );
+        testCases.put(
+                "COC1=CC(C(=O)OC2C3C=COC(C)C3C3(CO)OC23)=CC=C1O.OCC1OC(O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "COC1=CC(C(=O)OC2C3C=COC(C)C3C4(CO)OC24)=CC=C1O",
+                        "OCC1OC(O)C(O)C(O)C1O"
+                )
+        );
+        testCases.put(
+                "CC(=O)OCC1OC(OC2C(COC(C)=O)OC(OC(C)=O)C(OC(C)=O)C2OC(C)=O)C(OC(C)=O)C(OC(C)=O)C1OC(C)=O.CCC(=O)OCC1OC(OC2C(COC(=O)CC)OC(OC(=O)CC)C(OC(=O)CC)C2OC(=O)CC)C(OC(=O)CC)C(OC(=O)CC)C1OC(=O)CC.OCC1OC(OC2C(CO)OC(O)C(O)C2O)C(O)C(O)C1O",
+                Arrays.asList(
+                        "CC(=O)OCC1OC(OC2C(COC(C)=O)OC(OC(C)=O)C(OC(C)=O)C2OC(C)=O)C(OC(C)=O)C(OC(C)=O)C1OC(C)=O.CCC(=O)OCC1OC(OC2C(COC(=O)CC)OC(OC(=O)CC)C(OC(=O)CC)C2OC(=O)CC)C(OC(=O)CC)C(OC(=O)CC)C1OC(=O)CC",
+                        "OCC1OC(OC2C(CO)OC(O)C(O)C2O)C(O)C(O)C1O"
+                )
+        );
+        testCases.put(
+                "O=C([O-])C1OC(O)C(O)C(O)C1O.[Na+]",
+                Arrays.asList(
+                        "[Na+]",
+                        "O=C([O-])C1OC(O)C(O)C(O)C1O"
+                )
+        );
+        testCases.put(
+                "CC1OC(O)C(O)C(N)C1O.CNC1=CC=C(C(C)=O)C=C1",
+                Arrays.asList(
+                        "CNC1=CC=C(C(C)=O)C=C1",
+                        "CC1OC(O)C(O)C(N)C1O"
+                )
+        );
+        testCases.put(
+                "CCCCCC(=O)O.OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O",
+                Arrays.asList(
+                        "CCCCCC(=O)O",
+                        "OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O"
+                )
+        );
+        testCases.put(
+                "CCCCCCCC(=O)O.OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O",
+                Arrays.asList(
+                        "CCCCCCCC(=O)O",
+                        "OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O"
+                )
+        );
+        // Process each test case
+        for (Map.Entry<String, List<String>> entry : testCases.entrySet()) {
+            String inputSmiles = entry.getKey();
+            List<String> expectedSmilesList = entry.getValue();
+            List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(inputSmiles), true, false, true);
+            List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+            Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+        }
+    }
+
+    /**
+     * Test for correct circular sugar extraction from strictosidinic acid, a glycoside with a typical beta-D-glucose sugar moiety.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionStrictosidinicAcidTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0225072.2
+        IAtomContainer mol = smiPar.parseSmiles("C=CC1C(C[C@@H]2NCCC3=C2NC2=CC=CC=C32)C(C(=O)O)=CO[C@H]1O[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //aglycone
+        Assertions.assertEquals("C=CC1C(C[C@@H]2NCCC3=C2NC4=CC=CC=C34)C(C(=O)O)=CO[C@H]1O", smiGen.create(candidates.get(0)));
+        //beta-D-glucose
+        Assertions.assertEquals("[C@H]1(O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O)O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct circular sugar extraction from natural product CNP0580945.1.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionCNP0580945_1Test() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0580945.1
+        IAtomContainer mol = smiPar.parseSmiles("CC(=O)N[C@H]1[C@H](O[C@@H]2C3CO[C@H](O3)[C@H](NC(C)=O)[C@H]2O[C@H](C)C(=O)N[C@@H](C)C(=O)N[C@H](CCC(=O)N[C@@H](CCC[C@@H](N)C(=O)O)C(=O)N[C@H](C)C(=O)O)C(=O)O)O[C@H](CO)[C@@H](O)[C@@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //aglycone
+        Assertions.assertEquals("O[C@@H]1C2CO[C@H](O2)[C@H](NC(C)=O)[C@H]1O[C@H](C)C(=O)N[C@@H](C)C(=O)N[C@H](CCC(=O)N[C@@H](CCC[C@@H](N)C(=O)O)C(=O)N[C@H](C)C(=O)O)C(=O)O", smiGen.create(candidates.get(0)));
+        //N-Acetyl-beta-D-glucosamine
+        Assertions.assertEquals("CC(=O)N[C@H]1[C@@H](O[C@H](CO)[C@@H](O)[C@@H]1O)O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from Fusacandin B (CNP0295326.2).
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionFusacandin_BTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0295326.2
+        IAtomContainer mol = smiPar.parseSmiles("CCCCC/C=C/C=C/C(O)C/C=C/C=C/C(=O)O[C@@H]1[C@@H](O)[C@H](C2=C(O)C=C(O)C=C2CO)O[C@H](CO)[C@H]1O[C@@H]1O[C@H](CO)[C@H](O)[C@H](O)[C@H]1O[C@@H]1O[C@H](CO)[C@H](O)[C@H](O)[C@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //aglycone
+        Assertions.assertEquals("CCCCC/C=C/C=C/C(O)C/C=C/C=C/C(=O)O[C@@H]1[C@@H](O)[C@H](C2=C(O)C=C(O)C=C2CO)O[C@H](CO)[C@H]1O", smiGen.create(candidates.get(0)));
+        //2-O-beta-D-galactopyranosyl-beta-D-galactopyranose
+        Assertions.assertEquals("[C@H]1(O[C@H](CO)[C@H](O)[C@H](O)[C@H]1O[C@@H]2O[C@H](CO)[C@H](O)[C@H](O)[C@H]2O)O", smiGen.create(candidates.get(1)));
+        sdu.setRemoveOnlyTerminalSugarsSetting(false);
+        candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //disconnected aglycone
+        Assertions.assertEquals("CCCCC/C=C/C=C/C(O)C/C=C/C=C/C(=O)O.C1=C(O)C=C(O)C=C1CO", smiGen.create(candidates.get(0)));
+        //triple sugar
+        Assertions.assertEquals("[C@H]1([C@@H](O)CO[C@H](CO)[C@H]1O[C@@H]2O[C@H](CO)[C@H](O)[C@H](O)[C@H]2O[C@@H]3O[C@H](CO)[C@H](O)[C@H](O)[C@H]3O)O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from CID 131999265.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionCID131999265Test() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CID	131999265
+        IAtomContainer mol = smiPar.parseSmiles("CCCCCCCCCCCCOCC(COCCOCC(COCCCCCCCCCCCC)O[C@H]1[C@H](C([C@@H](C(O1)CO)O)O)O)O[C@H]2[C@H](C([C@@H](C(O2)CO)O)O)O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(3, candidates.size());
+        //aglycone
+        Assertions.assertEquals("CCCCCCCCCCCCOCC(COCCOCC(COCCCCCCCCCCCC)O)O", smiGen.create(candidates.get(0)));
+        //sugar 1, CID	58265196 (underdefined hexopyranose)
+        Assertions.assertEquals("[C@@H]1([C@H](C([C@@H](C(O1)CO)O)O)O)O", smiGen.create(candidates.get(1)));
+        //sugar 2 (the same)
+        Assertions.assertEquals("[C@@H]1([C@H](C([C@@H](C(O1)CO)O)O)O)O", smiGen.create(candidates.get(2)));
+    }
+
+    /**
+     * Test for correct sugar extraction from CNP0381981.2.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionCNP0381981_2Test() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0381981.2
+        IAtomContainer mol = smiPar.parseSmiles("CC1=C(O[C@@H]2O[C@H](CO)[C@@H](O)[C@H](O)[C@H]2O)C=CC2=C1OC(=O)C1=C2CCCC1");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //aglycone
+        Assertions.assertEquals("CC1=C(O)C=CC2=C1OC(=O)C3=C2CCCC3", smiGen.create(candidates.get(0)));
+        //beta-D-glucose
+        Assertions.assertEquals("[C@H]1(O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O)O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from CNP0151033.2 containing a non-terminal sugar.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionCNP0151033_2NonTerminalTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0151033.2
+        IAtomContainer mol = smiPar.parseSmiles("CC(=O)OC[C@]1(O)[C@H]2[C@H](OC(=O)CC(C)C)OC=C(CO[C@@H]3O[C@H](CO)[C@@H](O)[C@H](O)[C@H]3OC(=O)/C=C/C3=CC=C(O)C=C3)[C@H]2C[C@@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        sdu.setRemoveOnlyTerminalSugarsSetting(false);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //disconnected(!) aglycone
+        Assertions.assertEquals("CC(=O)OC[C@]1(O)[C@H]2[C@H](OC(=O)CC(C)C)OC=C(CO)[C@H]2C[C@@H]1O.OC(=O)/C=C/C1=CC=C(O)C=C1", smiGen.create(candidates.get(0)));
+        //beta-D-glucose
+        Assertions.assertEquals("[C@H]1(O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O)O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from CNP0125332.1, ribose bisphosphate, which should be recognized as a sugar completely.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionRiboseBisPhosphateTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0125332.1
+        IAtomContainer mol = smiPar.parseSmiles("O=P(O)(O)OC[C@H]1O[C@H](OP(=O)(O)O)[C@H](O)[C@@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        sdu.setPreservationModeThresholdSetting(7);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //empty aglycone
+        Assertions.assertEquals("", smiGen.create(candidates.get(0)));
+        //Ribose 1,5-bisphosphate
+        Assertions.assertEquals("O=P(O)(O)OC[C@H]1O[C@H](OP(=O)(O)O)[C@H](O)[C@@H]1O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from CNP0104886.1, which contains a sugar acid.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionCNP0104886_1Test() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0104886.1
+        IAtomContainer mol = smiPar.parseSmiles("CNC(=N)NC[C@H](CNC[C@]1(O)[C@H](OC2=CC=C3C(=O)C(C4=CC=C(O)C=C4)=COC3=C2)O[C@H](C(=O)O)[C@@H](O)[C@@H]1O)C(C)C");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        sdu.setRemoveOnlyTerminalSugarsSetting(false);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //disconnected aglycone
+        Assertions.assertEquals("CNC(=N)NC[C@H](CNC)C(C)C.OC1=CC=C2C(=O)C(C3=CC=C(O)C=C3)=COC2=C1", smiGen.create(candidates.get(0)));
+        //sugar acid
+        Assertions.assertEquals("[C@H]1(O)[C@@H](O[C@H](C(=O)O)[C@@H](O)[C@@H]1O)O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from Tangshenoside I (CNP0218440.3), which contains two beta-D-glucose moieties.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionTangshenosideITest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0218440.3
+        IAtomContainer mol = smiPar.parseSmiles("COC1=CC(/C=C/COC(=O)C[C@](C)(CC(=O)O)O[C@@H]2O[C@H](CO)[C@@H](O)[C@H](O)[C@H]2O)=CC(OC)=C1O[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(3, candidates.size());
+        //aglycone
+        Assertions.assertEquals("COC1=CC(/C=C/COC(=O)C[C@](C)(CC(=O)O)O)=CC(OC)=C1O", smiGen.create(candidates.get(0)));
+        //beta-D-glucose
+        Assertions.assertEquals("[C@H]1(O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O)O", smiGen.create(candidates.get(1)));
+        //beta-D-glucose
+        Assertions.assertEquals("[C@H]1(O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O)O", smiGen.create(candidates.get(2)));
+    }
+
+    /**
+     * Test for correct sugar extraction from Gitonin (CNP0209335.4), which contains a complex sugar structure.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionGitoninTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0209335.4
+        IAtomContainer mol = smiPar.parseSmiles("C[C@@H]1CC[C@@]2(OC1)O[C@H]1C[C@H]3[C@@H]4CC[C@H]5C[C@@H](O[C@@H]6O[C@H](CO)[C@H](O[C@@H]7O[C@H](CO)[C@@H](O)[C@H](O[C@@H]8OC[C@@H](O)[C@H](O)[C@H]8O)[C@H]7O[C@@H]7O[C@H](CO)[C@H](O)[C@H](O)[C@H]7O)[C@H](O)[C@H]6O)[C@H](O)C[C@]5(C)[C@H]4CC[C@]3(C)[C@H]1[C@@H]2C");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //aglycone
+        Assertions.assertEquals("C[C@@H]1CC[C@@]2(OC1)O[C@H]3C[C@H]4[C@@H]5CC[C@H]6C[C@@H](O)[C@H](O)C[C@]6(C)[C@H]5CC[C@]4(C)[C@H]3[C@@H]2C", smiGen.create(candidates.get(0)));
+        //connected sugars
+        Assertions.assertEquals("[C@H]1(O[C@H](CO)[C@H](O[C@@H]2O[C@H](CO)[C@@H](O)[C@H](O[C@@H]3OC[C@@H](O)[C@H](O)[C@H]3O)[C@H]2O[C@@H]4O[C@H](CO)[C@H](O)[C@H](O)[C@H]4O)[C@H](O)[C@H]1O)O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from alpha-l-mannuronic acid (CNP0171089.22), which should be recognized as a sugar.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionAlphaMannuronicAcidTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0171089.22
+        IAtomContainer mol = smiPar.parseSmiles("O=C(O)[C@@H]1O[C@@H](O)[C@H](O)[C@H](O)[C@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //empty aglycone
+        Assertions.assertEquals("", smiGen.create(candidates.get(0)));
+        //alpha-l-mannuronic acid
+        Assertions.assertEquals("O=C(O)[C@@H]1O[C@@H](O)[C@H](O)[C@H](O)[C@H]1O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from glycan G00008, which contains a complex structure with multiple sugars.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionglycanG00008Test() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0083402.1
+        IAtomContainer mol = smiPar.parseSmiles("CC(=O)N[C@H]1[C@H](O[C@H]2[C@H](O)[C@@H](NC(C)=O)[C@@H](OP(=O)(O)OP(=O)(O)OCCC(C)CC/C=C(\\C)CC/C=C(\\C)CC/C=C(\\C)CCC=C(C)C)O[C@@H]2CO)O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO[C@H]3O[C@H](CO[C@H]4O[C@H](CO)[C@@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]5O)[C@H](O)[C@@H]4O)[C@@H](O)[C@H](O[C@H]4O[C@H](CO)[C@@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]5O)[C@H](O)[C@@H]4O)[C@@H]3O)[C@@H](O)[C@H](O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]3O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]3O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O[C@H]4O[C@H](CO)[C@@H](O)[C@H](O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@H]5O[C@H]5O[C@H](CO)[C@@H](O)[C@H](O)[C@H]5O)[C@H]4O)[C@@H]3O)[C@@H]2O)[C@@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        //aglycone
+        Assertions.assertEquals("OP(=O)(O)OP(=O)(O)OCCC(C)CC/C=C(\\C)/CC/C=C(\\C)/CC/C=C(\\C)/CCC=C(C)C", smiGen.create(candidates.get(0)));
+        //sugars
+        Assertions.assertEquals("CC(=O)N[C@H]1[C@H](O[C@H]2[C@H](O)[C@@H](NC(C)=O)[C@H](O[C@@H]2CO)O)O[C@H](CO)[C@@H](O[C@@H]3O[C@H](CO[C@H]4O[C@H](CO[C@H]5O[C@H](CO)[C@@H](O[C@H]6O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]6O)[C@H](O)[C@@H]5O)[C@@H](O)[C@H](O[C@H]7O[C@H](CO)[C@@H](O[C@H]8O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]8O)[C@H](O)[C@@H]7O)[C@@H]4O)[C@@H](O)[C@H](O[C@H]9O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]9O[C@H]%10O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]%10O[C@H]%11O[C@H](CO)[C@@H](O)[C@H](O[C@H]%12O[C@H](CO)[C@@H](O)[C@H](O[C@H]%13O[C@H](CO)[C@@H](O)[C@H](O)[C@H]%13O[C@H]%14O[C@H](CO)[C@@H](O)[C@H](O)[C@H]%14O)[C@H]%12O)[C@@H]%11O)[C@@H]3O)[C@@H]1O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from a glycosidic natural product with an ester bond between aglycone and sugar.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionTestEster() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0214620.1
+        IAtomContainer mol = smiPar.parseSmiles("O=C(OC1=CC2=C(C(O)=C1O)C(=O)C=C(C1=CC=C(O)C(O)=C1)O2)[C@H]1O[C@@H](O)[C@H](O)[C@@H](O)[C@@H]1O");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, false);
+        Assertions.assertEquals(2, candidates.size());
+        // aglycone
+        Assertions.assertEquals("OC1=CC2=C(C(O)=C1O)C(=O)C=C(C3=CC=C(O)C(O)=C3)O2", smiGen.create(candidates.get(0)));
+        //sugar
+        Assertions.assertEquals("[C@@H]1(O[C@@H](O)[C@H](O)[C@@H](O)[C@@H]1O)C(=O)O", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from a glycosidic natural product with a spiro sugar.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionTestSpiro() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0360010.1 without the two standard sugars
+        IAtomContainer mol = smiPar.parseSmiles("C[C@@H]1CC[C@]2(O[C@H]3C[C@H]4[C@@H]5CC[C@H]6C[C@H](CC[C@@]6([C@H]5CC[C@@]4([C@H]3[C@@H]2C)C)C)O)CO1");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        sdu.setDetectSpiroRingsAsCircularSugarsSetting(true);
+        sdu.setDetectCircularSugarsOnlyWithEnoughExocyclicOxygenAtomsSetting(false);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, true, false);
+        Assertions.assertEquals(2, candidates.size());
+        // aglycone
+        Assertions.assertEquals("C1(O[C@H]2C[C@H]3[C@@H]4CC[C@H]5C[C@H](CC[C@@]5([C@H]4CC[C@@]3([C@H]2[C@@H]1C)C)C)O)(*)*", smiGen.create(candidates.get(0)));
+        //sugar
+        Assertions.assertEquals("C[C@@H]1CCC(CO1)(*)*", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * Test for correct sugar extraction from a glycosidic natural product with a spiro sugar where both rings connected
+     * to the spiro atom are sugars.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionTestSpiroInSugar() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0308702.1
+        IAtomContainer mol = smiPar.parseSmiles("CO[C@@H]1C[C@H](C[C@@H](O)CC[C@H](C)/C=C(/C)C(=O)O)O[C@]2(O[C@@](C)([C@@H]3CC[C@@](C)([C@H]4O[C@@H]([C@H]5O[C@@](O)(CO)[C@@H](C)C[C@H]5C)C[C@@H]4C)O3)C[C@@H]2C)[C@H]1C");
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        sdu.setDetectSpiroRingsAsCircularSugarsSetting(true);
+        sdu.setDetectCircularSugarsOnlyWithEnoughExocyclicOxygenAtomsSetting(false);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(mol, true, false, true, false);
+        Assertions.assertEquals(2, candidates.size());
+        // aglycone
+        Assertions.assertEquals("C([C@@H](O)CC[C@H](C)/C=C(/C)\\C(=O)O)*", smiGen.create(candidates.get(0)));
+        //sugar
+        Assertions.assertEquals("CO[C@@H]1CC(O[C@]2(O[C@@](C)([C@@H]3CC[C@@](C)([C@H]4O[C@@H]([C@H]5O[C@@](O)(CO)[C@@H](C)C[C@H]5C)C[C@@H]4C)O3)C[C@@H]2C)[C@H]1C)*", smiGen.create(candidates.get(1)));
+    }
+
+    /**
+     * The following tests had the purpose to single out molecules that had issues in batch processing in the past.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest1() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0183311.1
+        String glycosidicNP = "N[C@H]1[C@@H](O)[C@@H](O)[C@H](O)O[C@H]1[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)CO";
+        List<String> expectedSmilesList = Arrays.asList(
+                "C(O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)CO",
+                "N[C@H]1[C@@H](O)[C@@H](O)[C@H](O)OC1"
+        );
+        IAtomContainer molecule = smiPar.parseSmiles(glycosidicNP);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(molecule, true, false, false);
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * See above.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest2() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0151166.1
+        String smiles = "CCCCCCCCCCCCCCCC[C@@H](C(=O)O)[C@](O)(CC(=O)O)C(=O)O";
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, false, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "CCCCCCCCCCCCCCCC[C@@H](C(=O)O)[C@](O)(CC(=O)O)C(=O)O"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * See above.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest3() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0119227.1
+        String smiles = "OC[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O";
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, false, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "OC[C@H](O)[C@H](O)[C@H](O)CO",
+                "C1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * See above.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest4() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0438078.1
+        String smiles = "O=C(/C=C\\C1=CC=C(O)C=C1)C1=C(O)[C@@](O)([C@@H]2O[C@H](CO)[C@@H](O)[C@H](O)[C@H]2O)C(=O)[C@H]([C@H](O)[C@H]2OC[C@@H](O)[C@@H](O)[C@@H]2O)C1=O";
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, false, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "O=C(/C=C\\C1=CC=C(O)C=C1)C2=C(O)[C@H](O)C(=O)[C@H](CO)C2=O",
+                "C1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O",
+                "C1OC[C@@H](O)[C@@H](O)[C@@H]1O"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * See above.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest5() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        String smiles = "CC(N)C(=O)NC(CCC(N)=O)C(=O)NOC1OC(O)C(O)C(O)C1O";
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, false, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "CC(N)C(=O)NC(CCC(N)=O)C(=O)NO",
+                "C1(OC(O)C(O)C(O)C1O)O"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * See above.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest6() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        String smiles = "OC1OC(O)C(O)C1OC1C(OCCCCCCCCCCCCCCCCC)OC(OCCCCCCCCCCC)C(O)C1OC1C(O)C(O)C(O)OC(O)C1O";
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, false, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "OC1C(OCCCCCCCCCCCCCCCCC)OC(OCCCCCCCCCCC)C(O)C1O",
+                "OC1OC(O)C(O)C1O",
+                "C1(C(O)C(O)C(O)OC(O)C1O)O"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * See above.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest7() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        String smiles = "CCCCCC=CC=CC(O)CC=CC=CC(=O)OC1C(O)C(C2=C(O)C=C(O)C=C2CO)OC(CO)C1OC1OC(C)C(O)C(O)C1OC1OC(O)C(O)C(O)C1O";
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, false, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "CCCCCC=CC=CC(O)CC=CC=CC(=O)OC1C(O)C(C2=C(O)C=C(O)C=C2CO)OC(CO)C1O",
+                "C1(OC(C)C(O)C(O)C1OC2OC(O)C(O)C(O)C2O)O"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * This test is for a specific case where the sugar extraction should yield an empty aglycone but did not in the
+     * past because of a bug in the SugarRemovalUtility that is now fixed.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest8() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0336316.1
+        String smiles = "NC(=O)N[C@@H](C=O)[C@@H](O)[C@H](O)[C@H](O)CO";
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, true, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "",
+                "NC(=O)N[C@@H](C=O)[C@@H](O)[C@H](O)[C@H](O)CO"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * See above
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionIndividualTest9() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0595604.0
+        String smiles = "CC(=O)NC(C=O)C(O)C(OC1OC(CO)C(OC2OC(COC3OC(CO)C(O)C(O)C3O)C(O)C(OC3OC(CO)C(O)C(O)C3O)C2O)C(O)C1NC(C)=O)C(O)CO";
+        List<IAtomContainer> candidates =sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, true, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "",
+                "CC(=O)NC(C=O)C(O)C(OC1OC(CO)C(OC2OC(COC3OC(CO)C(O)C(O)C3O)C(O)C(OC4OC(CO)C(O)C(O)C4O)C2O)C(O)C1NC(C)=O)C(O)CO"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * A circular and a linear sugar that are correctly detected and split in postprocessing.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionCircularAndLinearSugarPostprocessingTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0274023.1
+        String smiles = "CC(=O)N[C@H]1[C@@H](O[C@@H]([C@H](O)[C@@H](O)C=O)[C@H](O)CO)O[C@H](CO)[C@H](O)[C@@H]1O";
+        List<IAtomContainer> candidates =sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, true, false, true);
+        List<String> expectedSmilesList = Arrays.asList(
+                "",
+                "CC(=O)N[C@H]1[C@H](O[C@H](CO)[C@H](O)[C@@H]1O)O",
+                "O[C@@H]([C@H](O)[C@@H](O)C=O)[C@H](O)CO"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * Tribenoside (CNP0273794.1) is not split very optimal, but it is seen as a corner case and added here for documentation.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void sugarExtractionTribenosideTest() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        sdu.setRemoveOnlyTerminalSugarsSetting(false);
+        //CNP0273794.1
+        String smiles = "CCOC1O[C@H]([C@@H](COCC2=CC=CC=C2)OCC2=CC=CC=C2)[C@H](OCC2=CC=CC=C2)[C@H]1O";
+        List<IAtomContainer> candidates =sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, true, true, true, true);
+        List<String> expectedSmilesList = Arrays.asList(
+                "C(COCC1=CC=CC=C1)(OCC2=CC=CC=C2)*.O(CC1=CC=CC=C1)*",
+                "CCOC1OC([C@@H]([C@H]1O)O*)*"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * Tests a structure where the SRU cuts between the sugar and its C6 atom but the SDU should correct that in extraction.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testC6Correction() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //Robustaside D (CNP0296149.1)
+        String smiles = "O=C1C=CC(O)(/C=C/C(=O)OC[C@H]2O[C@@H](OC3=CC=C(O)C=C3)[C@H](O)[C@@H](O)[C@@H]2O)C=C1";
+        sdu.setRemoveOnlyTerminalSugarsSetting(false);
+        List<IAtomContainer> candidates =sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, true, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "O=C1C=CC(O)(/C=C/C(=O)O)C=C1.OC1=CC=C(O)C=C1",
+                "[C@@H]1(O[C@H]([C@H](O)[C@@H](O)[C@@H]1O)O)CO"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * Tests a structure where the SRU cuts between the sugar and its C6 atom but the SDU should correct that in extraction.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testNicofuranose() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0074341.1
+        String smiles = "O=C(OC[C@H]1O[C@](O)(COC(=O)C2=CC=CN=C2)[C@@H](OC(=O)C2=CC=CN=C2)[C@@H]1OC(=O)C1=CC=CN=C1)C1=CC=CN=C1";
+        sdu.setRemoveOnlyTerminalSugarsSetting(false);
+        List<IAtomContainer> candidates =sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, true, true, true);
+        List<String> expectedSmilesList = Arrays.asList(
+                "O=C(O*)C1=CC=CN=C1.O(C(=O)C1=CC=CN=C1)*.O(C(=O)C1=CC=CN=C1)*.O(C(=O)C1=CC=CN=C1)*",
+                "[C@@H]1(O[C@@](O)([C@H]([C@@H]1O*)O*)CO*)CO*"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * Tests a structure where the SRU cuts between the sugar and its carboxy group but the SDU should correct that in extraction.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testTetraGalacturonicAcidHydroxyMethylEster() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0074587.1
+        String smiles = "CCOC(=O)[C@H]1O[C@H](O[C@@H]2[C@H](O)[C@@H](O)[C@@H](O[C@@H]3[C@H](O)[C@@H](O)[C@@H](O)O[C@@H]3C(=O)OCO)O[C@@H]2C(=O)OCO)[C@H](O)[C@@H](O)[C@H]1O[C@H]1O[C@H](C(=O)OCO)[C@H](O)[C@H](O)[C@H]1O";
+        sdu.setRemoveOnlyTerminalSugarsSetting(false);
+        List<IAtomContainer> candidates =sdu.copyAndExtractAglyconeAndSugars(smiPar.parseSmiles(smiles), true, true, true, true);
+        List<String> expectedSmilesList = Arrays.asList(
+                "CCO*.O(CO)*.O(CO)*.O(CO)*",
+                "[C@@H]1(O[C@@H]([C@H](O)[C@@H](O)[C@H]1O*)O*)C(=O)O*",
+                "O([C@@H]1[C@H](O)[C@@H](O)[C@H](O[C@@H]1C(=O)O*)O*)*",
+                "O([C@@H]1[C@H](O)[C@@H](O)[C@@H](O)O[C@@H]1C(=O)O*)*",
+                "O([C@H]1O[C@@H]([C@H](O)[C@H](O)[C@H]1O)C(=O)O*)*"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * Tests the postprocessing split of ester groups connecting linear sugar moieties.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testEsterSplittingInLinearSugars() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0138295
+        String smiles = "O=CC(O)C(O)C(O)C(O)COC(O)(C(O)COC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C)C(O)C(O)C=O";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        sdu.splitEsters(molecule, false, false, false);
+        Assertions.assertEquals("O=CC(O)C(O)C(O)C(O)COC(O)(C(O)CO)C(O)C(O)C=O.O=C(O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C",
+                smiGen.create(molecule));
+        molecule = smiPar.parseSmiles(smiles);
+        sdu.splitEsters(molecule, true, false, false);
+        Assertions.assertEquals("*OC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C.*OCC(O)C(O)(OCC(O)C(O)C(O)C(O)C=O)C(O)C(O)C=O",
+                smiGen.create(molecule));
+    }
+
+    /**
+     * Tests the postprocessing split of ether groups cross-linking linear sugar moieties.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testEtherCrossLinkingSplittingInLinearSugars() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0138295
+        String smiles = "O=CC(O)C(O)C(O)C(O)COC(O)(C(O)COC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C)C(O)C(O)C=O";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        sdu.splitEthersCrossLinking(molecule, false, false);
+        Assertions.assertEquals("O=CC(O)C(O)C(O)C(O)CO.O=CC(O)C(O)C(O)C(O)COC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C",
+                smiGen.create(molecule));
+        molecule = smiPar.parseSmiles(smiles);
+        sdu.splitEthersCrossLinking(molecule, true, false);
+        Assertions.assertEquals("*OCC(O)C(O)C(O)C(O)C=O.*C(O)(C(O)COC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C)C(O)C(O)C=O",
+                smiGen.create(molecule));
+    }
+
+    /**
+     * Tests the postprocessing split of ether groups connecting linear sugar moieties.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testEtherSplittingInLinearSugars() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0138295
+        String smiles = "O=CC(O)C(O)C(O)C(O)COC(O)(C(O)COC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C)C(O)C(O)C=O";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        sdu.splitOGlycosidicBondsAndEthers(molecule, false, false, false);
+        //note that this shows why the ether splitting should be done last because it also matches esters and crosslinking ehthers that are treated differently
+        Assertions.assertEquals("O=CC(O)C(O)C(O)C(O)CO.O=CC(O)C(O)C(O)(O)C(O)CO.O=C(O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C",
+                smiGen.create(molecule));
+        molecule = smiPar.parseSmiles(smiles);
+        sdu.splitOGlycosidicBondsAndEthers(molecule, true, false, false);
+        Assertions.assertEquals("*OC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C.*OCC(O)C(O)C(O)C(O)C=O.*OCC(O)C(O)(O*)C(O)C(O)C=O",
+                smiGen.create(molecule));
+    }
+
+    /**
+     * Tests the postprocessing split of peroxide groups connecting linear sugar moieties.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testPeroxideSplittingInLinearSugars() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0206763.1
+        String smiles = "COC1=C2C[C@@H](C(C)(C)O)OC2=CC2=C1C(=O)C=C(COOC[C@H](O)[C@@H](O)[C@H](O)[C@H](O)CO)O2";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        sdu.splitPeroxides(molecule, false, false, false);
+        //note that this shows why the ether splitting should be done last because it also matches esters and crosslinking ehthers that are treated differently
+        Assertions.assertEquals("O=C1C=C(OC=2C=C3OC(CC3=C(OC)C12)C(O)(C)C)CO.OCC(O)C(O)C(O)C(O)CO",
+                smiGen.create(molecule));
+        molecule = smiPar.parseSmiles(smiles);
+        sdu.splitPeroxides(molecule, true, false, false);
+        Assertions.assertEquals("*OCC=1OC=2C=C3OC(CC3=C(OC)C2C(=O)C1)C(O)(C)C.*OCC(O)C(O)C(O)C(O)CO",
+                smiGen.create(molecule));
+    }
+
+    /**
+     * Test for splitting O-glycosidic (ether) bonds in a molecule, using the splitOGlycosidicBonds method used for postprocessing
+     * extracted circular sugar moieties.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testSplitOGlycosidicBondsInCircularSugars() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0595604.0
+        String smiles = "CC(=O)NC(C=O)C(O)C(OC1OC(CO)C(OC2OC(COC3OC(CO)C(O)C(O)C3O)C(O)C(OC3OC(CO)C(O)C(O)C3O)C2O)C(O)C1NC(C)=O)C(O)CO";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        sdu.splitOGlycosidicBondsAndEthers(molecule, false, false, true);
+        Assertions.assertEquals("CC(=O)NC(C=O)C(O)C(O)C(O)CO.C1(OC(CO)C(C(O)C1NC(C)=O)O)O.OC1OC(CO)C(O)C(C1O)O.C1(OC(CO)C(O)C(O)C1O)O.OC1OC(CO)C(O)C(O)C1O",
+                smiGen.create(molecule));
+        molecule = smiPar.parseSmiles(smiles);
+        sdu.splitOGlycosidicBondsAndEthers(molecule, true, false, true);
+        Assertions.assertEquals("CC(=O)NC(C=O)C(O)C(O*)C(O)CO.C1(OC(CO)C(C(O)C1NC(C)=O)O*)O*.O(C1OC(CO*)C(O)C(C1O)O*)*.C1(OC(CO)C(O)C(O)C1O)O*.O(C1OC(CO)C(O)C(O)C1O)*",
+                smiGen.create(molecule));
+        //CNP0208164.1
+        smiles = "CC(=O)OC[C@H]1O[C@H](CO[C@]2(CO)O[C@H](COC(=O)/C=C/C3=CC=C(O)C=C3)[C@H](OC(C)=O)[C@H]2O)[C@H](O)[C@@H](OC(C)=O)[C@@H]1OC(C)=O";
+        molecule = smiPar.parseSmiles(smiles);
+        sdu.splitOGlycosidicBondsAndEthers(molecule, true, true, true);
+        //an earlier version had an issue here because carbons of degree 4 were not handled properly by the SMARTS pattern
+        Assertions.assertEquals("CC(=O)OC[C@H]1O[C@H](CO*)[C@H](O)[C@@H](OC(C)=O)[C@@H]1OC(C)=O.[C@@]1(CO)(O[C@H](COC(=O)/C=C/C2=CC=C(O)C=C2)[C@H](OC(C)=O)[C@H]1O)O*",
+                smiGen.create(molecule));
+    }
+
+    /**
+     * Test for splitting O-glycosidic (ether) bonds in a molecule, using the splitOGlycosidicBonds method used for postprocessing
+     * extracted circular sugar moieties. This test additionally checks that stereochemistry is preserved on both sides of the
+     * glycosidic bond, which was not the case in earlier versions of the code.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testSplitOGlycosidicBondsInCircularSugarsWithStereo() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //Beta-sophorose CID441432
+        String smiles = "OC[C@H]1O[C@@H](O[C@@H]2[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]2O)[C@H](O)[C@@H](O)[C@@H]1O";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        sdu.splitOGlycosidicBondsAndEthers(molecule, false, false, true);
+        Assertions.assertEquals("OC[C@H]1O[C@H]([C@H](O)[C@@H](O)[C@@H]1O)O.O[C@@H]1[C@@H](O)[C@H](O)[C@@H](CO)O[C@H]1O",
+                smiGen.create(molecule));
+    }
+
+    /**
+     * Tests the splitting of ester bonds connecting circular sugars in postprocessing with the correct preservation of stereochemistry.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testSplitEsterBondsInCircularSugarsWithStereo() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0320668.1
+        String smiles = "CC[C@H](/C=C/[C@@H](C)[C@H]1CC[C@H]2[C@@H]3CC=C4C[C@@H](O[C@@H]5O[C@H](C(=O)O[C@@H]6O[C@H](CO)[C@@H](O)[C@H](O)[C@H]6O)[C@@H](O)[C@H](O)[C@H]5O)CC[C@]4(C)[C@H]3CC[C@]12C)C(C)C";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(molecule, true, true, true, true, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "CC[C@H](/C=C/[C@@H](C)[C@H]1CC[C@H]2[C@@H]3CC=C4C[C@@H](O*)CC[C@]4(C)[C@H]3CC[C@]12C)C(C)C",
+                "[C@H]1(O[C@H](C(=O)O*)[C@@H](O)[C@H](O)[C@H]1O)O*",
+                "[C@H]1(O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O)O*"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * Tests the splitting of peroxide bonds connecting circular sugars in postprocessing with the correct preservation of stereochemistry.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testSplitPeroxideBondsInCircularSugarsWithStereo() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo | SmiFlavor.UseAromaticSymbols);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0125702.0 but with artificially added stereochemistry
+        String smiles = "C[C@@H]1O[C@@H](OO[C@@H]2O[C@@H](Oc3ccccc3O)[C@@H](O)[C@@H](O)[C@@H]2O)[C@@H](O)[C@@H](O)[C@@H]1O";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(molecule, true, true, true, true, false);
+        List<String> expectedSmilesList = Arrays.asList(
+                "O(c1ccccc1O)*",
+                "C[C@@H]1O[C@@H](O*)[C@@H](O)[C@@H](O)[C@@H]1O",
+                "O([C@@H]1O[C@H]([C@@H](O)[C@@H](O)[C@@H]1O)O*)*"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(candidates, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * Test for splitting ether, ester, and peroxide bonds in a molecule, using the postprocessing method for extracted
+     * sugar moieties.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testSplitEtherEsterPeroxideBondsLinearSugarsPostprocessing() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0138295
+        String smiles = "O=CC(O)C(O)C(O)C(O)COC(O)(C(O)COC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C)C(O)C(O)C=O";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        sdu.splitEtherEsterPeroxideBondsLinearSugarsPostProcessing(molecule, false, false);
+        Assertions.assertEquals("O=CC(O)C(O)C(O)C(O)CO.O=CC(O)C(O)C(O)C(O)CO.O=C(O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C",
+                smiGen.create(molecule));
+        molecule = smiPar.parseSmiles(smiles);
+        sdu.splitEtherEsterPeroxideBondsLinearSugarsPostProcessing(molecule, true, false);
+        Assertions.assertEquals("*OC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C.*OCC(O)C(O)C(O)C(O)C=O.*OCC(O)C(*)(O)C(O)C(O)C=O",
+                smiGen.create(molecule));
+    }
+
+    /**
+     * Tests that small fragments (e.g. methyl ether modifications) are preserved in the post-processing step
+     * of sugar extraction, which was an issue in earlier versions of the code (another option for this was introduced).
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testSmallFragmentPreservationInPostProcessing() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //CNP0189711.1
+        String smiles = "CO[C@@H]1[C@@H](O)[C@@H](O[C@@H]2O[C@H](C)[C@@H](O)[C@H](O)[C@H]2OC)[C@H](O[C@@H]2[C@@H](O)[C@@H](CO)O[C@@H](O)[C@@H]2NC(C)=O)O[C@@H]1CO";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        List<IAtomContainer> results = sdu.copyAndExtractAglyconeAndSugars(molecule, true, true, true, true, true);
+        //notice that the methyl ether modifications are not separated from the sugars
+        List<String> expectedSmilesList = Arrays.asList(
+                "",
+                "*OC1OC(CO)C(OC)C(O)C1O*",
+                "*OC1OC(C)C(O)C(O)C1OC",
+                "*OC1C(O)C(OC(O)C1NC(=O)C)CO"
+        );
+        List<String> generatedSmilesList = this.generateSmilesList(results, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+
+        //CNP0140416.1
+        smiles = "CO[C@@H]1[C@@H](OC(N)=O)[C@@H](O)[C@H](OC2=CC=C3C([O-])=C(NC(=O)C4=CC=C(O)C(CC=C(C)C)=C4)C(=O)OC3=C2C)OC1(C)C";
+        molecule = smiPar.parseSmiles(smiles);
+        results = sdu.copyAndExtractAglyconeAndSugars(molecule, true, true, true, true, true);
+        //the carbamic acid and methyl ether modifications are not be separated from the sugar
+        expectedSmilesList = Arrays.asList(
+                "*OC=1C=CC=2C([O-])=C(NC(=O)C3=CC=C(O)C(=C3)CC=C(C)C)C(=O)OC2C1C",
+                "*OC1OC(C)(C)C(OC)C(OC(=O)N)C1O"
+        );
+        generatedSmilesList = this.generateSmilesList(results, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+
+        //CNP0225661.1
+        smiles = "CC[C@H]1OC(=O)[C@H](C)[C@@H](O[C@H]2C[C@@](C)(OC)[C@@H](O)[C@H](C)O2)[C@H](C)[C@@H](O[C@@H]2O[C@H](C)C[C@H](N(C)C)[C@H]2OC(C)=O)[C@](C)(O)C[C@@H](C)C(=O)[C@H](C)[C@@H](O)[C@]1(C)O";
+        molecule = smiPar.parseSmiles(smiles);
+        //one of the sugars does not have enough exocyclic oxygen atoms
+        sdu.setExocyclicOxygenAtomsToAtomsInRingRatioThresholdSetting(0.1);
+        results = sdu.copyAndExtractAglyconeAndSugars(molecule, true, true, true, true, true);
+        //the ethyl ester and methyl ether modifications are not be separated from the sugar
+        expectedSmilesList = Arrays.asList(
+                "*OC1C(C(=O)OC(CC)C(O)(C)C(O)C(C(=O)C(C)CC(O)(C)C(O*)C1C)C)C",
+                "*OC1OC(C)C(O)C(OC)(C)C1",
+                "*OC1OC(C)CC(N(C)C)C1OC(=O)C"
+        );
+        generatedSmilesList = this.generateSmilesList(results, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+
+        //CNP0084266.1
+        smiles = "CCCCCC/C=C\\CCCCCCCCCC(=O)N[C@H]1[C@H](OC[C@H]2O[C@H](OP(=O)([O-])[O-])[C@H](NC(=O)CC(=O)CCCCCCCCCCC)[C@@H](OCCCCCCCCCC)[C@@H]2O)O[C@H](COC)[C@@H](OP(=O)([O-])[O-])[C@@H]1OCC[C@@H](CCCCCCC)OC";
+        molecule = smiPar.parseSmiles(smiles);
+        //back to default
+        sdu.setExocyclicOxygenAtomsToAtomsInRingRatioThresholdSetting(SugarRemovalUtility.EXOCYCLIC_OXYGEN_ATOMS_TO_ATOMS_IN_RING_RATIO_THRESHOLD_DEFAULT);
+        //the sugars are non-terminal
+        sdu.setRemoveOnlyTerminalSugarsSetting(false);
+        results = sdu.copyAndExtractAglyconeAndSugars(molecule, true, true, true, true, true);
+        //the methyl ether is not separated from the sugar
+        expectedSmilesList = Arrays.asList(
+                "*OCCCCCCCCCC.*OCCC(OC)CCCCCCC.*OP(=O)([O-])[O-].*OP(=O)([O-])[O-].*NC(=O)CC(=O)CCCCCCCCCCC.*NC(=O)CCCCCCCCCC=CCCCCCC",
+                "*OC1OC(COC)C(O*)C(O*)C1N*",
+                "*OCC1OC(O*)C(N*)C(O*)C1O"
+        );
+        generatedSmilesList = this.generateSmilesList(results, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+
+        //CNP0279873.1
+        smiles = "C[C@H]1O[C@@H](O[C@H]2[C@@H](OC=O)C[C@H](O[C@H]3[C@@H](OC=O)C[C@H](O[C@H]4CC[C@@]5(C)[C@H](CC[C@@H]6[C@@H]5CC[C@]5(C)[C@@H](C7=CC(=O)OC7)[C@@H](OC=O)C[C@]65O)C4)O[C@@H]3C)O[C@@H]2C)C[C@H](OC=O)[C@@H]1OC=O";
+        molecule = smiPar.parseSmiles(smiles);
+        //back to default
+        sdu.setRemoveOnlyTerminalSugarsSetting(true);
+        results = sdu.copyAndExtractAglyconeAndSugars(molecule, true, true, true, true, true);
+        //the formic acid moieties are not separated from the sugars
+        expectedSmilesList = Arrays.asList(
+                "*OC1CCC2(C)C(CCC3C2CCC4(C)C(C5=CC(=O)OC5)C(OC=O)CC34O)C1",
+                "*OC1OC(C)C(OC=O)C(OC=O)C1",
+                "*OC1OC(C)C(O*)C(OC=O)C1",
+                "*OC1OC(C)C(O*)C(OC=O)C1"
+        );
+        generatedSmilesList = this.generateSmilesList(results, smiGen);
+        Assertions.assertLinesMatch(expectedSmilesList, generatedSmilesList);
+    }
+
+    /**
+     * Tests the retrieval of atom indices for aglycone and sugar moieties from a molecule.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testRetrievalOfAtomIndices() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //Fusacandin B (CNP0295326.4)
+        String smiles = "CCCCC/C=C/C=C/[C@@H](O)C/C=C/C=C/C(=O)OC1C(O)[C@H](C2=C(O)C=C(O)C=C2CO)O[C@H](CO)[C@H]1O[C@@H]1OC(CO)[C@H](O)[C@H](O)C1O[C@@H]1OC(CO)[C@H](O)[C@H](O)C1O";
+        IAtomContainer mol = smiPar.parseSmiles(smiles);
+        Map<IAtom, IAtom> inputAtomToAglyconeAtomMap = new HashMap<>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f);
+        Map<IAtom, IAtom> inputAtomToSugarAtomMap = new HashMap<>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f);
+        List<IAtomContainer> candidates = sdu.copyAndExtractAglyconeAndSugars(
+                mol,
+                true,
+                false,
+                false,
+                true,
+                true,
+                inputAtomToAglyconeAtomMap,
+                new HashMap<>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f),
+                inputAtomToSugarAtomMap,
+                new HashMap<>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f));
+        int[] aglyconeAtomIndices = sdu.getAtomIndicesOfGroup(mol, candidates.get(0), inputAtomToAglyconeAtomMap);
+        Assertions.assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}, aglyconeAtomIndices);
+        Assertions.assertEquals(3, candidates.size());
+        int[] sugarOneAtomIndices = sdu.getAtomIndicesOfGroup(mol, candidates.get(1), inputAtomToSugarAtomMap);
+        int[] sugarTwoAtomIndices = sdu.getAtomIndicesOfGroup(mol, candidates.get(2), inputAtomToSugarAtomMap);
+        Assertions.assertArrayEquals(new int[] {38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48}, sugarOneAtomIndices);
+        Assertions.assertArrayEquals(new int[] {49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60}, sugarTwoAtomIndices);
+    }
+
+    /**
+     * Tests the retrieval of group indices for all atoms in a molecule, which is useful for visualisation.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testGetGroupIndicesForAllAtoms() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        //Fusacandin B (CNP0295326.4)
+        String smiles = "CCCCC/C=C/C=C/[C@@H](O)C/C=C/C=C/C(=O)OC1C(O)[C@H](C2=C(O)C=C(O)C=C2CO)O[C@H](CO)[C@H]1O[C@@H]1OC(CO)[C@H](O)[C@H](O)C1O[C@@H]1OC(CO)[C@H](O)[C@H](O)C1O";
+        IAtomContainer mol = smiPar.parseSmiles(smiles);
+        Map<IAtom, IAtom> inputAtomToAglyconeAtomMap = new HashMap<>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f);
+        Map<IAtom, IAtom> inputAtomToSugarAtomMap = new HashMap<>((int) ((mol.getAtomCount() / 0.75f) + 2), 0.75f);
+        List<IAtomContainer> aglyconeAndSugarsList = sdu.copyAndExtractAglyconeAndSugars(
+                mol,
+                true,
+                false,
+                false,
+                true,
+                true,
+                inputAtomToAglyconeAtomMap,
+                new HashMap<>((int) ((mol.getBondCount() / 0.75f) + 2), 0.75f),
+                inputAtomToSugarAtomMap,
+                new HashMap<>((int) ((mol.getBondCount() / 0.75f) + 2), 0.75f));
+        int[] groupIndices = sdu.getGroupIndicesForAllAtoms(mol, aglyconeAndSugarsList, inputAtomToAglyconeAtomMap, inputAtomToSugarAtomMap);
+        for (IAtom atom : mol.atoms()) {
+            atom.setMapIdx(groupIndices[atom.getIndex()] + 1);
+        }
+        String smi = new SmilesGenerator(SmiFlavor.Isomeric | SmiFlavor.AtomAtomMap).create(mol);
+        Assertions.assertEquals("[CH3:1][CH2:1][CH2:1][CH2:1][CH2:1]/[CH:1]=[CH:1]/[CH:1]=[CH:1]/[C@@H:1]([OH:1])[CH2:1]/[CH:1]=[CH:1]/[CH:1]=[CH:1]/[C:1](=[O:1])[O:1][CH:1]1[CH:1]([OH:1])[C@H:1]([C:1]2=[C:1]([OH:1])[CH:1]=[C:1]([OH:1])[CH:1]=[C:1]2[CH2:1][OH:1])[O:1][C@H:1]([CH2:1][OH:1])[C@H:1]1[O:2][C@@H:2]3[O:2][CH:2]([CH2:2][OH:2])[C@H:2]([OH:2])[C@H:2]([OH:2])[CH:2]3[O:3][C@@H:3]4[O:3][CH:3]([CH2:3][OH:3])[C@H:3]([OH:3])[C@H:3]([OH:3])[CH:3]4[OH:3]",
+                smi);
+    }
+
+    /**
+     * Tests the deeper copy method to create a full copy of a molecule including stereochemistry.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    void testCopy() throws Exception {
+        SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo);
+        //CNP0208164.1
+        String smiles = "CC(=O)OC[C@H]1O[C@H](CO[C@]2(CO)O[C@H](COC(=O)/C=C/C3=CC=C(O)C=C3)[C@H](OC(C)=O)[C@H]2O)[C@H](O)[C@@H](OC(C)=O)[C@@H]1OC(C)=O";
+        IAtomContainer molecule = smiPar.parseSmiles(smiles);
+        SugarDetectionUtility sdu = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
+        IAtomContainer copy = sdu.deeperCopy(molecule, new HashMap<>(), new HashMap<>());
+        Assertions.assertEquals(smiGen.create(molecule), smiGen.create(copy));
+    }
+
+    /**
+     * Helper method to convert a list of IAtomContainer to a list of SMILES strings.
+     *
+     * @param candidates List of IAtomContainer molecules to convert
+     * @param smiGen SMILES generator to use for conversion
+     * @return List of SMILES strings
+     * @throws CDKException if SMILES generation fails
+     */
+    protected List<String> generateSmilesList(List<IAtomContainer> candidates, SmilesGenerator smiGen) throws CDKException {
+        List<String> result = new ArrayList<>(candidates.size());
+        for (IAtomContainer mol : candidates) {
+            result.add(smiGen.create(mol));
+        }
+        return result;
+    }
+}

--- a/misc/extra/src/test/java/org/openscience/cdk/tools/SugarRemovalUtilityTest.java
+++ b/misc/extra/src/test/java/org/openscience/cdk/tools/SugarRemovalUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Jonas Schaub <jonas.schaub@uni-jena.de>
+ * Copyright (c) 2025 Jonas Schaub <jonas.schaub@uni-jena.de>
  *                    Achim Zielesny <achim.zielesny@w-hs.de>
  *                    Christoph Steinbeck <christoph.steinbeck@uni-jena.de>
  *                    Maria Sorokina <>
@@ -46,19 +46,13 @@ import java.util.Map;
  *     <a href="https://www.ebi.ac.uk/chembl/">ChEMBL database</a>.
  *     <br>Identifiers starting with 'CNP' refer to molecules in the
  *     <a href="https://coconut.naturalproducts.net">COCONUT database</a>.
+ *     <br>Identifiers starting with 'CID' refer to molecules in the
+ *     <a href="https://pubchem.ncbi.nlm.nih.gov">PubChem database</a>.
  * </p>
  *
  * @author Jonas Schaub
  */
-class SugarRemovalUtilityTest extends SugarRemovalUtility {
-    /**
-     * Constructor that uses SilentChemObjectBuilder as parameter for the
-     * SugarRemovalUtility constructor.
-     */
-    SugarRemovalUtilityTest() {
-        super(SilentChemObjectBuilder.getInstance());
-    }
-
+class SugarRemovalUtilityTest {
     /**
      * Example usage code for the class documentation.
      *
@@ -111,14 +105,14 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 "OC1C(OCCCCCCCCCCC)OC(OCCCCCCCCCCCCCCCCC)C(O)C1O");
         SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(true);
         for (String key : smilesBeforeAndAfterDeglycosylationMap.keySet()) {
             IAtomContainer originalMolecule = smiPar.parseSmiles(key);
             Assertions.assertTrue(sugarRemovalUtil.hasCircularSugars(originalMolecule));
             Assertions.assertTrue(sugarRemovalUtil.hasCircularOrLinearSugars(originalMolecule));
             sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-            SugarRemovalUtilityTest.saturate(originalMolecule);
+            this.saturate(originalMolecule);
             String smilesAfterDeglycosylation = smiGen.create(originalMolecule);
             Assertions.assertEquals(smilesBeforeAndAfterDeglycosylationMap.get(key), smilesAfterDeglycosylation);
         }
@@ -137,13 +131,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0220816
                 "CC1=CC(OC2OC(CO)C(O)C(O)C2O)=C2C3=C(CCC3)C(=O)OC2=C1");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //A simple example, the sugar has a glycosidic bond and is not terminal and therefore removed; the resulting
         // disconnected CH3OH is too small to keep and gets cleared away
@@ -164,12 +158,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0151033
                 "O=C(OC1C(OCC2=COC(OC(=O)CC(C)C)C3C2CC(O)C3(O)COC(=O)C)OC(CO)C(O)C1O)C=CC4=CC=C(O)C=C4");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The sugar ring is not terminal and should not be removed, so the molecule remains unchanged
         Assertions.assertEquals(
@@ -177,7 +171,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now that all sugars are removed, the sugar ring is removed and an unconnected structure remains
         Assertions.assertEquals(
@@ -199,18 +193,18 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0125332
                 "O=P(O)(O)OCC1OC(OP(=O)(O)O)C(O)C1O");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing is removed, the sugar is terminal because the two phosphate groups are big enough to keep (5 and 6 heavy atoms)
         Assertions.assertEquals("O=P(O)(O)OCC1OC(OP(=O)(O)O)C(O)C1O", smilesCode);
         sugarRemovalUtil.setPreservationModeThresholdSetting(6);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, one of the phosphate groups is removed because it has only 5 heavy atoms and therefore, the sugar is
         // no longer terminal and also removed
@@ -221,7 +215,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 "O=P(O)(O)OCC1OC(OP(=O)(O)O)C(O)C1O");
         sugarRemovalUtil.setPreservationModeThresholdSetting(7);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, both phosphate groups are removed because they are too small and nothing remains of the molecule
         Assertions.assertEquals("", smilesCode);
@@ -233,7 +227,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         //back to default
         sugarRemovalUtil.setPreservationModeThresholdSetting(5);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, also non-terminal sugars are removed, which leaves two unconnected phosphate groups in this case
         Assertions.assertEquals("O=P(O)(O)O.O=P(O)(O)OC", smilesCode);
@@ -243,7 +237,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 "O=P(O)(O)OCC1OC(OP(=O)(O)O)C(O)C1O");
         sugarRemovalUtil.setExocyclicOxygenAtomsToAtomsInRingRatioThresholdSetting(0.7);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, the sugar ring does not have enough oxygen atoms attached to be classified as a sugar and be removed
         // (3 oxygen atoms to 5 atoms in the ring makes a ratio of 3/5 = 0.6)
@@ -264,13 +258,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0426917
                 "O=C1OC2C(CCO)CCC3(C=C4C=CCC5C(C=CC(C45)C23)CCCC(C)(CC6=CN=C(N)C=C6)CC=7C=CC=C8C(=O)C9(OC19C(=O)C87)CC(=C(C)CC%10C=%11C=CN=C%12NC(NC)CC(C%12%11)CC%10)CO)NCC");
         Assertions.assertFalse(sugarRemovalUtil.hasLinearSugars(originalMolecule));
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //There is a structure at the center of the molecule that gets detected as a linear sugar having three carbon atoms,
         // but it should not be detected as a linear sugar and not be removed because it is in parts cyclic and too small.
@@ -279,7 +273,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //now too, nothing should happen because it is still too small
         Assertions.assertEquals(
@@ -287,7 +281,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setLinearSugarCandidateMinSizeSetting(3);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //now, the structure is big enough to be removed, and it is revealed that it is in fact terminal
         // but its removal breaks up the big ring
@@ -309,12 +303,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles("O=CCC12OC(OC1=O)C3(C)C(C)CCC3(C)C2"); //CNP0243650
         Assertions.assertFalse(sugarRemovalUtil.hasLinearSugars(originalMolecule));
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed here
         Assertions.assertEquals("O=CCC12OC(OC1=O)C3(C)C(C)CCC3(C)C2", smilesCode);
@@ -333,7 +327,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         //this molecule contains a fused, 8-membered macrocyle that is partly made up of sugars
         originalMolecule = smiPar.parseSmiles(
                 //CNP0098894
@@ -341,7 +335,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         //since linear sugars in cycles should not be removed, this must be false
         Assertions.assertFalse(sugarRemovalUtil.hasLinearSugars(originalMolecule));
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed here because the linear sugar in the macrocycle is cyclic and non-terminal
         Assertions.assertEquals(
@@ -351,7 +345,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         //now, the linear sugar is detected but still not removed because it is non-terminal
         Assertions.assertTrue(sugarRemovalUtil.hasLinearSugars(originalMolecule));
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed here because the linear sugar in the macrocycle is detected but not terminal
         Assertions.assertEquals(
@@ -359,7 +353,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //now, the sugar in the macrocycle is removed and the molecule is disconnected
         Assertions.assertEquals("OC=1C=CC=C(C1)C=2C=CC=C3OCC4C5=C(OC4C32)C(OC)=C(OC)C=C5CNC.NCCNC", smilesCode);
@@ -378,13 +372,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         //two structures connected by a circular sugar moiety
         originalMolecule = smiPar.parseSmiles(
                 //CNP0436852
                 "O=C(O)C1OC(OC=2C=CC=3C(=O)[C-](C=[O+]C3C2)C4=CC=C(O)C=C4)C(O)(CNCC(CC=5C=NCC5)C(C)C)C(O)C1O");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed here because the circular sugar is not terminal
         Assertions.assertEquals(
@@ -393,14 +387,14 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed because only linear sugars are removed and there are none!
         Assertions.assertEquals(
                 "O=C(O)C1OC(OC=2C=CC=3C(=O)[C-](C=[O+]C3C2)C4=CC=C(O)C=C4)C(O)(CNCC(CC=5C=NCC5)C(C)C)C(O)C1O",
                 smilesCode);
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, the circular sugar is removed
         Assertions.assertEquals(
@@ -421,10 +415,10 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles("O=C1OC(C2=COC=C2)CC3(C)C1CCC4(C)C3C5OC(=O)C4(O)C=C5"); //CNP0235814
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed here although there might be a match for the linear sugar patterns
         Assertions.assertEquals("O=C1OC(C2=COC=C2)CC3(C)C1CCC4(C)C3C5OC(=O)C4(O)C=C5", smilesCode);
@@ -443,12 +437,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0296940
                 "O=C1OC2CC3(OC4(O)C(CC5(OC45C(=O)OC)CCCCCCCCCCCCCCCC)C2(O3)C1)CCCCCCCCCCCCCCCC");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed here although there is a small match for the linear sugar patterns
         Assertions.assertEquals(
@@ -471,13 +465,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         //Interesting case because there are two macrocycles containing in principle a circular sugar that is not isolated
         originalMolecule = smiPar.parseSmiles(
                 //CNP0419027
                 "O=C1C2=CC=CC3=C2CN1CC(=O)C4=C(O)C5=C6OC7OC(COC(C=CC6=C(OC)C8=C5C=9C(=CC%10CCCC%10C49)CC8)C%11=CNC=%12C=CC(=CC%12%11)CNC)C(O)C(OC#CC3)C7(O)CO");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed here although there is a match for the linear sugar patterns in the said
         // non-isolated sugar cycle in the macrocycle
@@ -486,7 +480,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, the sugar cycle in the macrocyle is removed because it matches the linear sugar patterns;
         // the macrocycles are broken but the molecule does not get disconnected, so the moiety was terminal
@@ -507,13 +501,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0218440
                 "O=C(O)CC(OC1OC(CO)C(O)C(O)C1O)(C)CC(=O)OCC=CC2=CC(OC)=C(OC3OC(CO)C(O)C(O)C3O)C(OC)=C2");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The two circular sugar moieties and one connected linear sugar (a sugar acid) are removed (all terminal)
         Assertions.assertEquals("OC1=C(OC)C=C(C=CC)C=C1OC", smilesCode);
@@ -531,13 +525,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0120327
                 "O=C(O)CC(O)(C)CC(=O)OCC1=CC=C(OC2OC(CO)C(O)C(O)C2O)C=C1");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //One circular and one linear sugar moiety (a sugar acid) are removed
         Assertions.assertEquals("OC1=CC=C(C=C1)C", smilesCode);
@@ -555,13 +549,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0420141
                 "O=C(O)CC(C(=O)O)C(OCC1C(=C)CCC2C(C)(COC(=O)C(CC(=O)O)C(OCC3C(=C)CCC4C(C)(C)CCCC34C)C(=O)OC)CCCC12C)C(=O)OC");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //One linear sugar moiety is removed (a sugar acid), the other one is not because it is terminal;
         // no other changes are done to the molecule
@@ -588,13 +582,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0260973
                 "O=C(O)CC(O)(C)CC(=O)OC1COC(OC2C(O)C(OC(OC3C(O)C(O)C(OC4CC5CCC6C(CCC7(C)C6CC8OC9(OCC(C)CC9)C(C)C87)C5(C)CC4O)OC3CO)C2OC%10OC(CO)C(O)C(O)C%10O)CO)C(O)C1O");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //All sugars get removed although some circular sugars only become terminal after the removal of the linear one,
         // a sugar acid (that was a problem before)
@@ -604,7 +598,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //CNP0250097
                 "O=C(O)CC(O)(C)CC(=O)OCC1OC(OCC2OC(OC(=O)C34CCC(C)(C)CC4C5=CCC6C7(C)CCC(O)C(C(=O)OC8OC(CO)C(O)C(O)C8O)(C)C7CCC6(C)C5(C)CC3)C(O)C(OC9OC(CO)C(O)C(O)C9O)C2O)C(OC%10OC(CO)C(O)C(O)C%10O)C(O)C1O");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //All sugars get removed although some circular sugars only become terminal after the removal of the linear one,
         // a sugar acid (that was a problem before)
@@ -614,7 +608,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //CNP0428924
                 "O=C(O)CC(O)(C)CC(=O)OC1C(O)C(OC2C3=C(O)C(=CC=C3OC2C(=C)CO)C(=O)C)OC(CO)C1O");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //All sugars get removed although the circular sugar only becomes terminal after the removal of the linear one,
         // a sugar acid (that was a problem before)
@@ -624,7 +618,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //CNP0428862
                 "O=C(O)CC(O)(C)CC(=O)OCC1OC(C=2C(O)=CC(O)=C3C(=O)C=C(OC32)C=4C=CC(O)=C(O)C4)C(O)C(O)C1O");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //All sugars get removed although the circular sugar only become terminal after the removal of the linear one,
         // a sugar acid (that was a problem before)
@@ -634,7 +628,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //CNP0063672
                 "O=C(O)CC(O)(C)CC(=O)OCC1(O)COC(OC2C(O)C(OC(C)C2OC3OCC(O)C(OC4OCC(O)C(O)C4O)C3O)OC5C(OC(=O)C67CCC(C)(C)CC7C8=CCC9C%10(C)CC(O)C(OC%11OC(CO)C(O)C(O)C%11O)C(C(=O)O)(C)C%10CCC9(C)C8(CO)CC6)OC(C)C(OC(=O)C=CC%12=CC(OC)=C(OC)C(OC)=C%12)C5OC%13OC(C)C(O)C(O)C%13O)C1O");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //All sugars get removed although some circular sugars only become terminal after the removal of the linear one,
         // a sugar acid (that was a problem before), only one non-terminal sugar remains
@@ -657,16 +651,16 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles("O=C(O)C1OC(O)C(O)C(O)C1O"); //CNP0171089
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //This molecule is a sugar and should be completely removed
         Assertions.assertEquals("", smilesCode);
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Even with detection of glycosidic bonds, this sugar ring should be removed because there is no other structure
         // it can bind to via a glycosidic bond
@@ -685,11 +679,11 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         originalMolecule = smiPar.parseSmiles("O=C(O)CC(C(=O)O)C(OCC1C(=C)CCC2C(C)(C)CCCC12C)C(=O)O"); //CNP0321675
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The linear sugar moiety (a sugar acid) is removed
         Assertions.assertEquals("C=C1CCC2C(C)(C)CCCC2(C)C1C", smilesCode);
@@ -698,7 +692,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //CNP0032409
                 "O=C1C=C(OC=2C=C3OC(C)(CCC4CNC(=O)C4)C(OOCC(O)C(O)C(O)C(O)CO)CC3=CC12)C");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The linear sugar moiety (a hexose attached via a peroxide bond) is removed
         Assertions.assertEquals("O=C1C=C(OC=2C=C3OC(C)(CCC4CNC(=O)C4)C(O)CC3=CC12)C", smilesCode);
@@ -716,12 +710,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0163522
                 "O=C1C=C(OC=2C1=CC3=C(OC(C)(C)C(OOCC(O)C(O)C(O)C(O)CO)C3)C2[N+]=4C=C5N=CC=C5C4CC)C");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The linear sugar moiety is removed
         Assertions.assertEquals("O=C1C=C(OC=2C1=CC3=C(OC(C)(C)C(O)C3)C2[N+]=4C=C5N=CC=C5C4CC)C", smilesCode);
@@ -741,13 +735,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0162697
                 "O=C1C=C(OC2=CC(OC(=O)C3OC(O)C(O)C(O)C3O)=C(O)C(O)=C12)C=4C=CC(O)=CC4");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The sugar moiety is NOT connected to the core structure via a glycosidic bond, so it is not removed
         Assertions.assertEquals(
@@ -755,7 +749,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(false);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now that this setting is changed, the sugar moiety is removed
         //note: chemically, the carboxy group should be part of the sugar, not of the core
@@ -769,14 +763,14 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(true);
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The circular sugar moiety is NOT connected to the core structure via a glycosidic bond, so it is not removed;
         // also, the removal of linear sugars leaves the circular sugar untouched
         Assertions.assertEquals("O=C1C=C(OC=2C1=C(O)C=C(O)C2C3OC(CO)C(O)C(O)C3O)C=4C=CC(O)=C(O)C4", smilesCode);
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(false);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now that this setting is changed, the sugar moiety is removed
         Assertions.assertEquals("O=C1C=C(OC=2C=C(O)C=C(O)C12)C=3C=CC(O)=C(O)C3", smilesCode);
@@ -798,11 +792,11 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         originalMolecule = smiPar.parseSmiles("O=C(O)CC(O)(C(=O)O)C(C(=O)O)CCCCCCCCCCCCCC"); //CNP0231882
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Only the aliphatic chain remains (in its full length)
         Assertions.assertEquals("CCCCCCCCCCCCCC", smilesCode);
@@ -820,13 +814,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0097028
                 "O=CC1(C)C(OC2OC(C(=O)O)C(O)C(OC3OCC(O)C(O)C3O)C2OC4OC(CO)C(O)C(O)C4O)CCC5(C)C6CC=C7C8CC(C)(C)CCC8(C(=O)OC9OC(C)C(OC(=O)CC(O)CC(OC(=O)CC(O)CC(OC%10OC(CO)C(O)C%10O)C(C)CC)C(C)CC)C(O)C9OC%11OC(C)C(OC%12OCC(O)C(O)C%12O)C(O)C%11O)C(O)CC7(C)C6(C)CCC15");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Only the core structure remains
         Assertions.assertEquals(
@@ -849,18 +843,18 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0416117
                 "O=C(OCC)CCC1=CC=2C=COC2C=3OCCNCC4(SSCC5(OC(OC31)C(O)C(O)C5O)CO)CCCC4");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the sugar ring within the macrocycle can be matched by the linear sugar patterns but should not be removed
         Assertions.assertEquals("O=C(OCC)CCC1=CC=2C=COC2C=3OCCNCC4(SSCC5(OC(OC31)C(O)C(O)C5O)CO)CCCC4", smilesCode);
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, the (circular) sugar moiety within the macrocyle is removed
         Assertions.assertEquals("O=C(OCC)CCC=1C=C(OCCNCC2(SSC)CCCC2)C=3OC=CC3C1", smilesCode);
@@ -879,12 +873,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0230833
                 "O=C1OC2CC3(OC(CCC3)CC(O)CC)OC(CC4(O)OC(C)(C)CC4C=CCCCCCC(O)(C)C(O)C(OC5OC(C)C(N(C)C)CC5)C(O)C(C)C(O)C(O)(C=C1)C)C2C");
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing gets removed
         Assertions.assertEquals(
@@ -892,7 +886,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Again, nothing is removed because the linear sugar is contained in a (macro-)cycle
         Assertions.assertEquals(
@@ -900,7 +894,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, the linear sugar (a small, 4-carbon-membered one) gets removed and disconnects the molecule
         Assertions.assertEquals(
@@ -922,7 +916,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
@@ -930,7 +924,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //CNP0189711
                 "O=C(NC1C(O)OC(CO)C(O)C1OC2OC(CO)C(OC)C(O)C2OC3OC(C)C(O)C(O)C3OC)C");
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed because this molecule has only circular sugars (was a problem before)
         Assertions.assertEquals(
@@ -952,7 +946,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(true);
         sugarRemovalUtil.setDetectLinearAcidicSugarsSetting(true);
         //a molecule containing 2 circular sugars and 2 linear sugars (sugar acids), in both cases 1 terminal and 1 non-terminal
@@ -960,7 +954,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //imaginary molecule created for demonstration purposes
                 "O=C(O)CC(C)(O)CC(=O)OCc1ccc(cc1)OC1C(CO)OC(OC(C(=O)OCc2ccc(OC3OC(CO)CC(O)C3O)cc2)C(O)(CC(C)C)C(=O)OC2CCc3cc4cc(O)c(C)c(O)c4c(O)c3C2=O)C(O)C1O");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the terminal linear and circular sugar moieties are removed
         Assertions.assertEquals(
@@ -968,7 +962,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //all 4 sugar moieties are removed, the two non-terminal sugar moieties included
         Assertions.assertEquals(
@@ -981,7 +975,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         //back to default setting
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(true);
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //only the terminal linear sugar is removed
         Assertions.assertEquals(
@@ -989,7 +983,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the two linear sugar moieties are removed, disconnecting the molecule
         Assertions.assertEquals(
@@ -1000,7 +994,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //imaginary molecule created for demonstration purposes
                 "O=C(O)CC(C)(O)CC(=O)OCc1ccc(cc1)OC1C(CO)OC(OC(C(=O)OCc2ccc(OC3OC(CO)CC(O)C3O)cc2)C(O)(CC(C)C)C(=O)OC2CCc3cc4cc(O)c(C)c(O)c4c(O)c3C2=O)C(O)C1O");
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the two circular sugar moieties are removed, disconnecting the molecule
         Assertions.assertEquals(
@@ -1013,7 +1007,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         //back to default setting
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(true);
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //only the terminal circular sugar moiety is removed
         Assertions.assertEquals(
@@ -1036,17 +1030,17 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
 
         originalMolecule = smiPar.parseSmiles("OC1(OCCC21OC3(O)CCOC3(O2)C)C"); //CNP0017501
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed because the sugar is a spiro ring (before, these were not filtered)
         Assertions.assertEquals("OC1(OCCC21OC3(O)CCOC3(O2)C)C", smilesCode);
         sugarRemovalUtil.setDetectSpiroRingsAsCircularSugarsSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now that the spiro rings are detected, the sugar ring is removed; BUT the adjacent ring is left intact!
         Assertions.assertEquals("OC12OCOC2(OCC1)C", smilesCode);
@@ -1055,13 +1049,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
 
         originalMolecule = smiPar.parseSmiles("OCC1OC2(OC3C(O)C(OC3(OC2)CO)CO)C(O)C1O"); //CNP0306895
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed because the sugar is a spiro ring (before, these were not filtered)
         Assertions.assertEquals("OCC1OC2(OC3C(O)C(OC3(OC2)CO)CO)C(O)C1O", smilesCode);
         sugarRemovalUtil.setDetectSpiroRingsAsCircularSugarsSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now that the spiro rings are detected, the sugar ring is removed; BUT the adjacent ring is left intact!
         Assertions.assertEquals("OCC1OC2(OCCOC2C1O)CO", smilesCode);
@@ -1070,13 +1064,13 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
 
         originalMolecule = smiPar.parseSmiles("OCC1OC2(OCC3OC(OC2)(CO)C(O)C3O)C(O)C1O"); //CNP0341963
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed because the sugar is a spiro ring (before, these were not filtered)
         Assertions.assertEquals("OCC1OC2(OCC3OC(OC2)(CO)C(O)C3O)C(O)C1O", smilesCode);
         sugarRemovalUtil.setDetectSpiroRingsAsCircularSugarsSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now that the spiro rings are detected, the sugar ring is removed; BUT the adjacent ring is left intact!
         Assertions.assertEquals("OCC12OCCOCC(O1)C(O)C2O", smilesCode);
@@ -1097,7 +1091,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
 
         //A molecule consisting entirely of one circular and one linear sugar
         originalMolecule = smiPar.parseSmiles("OCC(O)C(O)C(O)C(O)C1OC(CO)C(O)C(O)C1O"); //CNP0119227
@@ -1105,21 +1099,21 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         Assertions.assertEquals(1, sugarRemovalUtil.getNumberOfCircularSugars(originalMolecule));
         Assertions.assertEquals(1, sugarRemovalUtil.getNumberOfLinearSugars(originalMolecule));
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Completely removed
         Assertions.assertEquals("", smilesCode);
 
         originalMolecule = smiPar.parseSmiles("OCC(O)C(O)C(O)C(O)C1OC(CO)C(O)C(O)C1O"); //CNP0119227
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Only the linear sugar remains
         Assertions.assertEquals("OCC(O)C(O)C(O)CO", smilesCode);
 
         originalMolecule = smiPar.parseSmiles("OCC(O)C(O)C(O)C(O)C1OC(CO)C(O)C(O)C1O"); //CNP0119227
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Only the circular sugar remains
         Assertions.assertEquals("OCC1OCC(O)C(O)C1O", smilesCode);
@@ -1130,21 +1124,21 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         Assertions.assertEquals(1, sugarRemovalUtil.getNumberOfCircularSugars(originalMolecule));
         Assertions.assertEquals(1, sugarRemovalUtil.getNumberOfLinearSugars(originalMolecule));
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Completely removed
         Assertions.assertEquals("", smilesCode);
 
         originalMolecule = smiPar.parseSmiles("OCC(O)C(O)C(O)C(O)C(O)C1OC(O)C(O)C(O)C1N"); //CNP0183311
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Only the linear sugar remains
         Assertions.assertEquals("OCC(O)C(O)C(O)C(O)CO", smilesCode);
 
         originalMolecule = smiPar.parseSmiles("OCC(O)C(O)C(O)C(O)C(O)C1OC(O)C(O)C(O)C1N"); //CNP0183311
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Only the circular sugar remains
         Assertions.assertEquals("OC1OCC(N)C(O)C1O", smilesCode);
@@ -1165,12 +1159,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0346956
                 "OCC1OC2OC3C(O)C(O)C(OC3CO)OC4C(O)C(O)C(OC4CO)OC5C(O)C(O)C(OC5CO)OC6C(O)C(O)C(OC6CO)OC7C(O)C(O)C(OC7CO)OC1C(O)C2O");
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The circular sugars do not get recognized as such because they are fused in the macrocycle
         Assertions.assertEquals(
@@ -1178,7 +1172,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //But the removal of linear sugars (also in cycles) also does not work because the algorithm to split ether bonds
         // (the glycosidic bonds between the sugars) protects bonds in cycles and therefore, the whole molecule gets returned
@@ -1188,7 +1182,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setLinearSugarCandidateMaxSizeSetting(36);
         sugarRemovalUtil.removeLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Only now, with the linear sugar maximum size vastly increased, the sugar molecule can be removed
         Assertions.assertEquals("", smilesCode);
@@ -1207,10 +1201,10 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles("O(*)C1OC(CN)CCC1N");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed because the cycle has not enough oxygen atoms attached
         Assertions.assertEquals("*OC1OC(CN)CCC1N", smilesCode);
@@ -1228,12 +1222,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0254143
                 "O=C(O)C1=CC(O)C(O)C(OC(=O)C2C(=CC=3C=C(O)C(OC4OC(CO)C(O)C(O)C4O)=CC3C2C5=CC=C(O)C(O)=C5)C(=O)OCC(O)C(O)C(O)C(O)C(O)CO)C1");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Both, the terminal circular sugar and the terminal linear sugar are removed
         Assertions.assertEquals(
@@ -1255,12 +1249,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0320551
                 "O=C1N=C2C(=NC=3C=C(C(=CC3N2CC(O)C(O)C(O)COC4OC(CO)C(O)C(O)C4O)C)C)C(=O)N1");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The circular sugar and the linear sugar are removed
         Assertions.assertEquals("O=C1N=C2C(=NC=3C=C(C(=CC3N2C)C)C)C(=O)N1", smilesCode);
@@ -1270,7 +1264,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 "O=C1N=C2C(=NC=3C=C(C(=CC3N2CC(O)C(O)C(O)COC4OC(CO)C(O)C(O)C4O)C)C)C(=O)N1");
         sugarRemovalUtil.setLinearSugarCandidateMinSizeSetting(5);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //The linear sugar is not removed because it is too small
         Assertions.assertEquals("O=C1N=C2C(=NC=3C=C(C(=CC3N2CC(O)C(O)C(O)CO)C)C)C(=O)N1", smilesCode);
@@ -1288,12 +1282,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0321545
                 "O=C(OCC(O)C(O)C(O)C(O)COC1=C(OC2=CC(O)=CC(OCC(O)C(O)C(O)C(O)CO)=C2C1)C=3C=C(O)C(O)=C(O)C3)C=CC4=CC=C(O)C=C4");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Only the one terminal linear sugar is removed
         Assertions.assertEquals(
@@ -1301,7 +1295,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, both linear sugar moieties are removed
         Assertions.assertEquals(
@@ -1321,12 +1315,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0149497
                 "O=C(OCC(O)C(O)C(O)CO)C1(C)CC2=C3C=CC4C5(C)CCC(OC6OC(C)C(O)C(OC7OC(CO)C(O)C(O)C7O)C6O)C(C)(CO)C5CCC4(C)C3(C)CC(O)C2(CO)CC1");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the two terminal circular sugars and the terminal linear sugar are removed
         Assertions.assertEquals(
@@ -1346,12 +1340,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0083402
                 "CC(CCC=C(C)CCC=C(C)CCC=C(C)CCC=C(C)C)CCOP(=O)(O)OP(=O)(O)OC1C(C(C(C(O1)CO)OC2C(C(C(C(O2)CO)OC3C(C(C(C(O3)COC4C(C(C(C(O4)COC5C(C(C(C(O5)CO)OC6C(C(C(C(O6)CO)O)O)O)O)O)O)OC7C(C(C(C(O7)CO)OC8C(C(C(C(O8)CO)O)O)O)O)O)O)O)OC9C(C(C(C(O9)CO)O)O)OC1C(C(C(C(O1)CO)O)O)OC1C(C(C(C(O1)CO)O)OC1C(C(C(C(O1)CO)O)OC1C(C(C(C(O1)CO)O)O)OC1C(C(C(C(O1)CO)O)O)O)O)O)O)O)NC(=O)C)O)NC(=O)C");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //All 14 circular sugar moieties are correctly removed
         Assertions.assertEquals(
@@ -1371,7 +1365,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
         IAtomContainer originalMolecule;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         //the molecule has three interlinked linear sugars, illustrating why splitting ether, ester, and peroxide bonds
         // makes sense in some cases, such as this one
         originalMolecule = smiPar.parseSmiles(
@@ -1405,10 +1399,10 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
     @Test
     void specificTest35() throws Exception {
         SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
-        sugarRemovalUtil.setPreservationModeSetting(PreservationMode.ALL);
+        sugarRemovalUtil.setPreservationModeSetting(SugarRemovalUtility.PreservationMode.ALL);
         float loadFactor = 0.75f;
         int testMoleculesCNPtoSMILESMapInitCapacity = (int)(4.0f * (1.0f / loadFactor) + 2.0f);
         HashMap<String, String> testMoleculesCNPtoSMILESMap = new HashMap<>(testMoleculesCNPtoSMILESMapInitCapacity, loadFactor);
@@ -1449,7 +1443,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectLinearSugarsInRingsSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0008636
@@ -1459,7 +1453,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         //no linear sugar is detected inside the spiro ring
         Assertions.assertFalse(sugarRemovalUtil.hasLinearSugars(originalMolecule));
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //nothing is removed due to the above reasons and because the circular spiro sugar is non-terminal
         Assertions.assertEquals(
@@ -1471,7 +1465,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         //now, spiro sugar rings are detected
         Assertions.assertTrue(sugarRemovalUtil.hasCircularSugars(originalMolecule));
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //still, nothing is removed because the circular spiro sugar is non-terminal
         Assertions.assertEquals(
@@ -1479,7 +1473,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(false);
         sugarRemovalUtil.removeCircularSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //now, the non-terminal spiro sugar ring is removed
         Assertions.assertEquals(
@@ -1509,12 +1503,12 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0310964
                 "O=C(OC1C2=C(O)C=3C(=O)C=4C=CC=C(O)C4C(=O)C3C(O)=C2C(OC5OC(C)C(OC6OC(C)C(OC7OC(C(=O)CC7O)C)C(O)C6)C(N(C)C)C5)CC1(O)CC)C");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing is removed because the terminal sugar-like moiety has a keto group and the option to detect those is turned off
         Assertions.assertEquals(
@@ -1522,7 +1516,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setDetectCircularSugarsWithKetoGroupsSetting(true);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, two sugar moieties are removed; the third sugar-like moiety does not have enough exocyclic oxygen atoms
         Assertions.assertEquals(
@@ -1530,7 +1524,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 smilesCode);
         sugarRemovalUtil.setExocyclicOxygenAtomsToAtomsInRingRatioThresholdSetting(0.3);
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Now, with the exocyclic oxygen ratio threshold lowered, this moiety is also removed
         Assertions.assertEquals(
@@ -1541,7 +1535,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //through manipulation of the SMILES string, the keto group was transformed into a double bound carbon atom (O -> C)
                 "O=C(OC1C2=C(O)C=3C(=O)C=4C=CC=C(O)C4C(=O)C3C(O)=C2C(OC5OC(C)C(OC6OC(C)C(OC7OC(C(=C)CC7O)C)C(O)C6)C(N(C)C)C5)CC1(O)CC)C");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //Nothing should be removed because the double bound carbon atom does not qualify as a keto group
         Assertions.assertEquals(
@@ -1555,17 +1549,17 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
      * @throws Exception if anything goes wrong or an AssertionError occurs
      */
     @Test
-    void testEtherEsterPeroxideSplitting() throws Exception {
+    void testEtherEsterPeroxideSplittingExtraction() throws Exception {
         SmilesParser smiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
         originalMolecule = smiPar.parseSmiles(
                 //CNP0138295
                 "O=CC(O)C(O)C(O)C(O)COC(O)(C(O)COC(=O)C(O)C(O)C(O)C(O)COC1=CC=CC=2C(=O)C3=CC(=CC(O)=C3C(=O)C12)C)C(O)C(O)C=O");
         List<IAtomContainer> beforeSplittingList = new ArrayList<>(1);
         beforeSplittingList.add(originalMolecule);
-        List<IAtomContainer> afterSplittingList = sugarRemovalUtil.splitEtherEsterAndPeroxideBonds(beforeSplittingList);
+        SugarRemovalUtility sru = this.getSugarRemovalUtilityV1200DefaultSettings();
+        List<IAtomContainer> afterSplittingList = sru.splitEtherEsterAndPeroxideBondsExtraction(beforeSplittingList);
         List<String> smilesAfterSplittingList = new ArrayList<>(3);
         for (IAtomContainer fragment : afterSplittingList) {
             String smilesCode = smiGen.create(fragment);
@@ -1591,14 +1585,14 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
         SmilesGenerator smiGen = new SmilesGenerator((SmiFlavor.Canonical));
         IAtomContainer originalMolecule;
         String smilesCode;
-        SugarRemovalUtility sugarRemovalUtil = SugarRemovalUtilityTest.getSugarRemovalUtilityV1200DefaultSettings();
+        SugarRemovalUtility sugarRemovalUtil = this.getSugarRemovalUtilityV1200DefaultSettings();
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(true);
         originalMolecule = smiPar.parseSmiles(
                 //CNP0220816 and CNP0218440
                 "CC1=CC(OC2OC(CO)C(O)C(O)C2O)=C2C3=C(CCC3)C(=O)OC2=C1" +
                         ".O=C(O)CC(OC1OC(CO)C(O)C(O)C1O)(C)CC(=O)OCC=CC2=CC(OC)=C(OC3OC(CO)C(O)C(O)C3O)C(OC)=C2");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the sugar moieties are correctly removed from both parts
         Assertions.assertEquals(
@@ -1609,7 +1603,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //CNP0220816 plus an unconnected propane
                 "CC1=CC(OC2OC(CO)C(O)C(O)C2O)=C2C3=C(CCC3)C(=O)OC2=C1.CCC");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the sugar is removed and the propane is also still there
         Assertions.assertEquals(
@@ -1621,7 +1615,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 // plus an unconnected propane
                 "OCC(O)C(O)C(O)C(O)C1OC(CO)C(O)C(O)C1O.CCC");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the sugar is removed completely but the propane is still there
         Assertions.assertEquals(
@@ -1632,7 +1626,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
                 //just the propane
                 "CCC");
         sugarRemovalUtil.removeCircularAndLinearSugars(originalMolecule);
-        SugarRemovalUtilityTest.saturate(originalMolecule);
+        this.saturate(originalMolecule);
         smilesCode = smiGen.create(originalMolecule);
         //the propane is still there
         Assertions.assertEquals(
@@ -1648,7 +1642,7 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
      * @throws CDKException if atom type perception or hydrogen atom addition
      *                      fails
      */
-    protected static void saturate(IAtomContainer molecule) throws CDKException {
+    protected void saturate(IAtomContainer molecule) throws CDKException {
         if (!molecule.isEmpty()) {
             AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(molecule);
             CDKHydrogenAdder.getInstance(SilentChemObjectBuilder.getInstance()).addImplicitHydrogens(molecule);
@@ -1663,11 +1657,11 @@ class SugarRemovalUtilityTest extends SugarRemovalUtility {
      *
      * @return a SugarRemovalUtility object with version 1.2.0.0 default settings
      */
-    protected static SugarRemovalUtility getSugarRemovalUtilityV1200DefaultSettings() {
+    protected SugarRemovalUtility getSugarRemovalUtilityV1200DefaultSettings() {
         SugarRemovalUtility sugarRemovalUtil = new SugarRemovalUtility(SilentChemObjectBuilder.getInstance());
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithOGlycosidicBondSetting(false);
         sugarRemovalUtil.setRemoveOnlyTerminalSugarsSetting(true);
-        sugarRemovalUtil.setPreservationModeSetting(PreservationMode.HEAVY_ATOM_COUNT);
+        sugarRemovalUtil.setPreservationModeSetting(SugarRemovalUtility.PreservationMode.HEAVY_ATOM_COUNT);
         sugarRemovalUtil.setPreservationModeThresholdSetting(5);
         sugarRemovalUtil.setDetectCircularSugarsOnlyWithEnoughExocyclicOxygenAtomsSetting(true);
         sugarRemovalUtil.setExocyclicOxygenAtomsToAtomsInRingRatioThresholdSetting(0.5);


### PR DESCRIPTION
This new functionality, the <i>SugarDetectionUtility</i>, can be used for algorithmically separating glycosides into their aglycone and sugar moieties. The main feature is the ability to create copies of both the aglycone and individual sugar fragments from a given molecule, with proper handling of attachment points and stereo chemistry, and some optional post-processing options. The new class extends the <i>SugarRemovalUtility</i> and uses the same algorithm (described [here](https://doi.org/10.1186/s13321-020-00467-y)) to generate the aglycone (with slight deviations, see below).

Background:
The <i>SugarRemovalUtility</i> is focused on generating a sensible aglycone and extracts the removed sugars only as Tetrahydrofuran/Tetrahydropyran (CNP IDs refer to compounds in the [COCONUT natural products database](https://coconut.naturalproducts.net/)):
<p></p>
<img width="3564" height="1417" alt="image" src="https://github.com/user-attachments/assets/7a023e78-320f-4a61-8f65-79262e92ab10" />
<p></p>
<p>This shortcoming is now resolved by the Sugar <i>Detection</i> Utility:</p>
<p></p>
<img width="3524" height="1457" alt="image" src="https://github.com/user-attachments/assets/2485932c-3bf0-4345-9498-b00c4ba9b383" />
<p></p>
<p>The Sugar <i>Detection</i> Utility supports:</p>
<ul>
  <li>Duplication of connecting hetero atoms in glycosidic bonds, to produce more sensible educts (see above)</li>
  <li>Preservation of stereo chemistry at connection points (see above)</li>
  <li>Detection and extraction of both circular and linear sugar moieties (see the Sugar Removal Utility documentation for more details on this)</li>
<p></p>
<img width="3626" height="1462" alt="image" src="https://github.com/user-attachments/assets/45b5f518-17ae-4fbb-9526-e163791e6413" />
<p></p>
  <li>Saturation of broken bonds with either implicit hydrogen atoms or pseudo ("R") atoms</li>
<p></p>
<img width="3576" height="1462" alt="image" src="https://github.com/user-attachments/assets/3161cec7-47db-431b-9011-f324d72b8490" />
<p></p>
  <li>Post-processing of sugar fragments including bond splitting (O-glycosidic, ether, ester, peroxide) to separate the individual sugars</li>
<p></p>
<img width="3418" height="1418" alt="image" src="https://github.com/user-attachments/assets/539a9511-7ef7-4d9f-aae1-e0eec60dd962" />
<p></p>
  <li>Limiting this post-processing by size, so that small modifications remain attached to the sugars</li>
<p></p>
<img width="3608" height="1457" alt="image" src="https://github.com/user-attachments/assets/e9661506-f7c2-4c99-8df0-31868aad6bfa" />
<p></p>
  <li>Optional mapping of atoms and bonds from the original molecule to their copies in the aglycone and sugar fragments (to retrieve atoms indices or an extracted fragment or to get group indices for all atoms in the original molecule</li>
</ul>

<p></p>All sugar detection and removal operations respect the settings inherited from the parent <i>SugarRemovalUtility</i> class, including terminal vs. non-terminal sugar removal, preservation mode settings, various detection thresholds, etc. (for documentation, see the code or the paper linked above)
<p></p>
<p>In two cases, the initial <i>SugarRemovalUtility</i> results are corrected for extraction:</p>
<ul>
    <li>When a sugar would lose its C6</li>
</ul>
<p></p>
<img width="3619" height="1345" alt="image" src="https://github.com/user-attachments/assets/755ceabb-71b5-4ca3-b37c-962e5a846237" />
<p></p>
<ul>
    <li>When a sugar is on the "carboxy end" of an ester bond to the aglycone</li>
<p></p>
<img width="3509" height="1367" alt="image" src="https://github.com/user-attachments/assets/1a1090fc-a0e5-4d97-9d7d-b5a8f4062468" />
<p></p>
</ul>
<p><strong>Basic Usage Example:</strong></p>
<pre>
SugarDetectionUtility utility = new SugarDetectionUtility(SilentChemObjectBuilder.getInstance());
//check the overloaded variants of this method for more options
List<IAtomContainer> fragments = utility.copyAndExtractAglyconeAndSugars(molecule);
IAtomContainer aglycone = fragments.get(0);  // First element is always the aglycone
// Subsequent elements are individual sugar fragments
</pre>

The code is documented and extensively tested.

If you want to see the SugarDetectionUtility in action, check out our [MOlecule fRagmenTAtion fRamework (MORTAR) application](https://github.com/FelixBaensch/MORTAR), the SDU will be part of the next release.

A paper describing the algorithm is coming up.

Looking forward to your feedback!