### PR TITLE
2026 04 24

### DIFF
--- a/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
+++ b/app/depict/src/main/java/org/openscience/cdk/depict/Abbreviations.java
@@ -1255,7 +1255,7 @@ public class Abbreviations implements Iterable<String> {
 
     private boolean addDisconnectedAbbreviation(IAtomContainer mol, String label) {
         try {
-            String cansmi = new SmilesGenerator(SmiFlavor.Unique).create(mol);
+            String cansmi = usmigen.create(mol);
             disconnectedAbbreviations.put(cansmi, label);
             labels.add(label);
             return true;

--- a/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
+++ b/app/depict/src/test/java/org/openscience/cdk/depict/AbbreviationsTest.java
@@ -901,6 +901,19 @@ class AbbreviationsTest {
     }
 
     @Test
+    void testIsotopesInAbbreviationDisconnecte() throws Exception {
+        String smi = "[2H]OC([2H])([2H])[2H]";
+        Abbreviations factory = new Abbreviations();
+        factory.add("[2H]C([2H])([2H])O[2H] CD3OD");
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_TERMINAL);
+        factory.with(Abbreviations.Option.AUTO_CONTRACT_HETERO);
+        factory.with(Abbreviations.Option.ALLOW_SINGLETON);
+        IAtomContainer mol = smi(smi);
+        List<Sgroup> sgroups = factory.generate(mol);
+        assertThat(sgroups.size(), is(1));
+    }
+
+    @Test
     void loadFromFile() throws Exception {
         Abbreviations factory = new Abbreviations();
         assertThat(factory.loadFromFile("obabel_superatoms.smi"), is(27));

--- a/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
+++ b/base/standard/src/main/java/org/openscience/cdk/stereo/StereoElementFactory.java
@@ -31,6 +31,7 @@ import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
+import org.openscience.cdk.interfaces.IElement;
 import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.interfaces.ITetrahedralChirality;
 import org.openscience.cdk.tools.ILoggingTool;
@@ -615,17 +616,21 @@ public abstract class StereoElementFactory {
                     // we have already previously checked whether 'v' is at the
                     // 'point' and so these must be inverse (fat-end of hatched
                     // wedge is a stereocenter) ala Daylight
-                    if (bond.getDisplay() == IBond.Display.WedgedHashBegin || bond.getDisplay() == IBond.Display.WedgedHashEnd) {
+                    if (bond.getDisplay() == IBond.Display.WedgedHashBegin ||
+                        bond.getDisplay() == IBond.Display.WedgedHashEnd) {
+
 
                         // we stick to the 'point' end convention but can
                         // interpret if the bond isn't connected to another
                         // stereocenter - otherwise it's ambiguous!
                         if (stereocenters.stereocenterType(w) != Stereocenters.Stereocenter.Non) {
                             stereocenters.checkSymmetry();
-                            if (stereocenters.isStereocenter(w)) {
+                            if (stereocenters.isStereocenter(w) && stereocenters.isStereocenter(v)) {
                                 logger.error("Ambiguous down wedge bond between atom indexes ", w, " and ", v);
                                 return null;
                             }
+                            if (!stereocenters.isStereocenter(v))
+                                continue;
                         }
 
                         logger.warn("Inverse wedge bond used for stereo at atom index ", v);


### PR DESCRIPTION
Two minor fixes.
- abbreviations should allow [2H] when collapsing the whole thing, simply we need to reuse the existing smiles generator field.
- the warning on stereochemistry can be better