### PR TITLE
adds the routine used in Hydrogens to update double bond stereo elements after atom/bond removal to AtomContainer atom removal

### DIFF
--- a/base/data/pom.xml
+++ b/base/data/pom.xml
@@ -67,6 +67,18 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.openscience.cdk</groupId>
+            <artifactId>cdk-smiles</artifactId>
+            <version>2.13-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openscience.cdk</groupId>
+            <artifactId>cdk-silent</artifactId>
+            <version>2.13-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/base/data/pom.xml
+++ b/base/data/pom.xml
@@ -67,18 +67,6 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
-        <dependency>
-            <groupId>org.openscience.cdk</groupId>
-            <artifactId>cdk-smiles</artifactId>
-            <version>2.13-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openscience.cdk</groupId>
-            <artifactId>cdk-silent</artifactId>
-            <version>2.13-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -370,13 +370,15 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
     }
 
     /**
-     * Updates carriers and conformation of a double bond stereochemistry element after an etom removal.
+     * Updates carriers and conformation of a double bond stereochemistry element after an atom removal.
+     * Note that the returned element must be added to the stereo elements manually.
      *
      * @param db the double bond stereochemistry element to update
-     * @param contract the atom that is removed
+     * @param contract the atom that is removed; must be part of a carrier bond of this stereo element,
+     *                 not part of the focus bond!
      * @return new double bond stereochemistry element, or null if the stereochemistry is no longer valid
      * @author John May (original implementation in Hydrogens class)
-     * @author Jonas Schaub (adaption to this use case)
+     * @author Jonas Schaub (adaption to this class)
      */
     private static IDoubleBondStereochemistry updateDoubleBondStereo(IDoubleBondStereochemistry db,
                                                                      IAtom contract) {
@@ -397,6 +399,11 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
         IAtom x = orgLeft.getOther(u);
         IAtom y = orgRight.getOther(v);
 
+        if (contract.equals(u) || contract.equals(v)) {
+            // The contracted atom is part of the focus bond, so we cannot update the stereochemistry
+            return null;
+        }
+
         // if xNew == x and yNew == y we don't need to find the
         // connecting bonds
         IAtom xNew = x;
@@ -412,14 +419,8 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
             yNew = findSingleBond(v, y);
         }
 
-        // corner case: the new atom which we will base stereo off is also
-        // going to be contracted! This happens if someone gives us something
-        // daft like C/C=C(/[H])[H]
-        if (contract.equals(xNew) || contract.equals(yNew))
-            return null;
-
         // no other atoms connected, invalid double-bond configuration
-        // is removed. example [2H]/C=C/[H]
+        // is removed.
         if (x == null || y == null ||
                 xNew == null || yNew == null) return null;
 
@@ -1397,12 +1398,19 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
                     } else {
                         bonds[i].removeListener(this);
                         delFromEndpoints(bonds[i]);
-                        //update double bond stereos that this atom is involved in here already,
+                        //update double bond stereo elements where this atom is involved in a carrier bond here already,
                         // before the general bond stereochem update below; using specific method taken from Hydrogens
                         for (int j = 0; j < stereo.size(); j++) {
                             IStereoElement<?, ?> se = stereo.get(j);
                             if (se.contains(atom) && se instanceof IDoubleBondStereochemistry) {
-                                stereo.set(j, updateDoubleBondStereo((IDoubleBondStereochemistry) se, atom));
+                                for (IChemObject carrier : se.getCarriers()) {
+                                    if (carrier instanceof IBond && ((IBond) carrier).contains(atom)) {
+                                        IDoubleBondStereochemistry updated = updateDoubleBondStereo((IDoubleBondStereochemistry) se, atom);
+                                        if (updated != null) {
+                                            stereo.set(j, updated);
+                                        } //else: it cannot be updated, so it is left alone here and collected for removal below
+                                    }
+                                }
                             }
                         }
                         updateStereochemistry(bonds[i]);

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * This class should not be used directly.
@@ -370,8 +369,17 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
         }
     }
 
