### PR TITLE
Handle Link Nodes in CXSMILES

### DIFF
--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesParser.java
@@ -25,9 +25,12 @@ package org.openscience.cdk.smiles;
 
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.sgroup.Sgroup;
+import org.openscience.cdk.sgroup.SgroupType;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -383,6 +386,38 @@ final class CxSmilesParser {
         return processIntListMap(state.ligandOrdering, iter);
     }
 
+    /**
+     * Link Nodes are used for repeats in query structures.
+     * @param iter the character iterator
+     * @param state the state
+     * @return the link node is valid or not
+     */
+    private static boolean processLinkNode(CharIter iter, CxSmilesState state) {
+        if (state.mysgroups == null)
+            state.mysgroups = new ArrayList<>();
+        final int aidx = processUnsignedInt(iter);
+        if (aidx < 0)
+            return false;
+        if (!iter.nextIf(':'))
+            return false;
+        List<Integer> vals = new ArrayList<>(4);
+        if (!processIntList(iter, DOT_SEPARATOR, vals))
+            return false;
+        if (vals.size() < 2)
+            return false;
+        int lowerBound = vals.get(0);
+        int upperBound = vals.get(1);
+        CxSmilesState.CxPolymerSgroup sgroup = new CxSmilesState.CxPolymerSgroup("n",
+                                                                                 Collections.singletonList(aidx),
+                                                                                 lowerBound + "-" + upperBound,
+                                                                                 "ht");
+        for (int i=2; i<vals.size(); i++) {
+            sgroup.bonds.add(vals.get(i));
+        }
+        state.mysgroups.add(sgroup);
+        return true;
+    }
+
     private static boolean processWedges(CharIter iter, CxSmilesState state, IBond.Display display) {
         boolean ok = false;
         while (iter.hasNext()) {
@@ -583,7 +618,13 @@ final class CxSmilesParser {
                         if (!processLigandOrdering(iter, state))
                             return -1;
                     }
-                    else {
+                    // LN, Link Node
+                    else if (iter.nextIf('N')) {
+                        if (!iter.nextIf(':'))
+                            return -1;
+                        if (!processLinkNode(iter, state))
+                            return -1;
+                    } else {
                         // LP, bond connected lone pair?
                         return -1;
                     }

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesState.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/CxSmilesState.java
@@ -65,6 +65,7 @@ final class CxSmilesState {
     static class CxSgroup {
         final Set<CxSgroup> children = new HashSet<>();
         List<Integer> atoms = new ArrayList<>();
+        List<Integer> bonds = new ArrayList<>();
         int id = -1;
     }
 

--- a/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
+++ b/storage/smiles/src/main/java/org/openscience/cdk/smiles/SmilesParser.java
@@ -54,9 +54,11 @@ import uk.ac.ebi.beam.Graph;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -200,7 +202,7 @@ public final class SmilesParser {
 
         final String reactants = smiles.substring(0, first);
         final String agents = smiles.substring(first + 1, second);
-        final String products = smiles.substring(second + 1, smiles.length());
+        final String products = smiles.substring(second + 1);
 
         IReaction reaction = builder.newInstance(IReaction.class);
 
@@ -346,6 +348,7 @@ public final class SmilesParser {
             // if a kekule structure could not be assigned.
             IAtomContainer mol = beamToCDK.toAtomContainer(kekulise ? g.kekule() : g,
                                                            kekulise);
+            Cycles.markRingAtomsAndBonds(mol);
 
             if (!isRxnPart) {
                 try {
@@ -772,8 +775,23 @@ public final class SmilesParser {
                 CxPolymerSgroup psgroup = (CxPolymerSgroup) cxsgroup;
                 Sgroup sgroup = new Sgroup();
 
-                Set<IAtom> atomset = new HashSet<>();
+                Set<IAtom> sgroupAtoms = new HashSet<>();
+                Set<IBond> xbonds = new HashSet<>();
+
                 IAtomContainer mol = null;
+                for (Integer idx : psgroup.bonds) {
+                    if (idx >= atoms.size())
+                        continue;
+                    IBond bond = bonds.get(idx);
+                    IAtomContainer bmol = atomToMol.get(bond.getBegin());
+                    if (mol == null)
+                        mol = bmol;
+                    else if (bmol != mol)
+                        continue PolySgroup;
+                    xbonds.add(bond);
+                }
+
+
                 for (Integer idx : psgroup.atoms) {
                     if (idx >= atoms.size())
                         continue;
@@ -785,34 +803,67 @@ public final class SmilesParser {
                     else if (amol != mol)
                         continue PolySgroup;
 
-                    atomset.add(atom);
+                    sgroupAtoms.add(atom);
                 }
 
                 if (mol == null)
                     continue;
 
-                for (IAtom atom : atomset) {
-                    for (IBond bond : mol.getConnectedBondsList(atom)) {
-                        IAtom nbor = bond.getOther(atom);
-                        if (!atomset.contains(nbor)) {
-                            boolean crossing = true;
+                // special case, if we have a single atom it may have been a link
+                // node if there is exactly 2 ring bonds we shouldn't need users
+                // to specify what the repeat pattern was
+                if (sgroupAtoms.size() == 1 && xbonds.isEmpty()) {
 
-                            // check for variable attachments see https://github.com/cdk/depict/issues/36
-                            if (cxstate.positionVar != null) {
-                                List<Integer> ends = cxstate.positionVar.get(mol.indexOf(nbor));
-                                if (ends != null) {
-                                    for (Integer end : ends) {
-                                        if (atomset.contains(mol.getAtom(end)))
-                                            crossing = false;
+                    IAtom atom = sgroupAtoms.iterator().next();
+                    for (IBond bond : atom.bonds()) {
+                        if (bond.isInRing())
+                            xbonds.add(bond);
+                    }
+
+                    if (xbonds.size() != 2)
+                        xbonds.clear();
+                }
+
+                // crossing bonds are implied
+                if (xbonds.isEmpty()) {
+                    for (IAtom atom : sgroupAtoms) {
+                        for (IBond bond : mol.getConnectedBondsList(atom)) {
+                            IAtom nbor = bond.getOther(atom);
+                            if (!sgroupAtoms.contains(nbor)) {
+                                boolean crossing = true;
+
+                                // check for variable attachments see https://github.com/cdk/depict/issues/36
+                                if (cxstate.positionVar != null) {
+                                    List<Integer> ends = cxstate.positionVar.get(mol.indexOf(nbor));
+                                    if (ends != null) {
+                                        for (Integer end : ends) {
+                                            if (sgroupAtoms.contains(mol.getAtom(end)))
+                                                crossing = false;
+                                        }
                                     }
                                 }
-                            }
 
-                            if (crossing)
-                                sgroup.addBond(bond);
+                                if (crossing)
+                                    sgroup.addBond(bond);
+                            }
+                        }
+                        sgroup.addAtom(atom);
+                    }
+                } else {
+                    Deque<IAtom> queue = new ArrayDeque<>(sgroupAtoms);
+                    while (!queue.isEmpty()) {
+                        IAtom atom = queue.poll();
+                        for (IBond bond : atom.bonds()) {
+                            if (xbonds.contains(bond))
+                                continue;
+                            IAtom nbor = bond.getOther(atom);
+                            if (sgroupAtoms.add(nbor)) {
+                                queue.add(nbor);
+                            }
                         }
                     }
-                    sgroup.addAtom(atom);
+                    for (IAtom atom : sgroupAtoms)
+                        sgroup.addAtom(atom);
                 }
 
                 sgroup.setSubscript(psgroup.subscript);
@@ -994,10 +1045,6 @@ public final class SmilesParser {
         // check for RDKit atropisomers
         if (!isAtropisomerAtom(atomToWedgeFrom))
             return;
-
-        // We need ring flags set, this is not cached but
-        // (hopefully) there are only a few wedges
-        Cycles.markRingAtomsAndBonds(atomToMol.get(atomToWedgeFrom));
 
         // Find the bond to apply the atropisomerism to
         IBond atropisomerBond = null;

--- a/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
+++ b/storage/smiles/src/test/java/org/openscience/cdk/smiles/CxSmilesTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.openscience.cdk.CDKConstants;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
-import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
@@ -486,5 +485,28 @@ class CxSmilesTest {
         Atropisomeric at = findAtropisomerStereo(mol);
         assertNotNull(at);
         assertEquals(IStereoElement.RIGHT, at.getConfigOrder());
+    }
+
+    @Test
+    void testSimpleLinkNode() throws CDKException {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        SmilesParser smipar = new SmilesParser(bldr);
+        IAtomContainer mol = smipar.parseSmiles("C1NCNC1 |LN:2:1.3|");
+        SmilesGenerator sg = new SmilesGenerator(SmiFlavor.Default);
+        Assertions.assertEquals("C1NCNC1 |Sg:n:2:1-3:ht|", sg.create(mol));
+    }
+
+    @Test
+    void testLinkNodeWithAttachedAtoms() throws CDKException {
+        IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+        SmilesParser smipar = new SmilesParser(bldr);
+
+        // xbonds are implied due to the ring bonds
+        IAtomContainer mol = smipar.parseSmiles("C1NC(O)NC1 |LN:2:1.3|");
+        SmilesGenerator sg = new SmilesGenerator(SmiFlavor.Default);
+        Assertions.assertEquals("C1NC(O)NC1 |Sg:n:2,3:1-3:ht|", sg.create(mol));
+
+        mol = smipar.parseSmiles("C1NC(O)NC1 |LN:2:1.3.1.3|");
+        Assertions.assertEquals("C1NC(O)NC1 |Sg:n:2,3:1-3:ht|", sg.create(mol));
     }
 }


### PR DESCRIPTION
In midst of writing a blog post on repeat groups I realised we don't handle link nodes CXSMILES. Quite east to handle just treated that as Sgroups.

It may be useful to add the optimisation going the other way as well.