### PR TITLE
use thread safe collection in RoundRobinFormulaGenerator

### DIFF
--- a/tool/formula/src/main/java/org/openscience/cdk/formula/RoundRobinFormulaGenerator.java
+++ b/tool/formula/src/main/java/org/openscience/cdk/formula/RoundRobinFormulaGenerator.java
@@ -1,5 +1,6 @@
 package org.openscience.cdk.formula;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IIsotope;
 import org.openscience.cdk.interfaces.IMolecularFormula;
@@ -156,10 +157,10 @@ final class DecomposerFactory {
 
     private static final int maximalNumberOfCachedDecomposers = 10;
     private final static DecomposerFactory instance = new DecomposerFactory();
-    private final List<RangeMassDecomposer> decomposerCache;
+    // use a thread safe collection as decomposers may be requested from multiple threads concurrently
+    private final ConcurrentLinkedQueue<RangeMassDecomposer> decomposerCache = new ConcurrentLinkedQueue<>();
 
     private DecomposerFactory() {
-        this.decomposerCache = new ArrayList<>(maximalNumberOfCachedDecomposers);
     }
 
     public static DecomposerFactory getInstance() {
@@ -172,7 +173,7 @@ final class DecomposerFactory {
                 return decomposer;
             }
         }
-        if (decomposerCache.size() >= maximalNumberOfCachedDecomposers) decomposerCache.remove(0);
+        if (decomposerCache.size() >= maximalNumberOfCachedDecomposers) decomposerCache.poll();
         final RangeMassDecomposer decomposer = new RangeMassDecomposer(alphabet);
         decomposerCache.add(decomposer);
         return decomposer;


### PR DESCRIPTION
Hi all,

thanks for providing the CDK first of all 👍. 

We use it in mzmine to generate molecular formulas and noticed, that we cannot parallelise the generation for the RoundRobinFormulaGenerator (line 170). The issue was that the cache in there was not thread safe and iteration caused a concurrent modification exception.

I replaced the current cache with a thread-safe ConcurrentLinkedQueque.