-    private static IDoubleBondStereochemistry update(IDoubleBondStereochemistry db,
-                                                     IAtom contract) {
+    /**
+     * Updates carriers and conformation of a double bond stereochemistry element after an etom removal.
+     *
+     * @param db the double bond stereochemistry element to update
+     * @param contract the atom that is removed
+     * @return new double bond stereochemistry element, or null if the stereochemistry is no longer valid
+     * @author John May (original implementation in Hydrogens class)
+     * @author Jonas Schaub (adaption to this use case)
+     */
+    private static IDoubleBondStereochemistry updateDoubleBondStereo(IDoubleBondStereochemistry db,
+                                                                     IAtom contract) {
         IDoubleBondStereochemistry.Conformation conformation = db.getStereo();
 
         IBond orgStereo = db.getStereoBond();
@@ -1387,14 +1395,16 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
                         bonds[newNumBonds].setIndex(newNumBonds);
                         newNumBonds++;
                     } else {
+                        bonds[i].removeListener(this);
+                        delFromEndpoints(bonds[i]);
+                        //update double bond stereos that this atom is involved in here already,
+                        // before the general bond stereochem update below; using specific method taken from Hydrogens
                         for (int j = 0; j < stereo.size(); j++) {
                             IStereoElement<?, ?> se = stereo.get(j);
                             if (se.contains(atom) && se instanceof IDoubleBondStereochemistry) {
-                                update((IDoubleBondStereochemistry) se, atom);
+                                stereo.set(j, updateDoubleBondStereo((IDoubleBondStereochemistry) se, atom));
                             }
                         }
-                        bonds[i].removeListener(this);
-                        delFromEndpoints(bonds[i]);
                         updateStereochemistry(bonds[i]);
                     }
                 }

--- a/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
+++ b/base/data/src/main/java/org/openscience/cdk/AtomContainer.java
@@ -41,6 +41,7 @@ import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtom;
 import org.openscience.cdk.isomorphism.matchers.IQueryBond;
 import org.openscience.cdk.sgroup.Sgroup;
+import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.tools.manipulator.SgroupManipulator;
 
 import java.util.ArrayList;
@@ -53,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * This class should not be used directly.
@@ -366,6 +368,84 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
                 setProperty(CDKConstants.CTAB_SGROUPS, sgroups);
             }
         }
