### PR TITLE
Fix a minor corner case in hydrogen normalisation.

### DIFF
--- a/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/Hydrogens.java
+++ b/base/standard/src/main/java/org/openscience/cdk/tools/manipulator/Hydrogens.java
@@ -506,19 +506,25 @@ final class Hydrogens {
                 IAtom focus = atomStereo.getFocus();
                 List<IAtom> carriers = atomStereo.getCarriers();
                 int rbonds = 0;
+                int bcount = 0;
                 for (IAtom nbor : carriers) {
                     IBond bond = container.getBond(focus, nbor);
-                    if (bond != null && bond.isInRing())
-                        rbonds++;
+                    if (bond != null) {
+                        if (nbor.getAtomicNumber() != IElement.H)
+                            bcount++;
+                        if (bond.isInRing())
+                            rbonds++;
+                    }
                 }
                 int adjacentStereo = 0;
                 for (IStereoElement<?, ?> otherStereo : container.stereoElements()) {
-                    if (otherStereo instanceof ITetrahedralChirality) {
-                        if (carriers.contains((IAtom) otherStereo.getFocus()))
+                    if (otherStereo instanceof ITetrahedralChirality && otherStereo != se) {
+                        if (carriers.contains((IAtom)otherStereo.getFocus())) {
                             adjacentStereo++;
+                        }
                     }
                 }
-                return rbonds >= 3 || adjacentStereo >= 3;
+                return rbonds >= 3 || adjacentStereo == bcount;
             case IStereoElement.Allenal:
             case IStereoElement.CisTrans:
             case IStereoElement.SquarePlanar:

--- a/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
+++ b/base/test-standard/src/test/java/org/openscience/cdk/tools/manipulator/AtomContainerManipulatorTest.java
@@ -2093,6 +2093,17 @@ class AtomContainerManipulatorTest extends CDKTestCase {
     }
 
     @Test
+    public void testAdjacentStereo() throws CDKException {
+        assertHydrogenConversion("O[C@@H]1[C@@H](N)C[C@@H](N)[C@@H]([C@H]1O)O[C@H]2OCCC[C@H]2O",
+                                 "O[C@@H]1[C@@H](N)C[C@@H](N)[C@@H]([C@H]1O)O[C@H]2OCCC[C@H]2O", HydrogenState.Minimal);
+        assertHydrogenConversion("O[C@@H]1[C@@H](N)C[C@@H](N)[C@@H]([C@H]1O)O[C@H]2OCCC[C@H]2O",
+                                 "O[C@@]1([C@@](N)(C[C@@](N)([C@@]([C@]1(O)[H])(O[C@]2(OCCC[C@]2(O)[H])[H])[H])[H])[H])[H]",
+                                 HydrogenState.Stereo);
+        assertHydrogenConversion("O[C@@H]1[C@@H](N)C[C@@H](N)[C@@H]([C@H]1O)O[C@H]2OCCC[C@H]2O",
+                                 "O[C@@H]1[C@@H](N)C[C@@H](N)[C@@H]([C@H]1O)O[C@H]2OCCC[C@H]2O", HydrogenState.Depiction);
+    }
+
+    @Test
     public void testExtendedCisTrans() throws CDKException {
         assertHydrogenConversion("C/C=C=C=C(\\[H])C",
                                  "C/C=C=C=C/C", HydrogenState.Minimal);


### PR DESCRIPTION
We add hydrogens to tetrahedral atoms only if the adjacent stereo elements stop

For example this does not need extra hydrogens:

<img width="173" height="114" alt="image" src="https://github.com/user-attachments/assets/e92402a5-206f-4048-a118-350cbab3399e" />

This example does: 

<img width="195" height="89" alt="image" src="https://github.com/user-attachments/assets/a9c1ea8d-7dc8-4f08-9721-44c89dc2f9ce" />
