### PR TITLE
Introduce separate base counter for /F: layer parsing in InChINumbersTools.parseUSmilesNumbers

### DIFF
--- a/storage/inchi/src/main/java/org/openscience/cdk/graph/invariant/InChINumbersTools.java
+++ b/storage/inchi/src/main/java/org/openscience/cdk/graph/invariant/InChINumbersTools.java
@@ -137,24 +137,30 @@ public class InChINumbersTools {
             Arrays.fill(first, -1);
 
             if ((index = aux.indexOf("/F:")) >= 0) {
-                String[] fixedHNumbers = aux.substring(index + 3, aux.indexOf('/', index + 3)).split(";");
+                int fEnd = aux.indexOf('/', index + 3);
+                if (fEnd < 0) fEnd = aux.length();
+                String[] fixedHNumbers = aux.substring(index + 3, fEnd).split(";");
+                int b = 0; // independent base-component cursor
                 for (int i = 0; i < fixedHNumbers.length; i++) {
                     String component = fixedHNumbers[i];
 
                     // m, 2m, 3m ... need to lookup number in the base numbering
                     if (component.charAt(component.length() - 1) == 'm') {
-                        int n = component.length() > 1 ? Integer
-                                .parseInt(component.substring(0, component.length() - 1)) : 1;
-                        for (int j = 0; j < n; j++) {
-                            String[] numbering = baseNumbers[i + j].split(",");
-                            first[i + j] = Integer.parseInt(numbering[0]) - 1;
+                        int n = component.length() > 1
+                                ? Integer.parseInt(component.substring(0, component.length() - 1))
+                                : 1;
+                        for (int j = 0; j < n && (b + j) < baseNumbers.length ; j++) {
+                            String[] numbering = baseNumbers[b + j].split(",");
+                            first[b + j] = Integer.parseInt(numbering[0]) - 1;
                             for (String number : numbering)
                                 numbers[Integer.parseInt(number) - 1] = label++;
                         }
+                        b += n;
                     } else {
                         String[] numbering = component.split(",");
                         for (String number : numbering)
                             numbers[Integer.parseInt(number)-1] = label++;
+                        b++;
                     }
                 }
             } else {

--- a/storage/inchi/src/test/java/org/openscience/cdk/graph/invariant/InChINumbersToolsTest.java
+++ b/storage/inchi/src/test/java/org/openscience/cdk/graph/invariant/InChINumbersToolsTest.java
@@ -32,6 +32,9 @@ import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesParser;
 
+import java.util.Arrays;
+import java.util.stream.LongStream;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
@@ -180,6 +183,53 @@ class InChINumbersToolsTest extends CDKTestCase {
     void emptyAtomContainer_test() throws Exception {
         IAtomContainer container = SilentChemObjectBuilder.getInstance().newAtomContainer();
         assertThat(InChINumbersTools.getUSmilesNumbers(container), is(new long[0]));
+    }
+
+    @Test
+    void fixedHydrogenLayerWithMixedMEntries() throws Exception {
+        // This aux string provides an /F: layer with mixed m-entries and explicit
+        // orderings: "4m;18,19,13,15,14,20,17,16;2m"
+        // The middle component overrides order in /N: layer  [...18,19,13,15,14,20,16,17...],
+        // swapping atoms 16 and 17. The resulting array must:
+        //   (a) label all 74 atoms with unique values 1..74
+        //   (b) respect the /F: override: atom 17 must receive an earlier label than atom 16
+        long[] numbers = InChINumbersTools.parseUSmilesNumbers(
+                "AuxInfo=1/1/N:62,68,67,69,64,63,65,66,71,72,70,73,74;1,3,7,6,4,8,2,5,10,9,11,12;" +
+                        "42,51,50,47,45,48,49,44,53,52,46,43;31,36,33,32,34,35,37,41,40,38,39;" +
+                        "18,19,13,15,14,20,16,17;54,57,59,56,60,61,58,55;24,23,21,30,22,27,28,29,25,26" +
+                        "/E:(12,13);(1,2)(4,5)(11,12);;(10,11);(7,8);(5,6);(6,7,8)" +
+                        "/F:4m;18,19,13,15,14,20,17,16;2m" +
+                        "/E:;(1,2)(4,5);;;;;m" +
+                        "/rA:74nCCCCCCCCOCOOCNCOOCCOCOCCOPOO-O-OCCCCCCCOOONCSCCOCCCCCONCSCCOCOOCCCCCCCCOCNOO" +
+                        "/rB:d1;s2;d3;s4;s1d5;s2;d+7;s5;s8;s10;d10;;s13;s13;w15;s15;s13;s18;d19;;d21;s21;" +
+                        "s21;s23;s25;w26;s26;s26;s24;;d31;s32;d33;s34;s31d35;s32;s37;d37;s35;s34;;V42;s43;" +
+                        "s44;d44;d45;s47;d48;s49;s45d50;s49;s48;;V54;s55;s56;d56;s57;s59;d59;;d62;s63;d64;" +
+                        "s65;s62d66;s63;d+68;s66;s69;s65;s71;d71;" +
+                        "/rC:482.8625,-229.1854,0;482.8625,-240.6946,0;492.8291,-246.4492,0;502.7958,-240.6946,0;" +
+                        "502.7958,-229.1854,0;492.8291,-223.4308,0;472.8958,-246.4492,0;462.9372,-240.6946,0;" +
+                        "512.7624,-223.4308,0;452.9706,-246.4492,0;443.0039,-240.6946,0;452.9706,-257.9584,0;" +
+                        "31.078,-340.7873,0;41.0446,-335.0327,0;21.1113,-335.0327,0;11.1846,-340.7713,0;" +
+                        "21.1113,-323.5635,0;31.078,-352.2965,0;41.0446,-358.0511,0;41.0446,-369.5603,0;" +
+                        "24.2524,-404.5035,0;34.227,-398.7489,0;14.2857,-398.7489,0;24.2524,-416.0126,0;" +
+                        "14.2857,-387.2397,0;4.3185,-381.4851,0;-5.6487,-387.2397,0;14.2857,-375.7305,0;" +
+                        "4.3185,-369.9759,0;34.227,-421.7672,0;117.5567,-348.1564,0;117.5567,-359.6656,0;" +
+                        "127.5234,-365.4202,0;137.49,-359.6656,0;137.49,-348.1564,0;127.5234,-342.4018,0;" +
+                        "107.5901,-365.4202,0;97.6234,-359.6656,0;107.5901,-376.9293,0;147.4566,-342.4018,0;" +
+                        "147.4566,-365.4202,0;211.0037,-365.3318,0;211.0037,-376.841,0;205.2491,-386.8077,0;" +
+                        "211.0037,-396.7743,0;193.7399,-386.8077,0;205.2491,-406.7409,0;211.0037,-416.7076,0;" +
+                        "222.5048,-416.7076,0;228.2594,-406.7409,0;222.5048,-396.7743,0;228.2594,-426.6742,0;" +
+                        "205.2491,-426.6742,0;276.8385,-412.3802,0;276.8385,-423.8893,0;271.0839,-433.856,0;" +
+                        "276.8385,-443.8226,0;259.5747,-433.856,0;271.0839,-453.7893,0;276.8385,-463.7559,0;" +
+                        "259.5747,-453.7893,0;335.3282,-348.3642,0;335.3282,-359.8734,0;345.2948,-365.628,0;" +
+                        "355.2615,-359.8734,0;355.2615,-348.3642,0;345.2948,-342.6096,0;325.3615,-365.628,0;" +
+                        "315.4029,-359.8734,0;365.2281,-342.6096,0;305.4363,-365.628,0;365.2281,-365.628,0;" +
+                        "295.4696,-359.8734,0;305.4363,-377.1371,0;",
+                mock(74));
+        long[] sorted = Arrays.stream(numbers).sorted().toArray();
+        long[] expected = LongStream.rangeClosed(1, 74).toArray();
+        Assertions.assertArrayEquals(expected, sorted);
+        Assertions.assertTrue(numbers[16]<numbers[15],
+                "atom 17 should be labelled before atom 16 due to /F: override");
     }
 
     static IAtomContainer mock(int nAtoms) {


### PR DESCRIPTION
An ArrayIndexOutOfBoundsException occurs when creating a ReactionSMILES for a reaction with the AuxInfo below during the SMILES generation process. The `long[]` resulting from `parseUSmilesNumbers` contains numbers higher than the amount of atoms. 

Problem: When parsing the `/F:` layer, the loop variable `i` was used as both index into the `fixedHNumbers` (F-layer entries) and the index into `baseNumbers` (N-layer entries). Both arrays advance differently, so an m-suffixed entry like 4m consumes 4 `baseNumbers` entries but only 1 entry `fixedHNumbers`. Using `i` for both meant that the cursor for `baseNumbers` was no longer synchronised, which could result in skipped or overwritten entries and lead to incorrect atom labels.

Solution: Introducing a separate integer `b`as an independent cursor for the `baseNumbers` array. It increases by `n` after an `nm` entry (e.g. n = 4 for 4m) and by 1 after a plain entry, while `i` continues to increase by 1 each iteration.

Please let me know what you think.

Disclaimer: comments in the test are AI generated and AI helps to format the AuxInfo string.

<details>
  <summary>AuxInfo</summary>
AuxInfo=1/1/N:62,68,67,69,64,63,65,66,71,72,70,73,74;1,3,7,6,4,8,2,5,10,9,11,12;42,51,50,47,45,48,49,44,53,52,46,43;31,36,33,32,34,35,37,41,40,38,39;18,19,13,15,14,20,16,17;54,57,59,56,60,61,58,55;24,23,21,30,22,27,28,29,25,26/E:(12,13);(1,2)(4,5)(11,12);;(10,11);(7,8);(5,6);(6,7,8)/F:4m;18,19,13,15,14,20,17,16;2m/E:;(1,2)(4,5);;;;;m/rA:74nCCCCCCCCOCOOCNCOOCCOCOCCOPOO-O-OCCCCCCCOOONCSCCOCCCCCONCSCCOCOOCCCCCCCCOCNOO/rB:d1;s2;d3;s4;s1d5;s2;d+7;s5;s8;s10;d10;;s13;s13;w15;s15;s13;s18;d19;;d21;s21;s21;s23;s25;w26;s26;s26;s24;;d31;s32;d33;s34;s31d35;s32;s37;d37;s35;s34;;V42;s43;s44;d44;d45;s47;d48;s49;s45d50;s49;s48;;V54;s55;s56;d56;s57;s59;d59;;d62;s63;d64;s65;s62d66;s63;d+68;s66;s69;s65;s71;d71;/rC:482.8625,-229.1854,0;482.8625,-240.6946,0;492.8291,-246.4492,0;502.7958,-240.6946,0;502.7958,-229.1854,0;492.8291,-223.4308,0;472.8958,-246.4492,0;462.9372,-240.6946,0;512.7624,-223.4308,0;452.9706,-246.4492,0;443.0039,-240.6946,0;452.9706,-257.9584,0;31.078,-340.7873,0;41.0446,-335.0327,0;21.1113,-335.0327,0;11.1846,-340.7713,0;21.1113,-323.5635,0;31.078,-352.2965,0;41.0446,-358.0511,0;41.0446,-369.5603,0;24.2524,-404.5035,0;34.227,-398.7489,0;14.2857,-398.7489,0;24.2524,-416.0126,0;14.2857,-387.2397,0;4.3185,-381.4851,0;-5.6487,-387.2397,0;14.2857,-375.7305,0;4.3185,-369.9759,0;34.227,-421.7672,0;117.5567,-348.1564,0;117.5567,-359.6656,0;127.5234,-365.4202,0;137.49,-359.6656,0;137.49,-348.1564,0;127.5234,-342.4018,0;107.5901,-365.4202,0;97.6234,-359.6656,0;107.5901,-376.9293,0;147.4566,-342.4018,0;147.4566,-365.4202,0;211.0037,-365.3318,0;211.0037,-376.841,0;205.2491,-386.8077,0;211.0037,-396.7743,0;193.7399,-386.8077,0;205.2491,-406.7409,0;211.0037,-416.7076,0;222.5048,-416.7076,0;228.2594,-406.7409,0;222.5048,-396.7743,0;228.2594,-426.6742,0;205.2491,-426.6742,0;276.8385,-412.3802,0;276.8385,-423.8893,0;271.0839,-433.856,0;276.8385,-443.8226,0;259.5747,-433.856,0;271.0839,-453.7893,0;276.8385,-463.7559,0;259.5747,-453.7893,0;335.3282,-348.3642,0;335.3282,-359.8734,0;345.2948,-365.628,0;355.2615,-359.8734,0;355.2615,-348.3642,0;345.2948,-342.6096,0;325.3615,-365.628,0;315.4029,-359.8734,0;365.2281,-342.6096,0;305.4363,-365.628,0;365.2281,-365.628,0;295.4696,-359.8734,0;305.4363,-377.1371,0;
</details>