+    }
+
+    private static IDoubleBondStereochemistry update(IDoubleBondStereochemistry db,
+                                                     IAtom contract) {
+        IDoubleBondStereochemistry.Conformation conformation = db.getStereo();
+
+        IBond orgStereo = db.getStereoBond();
+        IBond orgLeft = db.getBonds()[0];
+        IBond orgRight = db.getBonds()[1];
+
+        // we use the following variable names to refer to the
+        // double bond atoms and substituents
+        // x       y
+        //  \     /
+        //   u = v
+
+        IAtom u = orgStereo.getBegin();
+        IAtom v = orgStereo.getEnd();
+        IAtom x = orgLeft.getOther(u);
+        IAtom y = orgRight.getOther(v);
+
+        // if xNew == x and yNew == y we don't need to find the
+        // connecting bonds
+        IAtom xNew = x;
+        IAtom yNew = y;
+
+        if (contract.equals(x)) {
+            conformation = conformation.invert();
+            xNew = findSingleBond(u, x);
+        }
+
+        if (contract.equals(y)) {
+            conformation = conformation.invert();
+            yNew = findSingleBond(v, y);
+        }
+
+        // corner case: the new atom which we will base stereo off is also
+        // going to be contracted! This happens if someone gives us something
+        // daft like C/C=C(/[H])[H]
+        if (contract.equals(xNew) || contract.equals(yNew))
+            return null;
+
+        // no other atoms connected, invalid double-bond configuration
+        // is removed. example [2H]/C=C/[H]
+        if (x == null || y == null ||
+                xNew == null || yNew == null) return null;
+
+        // no changes
+        if (x.equals(xNew) && y.equals(yNew)) {
+            return db;
+        }
+
+        // XXX: may perform slow operations but works for now
+        IBond cpyLeft = !Objects.equals(xNew, x) ? u.getBond(xNew) : orgLeft;
+        IBond cpyRight = !Objects.equals(yNew, y) ? v.getBond(yNew) : orgRight;
+
+        return new DoubleBondStereochemistry(orgStereo,
+                new IBond[]{cpyLeft, cpyRight},
+                conformation);
+    }
+
+    /**
+     * Finds a neighbor connected to 'atom' which is connected by a
+     * single bond and is not 'exclude'.
+     *
+     * @param atom    atom to find a neighbor of
+     * @param exclude the neighbor should not be this atom
+     * @return a neighbor of 'atom', null if not found
+     */
+    private static IAtom findSingleBond(IAtom atom, IAtom exclude) {
+        for (IBond bond : atom.bonds()) {
+            if (bond.getOrder() != IBond.Order.SINGLE)
+                continue;
+            IAtom neighbor = bond.getOther(atom);
+            if (!neighbor.equals(exclude))
+                return neighbor;
+        }
+        return null;
     }
 
     /**
@@ -1140,7 +1220,6 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
                 invalidated.add(se);
             } else if (se instanceof IDoubleBondStereochemistry) {
                 IDoubleBondStereochemistry db = (IDoubleBondStereochemistry)se;
-                List<IBond> carriers = db.getCarriers();
                 final IAtom common = db.getFocus().getConnectedAtom(removedBond);
                 if (common != null) {
                     IBond otherBond = null;
@@ -1308,6 +1387,12 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
                         bonds[newNumBonds].setIndex(newNumBonds);
                         newNumBonds++;
                     } else {
+                        for (int j = 0; j < stereo.size(); j++) {
+                            IStereoElement<?, ?> se = stereo.get(j);
+                            if (se.contains(atom) && se instanceof IDoubleBondStereochemistry) {
+                                update((IDoubleBondStereochemistry) se, atom);
+                            }
+                        }
                         bonds[i].removeListener(this);
                         delFromEndpoints(bonds[i]);
                         updateStereochemistry(bonds[i]);

--- a/base/data/src/test/java/org/openscience/cdk/AtomContainerTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/AtomContainerTest.java
@@ -21,18 +21,14 @@ package org.openscience.cdk;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
 import org.openscience.cdk.interfaces.IStereoElement;
-import org.openscience.cdk.smiles.SmiFlavor;
-import org.openscience.cdk.smiles.SmilesGenerator;
-import org.openscience.cdk.smiles.SmilesParser;
+import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.test.interfaces.AbstractAtomContainerTest;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.ILonePair;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Checks the functionality of the AtomContainer.
@@ -104,35 +100,54 @@ class AtomContainerTest extends AbstractAtomContainerTest {
         Assertions.assertEquals(3, container.getBondCount());
     }
 
+    /**
+     * Tests the double bond stereochemistry update (carriers and conformation) after an atom removal.
+     */
     @Test
-    void testStereoUpdate () throws Exception {
-        SmilesParser smiPar = new SmilesParser(DefaultChemObjectBuilder.getInstance());
-        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo | SmiFlavor.AtomAtomMap);
-        IAtomContainer molecule = smiPar.parseSmiles("[CH2:1]1[CH2:1][CH2:1][CH2:1][CH:1](/C(=C(/C2CCCNCCC2)\\C3CCCCCCC3)/C4CCCCCNC4)[CH2:1][CH2:1][CH2:1]1");
-        List<IAtom> toRemove = new ArrayList<>(6);
-        for (IAtom atom : molecule.atoms()) {
-            if (atom.getMapIdx() == 1) {
-                toRemove.add(atom);
-            }
+    void testStereoUpdate() {
+        // we use the following variable names to refer to the
+        // double bond atoms and substituents
+        // x       y
+        //  \     /
+        //   u = v
+        //  /     \
+        // w       z
+        IAtomContainer mol = newChemObject().getBuilder().newInstance(IAtomContainer.class);
+        IAtom u = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom v = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom w = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom x = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom y = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom z = mol.getBuilder().newInstance(IAtom.class, "C");
+        mol.addAtom(u);
+        mol.addAtom(v);
+        mol.addAtom(w);
+        mol.addAtom(x);
+        mol.addAtom(y);
+        mol.addAtom(z);
+        IBond uv = mol.getBuilder().newInstance(IBond.class, u, v, IBond.Order.DOUBLE);
+        IBond uw = mol.getBuilder().newInstance(IBond.class, u, w, IBond.Order.SINGLE);
+        IBond ux = mol.getBuilder().newInstance(IBond.class, u, x, IBond.Order.SINGLE);
+        IBond vy = mol.getBuilder().newInstance(IBond.class, v, y, IBond.Order.SINGLE);
+        IBond vz = mol.getBuilder().newInstance(IBond.class, v, z, IBond.Order.SINGLE);
+        mol.addBond(uv);
+        mol.addBond(uw);
+        mol.addBond(ux);
+        mol.addBond(vy);
+        mol.addBond(vz);
+        mol.addStereoElement(new DoubleBondStereochemistry(uv, new IBond[]{ux, vz}, DoubleBondStereochemistry.Conformation.OPPOSITE));
+        for (IStereoElement<?, ?> elem : mol.stereoElements()) {
+            Assertions.assertTrue(elem.getCarriers().contains(ux));
+            Assertions.assertTrue(elem.getCarriers().contains(vz));
+            Assertions.assertEquals(IDoubleBondStereochemistry.Conformation.OPPOSITE, ((IDoubleBondStereochemistry) elem).getStereo());
         }
-        for (IStereoElement elem : molecule.stereoElements()) {
-            for (Object obj : elem.getCarriers()) {
-                for (IAtom atom : ((IBond) obj).atoms()) {
-                    atom.setMapIdx(2);
-                }
-            }
+        mol.removeAtom(z);
+        for (IStereoElement<?, ?> elem : mol.stereoElements()) {
+            Assertions.assertTrue(elem.getCarriers().contains(ux));
+            //the other carrier is updated to vy
+            Assertions.assertTrue(elem.getCarriers().contains(vy));
+            //the configuration therefore needs to be TOGETHER now
+            Assertions.assertEquals(IDoubleBondStereochemistry.Conformation.TOGETHER, ((IDoubleBondStereochemistry) elem).getStereo());
         }
-        System.out.println(smiGen.create(molecule));
-        for (IAtom atom : toRemove) {
-            molecule.removeAtom(atom);
-        }
-        for (IStereoElement elem : molecule.stereoElements()) {
-            for (Object obj : elem.getCarriers()) {
-                for (IAtom atom : ((IBond) obj).atoms()) {
-                    atom.setMapIdx(3);
-                }
-            }
-        }
-        System.out.println(smiGen.create(molecule));
     }
 }

--- a/base/data/src/test/java/org/openscience/cdk/AtomContainerTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/AtomContainerTest.java
@@ -139,6 +139,7 @@ class AtomContainerTest extends AbstractAtomContainerTest {
         for (IStereoElement<?, ?> elem : mol.stereoElements()) {
             Assertions.assertTrue(elem.getCarriers().contains(ux));
             Assertions.assertTrue(elem.getCarriers().contains(vz));
+            Assertions.assertEquals(uv, elem.getFocus());
             Assertions.assertEquals(IDoubleBondStereochemistry.Conformation.OPPOSITE, ((IDoubleBondStereochemistry) elem).getStereo());
         }
         mol.removeAtom(z);

--- a/base/data/src/test/java/org/openscience/cdk/AtomContainerTest.java
+++ b/base/data/src/test/java/org/openscience/cdk/AtomContainerTest.java
@@ -21,11 +21,18 @@ package org.openscience.cdk;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.smiles.SmiFlavor;
+import org.openscience.cdk.smiles.SmilesGenerator;
+import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.test.interfaces.AbstractAtomContainerTest;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.ILonePair;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Checks the functionality of the AtomContainer.
@@ -95,5 +102,37 @@ class AtomContainerTest extends AbstractAtomContainerTest {
         IAtomContainer container = new AtomContainer(acetone);
         Assertions.assertEquals(4, container.getAtomCount());
         Assertions.assertEquals(3, container.getBondCount());
+    }
+
+    @Test
+    void testStereoUpdate () throws Exception {
+        SmilesParser smiPar = new SmilesParser(DefaultChemObjectBuilder.getInstance());
+        SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Stereo | SmiFlavor.AtomAtomMap);
+        IAtomContainer molecule = smiPar.parseSmiles("[CH2:1]1[CH2:1][CH2:1][CH2:1][CH:1](/C(=C(/C2CCCNCCC2)\\C3CCCCCCC3)/C4CCCCCNC4)[CH2:1][CH2:1][CH2:1]1");
+        List<IAtom> toRemove = new ArrayList<>(6);
+        for (IAtom atom : molecule.atoms()) {
+            if (atom.getMapIdx() == 1) {
+                toRemove.add(atom);
+            }
+        }
+        for (IStereoElement elem : molecule.stereoElements()) {
+            for (Object obj : elem.getCarriers()) {
+                for (IAtom atom : ((IBond) obj).atoms()) {
+                    atom.setMapIdx(2);
+                }
+            }
+        }
+        System.out.println(smiGen.create(molecule));
+        for (IAtom atom : toRemove) {
+            molecule.removeAtom(atom);
+        }
+        for (IStereoElement elem : molecule.stereoElements()) {
+            for (Object obj : elem.getCarriers()) {
+                for (IAtom atom : ((IBond) obj).atoms()) {
+                    atom.setMapIdx(3);
+                }
+            }
+        }
+        System.out.println(smiGen.create(molecule));
     }
 }

--- a/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/AtomContainer.java
@@ -44,6 +44,7 @@ import org.openscience.cdk.interfaces.IStereoElement;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtom;
 import org.openscience.cdk.isomorphism.matchers.IQueryBond;
 import org.openscience.cdk.sgroup.Sgroup;
+import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.tools.manipulator.SgroupManipulator;
 
 import java.util.ArrayList;
@@ -361,6 +362,94 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
                 setProperty(CDKConstants.CTAB_SGROUPS, sgroups);
             }
         }
+    }
+
+    /**
+     * Updates carriers and conformation of a double bond stereochemistry element after an atom removal.
+     * Note that the returned element must be added to the stereo elements manually.
+     *
+     * @param db the double bond stereochemistry element to update
+     * @param contract the atom that is removed; must be part of a carrier bond of this stereo element,
+     *                 not part of the focus bond!
+     * @return new double bond stereochemistry element, or null if the stereochemistry is no longer valid
+     * @author John May (original implementation in Hydrogens class)
+     * @author Jonas Schaub (adaption to this class)
+     */
+    private static IDoubleBondStereochemistry updateDoubleBondStereo(IDoubleBondStereochemistry db,
+                                                                     IAtom contract) {
+        IDoubleBondStereochemistry.Conformation conformation = db.getStereo();
+
+        IBond orgStereo = db.getStereoBond();
+        IBond orgLeft = db.getBonds()[0];
+        IBond orgRight = db.getBonds()[1];
+
+        // we use the following variable names to refer to the
+        // double bond atoms and substituents
+        // x       y
+        //  \     /
+        //   u = v
+
+        IAtom u = orgStereo.getBegin();
+        IAtom v = orgStereo.getEnd();
+        IAtom x = orgLeft.getOther(u);
+        IAtom y = orgRight.getOther(v);
+
+        if (contract.equals(u) || contract.equals(v)) {
+            // The contracted atom is part of the focus bond, so we cannot update the stereochemistry
+            return null;
+        }
+
+        // if xNew == x and yNew == y we don't need to find the
+        // connecting bonds
+        IAtom xNew = x;
+        IAtom yNew = y;
+
+        if (contract.equals(x)) {
+            conformation = conformation.invert();
+            xNew = findSingleBond(u, x);
+        }
+
+        if (contract.equals(y)) {
+            conformation = conformation.invert();
+            yNew = findSingleBond(v, y);
+        }
+
+        // no other atoms connected, invalid double-bond configuration
+        // is removed.
+        if (x == null || y == null ||
+                xNew == null || yNew == null) return null;
+
+        // no changes
+        if (x.equals(xNew) && y.equals(yNew)) {
+            return db;
+        }
+
+        // XXX: may perform slow operations but works for now
+        IBond cpyLeft = !Objects.equals(xNew, x) ? u.getBond(xNew) : orgLeft;
+        IBond cpyRight = !Objects.equals(yNew, y) ? v.getBond(yNew) : orgRight;
+
+        return new DoubleBondStereochemistry(orgStereo,
+                new IBond[]{cpyLeft, cpyRight},
+                conformation);
+    }
+
+    /**
+     * Finds a neighbor connected to 'atom' which is connected by a
+     * single bond and is not 'exclude'.
+     *
+     * @param atom    atom to find a neighbor of
+     * @param exclude the neighbor should not be this atom
+     * @return a neighbor of 'atom', null if not found
+     */
+    private static IAtom findSingleBond(IAtom atom, IAtom exclude) {
+        for (IBond bond : atom.bonds()) {
+            if (bond.getOrder() != IBond.Order.SINGLE)
+                continue;
+            IAtom neighbor = bond.getOther(atom);
+            if (!neighbor.equals(exclude))
+                return neighbor;
+        }
+        return null;
     }
 
     /**
@@ -1112,7 +1201,6 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
                 invalidated.add(se);
             } else if (se instanceof IDoubleBondStereochemistry) {
                 IDoubleBondStereochemistry db = (IDoubleBondStereochemistry)se;
-                List<IBond> carriers = db.getCarriers();
                 final IAtom common = db.getFocus().getConnectedAtom(removedBond);
                 if (common != null) {
                     IBond otherBond = null;
@@ -1264,7 +1352,7 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
     @Override
     public void removeAtom(IAtom atom) {
         AtomRef atomref = getAtomRefUnsafe(atom);
-                if (atomref != null) {
+        if (atomref != null) {
             if (atomref.getBondCount() > 0) {
                 // update bonds
                 int newNumBonds = 0;
@@ -1275,6 +1363,21 @@ public class AtomContainer extends ChemObject implements IAtomContainer {
                         newNumBonds++;
                     } else {
                         delFromEndpoints(bonds[i]);
+                        //update double bond stereo elements where this atom is involved in a carrier bond here already,
+                        // before the general bond stereochem update below; using specific method taken from Hydrogens
+                        for (int j = 0; j < stereo.size(); j++) {
+                            IStereoElement<?, ?> se = stereo.get(j);
+                            if (se.contains(atom) && se instanceof IDoubleBondStereochemistry) {
+                                for (IChemObject carrier : se.getCarriers()) {
+                                    if (carrier instanceof IBond && ((IBond) carrier).contains(atom)) {
+                                        IDoubleBondStereochemistry updated = updateDoubleBondStereo((IDoubleBondStereochemistry) se, atom);
+                                        if (updated != null) {
+                                            stereo.set(j, updated);
+                                        } //else: it cannot be updated, so it is left alone here and collected for removal below
+                                    }
+                                }
+                            }
+                        }
                         updateStereochemistry(bonds[i]);
                     }
                 }

--- a/base/silent/src/test/java/org/openscience/cdk/silent/AtomContainerTest.java
+++ b/base/silent/src/test/java/org/openscience/cdk/silent/AtomContainerTest.java
@@ -21,6 +21,9 @@ package org.openscience.cdk.silent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openscience.cdk.interfaces.IDoubleBondStereochemistry;
+import org.openscience.cdk.interfaces.IStereoElement;
+import org.openscience.cdk.stereo.DoubleBondStereochemistry;
 import org.openscience.cdk.test.interfaces.AbstractAtomContainerTest;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -95,6 +98,58 @@ class AtomContainerTest extends AbstractAtomContainerTest {
         IAtomContainer container = new AtomContainer(acetone);
         Assertions.assertEquals(4, container.getAtomCount());
         Assertions.assertEquals(3, container.getBondCount());
+    }
+
+    /**
+     * Tests the double bond stereochemistry update (carriers and conformation) after an atom removal.
+     */
+    @Test
+    void testStereoUpdate() {
+        // we use the following variable names to refer to the
+        // double bond atoms and substituents
+        // x       y
+        //  \     /
+        //   u = v
+        //  /     \
+        // w       z
+        IAtomContainer mol = newChemObject().getBuilder().newInstance(IAtomContainer.class);
+        IAtom u = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom v = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom w = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom x = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom y = mol.getBuilder().newInstance(IAtom.class, "C");
+        IAtom z = mol.getBuilder().newInstance(IAtom.class, "C");
+        mol.addAtom(u);
+        mol.addAtom(v);
+        mol.addAtom(w);
+        mol.addAtom(x);
+        mol.addAtom(y);
+        mol.addAtom(z);
+        IBond uv = mol.getBuilder().newInstance(IBond.class, u, v, IBond.Order.DOUBLE);
+        IBond uw = mol.getBuilder().newInstance(IBond.class, u, w, IBond.Order.SINGLE);
+        IBond ux = mol.getBuilder().newInstance(IBond.class, u, x, IBond.Order.SINGLE);
+        IBond vy = mol.getBuilder().newInstance(IBond.class, v, y, IBond.Order.SINGLE);
+        IBond vz = mol.getBuilder().newInstance(IBond.class, v, z, IBond.Order.SINGLE);
+        mol.addBond(uv);
+        mol.addBond(uw);
+        mol.addBond(ux);
+        mol.addBond(vy);
+        mol.addBond(vz);
+        mol.addStereoElement(new DoubleBondStereochemistry(uv, new IBond[]{ux, vz}, DoubleBondStereochemistry.Conformation.OPPOSITE));
+        for (IStereoElement<?, ?> elem : mol.stereoElements()) {
+            Assertions.assertTrue(elem.getCarriers().contains(ux));
+            Assertions.assertTrue(elem.getCarriers().contains(vz));
+            Assertions.assertEquals(uv, elem.getFocus());
+            Assertions.assertEquals(IDoubleBondStereochemistry.Conformation.OPPOSITE, ((IDoubleBondStereochemistry) elem).getStereo());
+        }
+        mol.removeAtom(z);
+        for (IStereoElement<?, ?> elem : mol.stereoElements()) {
+            Assertions.assertTrue(elem.getCarriers().contains(ux));
+            //the other carrier is updated to vy
+            Assertions.assertTrue(elem.getCarriers().contains(vy));
+            //the configuration therefore needs to be TOGETHER now
+            Assertions.assertEquals(IDoubleBondStereochemistry.Conformation.TOGETHER, ((IDoubleBondStereochemistry) elem).getStereo());
+        }
     }
 
     // Overwrite default methods: no notifications are expected!


### PR DESCRIPTION
In reference to https://github.com/cdk/cdk-scaffold/issues/19

The changes are applied to data AtomContainer and silent AtomContainer. Tests are also added.

@johnmay, please advise whether this is what you proposed in the issue linked above.